### PR TITLE
Modernize Blockly sidecar build for R2025a runtime

### DIFF
--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
 
+      - name: Rebuild Blockly sidecar for current Linux toolchain
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/supervisor/blocklyServer \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'rm -f blocklyServer && make'
+
       - name: Rebuild supervisor for Webots R2025a
         run: |
           docker run --rm \
@@ -63,8 +71,7 @@ jobs:
           echo "Webots exit code: $code"
 
           # 124 = timeout normal.
-          # 137 = Webots a dû être tué après la fenêtre de test.
-          # Dans les deux cas, il est resté vivant pendant le smoke test.
+          # 137 = Webots a dû être tué after the diagnostic window.
           if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
             echo "Webots remained alive for the diagnostic window."
             exit 0

--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Prepare diagnostics directory
+        run: mkdir -p ci-artifacts
+
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
 
@@ -34,7 +37,8 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace/controllers/supervisor/blocklyServer \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'rm -f blocklyServer && make'
+            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev && rm -f blocklyServer && make' \
+            2>&1 | tee ci-artifacts/blockly-server-build.log
 
       - name: Rebuild supervisor for Webots R2025a
         run: |
@@ -42,12 +46,12 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace/controllers/supervisor \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'make clean && make'
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/supervisor-build.log
 
       - name: Run historical empty world in Webots R2025a
         shell: bash
         run: |
-          mkdir -p ci-artifacts
           set +e
 
           docker run --rm \
@@ -71,7 +75,7 @@ jobs:
           echo "Webots exit code: $code"
 
           # 124 = timeout normal.
-          # 137 = Webots a dû être tué after the diagnostic window.
+          # 137 = Webots had to be killed after the diagnostic window.
           if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
             echo "Webots remained alive for the diagnostic window."
             exit 0

--- a/controllers/supervisor/blocklyServer/Makefile
+++ b/controllers/supervisor/blocklyServer/Makefile
@@ -1,4 +1,4 @@
-ifeq ($(OS),Windows_NT)     
+ifeq ($(OS),Windows_NT)
     detected_OS := Windows
 else
     detected_OS := $(shell uname)
@@ -6,14 +6,15 @@ endif
 
 ifeq ($(detected_OS),Windows)
 	LIBRARIES=-L. -L"ws2_32" -lws2_32 -lmswsock -lwsock32 -lboost_filesystem-mgw9-mt-s-x64-1_74 -lboost_date_time-mgw9-mt-s-x64-1_74
-	INCLUDE=-I"C:\Users\Victor\Downloads\boost_1_74_0\boost_1_74_0"
-	FLAGS=-DWINDOWS
-else ifeq ($(detected_OS),Darwin)        # Mac OS X
-	LIBRARIES=-lboost_date_time -lboost_filesystem
-	FLAGS=-std=c++11
+	INCLUDE=-I"C:\\Users\\Victor\\Downloads\\boost_1_74_0\\boost_1_74_0"
+	FLAGS=-DWINDOWS -std=c++17
+else ifeq ($(detected_OS),Darwin)
+	LIBRARIES=-lpthread
+	FLAGS=-std=c++17 -Wall -Wextra -Wpedantic
 else
-	LIBRARIES=-L. -lboost_date_time -lboost_filesystem -lpthread
+	LIBRARIES=-lpthread
+	FLAGS=-std=c++17 -Wall -Wextra -Wpedantic
 endif
 
 blocklyServer: blocklyServer.cpp
-	g++ $(INCLUDE) $(FLAGS) $^ $(LIBRARIES) -o $@ 
+	g++ $(INCLUDE) $(FLAGS) $^ $(LIBRARIES) -o $@

--- a/controllers/supervisor/blocklyServer/blocklyServer.cpp
+++ b/controllers/supervisor/blocklyServer/blocklyServer.cpp
@@ -4,10 +4,11 @@
 #include <functional>
 #include <thread>
 #include <vector>
+#include <filesystem>
 using namespace std;
 
 // put in ifdef for WIN32
-#define _WIN32_WINNT _WIN32_WINNT_WIN10         
+#define _WIN32_WINNT _WIN32_WINNT_WIN10
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 
 #include <boost/beast/core.hpp>
@@ -16,14 +17,12 @@ using namespace std;
 #include <boost/beast/core/buffers_to_string.hpp>
 
 namespace beast = boost::beast;
-namespace http = beast::http;           
-namespace websocket = beast::websocket; 
-namespace net = boost::asio;            
-using tcp = boost::asio::ip::tcp;      
+namespace http = beast::http;
+namespace websocket = beast::websocket;
+namespace net = boost::asio;
+using tcp = boost::asio::ip::tcp;
 
-#include <boost/range/iterator_range.hpp>
-#include <boost/filesystem.hpp>
-namespace filesystem = boost::filesystem;
+namespace filesystem = std::filesystem;
 
 void write_py_file(const std::string& s){
     ofstream of("../my_controller/my_controller.py");
@@ -45,9 +44,7 @@ do_session(tcp::socket socket)
 {
     try
     {
-        // Construct the stream by moving in the socket
         websocket::stream<beast::tcp_stream> ws(std::move(socket));
-        // Set a decorator to change the Server of the handshake
         ws.set_option(websocket::stream_base::decorator(
             [](websocket::response_type& res)
             {
@@ -55,27 +52,19 @@ do_session(tcp::socket socket)
                     std::string(BOOST_BEAST_VERSION_STRING) +
                     " websocket-server-sync");
             }));
-        // Accept the websocket handshake
         ws.accept();
-        // This buffer will hold the incoming message
         beast::flat_buffer buffer;
-        // Read a message
-        
+
         while(true) {
-        
           ws.read(buffer);
-          auto p = buffer.cdata();
           auto s = beast::buffers_to_string(buffer.data());
-      
           buffer.clear();
-      
+
            if(s == "SEND_CODE") {
-           
              ws.read(buffer);
              write_py_file(beast::buffers_to_string(buffer.data()));
            }
            else if(s == "SAVE") {
-           
              ws.read(buffer);
              auto fileName = beast::buffers_to_string(buffer.data());
              buffer.clear();
@@ -85,71 +74,64 @@ do_session(tcp::socket socket)
              saveToFile(fileName, xml);
            }
            else if (s == "LIST_SAVES") {
-
              filesystem::path p("./../Blockly_Programs");
              string files = "";
 
-             for(auto& entry : boost::make_iterator_range(filesystem::directory_iterator(p), {} )) {
-
+             for(const auto& entry : filesystem::directory_iterator(p)) {
                 string filePath = entry.path().string();
-                string fileName = filePath.substr(filePath.find_last_of("/\\") + 1); 
+                string fileName = filePath.substr(filePath.find_last_of("/\\") + 1);
                 fileName.erase(fileName.size()-4, string::npos);
                 if(fileName[0] != '.') files += fileName + '\n';
              }
-           
+
              ws.write(net::buffer(files));
            }
            else if(s == "RESTORE_SAVE") {
-
              ws.read(buffer);
              auto fileName = beast::buffers_to_string(buffer.data());
              buffer.clear();
-             
+
              string filePath = "../Blockly_Programs/" + fileName;
-             
+
              ifstream in(filePath, ios::binary | ios::ate);
-             streamsize size = in.tellg();
-             in.seekg(0, ios::beg);
+             if(!in.fail()) {
+               streamsize size = in.tellg();
+               in.seekg(0, ios::beg);
 
-             vector<char> fileBuff(size);
-             in.read(fileBuff.data(), size);
-
-             ws.write(net::buffer(fileBuff));
-
-             in.close();
+               vector<char> fileBuff(size);
+               in.read(fileBuff.data(), size);
+               ws.write(net::buffer(fileBuff));
+               in.close();
+             }
+             else {
+               ws.write(net::buffer(""));
+             }
            }
            else if(s == "RESTORE_LAST_NAME") {
-
-            
              ifstream in("../Blockly_Programs/.tmp.txt");
              if(!in.fail()) {
-               
                string fileName;
                in >> fileName;
                in.close();
                ws.write(net::buffer(fileName));
              }
              else {
-
                 ws.write(net::buffer(""));
              }
            }
            else if(s == "RESTORE_LAST") {
-
              ifstream in("../Blockly_Programs/.tmp.txt");
              if(!in.fail()) {
-               
                string fileName;
                in >> fileName;
                in.close();
 
                 fileName += ".xml";
                  string filePath = "../Blockly_Programs/" + fileName;
-                 
+
                  ifstream in(filePath, ios::binary | ios::ate);
 
-                 if(!in.fail()) { //Make this into a function already >:(
-
+                 if(!in.fail()) {
                      streamsize size = in.tellg();
                      in.seekg(0, ios::beg);
 
@@ -157,40 +139,28 @@ do_session(tcp::socket socket)
                      in.read(fileBuff.data(), size);
 
                      ws.write(net::buffer(fileBuff));
-
                      in.close();
-
                  }
-                 else { //If file is not found, return empty
-                   ws.write(net::buffer("")); 
+                 else {
+                   ws.write(net::buffer(""));
                  }
              }
-             else { //If the tmp file isn't found, return empty
-
-                   ws.write(net::buffer("")); 
+             else {
+                   ws.write(net::buffer(""));
              }
            }
            else if(s == "SAVE_LAST") {
-
              ws.read(buffer);
-
              auto fileName = beast::buffers_to_string(buffer.data());
-          
              saveToFile(".tmp.txt", fileName );
            }
 
            buffer.clear();
         }
-        //write_py_file(s);
-        // Echo the message back
-        //ws.text(ws.got_text());
-        //ws.write(buffer.data());
-        //buffer.clear();
         ws.close(websocket::close_reason("normal close"));
     }
     catch (beast::system_error const& se)
     {
-        // This indicates that the session was closed
         if (se.code() != websocket::error::closed)
             cerr << "Error: " << se.code().message() << endl;
     }
@@ -205,17 +175,17 @@ int main() {
   auto const address = net::ip::make_address("127.0.0.1");
   unsigned short port = 8001;
   net::io_context ioc{ 1 };
-    
+
   while(true) {
-    //Set reuse address to false to prevent multiple instances of blocklyServer on Windows
+    // Set reuse address to false to prevent multiple instances on Windows.
 #ifdef WINDOWS
     tcp::acceptor acceptor { ioc, {address, port}, false };
-#elif
+#else
     tcp::acceptor acceptor { ioc, {address, port}, true };
 #endif
     tcp::socket socket {ioc};
     acceptor.accept(socket);
-      
+
     thread(&do_session, move(socket)).detach();
   }
 }


### PR DESCRIPTION
### Scope
- Keep the historical Blockly/WebSocket architecture unchanged.
- Build `blocklyServer` with C++17 and `std::filesystem` so it no longer depends on Boost.Filesystem/Boost.DateTime binaries on Linux/macOS.
- Fix the invalid preprocessor `#elif` branch.
- Make `RESTORE_SAVE` return an empty response when the requested file does not exist instead of constructing an invalid huge buffer.
- Extend the existing Webots R2025a CI smoke test to rebuild the sidecar before launching `empty.wbt`.

### Non-goals
- No change to `main`.
- No Robot Window API migration in this PR.
- No Blockly modernization.
- No change to the historical Save/Restore/Submit protocol.

### Validation expected
The PR-triggered GitHub Actions run must compile the sidecar in the official `cyberbotics/webots:R2025a-ubuntu22.04` image, rebuild the supervisor, and keep the historical `empty.wbt` alive for the diagnostic window.