### PR TITLE
Use Webots R2025a Robot Window API

### DIFF
--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Prepare diagnostics directory
         run: mkdir -p ci-artifacts
 
+      - name: Validate Robot Window JavaScript
+        shell: bash
+        run: |
+          node --check plugins/robot_windows/blockly/main.js
+          if grep -Fq 'webots.window(' plugins/robot_windows/blockly/main.js; then
+            echo "::error::Legacy Robot Window API is still present."
+            exit 1
+          fi
+
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
 

--- a/plugins/robot_windows/blockly/main.js
+++ b/plugins/robot_windows/blockly/main.js
@@ -194,7 +194,9 @@ document.getElementById("projectTitle").addEventListener("keydown", (e) => {
     if(e.key === "Enter") e.preventDefault();
 });
 
-window.onload = function() {
+window.onload = async function() {
+    const module = await import('https://cyberbotics.com/wwi/R2025a/RobotWindow.js');
+    window.robotWindow = new module.default();
     window.robotWindow.receive = receiveMessage;
 }
 

--- a/plugins/robot_windows/blockly/main.js
+++ b/plugins/robot_windows/blockly/main.js
@@ -195,7 +195,6 @@ document.getElementById("projectTitle").addEventListener("keydown", (e) => {
 });
 
 window.onload = function() {
-    window.robotWindow = webots.window("Blockly");
     window.robotWindow.receive = receiveMessage;
 }
 


### PR DESCRIPTION
### Scope
- Replace the historical `webots.window("Blockly")` initialization with the R2025a `window.robotWindow` object.
- Keep the existing `receiveMessage` callback and historical WebSocket Save/Restore/Submit transport unchanged.
- Add a CI syntax check for `plugins/robot_windows/blockly/main.js` and fail if the legacy `webots.window(` API reappears.

### Non-goals
- No Blockly modernization.
- No change to `blocklyServer` protocol.
- No camera generator changes.
- No changes to `main`.

### Validation expected
The PR CI must pass JavaScript syntax validation, rebuild the sidecar and supervisor, and keep `worlds/empty.wbt` alive under real Webots R2025a for the diagnostic window.