### PR TITLE
Exercise historical Blockly sidecar protocol in CI

### DIFF
--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -41,6 +41,7 @@ jobs:
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
 
       - name: Rebuild and exercise Blockly sidecar protocol
+        shell: bash
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
@@ -50,6 +51,7 @@ jobs:
             2>&1 | tee ci-artifacts/blockly-server-protocol.log
 
       - name: Rebuild supervisor for Webots R2025a
+        shell: bash
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \

--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -47,7 +47,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace/controllers/supervisor/blocklyServer \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev python3-websockets && rm -f blocklyServer && make && python3 protocol_smoke.py' \
+            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev python3-pip && python3 -m pip install --no-cache-dir websockets==10.4 && rm -f blocklyServer && make && python3 protocol_smoke.py' \
             2>&1 | tee ci-artifacts/blockly-server-protocol.log
 
       - name: Rebuild supervisor for Webots R2025a

--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -40,14 +40,14 @@ jobs:
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
 
-      - name: Rebuild Blockly sidecar for current Linux toolchain
+      - name: Rebuild and exercise Blockly sidecar protocol
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace/controllers/supervisor/blocklyServer \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev && rm -f blocklyServer && make' \
-            2>&1 | tee ci-artifacts/blockly-server-build.log
+            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev python3-websockets && rm -f blocklyServer && make && python3 protocol_smoke.py' \
+            2>&1 | tee ci-artifacts/blockly-server-protocol.log
 
       - name: Rebuild supervisor for Webots R2025a
         run: |

--- a/controllers/supervisor/blocklyServer/protocol_smoke.py
+++ b/controllers/supervisor/blocklyServer/protocol_smoke.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import asyncio
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import websockets
+
+ROOT = Path(__file__).resolve().parent
+PROGRAMS = (ROOT / "../Blockly_Programs").resolve()
+CONTROLLER = (ROOT / "../my_controller/my_controller.py").resolve()
+SMOKE_NAME = "__ci_protocol_smoke__"
+SMOKE_XML = PROGRAMS / f"{SMOKE_NAME}.xml"
+SMOKE_CODE = "print('webeeblocks-ci-protocol-smoke')\n"
+
+
+def wait_for_port(host="127.0.0.1", port=8001, timeout_s=5.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        with socket.socket() as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex((host, port)) == 0:
+                return
+        time.sleep(0.05)
+    raise RuntimeError(f"blocklyServer did not listen on {host}:{port}")
+
+
+async def exercise_protocol():
+    uri = "ws://127.0.0.1:8001/test.py"
+    async with websockets.connect(uri) as ws:
+        await ws.send("LIST_SAVES")
+        saves = await ws.recv()
+        if not isinstance(saves, str):
+            raise AssertionError("LIST_SAVES did not return text")
+
+        xml = "<xml><block type=\"text\"></block></xml>"
+        await ws.send("SAVE")
+        await ws.send(SMOKE_XML.name)
+        await ws.send(xml)
+
+        await ws.send("RESTORE_SAVE")
+        await ws.send(SMOKE_XML.name)
+        restored = await ws.recv()
+        if restored != xml:
+            raise AssertionError(f"RESTORE_SAVE mismatch: {restored!r}")
+
+        await ws.send("SEND_CODE")
+        await ws.send(SMOKE_CODE)
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if CONTROLLER.read_text(encoding="utf-8") == SMOKE_CODE:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError("SEND_CODE did not update my_controller.py")
+
+
+def main():
+    backup = ROOT / "my_controller.py.ci-backup"
+    shutil.copy2(CONTROLLER, backup)
+    server = subprocess.Popen([str(ROOT / "blocklyServer")], cwd=ROOT)
+    try:
+        wait_for_port()
+        asyncio.run(exercise_protocol())
+        print("PASS: LIST_SAVES, SAVE, RESTORE_SAVE and SEND_CODE")
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            server.kill()
+            server.wait(timeout=2)
+        shutil.copy2(backup, CONTROLLER)
+        backup.unlink(missing_ok=True)
+        SMOKE_XML.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/controllers/supervisor/blocklyServer/protocol_smoke.py
+++ b/controllers/supervisor/blocklyServer/protocol_smoke.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import websockets
 
 ROOT = Path(__file__).resolve().parent
-PROGRAMS = (ROOT / "../Blockly_Programs").resolve()
-CONTROLLER = (ROOT / "../my_controller/my_controller.py").resolve()
+SUPERVISOR_DIR = ROOT.parent
+CONTROLLERS_DIR = SUPERVISOR_DIR.parent
+PROGRAMS = (CONTROLLERS_DIR / "Blockly_Programs").resolve()
+CONTROLLER = (CONTROLLERS_DIR / "my_controller/my_controller.py").resolve()
 SMOKE_NAME = "__ci_protocol_smoke__"
 SMOKE_XML = PROGRAMS / f"{SMOKE_NAME}.xml"
 SMOKE_CODE = "print('webeeblocks-ci-protocol-smoke')\n"
@@ -60,7 +62,10 @@ async def exercise_protocol():
 def main():
     backup = ROOT / "my_controller.py.ci-backup"
     shutil.copy2(CONTROLLER, backup)
-    server = subprocess.Popen([str(ROOT / "blocklyServer")], cwd=ROOT)
+    # The historical supervisor launches ./blocklyServer/blocklyServer while its
+    # current working directory is controllers/supervisor. Preserve that exact
+    # runtime contract so the sidecar's ../ paths resolve as they do in Webots.
+    server = subprocess.Popen([str(ROOT / "blocklyServer")], cwd=SUPERVISOR_DIR)
     try:
         wait_for_port()
         asyncio.run(exercise_protocol())


### PR DESCRIPTION
### Scope
- Add a self-cleaning protocol smoke test for the historical `blocklyServer`.
- Exercise `LIST_SAVES`, `SAVE`, `RESTORE_SAVE`, and `SEND_CODE` over a real WebSocket connection.
- Restore `my_controller.py` and remove the temporary saved program after the test.
- Run this test inside the official Webots R2025a Ubuntu 22.04 container after rebuilding the sidecar.

### Non-goals
- No change to the historical protocol.
- No Blockly modernization.
- No camera API changes.
- No changes to `main`.

### Validation expected
The PR CI must prove the rebuilt C++ sidecar preserves the four historical operations, rebuild the supervisor, and keep `worlds/empty.wbt` alive under Webots R2025a.