### PR TITLE
Execute submitted controller in R2025a smoke test

### DIFF
--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -58,7 +58,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace/controllers/supervisor/blocklyServer \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev python3-pip && python3 -m pip install --no-cache-dir websockets==10.4 && rm -f blocklyServer && make && python3 protocol_smoke.py' \
+            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev python3-pip && python3 -m pip install --no-cache-dir websockets==10.4 && rm -f blocklyServer && make && python3 protocol_smoke.py && python3 execution_smoke.py prepare' \
             2>&1 | tee ci-artifacts/blockly-server-protocol.log
 
       - name: Rebuild supervisor for Webots R2025a
@@ -107,6 +107,10 @@ jobs:
 
           exit "$code"
 
+      - name: Restore historical robot controller
+        if: always()
+        run: python3 controllers/supervisor/blocklyServer/execution_smoke.py restore
+
       - name: Validate Webots runtime diagnostics
         shell: bash
         run: |
@@ -134,7 +138,12 @@ jobs:
             exit 1
           fi
 
-          echo 'PASS: no migration/ABI error and both historical controllers started.'
+          if ! grep -Fq 'WEBEEBLOCKS_CI_SUBMITTED_CONTROLLER_EXECUTED' "$LOG"; then
+            echo "::error::Controller installed through historical SEND_CODE was not executed by Webots."
+            exit 1
+          fi
+
+          echo 'PASS: R2025a started both controllers and executed code installed through SEND_CODE.'
 
       - name: Upload Webots diagnostics
         if: always()

--- a/controllers/supervisor/blocklyServer/execution_smoke.py
+++ b/controllers/supervisor/blocklyServer/execution_smoke.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import asyncio
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SUPERVISOR_DIR = ROOT.parent
+CONTROLLERS_DIR = SUPERVISOR_DIR.parent
+CONTROLLER = (CONTROLLERS_DIR / "my_controller/my_controller.py").resolve()
+BACKUP = ROOT / "my_controller.py.execution-smoke-backup"
+MARKER = "WEBEEBLOCKS_CI_SUBMITTED_CONTROLLER_EXECUTED"
+SMOKE_CODE = f"print('{MARKER}')\n"
+
+
+def wait_for_port(host="127.0.0.1", port=8001, timeout_s=5.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        with socket.socket() as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex((host, port)) == 0:
+                return
+        time.sleep(0.05)
+    raise RuntimeError(f"blocklyServer did not listen on {host}:{port}")
+
+
+async def send_code():
+    import websockets
+
+    async with websockets.connect("ws://127.0.0.1:8001/test.py") as ws:
+        await ws.send("SEND_CODE")
+        await ws.send(SMOKE_CODE)
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if CONTROLLER.read_text(encoding="utf-8") == SMOKE_CODE:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError("SEND_CODE did not install the execution smoke controller")
+
+
+def prepare():
+    if BACKUP.exists():
+        raise RuntimeError(f"stale execution smoke backup exists: {BACKUP}")
+
+    shutil.copy2(CONTROLLER, BACKUP)
+    server = subprocess.Popen([str(ROOT / "blocklyServer")], cwd=SUPERVISOR_DIR)
+    try:
+        wait_for_port()
+        asyncio.run(send_code())
+        print(f"PASS: SEND_CODE installed controller marker {MARKER}")
+    except BaseException:
+        restore()
+        raise
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            server.kill()
+            server.wait(timeout=2)
+
+
+def restore():
+    if not BACKUP.exists():
+        print("No execution smoke backup to restore.")
+        return
+    shutil.copy2(BACKUP, CONTROLLER)
+    BACKUP.unlink()
+    print("PASS: restored historical my_controller.py")
+
+
+def main():
+    if len(sys.argv) != 2 or sys.argv[1] not in {"prepare", "restore"}:
+        raise SystemExit("usage: execution_smoke.py {prepare|restore}")
+    if sys.argv[1] == "prepare":
+        prepare()
+    else:
+        restore()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Scope
- Extend the historical Blockly sidecar CI so `SEND_CODE` installs a deterministic Python controller marker.
- Launch `worlds/empty.wbt` under the official Webots R2025a image with that submitted controller in place.
- Require the marker to appear in Webots logs, proving code installed through the historical Submit transport is actually executed by Webots.
- Restore the repository's historical `my_controller.py` after the run, including on failures.

### Non-goals
- No UI automation yet.
- No Reset-button automation yet.
- No Blockly modernization.
- No changes to `main`.

### Validation expected
The PR CI must keep the existing protocol/ABI/EXTERNPROTO/startup gates green and additionally prove `SEND_CODE -> my_controller.py -> Webots execution` end to end.