### PR TITLE
Validate controller restart in Webots R2025a

### DIFF
--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -47,6 +47,9 @@ jobs:
             exit 1
           fi
 
+      - name: Validate restart smoke helpers
+        run: python3 -m py_compile controllers/ci_restart_supervisor/*.py
+
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
 
@@ -144,6 +147,65 @@ jobs:
           fi
 
           echo 'PASS: R2025a started both controllers and executed code installed through SEND_CODE.'
+
+      - name: Prepare controller restart smoke fixture
+        run: python3 controllers/ci_restart_supervisor/restart_smoke.py prepare
+
+      - name: Exercise simulation reset and controller restart
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
+              --stdout \
+              --stderr \
+              --batch \
+              --mode=fast \
+              /workspace/worlds/ci_restart_smoke.wbt' \
+            2>&1 | tee ci-artifacts/webots-restart.log
+
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" | tee ci-artifacts/webots-restart-exit-code.txt
+
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Restart smoke Webots run exited with code $code."
+            exit "$code"
+          fi
+
+      - name: Restore restart smoke fixtures
+        if: always()
+        run: python3 controllers/ci_restart_supervisor/restart_smoke.py restore
+
+      - name: Validate controller restart diagnostics
+        shell: bash
+        run: |
+          LOG=ci-artifacts/webots-restart.log
+
+          for marker in \
+            WEBEEBLOCKS_CI_RESTART_SUPERVISOR_STARTED \
+            WEBEEBLOCKS_CI_RESTART_INITIAL \
+            WEBEEBLOCKS_CI_RESTARTED_CONTROLLER; do
+            if ! grep -Fq "$marker" "$LOG"; then
+              echo "::error::Restart smoke marker missing: $marker"
+              exit 1
+            fi
+          done
+
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo "::error::Webots emitted an error during restart smoke."
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+
+          echo 'PASS: simulationReset + restartController reloaded the updated Python controller in R2025a.'
 
       - name: Upload Webots diagnostics
         if: always()

--- a/controllers/ci_restart_supervisor/ci_restart_supervisor.py
+++ b/controllers/ci_restart_supervisor/ci_restart_supervisor.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from controller import Supervisor
+
+INITIAL = "WEBEEBLOCKS_CI_RESTART_INITIAL"
+RESTARTED = "WEBEEBLOCKS_CI_RESTARTED_CONTROLLER"
+
+robot = Supervisor()
+time_step = int(robot.getBasicTimeStep())
+target = robot.getFromDef("ROBOT")
+project = Path(robot.getProjectPath())
+controller_path = project / "controllers" / "my_controller" / "my_controller.py"
+
+print("WEBEEBLOCKS_CI_RESTART_SUPERVISOR_STARTED", flush=True)
+
+# Let the initial controller start and print its marker.
+for _ in range(12):
+    if robot.step(time_step) == -1:
+        raise SystemExit(1)
+
+controller_path.write_text(
+    "from controller import Robot\n"
+    "robot = Robot()\n"
+    f"print('{RESTARTED}', flush=True)\n"
+    "while robot.step(int(robot.getBasicTimeStep())) != -1:\n"
+    "    pass\n",
+    encoding="utf-8",
+)
+
+# Exercise the same Webots primitives present in the historical supervisor.
+robot.simulationReset()
+target.restartController()
+
+for _ in range(30):
+    if robot.step(time_step) == -1:
+        break
+
+robot.simulationQuit(0)

--- a/controllers/ci_restart_supervisor/restart_smoke.py
+++ b/controllers/ci_restart_supervisor/restart_smoke.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORLD = ROOT / "worlds" / "empty.wbt"
+TEMP_WORLD = ROOT / "worlds" / "ci_restart_smoke.wbt"
+CONTROLLER = ROOT / "controllers" / "my_controller" / "my_controller.py"
+BACKUP = Path(__file__).resolve().parent / "my_controller.py.restart-smoke-backup"
+INITIAL = "WEBEEBLOCKS_CI_RESTART_INITIAL"
+
+INITIAL_CODE = (
+    "from controller import Robot\n"
+    "robot = Robot()\n"
+    f"print('{INITIAL}', flush=True)\n"
+    "while robot.step(int(robot.getBasicTimeStep())) != -1:\n"
+    "    pass\n"
+)
+
+
+def prepare():
+    if BACKUP.exists() or TEMP_WORLD.exists():
+        raise RuntimeError("stale restart smoke fixture exists")
+    shutil.copy2(CONTROLLER, BACKUP)
+    CONTROLLER.write_text(INITIAL_CODE, encoding="utf-8")
+    source = WORLD.read_text(encoding="utf-8")
+    old = 'controller "supervisor"'
+    if source.count(old) != 1:
+        restore()
+        raise RuntimeError(f"expected exactly one {old!r} in empty.wbt")
+    TEMP_WORLD.write_text(source.replace(old, 'controller "ci_restart_supervisor"', 1), encoding="utf-8")
+    print(f"PASS: prepared {TEMP_WORLD.name} and initial controller marker")
+
+
+def restore():
+    if BACKUP.exists():
+        shutil.copy2(BACKUP, CONTROLLER)
+        BACKUP.unlink()
+    TEMP_WORLD.unlink(missing_ok=True)
+    print("PASS: restored restart smoke fixtures")
+
+
+def main():
+    if len(sys.argv) != 2 or sys.argv[1] not in {"prepare", "restore"}:
+        raise SystemExit("usage: restart_smoke.py {prepare|restore}")
+    prepare() if sys.argv[1] == "prepare" else restore()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Scope
- Add a CI-only supervisor that exercises `simulationReset()` followed by `restartController()` on the historical `DEF ROBOT` node.
- Start with an initial Python controller marker, replace `my_controller.py` during the simulation, restart the controller, and require a second marker from the reloaded controller.
- Keep the historical user-facing supervisor and Blockly transport unchanged.
- Restore all temporary world/controller fixtures after the test.

### Why
The historical `supervisor.cpp` already contains `simulationReset()` + `restartController()`, but this path has not yet been proven against Webots R2025a. This PR isolates that compatibility question before any UI automation or Blockly modernization.

### Validation expected
The existing R2025a smoke gates must remain green, and the restart smoke must show all three markers: CI supervisor started, initial controller executed, restarted controller executed. No changes to `main`.