### PR TITLE
Execute historical distance-sensor program in R2025a

### DIFF
--- a/.github/workflows/webots-ci.yml
+++ b/.github/workflows/webots-ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   webots-smoke:
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout repository
@@ -153,6 +153,81 @@ jobs:
           fi
 
           echo 'PASS: R2025a started both controllers and executed code installed through SEND_CODE.'
+
+      - name: Export historical BoxWithDistSensor controller
+        shell: bash
+        run: |
+          cp controllers/my_controller/my_controller.py controllers/my_controller/.ci-controller-backup.py
+          python3 tools/ci/export_historical_blockly_program.py \
+            BoxWithDistSensor.xml \
+            controllers/my_controller/my_controller.py
+
+      - name: Execute generated historical controller in box challenge
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
+              --stdout \
+              --stderr \
+              --batch \
+              --mode=fast \
+              /workspace/worlds/boxChallenge.wbt' \
+            2>&1 | tee ci-artifacts/webots-box-challenge.log
+
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" | tee ci-artifacts/webots-box-challenge-exit-code.txt
+
+          if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
+            echo 'Generated historical controller remained active for the diagnostic window.'
+            exit 0
+          fi
+          exit "$code"
+
+      - name: Restore controller after box challenge
+        if: always()
+        shell: bash
+        run: |
+          if [ -f controllers/my_controller/.ci-controller-backup.py ]; then
+            mv controllers/my_controller/.ci-controller-backup.py controllers/my_controller/my_controller.py
+          fi
+
+      - name: Validate generated historical controller diagnostics
+        shell: bash
+        run: |
+          LOG=ci-artifacts/webots-box-challenge.log
+
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo '::error::Webots emitted an error in boxChallenge.wbt.'
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+
+          if grep -Fq 'Traceback (most recent call last)' "$LOG"; then
+            echo '::error::Generated historical Blockly Python raised an exception.'
+            grep -A20 -F 'Traceback (most recent call last)' "$LOG"
+            exit 1
+          fi
+
+          if ! grep -Fq 'INFO: supervisor: Starting controller:' "$LOG"; then
+            echo '::error::Supervisor did not start in boxChallenge.wbt.'
+            exit 1
+          fi
+
+          if ! grep -Fq 'INFO: my_controller: Starting controller:' "$LOG"; then
+            echo '::error::Generated historical controller did not start in boxChallenge.wbt.'
+            exit 1
+          fi
+
+          echo 'PASS: Blockly-generated BoxWithDistSensor Python started in boxChallenge.wbt under R2025a without Webots or Python runtime errors.'
 
       - name: Prepare controller restart smoke fixture
         run: python3 controllers/ci_restart_supervisor/restart_smoke.py prepare

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -16,6 +16,53 @@ from run_historical_blockly_oracle import (
 )
 
 
+def instrument_box_distance_controller(code: str) -> str:
+    """Run the exact generated source while requiring its historical print block to execute.
+
+    BoxWithDistSensor contains a Blockly ``text_print`` block inside the distance-sensor
+    loop.  The CI wrapper observes calls to Python's builtin ``print`` without changing
+    the generated source bytes, then fails after execution if that Blockly-generated
+    behavior was never reached.  This prevents the supervisor timeout from creating a
+    false-positive end-to-end result when ``my_controller`` exits too early.
+    """
+
+    return f'''# CI-only observer around exact Blockly-generated source.
+import builtins as _webeeblocks_ci_builtins
+
+_WEBEEBLOCKS_CI_GENERATED_SOURCE = {code!r}
+_webeeblocks_ci_original_print = _webeeblocks_ci_builtins.print
+_webeeblocks_ci_observed_print = False
+
+
+def _webeeblocks_ci_print(*args, **kwargs):
+    global _webeeblocks_ci_observed_print
+    _webeeblocks_ci_observed_print = True
+    return _webeeblocks_ci_original_print(*args, **kwargs)
+
+
+_webeeblocks_ci_builtins.print = _webeeblocks_ci_print
+try:
+    exec(
+        compile(
+            _WEBEEBLOCKS_CI_GENERATED_SOURCE,
+            "<Blockly:BoxWithDistSensor.xml>",
+            "exec",
+        ),
+        globals(),
+        globals(),
+    )
+finally:
+    _webeeblocks_ci_builtins.print = _webeeblocks_ci_original_print
+
+if not _webeeblocks_ci_observed_print:
+    raise RuntimeError(
+        "BoxWithDistSensor controller exited without reaching its Blockly text_print sensor behavior"
+    )
+
+_webeeblocks_ci_original_print("WEBEEBLOCKS_CI_BOX_DISTANCE_BEHAVIOR_EXECUTED")
+'''
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("program", choices=tuple(EXPECTED_PYTHON_SHA256))
@@ -52,11 +99,18 @@ def main() -> int:
         )
 
     compile(code, f"<Blockly:{args.program}>", "exec")
+    output_code = (
+        instrument_box_distance_controller(code)
+        if args.program == "BoxWithDistSensor.xml"
+        else code
+    )
+    compile(output_code, f"<CI:{args.program}>", "exec")
+
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(code, encoding="utf-8")
+    args.output.write_text(output_code, encoding="utf-8")
     print(
-        f"PASS: exported {args.program} to {args.output} "
-        f"({len(code.encode('utf-8'))} bytes, sha256={digest})"
+        f"PASS: exported exact {args.program} source (sha256={digest}) to {args.output}; "
+        f"CI wrapper bytes={len(output_code.encode('utf-8'))}"
     )
     return 0
 

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Export one preserved Blockly fixture using the real vendored Blockly 2020 runtime."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import tempfile
+from pathlib import Path
+
+from run_historical_blockly_oracle import (
+    EXPECTED_PYTHON_SHA256,
+    ROBOT_WINDOW_DIR,
+    build_harness,
+    run_browser,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("program", choices=tuple(EXPECTED_PYTHON_SHA256))
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".html", dir=ROBOT_WINDOW_DIR, encoding="utf-8", delete=False
+    ) as handle:
+        handle.write(build_harness())
+        harness_path = Path(handle.name)
+
+    try:
+        result = run_browser(harness_path)
+    finally:
+        harness_path.unlink(missing_ok=True)
+
+    if not result.get("ok"):
+        raise RuntimeError(f"Blockly browser execution failed: {result.get('error')}")
+
+    generated = result.get("programs")
+    if not isinstance(generated, dict):
+        raise RuntimeError("Blockly browser result is malformed")
+    entry = generated.get(args.program)
+    if not isinstance(entry, dict) or not isinstance(entry.get("code"), str):
+        raise RuntimeError(f"missing generated Python for {args.program}")
+
+    code = entry["code"]
+    digest = hashlib.sha256(code.encode("utf-8")).hexdigest()
+    expected = EXPECTED_PYTHON_SHA256[args.program]
+    if digest != expected:
+        raise RuntimeError(
+            f"generated Python drift for {args.program}: sha256={digest}, expected={expected}"
+        )
+
+    compile(code, f"<Blockly:{args.program}>", "exec")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(code, encoding="utf-8")
+    print(
+        f"PASS: exported {args.program} to {args.output} "
+        f"({len(code.encode('utf-8'))} bytes, sha256={digest})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worlds/boxChallenge.wbt
+++ b/worlds/boxChallenge.wbt
@@ -1,5 +1,13 @@
-#VRML_SIM R2020a utf8
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/RectangleArena.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/apartment_structure/protos/Wall.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/adept/pioneer3/protos/Pioneer3dx.proto"
+
 WorldInfo {
+  coordinateSystem "NUE"
 }
 Viewpoint {
   orientation -0.9999773783711899 -0.004807906004672923 0.004703911747918469 0.9881255615201564
@@ -38,14 +46,14 @@ DEF ROBOT Pioneer3dx {
     DistanceSensor {
       lookupTable [
         0 0 0
-				10 1000 0
+        10 1000 0
       ]
     }
     GPS {
     }
     Gyro {
     }
-		Camera {
+    Camera {
       translation 0 0 -0.14
       rotation 0 0 1 0
       recognition Recognition {


### PR DESCRIPTION
### Goal
Prove the first real historical Blockly teaching program runs in its historical challenge world under Webots R2025a.

### Changes
- minimally port `worlds/boxChallenge.wbt` to R2025a compatibility mode while deliberately preserving historical `NUE` axes and geometry;
- add a CI helper that exports a preserved Blockly XML fixture through the real vendored Blockly 2020 browser runtime and verifies its pinned Python SHA-256;
- execute the exact generated `BoxWithDistSensor.xml` Python as `my_controller` in `boxChallenge.wbt` under the official R2025a image;
- fail on Webots errors or Python tracebacks and always restore the historical controller afterward.

### Scope
This does not convert the world to ENU/FLU, does not modernize Blockly, and does not touch `main`. It is the first end-to-end historical program execution gate.