### PR TITLE
Execute historical Gyro GPS program in R2025a

### DIFF
--- a/.github/workflows/historical-gyro-gps-ci.yml
+++ b/.github/workflows/historical-gyro-gps-ci.yml
@@ -1,0 +1,127 @@
+name: Historical Gyro GPS R2025a gate
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gyro-gps-historical:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare diagnostics
+        run: mkdir -p ci-artifacts
+
+      - name: Export exact historical BoxWithGyroGPS controller
+        shell: bash
+        run: |
+          cp controllers/my_controller/my_controller.py controllers/my_controller/.ci-gyro-gps-backup.py
+          python3 tools/ci/export_historical_blockly_program.py \
+            BoxWithGyroGPS.xml \
+            controllers/my_controller/my_controller.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Rebuild sidecar and supervisor for R2025a
+        shell: bash
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev
+              cd /workspace/controllers/supervisor/blocklyServer
+              rm -f blocklyServer
+              make
+              cd /workspace/controllers/supervisor
+              make clean
+              make
+            ' 2>&1 | tee ci-artifacts/gyro-gps-build.log
+
+      - name: Execute historical Gyro GPS program in box challenge
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
+              --stdout \
+              --stderr \
+              --batch \
+              --mode=fast \
+              /workspace/worlds/boxChallenge.wbt' \
+            2>&1 | tee ci-artifacts/webots-box-gyro-gps.log
+
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" | tee ci-artifacts/webots-box-gyro-gps-exit-code.txt
+
+          if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
+            exit 0
+          fi
+          exit "$code"
+
+      - name: Restore historical controller
+        if: always()
+        shell: bash
+        run: |
+          if [ -f controllers/my_controller/.ci-gyro-gps-backup.py ]; then
+            mv controllers/my_controller/.ci-gyro-gps-backup.py controllers/my_controller/my_controller.py
+          fi
+
+      - name: Validate Gyro GPS historical behavior
+        shell: bash
+        run: |
+          LOG=ci-artifacts/webots-box-gyro-gps.log
+
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo '::error::Webots emitted an error while running BoxWithGyroGPS.'
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+
+          if grep -Fq 'Traceback (most recent call last)' "$LOG"; then
+            echo '::error::Historical Gyro GPS Python raised an exception.'
+            grep -A30 -F 'Traceback (most recent call last)' "$LOG"
+            exit 1
+          fi
+
+          if ! grep -Fq 'INFO: my_controller: Starting controller:' "$LOG"; then
+            echo '::error::Generated BoxWithGyroGPS controller did not start.'
+            exit 1
+          fi
+
+          if ! grep -Fq 'WEBEEBLOCKS_CI_BOX_GYRO_GPS_BEHAVIOR_EXECUTED' "$LOG"; then
+            echo '::error::Generated BoxWithGyroGPS controller never reached its Blockly text_print behavior.'
+            exit 1
+          fi
+
+          echo 'PASS: exact historical BoxWithGyroGPS Blockly Python reached observable behavior under Webots R2025a.'
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: historical-gyro-gps-r2025a
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -15,16 +15,14 @@ from run_historical_blockly_oracle import (
     run_browser,
 )
 
+PRINT_OBSERVER_MARKERS = {
+    "BoxWithDistSensor.xml": "WEBEEBLOCKS_CI_BOX_DISTANCE_BEHAVIOR_EXECUTED",
+    "BoxWithGyroGPS.xml": "WEBEEBLOCKS_CI_BOX_GYRO_GPS_BEHAVIOR_EXECUTED",
+}
 
-def instrument_box_distance_controller(code: str) -> str:
-    """Run the exact generated source while requiring its historical print block to execute.
 
-    BoxWithDistSensor contains a Blockly ``text_print`` block inside the distance-sensor
-    loop.  The CI wrapper observes calls to Python's builtin ``print`` without changing
-    the generated source bytes, then fails after execution if that Blockly-generated
-    behavior was never reached.  This prevents the supervisor timeout from creating a
-    false-positive end-to-end result when ``my_controller`` exits too early.
-    """
+def instrument_print_observer(code: str, program: str, marker: str) -> str:
+    """Run exact generated source while requiring a Blockly text_print path to execute."""
 
     return f'''# CI-only observer around exact Blockly-generated source.
 import builtins as _webeeblocks_ci_builtins
@@ -45,7 +43,7 @@ try:
     exec(
         compile(
             _WEBEEBLOCKS_CI_GENERATED_SOURCE,
-            "<Blockly:BoxWithDistSensor.xml>",
+            "<Blockly:{program}>",
             "exec",
         ),
         globals(),
@@ -56,10 +54,10 @@ finally:
 
 if not _webeeblocks_ci_observed_print:
     raise RuntimeError(
-        "BoxWithDistSensor controller exited without reaching its Blockly text_print sensor behavior"
+        "{program} exited without reaching its Blockly text_print behavior"
     )
 
-_webeeblocks_ci_original_print("WEBEEBLOCKS_CI_BOX_DISTANCE_BEHAVIOR_EXECUTED")
+_webeeblocks_ci_original_print("{marker}")
 '''
 
 
@@ -99,11 +97,8 @@ def main() -> int:
         )
 
     compile(code, f"<Blockly:{args.program}>", "exec")
-    output_code = (
-        instrument_box_distance_controller(code)
-        if args.program == "BoxWithDistSensor.xml"
-        else code
-    )
+    marker = PRINT_OBSERVER_MARKERS.get(args.program)
+    output_code = instrument_print_observer(code, args.program, marker) if marker else code
     compile(output_code, f"<CI:{args.program}>", "exec")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -34,7 +34,9 @@ _webeeblocks_ci_observed_print = False
 
 def _webeeblocks_ci_print(*args, **kwargs):
     global _webeeblocks_ci_observed_print
-    _webeeblocks_ci_observed_print = True
+    if not _webeeblocks_ci_observed_print:
+        _webeeblocks_ci_observed_print = True
+        _webeeblocks_ci_original_print("{marker}")
     return _webeeblocks_ci_original_print(*args, **kwargs)
 
 
@@ -56,8 +58,6 @@ if not _webeeblocks_ci_observed_print:
     raise RuntimeError(
         "{program} exited without reaching its Blockly text_print behavior"
     )
-
-_webeeblocks_ci_original_print("{marker}")
 '''
 
 


### PR DESCRIPTION
### Goal
Prove a second preserved historical Blockly teaching program, `BoxWithGyroGPS.xml`, reaches real generated behavior under Webots R2025a.

### Changes
- reuse the already R2025a-compatible `worlds/boxChallenge.wbt` while deliberately preserving the historical `NUE` compatibility contract;
- generalize the CI-only observer around exact Blockly-generated source so a historical `text_print` path must actually execute;
- export `BoxWithGyroGPS.xml` through the real vendored Blockly 2020 browser runtime and keep its pinned Python SHA-256 as the source oracle;
- run that controller in the official `cyberbotics/webots:R2025a-ubuntu22.04` image and require the observable marker `WEBEEBLOCKS_CI_BOX_GYRO_GPS_BEHAVIOR_EXECUTED`;
- always restore the historical `my_controller.py` after the test.

### Scope
This does not convert NUE/RUB to ENU/FLU, does not change the historical gyro/GPS axis assumptions speculatively, does not modernize Blockly, and does not touch `main`. Any runtime incompatibility found here will be fixed from real R2025a evidence only.