### PR TITLE
Execute historical light-sensor program in R2025a

### DIFF
--- a/.github/workflows/historical-light-sensor-ci.yml
+++ b/.github/workflows/historical-light-sensor-ci.yml
@@ -1,0 +1,127 @@
+name: Historical Light Sensor R2025a gate
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  light-sensor-historical:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare diagnostics
+        run: mkdir -p ci-artifacts
+
+      - name: Export exact historical BoxWithLightSensor controller
+        shell: bash
+        run: |
+          cp controllers/my_controller/my_controller.py controllers/my_controller/.ci-light-sensor-backup.py
+          python3 tools/ci/export_historical_blockly_program.py \
+            BoxWithLightSensor.xml \
+            controllers/my_controller/my_controller.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Rebuild sidecar and supervisor for R2025a
+        shell: bash
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev
+              cd /workspace/controllers/supervisor/blocklyServer
+              rm -f blocklyServer
+              make
+              cd /workspace/controllers/supervisor
+              make clean
+              make
+            ' 2>&1 | tee ci-artifacts/light-sensor-build.log
+
+      - name: Execute historical light sensor program
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
+              --stdout \
+              --stderr \
+              --batch \
+              --mode=fast \
+              /workspace/worlds/lightSensorBoxChallenge.wbt' \
+            2>&1 | tee ci-artifacts/webots-light-sensor.log
+
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" | tee ci-artifacts/webots-light-sensor-exit-code.txt
+
+          if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
+            exit 0
+          fi
+          exit "$code"
+
+      - name: Restore historical controller
+        if: always()
+        shell: bash
+        run: |
+          if [ -f controllers/my_controller/.ci-light-sensor-backup.py ]; then
+            mv controllers/my_controller/.ci-light-sensor-backup.py controllers/my_controller/my_controller.py
+          fi
+
+      - name: Validate historical light sensor behavior
+        shell: bash
+        run: |
+          LOG=ci-artifacts/webots-light-sensor.log
+
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo '::error::Webots emitted an error while running BoxWithLightSensor.'
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+
+          if grep -Fq 'Traceback (most recent call last)' "$LOG"; then
+            echo '::error::Historical light-sensor Python raised an exception.'
+            grep -A30 -F 'Traceback (most recent call last)' "$LOG"
+            exit 1
+          fi
+
+          if ! grep -Fq 'INFO: my_controller: Starting controller:' "$LOG"; then
+            echo '::error::Generated BoxWithLightSensor controller did not start.'
+            exit 1
+          fi
+
+          if ! grep -Fq 'WEBEEBLOCKS_CI_BOX_LIGHT_SENSOR_BEHAVIOR_EXECUTED' "$LOG"; then
+            echo '::error::Generated BoxWithLightSensor controller never reached its Blockly text_print behavior.'
+            exit 1
+          fi
+
+          echo 'PASS: exact historical BoxWithLightSensor Blockly Python reached observable behavior under Webots R2025a.'
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: historical-light-sensor-r2025a
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -18,6 +18,7 @@ from run_historical_blockly_oracle import (
 PRINT_OBSERVER_MARKERS = {
     "BoxWithDistSensor.xml": "WEBEEBLOCKS_CI_BOX_DISTANCE_BEHAVIOR_EXECUTED",
     "BoxWithGyroGPS.xml": "WEBEEBLOCKS_CI_BOX_GYRO_GPS_BEHAVIOR_EXECUTED",
+    "BoxWithLightSensor.xml": "WEBEEBLOCKS_CI_BOX_LIGHT_SENSOR_BEHAVIOR_EXECUTED",
 }
 
 

--- a/worlds/lightSensorBoxChallenge.wbt
+++ b/worlds/lightSensorBoxChallenge.wbt
@@ -77,8 +77,8 @@ DEF ROBOT Pioneer3dx {
       translation 0.01 0 0
       rotation -1 0 0 1.5708
       name "color sensor"
-      width 1
-      height 1
+      width 10
+      height 10
     }
     DistanceSensor {
       lookupTable [

--- a/worlds/lightSensorBoxChallenge.wbt
+++ b/worlds/lightSensorBoxChallenge.wbt
@@ -1,5 +1,15 @@
-#VRML_SIM R2020a utf8
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/RectangleArena.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/appearances/protos/Parquetry.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/apartment_structure/protos/Wall.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/adept/pioneer3/protos/Pioneer3dx.proto"
+
 WorldInfo {
+  coordinateSystem "NUE"
 }
 Viewpoint {
   orientation -0.9999773783711899 -0.004807906004672923 0.004703911747918469 0.9881255615201564
@@ -66,21 +76,21 @@ DEF ROBOT Pioneer3dx {
     Camera {
       translation 0.01 0 0
       rotation -1 0 0 1.5708
-      name "light sensor"
+      name "color sensor"
       width 1
       height 1
     }
     DistanceSensor {
       lookupTable [
         0 0 0
-				10 1000 0
+        10 1000 0
       ]
     }
     GPS {
     }
     Gyro {
     }
-		Camera {
+    Camera {
       translation 0 0 -0.14
       rotation 0 0 1 0
       recognition Recognition {


### PR DESCRIPTION
### Goal
Prove the preserved `BoxWithLightSensor.xml` teaching program reaches real generated behavior in its historical `lightSensorBoxChallenge.wbt` world under Webots R2025a.

### Changes
- add `BoxWithLightSensor.xml` to the existing CI-only print observer while preserving the exact Blockly 2020 generated Python SHA-256 oracle;
- run the exact generated controller in `worlds/lightSensorBoxChallenge.wbt` using the official `cyberbotics/webots:R2025a-ubuntu22.04` image;
- require the controller to start and reach its historical `text_print` color/light-sensor behavior;
- always restore the historical `my_controller.py` after the test.

### Scope
This deliberately preserves the historical coordinate convention and generator semantics. It does not modernize Blockly, does not convert NUE/RUB to ENU/FLU, does not change camera/gyro math speculatively, and does not touch `main`.