### PR TITLE
Execute historical encoder program in R2025a

### DIFF
--- a/.github/workflows/historical-encoders-ci.yml
+++ b/.github/workflows/historical-encoders-ci.yml
@@ -1,0 +1,127 @@
+name: Historical Encoders R2025a gate
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  encoders-historical:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare diagnostics
+        run: mkdir -p ci-artifacts
+
+      - name: Export exact historical BoxWithEncoders controller
+        shell: bash
+        run: |
+          cp controllers/my_controller/my_controller.py controllers/my_controller/.ci-encoders-backup.py
+          python3 tools/ci/export_historical_blockly_program.py \
+            BoxWithEncoders.xml \
+            controllers/my_controller/my_controller.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Rebuild sidecar and supervisor for R2025a
+        shell: bash
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev
+              cd /workspace/controllers/supervisor/blocklyServer
+              rm -f blocklyServer
+              make
+              cd /workspace/controllers/supervisor
+              make clean
+              make
+            ' 2>&1 | tee ci-artifacts/encoders-build.log
+
+      - name: Execute historical encoder program in box challenge
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
+              --stdout \
+              --stderr \
+              --batch \
+              --mode=fast \
+              /workspace/worlds/boxChallenge.wbt' \
+            2>&1 | tee ci-artifacts/webots-box-encoders.log
+
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" | tee ci-artifacts/webots-box-encoders-exit-code.txt
+
+          if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
+            exit 0
+          fi
+          exit "$code"
+
+      - name: Restore historical controller
+        if: always()
+        shell: bash
+        run: |
+          if [ -f controllers/my_controller/.ci-encoders-backup.py ]; then
+            mv controllers/my_controller/.ci-encoders-backup.py controllers/my_controller/my_controller.py
+          fi
+
+      - name: Validate encoder historical behavior
+        shell: bash
+        run: |
+          LOG=ci-artifacts/webots-box-encoders.log
+
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo '::error::Webots emitted an error while running BoxWithEncoders.'
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+
+          if grep -Fq 'Traceback (most recent call last)' "$LOG"; then
+            echo '::error::Historical encoder Python raised an exception.'
+            grep -A30 -F 'Traceback (most recent call last)' "$LOG"
+            exit 1
+          fi
+
+          if ! grep -Fq 'INFO: my_controller: Starting controller:' "$LOG"; then
+            echo '::error::Generated BoxWithEncoders controller did not start.'
+            exit 1
+          fi
+
+          if ! grep -Fq 'WEBEEBLOCKS_CI_BOX_ENCODERS_PROGRAM_COMPLETED' "$LOG"; then
+            echo '::error::Generated BoxWithEncoders controller did not complete its four encoder-driven movement cycles.'
+            exit 1
+          fi
+
+          echo 'PASS: exact historical BoxWithEncoders Blockly Python completed under Webots R2025a.'
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: historical-encoders-r2025a
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -21,6 +21,10 @@ PRINT_OBSERVER_MARKERS = {
     "BoxWithLightSensor.xml": "WEBEEBLOCKS_CI_BOX_LIGHT_SENSOR_BEHAVIOR_EXECUTED",
 }
 
+COMPLETION_OBSERVER_MARKERS = {
+    "BoxWithEncoders.xml": "WEBEEBLOCKS_CI_BOX_ENCODERS_PROGRAM_COMPLETED",
+}
+
 
 def instrument_print_observer(code: str, program: str, marker: str) -> str:
     """Run exact generated source while requiring a Blockly text_print path to execute."""
@@ -62,6 +66,26 @@ if not _webeeblocks_ci_observed_print:
 '''
 
 
+def instrument_completion_observer(code: str, program: str, marker: str) -> str:
+    """Run exact generated source and emit a marker only after it completes."""
+
+    return f'''# CI-only completion observer around exact Blockly-generated source.
+_WEBEEBLOCKS_CI_GENERATED_SOURCE = {code!r}
+
+exec(
+    compile(
+        _WEBEEBLOCKS_CI_GENERATED_SOURCE,
+        "<Blockly:{program}>",
+        "exec",
+    ),
+    globals(),
+    globals(),
+)
+
+print("{marker}")
+'''
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("program", choices=tuple(EXPECTED_PYTHON_SHA256))
@@ -98,8 +122,14 @@ def main() -> int:
         )
 
     compile(code, f"<Blockly:{args.program}>", "exec")
-    marker = PRINT_OBSERVER_MARKERS.get(args.program)
-    output_code = instrument_print_observer(code, args.program, marker) if marker else code
+    print_marker = PRINT_OBSERVER_MARKERS.get(args.program)
+    completion_marker = COMPLETION_OBSERVER_MARKERS.get(args.program)
+    if print_marker:
+        output_code = instrument_print_observer(code, args.program, print_marker)
+    elif completion_marker:
+        output_code = instrument_completion_observer(code, args.program, completion_marker)
+    else:
+        output_code = code
     compile(output_code, f"<CI:{args.program}>", "exec")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Goal
Prove the preserved `BoxWithEncoders.xml` teaching program completes its encoder-driven movement sequence under Webots R2025a.

### Changes
- add a CI-only completion observer while preserving the exact Blockly 2020 generated Python SHA-256 oracle;
- run the exact generated controller in the already-stabilized `worlds/boxChallenge.wbt` using the official `cyberbotics/webots:R2025a-ubuntu22.04` image;
- require the generated controller to start without Webots errors or Python traceback;
- require the full four-cycle encoder-driven program to return before emitting the completion marker;
- always restore the historical `my_controller.py` after the test.

### Scope
No Blockly modernization, no coordinate conversion, no changes to `main`, and no speculative encoder API changes. The test first measures the preserved historical behavior under the R2025a compatibility baseline.