### PR TITLE
Execute historical sensor probing program in R2025a

### DIFF
--- a/.github/workflows/historical-sensor-probing-ci.yml
+++ b/.github/workflows/historical-sensor-probing-ci.yml
@@ -1,0 +1,134 @@
+name: Historical Sensor Probing R2025a gate
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sensor-probing-historical:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare diagnostics
+        run: mkdir -p ci-artifacts
+
+      - name: Export exact historical sensorProbing controller
+        shell: bash
+        run: |
+          cp controllers/my_controller/my_controller.py controllers/my_controller/.ci-sensor-probing-backup.py
+          python3 tools/ci/export_historical_blockly_program.py \
+            sensorProbing.xml \
+            controllers/my_controller/my_controller.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Rebuild sidecar and supervisor for R2025a
+        shell: bash
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev
+              cd /workspace/controllers/supervisor/blocklyServer
+              rm -f blocklyServer
+              make
+              cd /workspace/controllers/supervisor
+              make clean
+              make
+            ' 2>&1 | tee ci-artifacts/sensor-probing-build.log
+
+      - name: Execute historical sensor probing program in empty world
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
+              --stdout \
+              --stderr \
+              --batch \
+              --mode=fast \
+              /workspace/worlds/empty.wbt' \
+            2>&1 | tee ci-artifacts/webots-sensor-probing.log
+
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" | tee ci-artifacts/webots-sensor-probing-exit-code.txt
+
+          if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
+            exit 0
+          fi
+          exit "$code"
+
+      - name: Restore historical controller
+        if: always()
+        shell: bash
+        run: |
+          if [ -f controllers/my_controller/.ci-sensor-probing-backup.py ]; then
+            mv controllers/my_controller/.ci-sensor-probing-backup.py controllers/my_controller/my_controller.py
+          fi
+
+      - name: Validate multi-sensor historical behavior
+        shell: bash
+        run: |
+          LOG=ci-artifacts/webots-sensor-probing.log
+
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo '::error::Webots emitted an error while running sensorProbing.'
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+
+          if grep -Fq 'Traceback (most recent call last)' "$LOG"; then
+            echo '::error::Historical sensorProbing Python raised an exception.'
+            grep -A30 -F 'Traceback (most recent call last)' "$LOG"
+            exit 1
+          fi
+
+          if ! grep -Fq 'INFO: my_controller: Starting controller:' "$LOG"; then
+            echo '::error::Generated sensorProbing controller did not start.'
+            exit 1
+          fi
+
+          if ! grep -Fq 'WEBEEBLOCKS_CI_SENSOR_PROBE_BEHAVIOR_EXECUTED' "$LOG"; then
+            echo '::error::sensorProbing did not reach Gyro, GPS, distance and color outputs.'
+            exit 1
+          fi
+
+          for prefix in 'Gyro:' 'GPS:' 'getDist:' 'getColor:'; do
+            if ! grep -Fq "$prefix" "$LOG"; then
+              echo "::error::Missing historical sensor output: $prefix"
+              exit 1
+            fi
+          done
+
+          echo 'PASS: exact historical sensorProbing Blockly Python exercised Gyro, GPS, DistanceSensor and color sensor under Webots R2025a.'
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: historical-sensor-probing-r2025a
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/tools/ci/export_historical_blockly_program.py
+++ b/tools/ci/export_historical_blockly_program.py
@@ -25,6 +25,13 @@ COMPLETION_OBSERVER_MARKERS = {
     "BoxWithEncoders.xml": "WEBEEBLOCKS_CI_BOX_ENCODERS_PROGRAM_COMPLETED",
 }
 
+SENSOR_PROBE_OBSERVER = {
+    "sensorProbing.xml": (
+        "WEBEEBLOCKS_CI_SENSOR_PROBE_BEHAVIOR_EXECUTED",
+        ("Gyro:", "GPS:", "getDist:", "getColor:"),
+    ),
+}
+
 
 def instrument_print_observer(code: str, program: str, marker: str) -> str:
     """Run exact generated source while requiring a Blockly text_print path to execute."""
@@ -86,6 +93,58 @@ print("{marker}")
 '''
 
 
+def instrument_sensor_probe_observer(
+    code: str, program: str, marker: str, required_prefixes: tuple[str, ...]
+) -> str:
+    """Require all preserved sensorProbing output families to execute."""
+
+    return f'''# CI-only multi-sensor observer around exact Blockly-generated source.
+import builtins as _webeeblocks_ci_builtins
+
+_WEBEEBLOCKS_CI_GENERATED_SOURCE = {code!r}
+_WEBEEBLOCKS_CI_REQUIRED_PREFIXES = {required_prefixes!r}
+_webeeblocks_ci_original_print = _webeeblocks_ci_builtins.print
+_webeeblocks_ci_seen = set()
+_webeeblocks_ci_marker_emitted = False
+
+
+def _webeeblocks_ci_print(*args, **kwargs):
+    global _webeeblocks_ci_marker_emitted
+    rendered = " ".join(str(arg) for arg in args)
+    for prefix in _WEBEEBLOCKS_CI_REQUIRED_PREFIXES:
+        if rendered.startswith(prefix):
+            _webeeblocks_ci_seen.add(prefix)
+    if (
+        not _webeeblocks_ci_marker_emitted
+        and len(_webeeblocks_ci_seen) == len(_WEBEEBLOCKS_CI_REQUIRED_PREFIXES)
+    ):
+        _webeeblocks_ci_marker_emitted = True
+        _webeeblocks_ci_original_print("{marker}")
+    return _webeeblocks_ci_original_print(*args, **kwargs)
+
+
+_webeeblocks_ci_builtins.print = _webeeblocks_ci_print
+try:
+    exec(
+        compile(
+            _WEBEEBLOCKS_CI_GENERATED_SOURCE,
+            "<Blockly:{program}>",
+            "exec",
+        ),
+        globals(),
+        globals(),
+    )
+finally:
+    _webeeblocks_ci_builtins.print = _webeeblocks_ci_original_print
+
+if not _webeeblocks_ci_marker_emitted:
+    missing = sorted(set(_WEBEEBLOCKS_CI_REQUIRED_PREFIXES) - _webeeblocks_ci_seen)
+    raise RuntimeError(
+        "{program} exited before all sensor behaviors were observed: " + repr(missing)
+    )
+'''
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("program", choices=tuple(EXPECTED_PYTHON_SHA256))
@@ -124,10 +183,16 @@ def main() -> int:
     compile(code, f"<Blockly:{args.program}>", "exec")
     print_marker = PRINT_OBSERVER_MARKERS.get(args.program)
     completion_marker = COMPLETION_OBSERVER_MARKERS.get(args.program)
+    sensor_probe = SENSOR_PROBE_OBSERVER.get(args.program)
     if print_marker:
         output_code = instrument_print_observer(code, args.program, print_marker)
     elif completion_marker:
         output_code = instrument_completion_observer(code, args.program, completion_marker)
+    elif sensor_probe:
+        marker, required_prefixes = sensor_probe
+        output_code = instrument_sensor_probe_observer(
+            code, args.program, marker, required_prefixes
+        )
     else:
         output_code = code
     compile(output_code, f"<CI:{args.program}>", "exec")

--- a/tools/ci/run_historical_blockly_oracle.py
+++ b/tools/ci/run_historical_blockly_oracle.py
@@ -94,6 +94,16 @@ def build_harness() -> str:
 </script></body></html>"""
 
 
+def parse_browser_output(stdout: str) -> dict[str, object]:
+    match = RESULT_RE.search(stdout)
+    if not match:
+        raise RuntimeError("headless browser did not emit oracle-result")
+    raw = html.unescape(match.group(1))
+    if raw == "NOT_RUN":
+        raise RuntimeError("Blockly harness JavaScript did not run")
+    return json.loads(raw)
+
+
 def run_browser(harness_path: Path) -> dict[str, object]:
     chrome = chrome_executable()
     command = [
@@ -102,30 +112,52 @@ def run_browser(harness_path: Path) -> dict[str, object]:
         "--no-sandbox",
         "--disable-gpu",
         "--disable-dev-shm-usage",
+        "--disable-background-networking",
         "--allow-file-access-from-files",
         "--virtual-time-budget=5000",
         "--dump-dom",
         harness_path.as_uri(),
     ]
-    result = subprocess.run(
+    process = subprocess.Popen(
         command,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        check=False,
-        timeout=30,
     )
-    if result.returncode:
+    timed_out = False
+    try:
+        stdout, stderr = process.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        # Some hosted Chrome builds can finish --dump-dom yet linger during
+        # browser shutdown. Kill the browser, collect its already-produced DOM,
+        # and accept the run only if the oracle payload is actually present.
+        timed_out = True
+        process.kill()
+        stdout, stderr = process.communicate()
+
+    try:
+        parsed = parse_browser_output(stdout)
+    except RuntimeError as exc:
+        if timed_out:
+            raise RuntimeError(
+                f"headless browser timed out before emitting oracle-result: {stderr.strip()}"
+            ) from exc
+        if process.returncode:
+            raise RuntimeError(
+                f"headless browser exited with {process.returncode}: {stderr.strip()}"
+            ) from exc
+        raise
+
+    if not timed_out and process.returncode:
         raise RuntimeError(
-            f"headless browser exited with {result.returncode}: {result.stderr.strip()}"
+            f"headless browser exited with {process.returncode}: {stderr.strip()}"
         )
-    match = RESULT_RE.search(result.stdout)
-    if not match:
-        raise RuntimeError("headless browser did not emit oracle-result")
-    raw = html.unescape(match.group(1))
-    if raw == "NOT_RUN":
-        raise RuntimeError("Blockly harness JavaScript did not run")
-    return json.loads(raw)
+    if timed_out:
+        print(
+            "WARN: headless browser required forced shutdown after emitting oracle-result; accepting the verified DOM payload.",
+            file=sys.stderr,
+        )
+    return parsed
 
 
 def main() -> int:


### PR DESCRIPTION
### Goal
Prove the preserved `sensorProbing.xml` program exercises its four historical sensor output families under Webots R2025a.

### Changes
- add a CI-only multi-print observer that preserves the exact Blockly 2020 generated Python SHA-256 oracle;
- require one observed output from each preserved family: `Gyro:`, `GPS:`, `getDist:`, and `getColor:`;
- execute the exact generated program in the stabilized `worlds/empty.wbt` using the official `cyberbotics/webots:R2025a-ubuntu22.04` image;
- require no Webots error and no Python traceback;
- always restore the historical `my_controller.py` after the test.

### Scope
No Blockly modernization, no coordinate conversion, no sensor API redesign, and no changes to `main`. This is the final non-empty historical XML fixture not yet exercised live under the R2025a compatibility baseline.