### PR TITLE
Exercise historical Blockly UI against real sidecar

### DIFF
--- a/.github/workflows/historical-blockly-ui-ci.yml
+++ b/.github/workflows/historical-blockly-ui-ci.yml
@@ -1,0 +1,35 @@
+name: Historical Blockly UI sidecar gate
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  historical-blockly-ui:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 6
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Rebuild historical Blockly sidecar
+        shell: bash
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/supervisor/blocklyServer \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev && rm -f blocklyServer && make'
+
+      - name: Exercise real Blockly Save Submit Restore buttons
+        run: python3 tools/ci/run_blockly_ui_sidecar_test.py

--- a/.github/workflows/historical-blockly-ui-ci.yml
+++ b/.github/workflows/historical-blockly-ui-ci.yml
@@ -32,4 +32,4 @@ jobs:
             bash -lc 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libboost-dev && rm -f blocklyServer && make'
 
       - name: Exercise real Blockly Save Submit Restore buttons
-        run: python3 tools/ci/run_blockly_ui_sidecar_test.py
+        run: python3 tools/ci/run_blockly_ui_sidecar_diagnostic.py

--- a/tools/ci/run_blockly_ui_sidecar_diagnostic.py
+++ b/tools/ci/run_blockly_ui_sidecar_diagnostic.py
@@ -14,6 +14,20 @@ _original_injected_harness = module.injected_harness
 
 def injected_harness():
     source = _original_injected_harness()
+
+    # main.js appends a <style> child to every saved-project <a>. That CSS text
+    # is therefore part of anchor.textContent, even though the historical
+    # restore() handler correctly uses this.innerText. Match the stable title
+    # attribute set by main.js instead of treating CSS text as the project name.
+    project_lookup = 'Array.from(list.querySelectorAll("a")).find(a=>a.textContent===name)'
+    if project_lookup not in source:
+        raise RuntimeError("unable to patch saved-project lookup")
+    source = source.replace(
+        project_lookup,
+        'Array.from(list.querySelectorAll("a")).find(a=>a.title===name)',
+        1,
+    )
+
     needle = 'ws.addEventListener("error",()=>{result.websocketEvents.push("error");void post("/__ci_progress",{stage:result.stage,websocket:"error"});});'
     addition = needle + '\n      ws.addEventListener("message",e=>{const kind=(e.data&&e.data.constructor&&e.data.constructor.name)||typeof e.data;const preview=typeof e.data==="string"?e.data.slice(0,160):String(e.data);result.websocketEvents.push("message:"+String(currCommand)+":"+kind+":"+preview);void post("/__ci_progress",{stage:result.stage,websocket:"message",currCommand:String(currCommand),payloadType:kind,payloadPreview:preview});});'
     if needle not in source:

--- a/tools/ci/run_blockly_ui_sidecar_diagnostic.py
+++ b/tools/ci/run_blockly_ui_sidecar_diagnostic.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("run_blockly_ui_sidecar_test.py")
+spec = importlib.util.spec_from_file_location("blockly_ui_test", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+_original_injected_harness = module.injected_harness
+
+
+def injected_harness():
+    source = _original_injected_harness()
+    needle = 'ws.addEventListener("error",()=>{result.websocketEvents.push("error");void post("/__ci_progress",{stage:result.stage,websocket:"error"});});'
+    addition = needle + '\n      ws.addEventListener("message",e=>{const kind=(e.data&&e.data.constructor&&e.data.constructor.name)||typeof e.data;const preview=typeof e.data==="string"?e.data.slice(0,160):String(e.data);result.websocketEvents.push("message:"+String(currCommand)+":"+kind+":"+preview);void post("/__ci_progress",{stage:result.stage,websocket:"message",currCommand:String(currCommand),payloadType:kind,payloadPreview:preview});});'
+    if needle not in source:
+        raise RuntimeError("unable to inject WebSocket message diagnostics")
+    return source.replace(needle, addition, 1)
+
+
+module.injected_harness = injected_harness
+
+# The old TCP readiness probe intentionally opens a non-WebSocket connection,
+# which makes blocklyServer log "Transport endpoint is not connected". The real
+# browser flow already waits for WebSocket.OPEN, so suppress that misleading
+# probe in this diagnostic run.
+module.wait_for_port = lambda port, timeout=5: None
+
+if __name__ == "__main__":
+    raise SystemExit(module.main())

--- a/tools/ci/run_blockly_ui_sidecar_test.py
+++ b/tools/ci/run_blockly_ui_sidecar_test.py
@@ -44,6 +44,19 @@ def injected_harness():
 (async function() {{
  const result={{ok:false,initialRestore:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
  const waitFor=async (p,label,limit=10000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
+ const waitForSavedProject=(name)=>new Promise(resolve=>{{
+   const list=document.getElementById("saveList");
+   const find=()=>Array.from(list.querySelectorAll("a")).find(a=>a.textContent===name);
+   const existing=find(); if(existing){{resolve(existing);return;}}
+   const observer=new MutationObserver(()=>{{const link=find();if(link){{observer.disconnect();resolve(link);}}}});
+   observer.observe(list,{{childList:true,subtree:true,characterData:true}});
+ }});
+ const waitForRestoredWorkspace=()=>new Promise(resolve=>{{
+   const done=()=>Blockly.mainWorkspace.getTopBlocks(false).length>0;
+   if(done()){{resolve();return;}}
+   const listener=()=>{{if(done()){{Blockly.mainWorkspace.removeChangeListener(listener);resolve();}}}};
+   Blockly.mainWorkspace.addChangeListener(listener);
+ }});
  try {{
   const saveButton=document.getElementById("save");
   const submitButton=document.getElementById("submit");
@@ -53,14 +66,15 @@ def injected_harness():
   await waitFor(()=>titleElement.textContent==="{FIXTURE_NAME}" && Blockly.mainWorkspace.getTopBlocks(false).length>0,"initial RESTORE_LAST");
   result.initialRestore=true;
   titleElement.textContent="{PROJECT_NAME}";
-  saveButton.click(); result.saveClicked=true; await new Promise(r=>setTimeout(r,300));
-  submitButton.click(); result.submitClicked=true; await new Promise(r=>setTimeout(r,300));
+  saveButton.click(); result.saveClicked=true;
+  submitButton.click(); result.submitClicked=true;
   Blockly.mainWorkspace.clear();
   if(Blockly.mainWorkspace.getTopBlocks(false).length!==0)throw new Error("workspace clear failed");
   restoreButton.click(); result.restoreClicked=true;
-  await waitFor(()=>Array.from(document.querySelectorAll("#saveList a")).some(a=>a.textContent==="{PROJECT_NAME}"),"saved project");
-  Array.from(document.querySelectorAll("#saveList a")).find(a=>a.textContent==="{PROJECT_NAME}").click();
-  await waitFor(()=>Blockly.mainWorkspace.getTopBlocks(false).length>0,"restored workspace");
+  const savedLink=await waitForSavedProject("{PROJECT_NAME}");
+  const restored=waitForRestoredWorkspace();
+  savedLink.click();
+  await restored;
   result.restoredTopBlocks=Blockly.mainWorkspace.getTopBlocks(false).length; result.ok=true;
  }} catch(e) {{ result.error=String(e&&e.stack?e.stack:e); }}
  document.getElementById("ui-result").textContent=JSON.stringify(result);

--- a/tools/ci/run_blockly_ui_sidecar_test.py
+++ b/tools/ci/run_blockly_ui_sidecar_test.py
@@ -45,16 +45,20 @@ def injected_harness():
  const result={{ok:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
  const waitFor=async (p,label,limit=10000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
  try {{
-  await waitFor(()=>window.ws && ws.readyState===WebSocket.OPEN && !save.disabled && !submit.disabled,"WebSocket/buttons");
+  const saveButton=document.getElementById("save");
+  const submitButton=document.getElementById("submit");
+  const restoreButton=document.getElementById("restore");
+  const titleElement=document.getElementById("projectTitle");
+  await waitFor(()=>window.ws && ws.readyState===WebSocket.OPEN && !saveButton.disabled && !submitButton.disabled && !restoreButton.disabled,"WebSocket/buttons");
   await new Promise(r=>setTimeout(r,300));
   Blockly.mainWorkspace.clear();
   Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom({fixture}),Blockly.mainWorkspace);
-  projectTitle.textContent="{PROJECT_NAME}";
-  save.click(); result.saveClicked=true; await new Promise(r=>setTimeout(r,300));
-  submit.click(); result.submitClicked=true; await new Promise(r=>setTimeout(r,300));
+  titleElement.textContent="{PROJECT_NAME}";
+  saveButton.click(); result.saveClicked=true; await new Promise(r=>setTimeout(r,300));
+  submitButton.click(); result.submitClicked=true; await new Promise(r=>setTimeout(r,300));
   Blockly.mainWorkspace.clear();
   if(Blockly.mainWorkspace.getTopBlocks(false).length!==0)throw new Error("workspace clear failed");
-  restore.click(); result.restoreClicked=true;
+  restoreButton.click(); result.restoreClicked=true;
   await waitFor(()=>Array.from(document.querySelectorAll("#saveList a")).some(a=>a.textContent==="{PROJECT_NAME}"),"saved project");
   Array.from(document.querySelectorAll("#saveList a")).find(a=>a.textContent==="{PROJECT_NAME}").click();
   await waitFor(()=>Blockly.mainWorkspace.getTopBlocks(false).length>0,"restored workspace");

--- a/tools/ci/run_blockly_ui_sidecar_test.py
+++ b/tools/ci/run_blockly_ui_sidecar_test.py
@@ -19,22 +19,36 @@ FIXTURE_NAME=Path(FIXTURE).stem
 PROJECT_NAME="CIUiRoundTrip"
 SAVED_XML=PROGRAM_DIR/(PROJECT_NAME+".xml")
 
+def read_log(handle):
+    if handle is None:
+        return ""
+    try:
+        handle.flush()
+        handle.seek(0)
+        return handle.read().strip()
+    except Exception as exc:
+        return f"<unable to read log: {exc}>"
+
 class ResultHandler(SimpleHTTPRequestHandler):
     def log_message(self, format, *args): pass
 
     def do_POST(self):
-        if self.path != "/__ci_result":
+        if self.path not in ("/__ci_result", "/__ci_progress"):
             self.send_error(404)
             return
         try:
             length=int(self.headers.get("Content-Length","0"))
             payload=json.loads(self.rfile.read(length).decode("utf-8"))
-            self.server.ui_result=payload
-            self.server.ui_event.set()
+            if self.path == "/__ci_progress":
+                self.server.ui_progress=payload
+                print("CI_UI_PROGRESS="+json.dumps(payload, sort_keys=True), flush=True)
+            else:
+                self.server.ui_result=payload
+                self.server.ui_event.set()
             self.send_response(204)
             self.end_headers()
         except Exception as exc:
-            self.server.ui_result={"ok":False,"error":f"result callback failed: {exc}"}
+            self.server.ui_result={"ok":False,"stage":"result-callback","error":f"result callback failed: {exc}"}
             self.server.ui_event.set()
             self.send_error(400)
 
@@ -56,12 +70,24 @@ def injected_harness():
     return source+f"""
 <script>
 (async function() {{
- const result={{ok:false,stage:"start",initialRestore:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
- const finish=async()=>{{
-   try {{
-     await fetch("/__ci_result",{{method:"POST",headers:{{"Content-Type":"application/json"}},body:JSON.stringify(result)}});
-   }} catch(e) {{ console.error("CI result callback failed",e); }}
+ const result={{ok:false,stage:"start",initialRestore:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null,browserErrors:[],websocketEvents:[]}};
+ const post=async(path,payload)=>{{
+   try {{ await fetch(path,{{method:"POST",headers:{{"Content-Type":"application/json"}},body:JSON.stringify(payload)}}); }}
+   catch(e) {{ console.error("CI callback failed",path,e); }}
  }};
+ const progress=async(stage,extra={{}})=>{{
+   result.stage=stage;
+   await post("/__ci_progress",Object.assign({{stage:stage}},extra));
+ }};
+ const finish=async()=>post("/__ci_result",result);
+ window.addEventListener("error",e=>{{
+   result.browserErrors.push("error: "+String(e.message||e.error||e));
+   void post("/__ci_progress",{{stage:result.stage,browserError:result.browserErrors[result.browserErrors.length-1]}});
+ }});
+ window.addEventListener("unhandledrejection",e=>{{
+   result.browserErrors.push("unhandledrejection: "+String(e.reason&&e.reason.stack?e.reason.stack:e.reason));
+   void post("/__ci_progress",{{stage:result.stage,browserError:result.browserErrors[result.browserErrors.length-1]}});
+ }});
  const waitFor=async (p,label,limit=15000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
  const waitForSavedProject=(name,limit=15000)=>new Promise((resolve,reject)=>{{
    const list=document.getElementById("saveList");
@@ -83,38 +109,54 @@ def injected_harness():
   const submitButton=document.getElementById("submit");
   const restoreButton=document.getElementById("restore");
   const titleElement=document.getElementById("projectTitle");
-  result.stage="wait-websocket";
-  await waitFor(()=>window.ws && ws.readyState===WebSocket.OPEN && !saveButton.disabled && !submitButton.disabled && !restoreButton.disabled,"WebSocket/buttons");
-  result.stage="wait-initial-restore";
+
+  await progress("wait-websocket");
+  let socketInstrumented=false;
+  await waitFor(()=>{{
+    if(window.ws && !socketInstrumented){{
+      socketInstrumented=true;
+      ws.addEventListener("open",()=>{{result.websocketEvents.push("open");void post("/__ci_progress",{{stage:result.stage,websocket:"open"}});}});
+      ws.addEventListener("error",()=>{{result.websocketEvents.push("error");void post("/__ci_progress",{{stage:result.stage,websocket:"error"}});}});
+      ws.addEventListener("close",e=>{{result.websocketEvents.push("close:"+e.code);void post("/__ci_progress",{{stage:result.stage,websocket:"close",code:e.code,reason:e.reason}});}});
+    }}
+    return window.ws && ws.readyState===WebSocket.OPEN && !saveButton.disabled && !submitButton.disabled && !restoreButton.disabled;
+  }},"WebSocket/buttons");
+
+  await progress("wait-initial-restore",{{websocketState:ws.readyState}});
   await waitFor(()=>titleElement.textContent==="{FIXTURE_NAME}" && Blockly.mainWorkspace.getTopBlocks(false).length>0,"initial RESTORE_LAST");
   result.initialRestore=true;
+  await progress("initial-restore-complete",{{topBlocks:Blockly.mainWorkspace.getTopBlocks(false).length}});
 
   titleElement.textContent="{PROJECT_NAME}";
-  result.stage="save";
+  await progress("save");
   saveButton.click(); result.saveClicked=true;
 
   // Listing saved projects is our browser-visible acknowledgement that the
   // preceding SAVE/SAVE_LAST frames have been processed by the real sidecar.
-  result.stage="list-after-save";
+  await progress("list-after-save");
   restoreButton.click(); result.restoreClicked=true;
   const savedLink=await waitForSavedProject("{PROJECT_NAME}");
+  await progress("saved-project-visible");
 
   // Submit only after SAVE has been observed, avoiding races in the historical
   // single `currCommand` state machine. WebSocket frame ordering then ensures
   // SEND_CODE/SAVE_LAST are processed before the following RESTORE_SAVE.
-  result.stage="submit";
+  await progress("submit");
   submitButton.click(); result.submitClicked=true;
 
   Blockly.mainWorkspace.clear();
   if(Blockly.mainWorkspace.getTopBlocks(false).length!==0)throw new Error("workspace clear failed");
-  result.stage="restore";
+  await progress("restore");
   const restored=waitForRestoredWorkspace();
   savedLink.click();
   await restored;
   result.restoredTopBlocks=Blockly.mainWorkspace.getTopBlocks(false).length;
-  result.stage="complete";
+  await progress("complete",{{restoredTopBlocks:result.restoredTopBlocks}});
   result.ok=true;
- }} catch(e) {{ result.error=String(e&&e.stack?e.stack:e); }}
+ }} catch(e) {{
+   result.error=String(e&&e.stack?e.stack:e);
+   await post("/__ci_progress",{{stage:result.stage,error:result.error,browserErrors:result.browserErrors,websocketEvents:result.websocketEvents}});
+ }}
  await finish();
 }})();
 </script>
@@ -122,26 +164,34 @@ def injected_harness():
 
 def run_chrome(url, server, timeout=35):
     # Keep a real headless browser alive while actual WebSocket/network events
-    # occur. `--dump-dom --virtual-time-budget` is appropriate for the purely
-    # synchronous Blockly oracle, but it can render before asynchronous socket
-    # work finishes. The page POSTs its final result to our local HTTP server.
+    # occur. Persist Chrome stderr to a file so a timeout cannot hide browser
+    # diagnostics or deadlock on a full stderr pipe.
     cmd=[chrome_executable(),"--headless=new","--no-sandbox","--disable-gpu","--disable-dev-shm-usage","--disable-background-networking","--remote-debugging-port=0",url]
-    p=subprocess.Popen(cmd,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    chrome_out=tempfile.TemporaryFile(mode="w+",encoding="utf-8")
+    chrome_err=tempfile.TemporaryFile(mode="w+",encoding="utf-8")
+    p=subprocess.Popen(cmd,text=True,stdout=chrome_out,stderr=chrome_err)
     deadline=time.monotonic()+timeout
     try:
         while time.monotonic()<deadline:
             if server.ui_event.wait(timeout=.1):
                 return server.ui_result
             if p.poll() is not None:
-                out,err=p.communicate()
-                raise RuntimeError(f"headless browser exited before UI result callback ({p.returncode}): {err.strip()}")
-        raise RuntimeError("timeout waiting for browser UI result callback")
+                raise RuntimeError(
+                    f"headless browser exited before UI result callback ({p.returncode}); "
+                    f"last progress={server.ui_progress}; stderr={read_log(chrome_err)}"
+                )
+        raise RuntimeError(
+            "timeout waiting for browser UI result callback; "
+            f"last progress={server.ui_progress}; chrome stderr={read_log(chrome_err)}"
+        )
     finally:
         if p.poll() is None:
             p.terminate()
             try: p.wait(timeout=3)
             except subprocess.TimeoutExpired:
                 p.kill(); p.wait(timeout=3)
+        chrome_out.close()
+        chrome_err.close()
 
 def main():
     if not SIDECAR.is_file(): raise RuntimeError(f"rebuilt sidecar missing: {SIDECAR}")
@@ -149,22 +199,39 @@ def main():
     tmp_backup=TMP_LAST.read_bytes() if TMP_LAST.exists() else None
     saved_backup=SAVED_XML.read_bytes() if SAVED_XML.exists() else None
     sidecar=server=thread=harness_path=None
+    sidecar_out=sidecar_err=None
     try:
         SAVED_XML.unlink(missing_ok=True)
         # Seed a real existing last project so main.js completes its historical
         # RESTORE_LAST_NAME -> RESTORE_LAST startup exchange before the test
         # starts issuing new commands on the single currCommand state machine.
         TMP_LAST.write_text(FIXTURE_NAME,encoding="utf-8")
-        sidecar=subprocess.Popen([str(SIDECAR)],cwd=SUPERVISOR_DIR,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        sidecar_out=tempfile.TemporaryFile(mode="w+",encoding="utf-8")
+        sidecar_err=tempfile.TemporaryFile(mode="w+",encoding="utf-8")
+        sidecar=subprocess.Popen([str(SIDECAR)],cwd=SUPERVISOR_DIR,text=True,stdout=sidecar_out,stderr=sidecar_err)
         wait_for_port(8001)
         with tempfile.NamedTemporaryFile(mode="w",suffix=".html",prefix="ci-ui-",dir=WINDOW_DIR,encoding="utf-8",delete=False) as h:
             h.write(injected_harness()); harness_path=Path(h.name)
         port=free_port()
         server=ThreadingHTTPServer(("127.0.0.1",port),partial(ResultHandler,directory=str(WINDOW_DIR)))
-        server.ui_event=threading.Event(); server.ui_result=None
+        server.ui_event=threading.Event(); server.ui_result=None; server.ui_progress={"stage":"server-started"}
         thread=threading.Thread(target=server.serve_forever,daemon=True); thread.start()
-        result=run_chrome(f"http://127.0.0.1:{port}/{harness_path.name}",server)
-        if not result or not result.get("ok"): raise RuntimeError("browser UI flow failed at "+str(result.get("stage") if result else "unknown")+": "+str(result.get("error") if result else "no result"))
+        try:
+            result=run_chrome(f"http://127.0.0.1:{port}/{harness_path.name}",server)
+        except Exception as exc:
+            raise RuntimeError(
+                f"{exc}; blocklyServer stdout={read_log(sidecar_out)}; "
+                f"blocklyServer stderr={read_log(sidecar_err)}"
+            ) from exc
+        if not result or not result.get("ok"):
+            raise RuntimeError(
+                "browser UI flow failed at "+str(result.get("stage") if result else "unknown")+": "
+                +str(result.get("error") if result else "no result")
+                +"; browserErrors="+str(result.get("browserErrors") if result else None)
+                +"; websocketEvents="+str(result.get("websocketEvents") if result else None)
+                +"; blocklyServer stdout="+read_log(sidecar_out)
+                +"; blocklyServer stderr="+read_log(sidecar_err)
+            )
         if not result.get("initialRestore"): raise RuntimeError("historical initial restore did not complete")
         if not all(result.get(k) for k in ("saveClicked","submitClicked","restoreClicked")): raise RuntimeError("not all real UI buttons were exercised")
         if int(result.get("restoredTopBlocks",0))<=0: raise RuntimeError("Restore did not repopulate workspace")
@@ -183,6 +250,8 @@ def main():
             sidecar.terminate()
             try: sidecar.wait(timeout=2)
             except subprocess.TimeoutExpired: sidecar.kill(); sidecar.wait(timeout=2)
+        if sidecar_out is not None: sidecar_out.close()
+        if sidecar_err is not None: sidecar_err.close()
         if harness_path is not None: harness_path.unlink(missing_ok=True)
         CONTROLLER.write_bytes(controller_backup)
         (TMP_LAST.unlink(missing_ok=True) if tmp_backup is None else TMP_LAST.write_bytes(tmp_backup))

--- a/tools/ci/run_blockly_ui_sidecar_test.py
+++ b/tools/ci/run_blockly_ui_sidecar_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import hashlib, html, json, re, socket, subprocess, sys, tempfile, threading, time
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from run_historical_blockly_oracle import EXPECTED_PYTHON_SHA256, chrome_executable
+
+ROOT=Path(__file__).resolve().parents[2]
+WINDOW_DIR=ROOT/"plugins"/"robot_windows"/"blockly"
+HTML_PATH=WINDOW_DIR/"blockly.html"
+PROGRAM_DIR=ROOT/"controllers"/"Blockly_Programs"
+SUPERVISOR_DIR=ROOT/"controllers"/"supervisor"
+SIDECAR=SUPERVISOR_DIR/"blocklyServer"/"blocklyServer"
+CONTROLLER=ROOT/"controllers"/"my_controller"/"my_controller.py"
+TMP_LAST=PROGRAM_DIR/".tmp.txt"
+FIXTURE="BoxWithDistSensor.xml"
+PROJECT_NAME="CIUiRoundTrip"
+SAVED_XML=PROGRAM_DIR/(PROJECT_NAME+".xml")
+RESULT_RE=re.compile(r'<pre id="ui-result">(.*?)</pre>', re.DOTALL)
+
+class QuietHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format, *args): pass
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1",0)); return sock.getsockname()[1]
+
+def wait_for_port(port, timeout=5):
+    deadline=time.monotonic()+timeout
+    while time.monotonic()<deadline:
+        with socket.socket() as sock:
+            sock.settimeout(.2)
+            if sock.connect_ex(("127.0.0.1",port))==0: return
+        time.sleep(.05)
+    raise RuntimeError(f"port {port} did not open")
+
+def injected_harness():
+    source=HTML_PATH.read_text(encoding="utf-8")
+    fixture=json.dumps((PROGRAM_DIR/FIXTURE).read_text(encoding="utf-8"))
+    return source+f"""
+<pre id="ui-result">NOT_RUN</pre>
+<script>
+(async function() {{
+ const result={{ok:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
+ const waitFor=async (p,label,limit=10000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
+ try {{
+  await waitFor(()=>window.ws && ws.readyState===WebSocket.OPEN && !save.disabled && !submit.disabled,"WebSocket/buttons");
+  await new Promise(r=>setTimeout(r,300));
+  Blockly.mainWorkspace.clear();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom({fixture}),Blockly.mainWorkspace);
+  projectTitle.textContent="{PROJECT_NAME}";
+  save.click(); result.saveClicked=true; await new Promise(r=>setTimeout(r,300));
+  submit.click(); result.submitClicked=true; await new Promise(r=>setTimeout(r,300));
+  Blockly.mainWorkspace.clear();
+  if(Blockly.mainWorkspace.getTopBlocks(false).length!==0)throw new Error("workspace clear failed");
+  restore.click(); result.restoreClicked=true;
+  await waitFor(()=>Array.from(document.querySelectorAll("#saveList a")).some(a=>a.textContent==="{PROJECT_NAME}"),"saved project");
+  Array.from(document.querySelectorAll("#saveList a")).find(a=>a.textContent==="{PROJECT_NAME}").click();
+  await waitFor(()=>Blockly.mainWorkspace.getTopBlocks(false).length>0,"restored workspace");
+  result.restoredTopBlocks=Blockly.mainWorkspace.getTopBlocks(false).length; result.ok=true;
+ }} catch(e) {{ result.error=String(e&&e.stack?e.stack:e); }}
+ document.getElementById("ui-result").textContent=JSON.stringify(result);
+}})();
+</script>
+"""
+
+def parse_output(stdout):
+    m=RESULT_RE.search(stdout)
+    if not m: raise RuntimeError("headless browser did not emit ui-result")
+    raw=html.unescape(m.group(1))
+    if raw=="NOT_RUN": raise RuntimeError("UI harness did not run")
+    return json.loads(raw)
+
+def run_chrome(url):
+    cmd=[chrome_executable(),"--headless=new","--no-sandbox","--disable-gpu","--disable-dev-shm-usage","--disable-background-networking","--virtual-time-budget=15000","--dump-dom",url]
+    p=subprocess.Popen(cmd,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    timed=False
+    try: out,err=p.communicate(timeout=35)
+    except subprocess.TimeoutExpired:
+        timed=True; p.kill(); out,err=p.communicate()
+    try: result=parse_output(out)
+    except Exception as exc: raise RuntimeError(f"browser UI test produced no valid result{' after timeout' if timed else ''}: {err.strip()}") from exc
+    if not timed and p.returncode: raise RuntimeError(f"headless browser exited with {p.returncode}: {err.strip()}")
+    return result
+
+def main():
+    if not SIDECAR.is_file(): raise RuntimeError(f"rebuilt sidecar missing: {SIDECAR}")
+    controller_backup=CONTROLLER.read_bytes()
+    tmp_backup=TMP_LAST.read_bytes() if TMP_LAST.exists() else None
+    saved_backup=SAVED_XML.read_bytes() if SAVED_XML.exists() else None
+    sidecar=server=thread=harness_path=None
+    try:
+        TMP_LAST.unlink(missing_ok=True); SAVED_XML.unlink(missing_ok=True)
+        sidecar=subprocess.Popen([str(SIDECAR)],cwd=SUPERVISOR_DIR,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        wait_for_port(8001)
+        with tempfile.NamedTemporaryFile(mode="w",suffix=".html",prefix="ci-ui-",dir=WINDOW_DIR,encoding="utf-8",delete=False) as h:
+            h.write(injected_harness()); harness_path=Path(h.name)
+        port=free_port(); server=ThreadingHTTPServer(("127.0.0.1",port),partial(QuietHandler,directory=str(WINDOW_DIR)))
+        thread=threading.Thread(target=server.serve_forever,daemon=True); thread.start()
+        result=run_chrome(f"http://127.0.0.1:{port}/{harness_path.name}")
+        if not result.get("ok"): raise RuntimeError("browser UI flow failed: "+str(result.get("error")))
+        if not all(result.get(k) for k in ("saveClicked","submitClicked","restoreClicked")): raise RuntimeError("not all real UI buttons were exercised")
+        if int(result.get("restoredTopBlocks",0))<=0: raise RuntimeError("Restore did not repopulate workspace")
+        if not SAVED_XML.is_file(): raise RuntimeError("Save did not create XML")
+        saved=SAVED_XML.read_text(encoding="utf-8")
+        if "<xml" not in saved or "motors_" not in saved: raise RuntimeError("saved XML lacks historical fixture blocks")
+        digest=hashlib.sha256(CONTROLLER.read_bytes()).hexdigest(); expected=EXPECTED_PYTHON_SHA256[FIXTURE]
+        if digest!=expected: raise RuntimeError(f"Submit Python sha256={digest}, expected={expected}")
+        if not TMP_LAST.is_file() or TMP_LAST.read_text(encoding="utf-8").strip()!=PROJECT_NAME: raise RuntimeError("last-project state not updated")
+        print(f"PASS: real blockly.html/main.js Save, Submit and Restore buttons worked against real blocklyServer; submitted {FIXTURE} Python sha256 matched.")
+        return 0
+    finally:
+        if server is not None: server.shutdown(); server.server_close()
+        if thread is not None: thread.join(timeout=2)
+        if sidecar is not None:
+            sidecar.terminate()
+            try: sidecar.wait(timeout=2)
+            except subprocess.TimeoutExpired: sidecar.kill(); sidecar.wait(timeout=2)
+        if harness_path is not None: harness_path.unlink(missing_ok=True)
+        CONTROLLER.write_bytes(controller_backup)
+        (TMP_LAST.unlink(missing_ok=True) if tmp_backup is None else TMP_LAST.write_bytes(tmp_backup))
+        (SAVED_XML.unlink(missing_ok=True) if saved_backup is None else SAVED_XML.write_bytes(saved_backup))
+if __name__=="__main__": raise SystemExit(main())

--- a/tools/ci/run_blockly_ui_sidecar_test.py
+++ b/tools/ci/run_blockly_ui_sidecar_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import hashlib, html, json, re, socket, subprocess, sys, tempfile, threading, time
+import hashlib, json, socket, subprocess, tempfile, threading, time
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -18,10 +18,25 @@ FIXTURE="BoxWithDistSensor.xml"
 FIXTURE_NAME=Path(FIXTURE).stem
 PROJECT_NAME="CIUiRoundTrip"
 SAVED_XML=PROGRAM_DIR/(PROJECT_NAME+".xml")
-RESULT_RE=re.compile(r'<pre id="ui-result">(.*?)</pre>', re.DOTALL)
 
-class QuietHandler(SimpleHTTPRequestHandler):
+class ResultHandler(SimpleHTTPRequestHandler):
     def log_message(self, format, *args): pass
+
+    def do_POST(self):
+        if self.path != "/__ci_result":
+            self.send_error(404)
+            return
+        try:
+            length=int(self.headers.get("Content-Length","0"))
+            payload=json.loads(self.rfile.read(length).decode("utf-8"))
+            self.server.ui_result=payload
+            self.server.ui_event.set()
+            self.send_response(204)
+            self.end_headers()
+        except Exception as exc:
+            self.server.ui_result={"ok":False,"error":f"result callback failed: {exc}"}
+            self.server.ui_event.set()
+            self.send_error(400)
 
 def free_port():
     with socket.socket() as sock:
@@ -39,22 +54,28 @@ def wait_for_port(port, timeout=5):
 def injected_harness():
     source=HTML_PATH.read_text(encoding="utf-8")
     return source+f"""
-<pre id="ui-result">NOT_RUN</pre>
 <script>
 (async function() {{
- const result={{ok:false,initialRestore:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
- const waitFor=async (p,label,limit=10000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
- const waitForSavedProject=(name)=>new Promise(resolve=>{{
+ const result={{ok:false,stage:"start",initialRestore:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
+ const finish=async()=>{{
+   try {{
+     await fetch("/__ci_result",{{method:"POST",headers:{{"Content-Type":"application/json"}},body:JSON.stringify(result)}});
+   }} catch(e) {{ console.error("CI result callback failed",e); }}
+ }};
+ const waitFor=async (p,label,limit=15000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
+ const waitForSavedProject=(name,limit=15000)=>new Promise((resolve,reject)=>{{
    const list=document.getElementById("saveList");
    const find=()=>Array.from(list.querySelectorAll("a")).find(a=>a.textContent===name);
    const existing=find(); if(existing){{resolve(existing);return;}}
-   const observer=new MutationObserver(()=>{{const link=find();if(link){{observer.disconnect();resolve(link);}}}});
+   const timer=setTimeout(()=>{{observer.disconnect();reject(new Error("timeout waiting for saved project "+name));}},limit);
+   const observer=new MutationObserver(()=>{{const link=find();if(link){{clearTimeout(timer);observer.disconnect();resolve(link);}}}});
    observer.observe(list,{{childList:true,subtree:true,characterData:true}});
  }});
- const waitForRestoredWorkspace=()=>new Promise(resolve=>{{
+ const waitForRestoredWorkspace=(limit=15000)=>new Promise((resolve,reject)=>{{
    const done=()=>Blockly.mainWorkspace.getTopBlocks(false).length>0;
    if(done()){{resolve();return;}}
-   const listener=()=>{{if(done()){{Blockly.mainWorkspace.removeChangeListener(listener);resolve();}}}};
+   const timer=setTimeout(()=>{{Blockly.mainWorkspace.removeChangeListener(listener);reject(new Error("timeout waiting for restored workspace"));}},limit);
+   const listener=()=>{{if(done()){{clearTimeout(timer);Blockly.mainWorkspace.removeChangeListener(listener);resolve();}}}};
    Blockly.mainWorkspace.addChangeListener(listener);
  }});
  try {{
@@ -62,44 +83,65 @@ def injected_harness():
   const submitButton=document.getElementById("submit");
   const restoreButton=document.getElementById("restore");
   const titleElement=document.getElementById("projectTitle");
+  result.stage="wait-websocket";
   await waitFor(()=>window.ws && ws.readyState===WebSocket.OPEN && !saveButton.disabled && !submitButton.disabled && !restoreButton.disabled,"WebSocket/buttons");
+  result.stage="wait-initial-restore";
   await waitFor(()=>titleElement.textContent==="{FIXTURE_NAME}" && Blockly.mainWorkspace.getTopBlocks(false).length>0,"initial RESTORE_LAST");
   result.initialRestore=true;
+
   titleElement.textContent="{PROJECT_NAME}";
+  result.stage="save";
   saveButton.click(); result.saveClicked=true;
-  submitButton.click(); result.submitClicked=true;
-  Blockly.mainWorkspace.clear();
-  if(Blockly.mainWorkspace.getTopBlocks(false).length!==0)throw new Error("workspace clear failed");
+
+  // Listing saved projects is our browser-visible acknowledgement that the
+  // preceding SAVE/SAVE_LAST frames have been processed by the real sidecar.
+  result.stage="list-after-save";
   restoreButton.click(); result.restoreClicked=true;
   const savedLink=await waitForSavedProject("{PROJECT_NAME}");
+
+  // Submit only after SAVE has been observed, avoiding races in the historical
+  // single `currCommand` state machine. WebSocket frame ordering then ensures
+  // SEND_CODE/SAVE_LAST are processed before the following RESTORE_SAVE.
+  result.stage="submit";
+  submitButton.click(); result.submitClicked=true;
+
+  Blockly.mainWorkspace.clear();
+  if(Blockly.mainWorkspace.getTopBlocks(false).length!==0)throw new Error("workspace clear failed");
+  result.stage="restore";
   const restored=waitForRestoredWorkspace();
   savedLink.click();
   await restored;
-  result.restoredTopBlocks=Blockly.mainWorkspace.getTopBlocks(false).length; result.ok=true;
+  result.restoredTopBlocks=Blockly.mainWorkspace.getTopBlocks(false).length;
+  result.stage="complete";
+  result.ok=true;
  }} catch(e) {{ result.error=String(e&&e.stack?e.stack:e); }}
- document.getElementById("ui-result").textContent=JSON.stringify(result);
+ await finish();
 }})();
 </script>
 """
 
-def parse_output(stdout):
-    m=RESULT_RE.search(stdout)
-    if not m: raise RuntimeError("headless browser did not emit ui-result")
-    raw=html.unescape(m.group(1))
-    if raw=="NOT_RUN": raise RuntimeError("UI harness did not run")
-    return json.loads(raw)
-
-def run_chrome(url):
-    cmd=[chrome_executable(),"--headless=new","--no-sandbox","--disable-gpu","--disable-dev-shm-usage","--disable-background-networking","--virtual-time-budget=15000","--dump-dom",url]
+def run_chrome(url, server, timeout=35):
+    # Keep a real headless browser alive while actual WebSocket/network events
+    # occur. `--dump-dom --virtual-time-budget` is appropriate for the purely
+    # synchronous Blockly oracle, but it can render before asynchronous socket
+    # work finishes. The page POSTs its final result to our local HTTP server.
+    cmd=[chrome_executable(),"--headless=new","--no-sandbox","--disable-gpu","--disable-dev-shm-usage","--disable-background-networking","--remote-debugging-port=0",url]
     p=subprocess.Popen(cmd,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-    timed=False
-    try: out,err=p.communicate(timeout=35)
-    except subprocess.TimeoutExpired:
-        timed=True; p.kill(); out,err=p.communicate()
-    try: result=parse_output(out)
-    except Exception as exc: raise RuntimeError(f"browser UI test produced no valid result{' after timeout' if timed else ''}: {err.strip()}") from exc
-    if not timed and p.returncode: raise RuntimeError(f"headless browser exited with {p.returncode}: {err.strip()}")
-    return result
+    deadline=time.monotonic()+timeout
+    try:
+        while time.monotonic()<deadline:
+            if server.ui_event.wait(timeout=.1):
+                return server.ui_result
+            if p.poll() is not None:
+                out,err=p.communicate()
+                raise RuntimeError(f"headless browser exited before UI result callback ({p.returncode}): {err.strip()}")
+        raise RuntimeError("timeout waiting for browser UI result callback")
+    finally:
+        if p.poll() is None:
+            p.terminate()
+            try: p.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                p.kill(); p.wait(timeout=3)
 
 def main():
     if not SIDECAR.is_file(): raise RuntimeError(f"rebuilt sidecar missing: {SIDECAR}")
@@ -117,10 +159,12 @@ def main():
         wait_for_port(8001)
         with tempfile.NamedTemporaryFile(mode="w",suffix=".html",prefix="ci-ui-",dir=WINDOW_DIR,encoding="utf-8",delete=False) as h:
             h.write(injected_harness()); harness_path=Path(h.name)
-        port=free_port(); server=ThreadingHTTPServer(("127.0.0.1",port),partial(QuietHandler,directory=str(WINDOW_DIR)))
+        port=free_port()
+        server=ThreadingHTTPServer(("127.0.0.1",port),partial(ResultHandler,directory=str(WINDOW_DIR)))
+        server.ui_event=threading.Event(); server.ui_result=None
         thread=threading.Thread(target=server.serve_forever,daemon=True); thread.start()
-        result=run_chrome(f"http://127.0.0.1:{port}/{harness_path.name}")
-        if not result.get("ok"): raise RuntimeError("browser UI flow failed: "+str(result.get("error")))
+        result=run_chrome(f"http://127.0.0.1:{port}/{harness_path.name}",server)
+        if not result or not result.get("ok"): raise RuntimeError("browser UI flow failed at "+str(result.get("stage") if result else "unknown")+": "+str(result.get("error") if result else "no result"))
         if not result.get("initialRestore"): raise RuntimeError("historical initial restore did not complete")
         if not all(result.get(k) for k in ("saveClicked","submitClicked","restoreClicked")): raise RuntimeError("not all real UI buttons were exercised")
         if int(result.get("restoredTopBlocks",0))<=0: raise RuntimeError("Restore did not repopulate workspace")

--- a/tools/ci/run_blockly_ui_sidecar_test.py
+++ b/tools/ci/run_blockly_ui_sidecar_test.py
@@ -15,6 +15,7 @@ SIDECAR=SUPERVISOR_DIR/"blocklyServer"/"blocklyServer"
 CONTROLLER=ROOT/"controllers"/"my_controller"/"my_controller.py"
 TMP_LAST=PROGRAM_DIR/".tmp.txt"
 FIXTURE="BoxWithDistSensor.xml"
+FIXTURE_NAME=Path(FIXTURE).stem
 PROJECT_NAME="CIUiRoundTrip"
 SAVED_XML=PROGRAM_DIR/(PROJECT_NAME+".xml")
 RESULT_RE=re.compile(r'<pre id="ui-result">(.*?)</pre>', re.DOTALL)
@@ -37,12 +38,11 @@ def wait_for_port(port, timeout=5):
 
 def injected_harness():
     source=HTML_PATH.read_text(encoding="utf-8")
-    fixture=json.dumps((PROGRAM_DIR/FIXTURE).read_text(encoding="utf-8"))
     return source+f"""
 <pre id="ui-result">NOT_RUN</pre>
 <script>
 (async function() {{
- const result={{ok:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
+ const result={{ok:false,initialRestore:false,saveClicked:false,submitClicked:false,restoreClicked:false,restoredTopBlocks:0,error:null}};
  const waitFor=async (p,label,limit=10000)=>{{const start=Date.now();while(Date.now()-start<limit){{if(p())return;await new Promise(r=>setTimeout(r,50));}}throw new Error("timeout waiting for "+label);}};
  try {{
   const saveButton=document.getElementById("save");
@@ -50,9 +50,8 @@ def injected_harness():
   const restoreButton=document.getElementById("restore");
   const titleElement=document.getElementById("projectTitle");
   await waitFor(()=>window.ws && ws.readyState===WebSocket.OPEN && !saveButton.disabled && !submitButton.disabled && !restoreButton.disabled,"WebSocket/buttons");
-  await new Promise(r=>setTimeout(r,300));
-  Blockly.mainWorkspace.clear();
-  Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom({fixture}),Blockly.mainWorkspace);
+  await waitFor(()=>titleElement.textContent==="{FIXTURE_NAME}" && Blockly.mainWorkspace.getTopBlocks(false).length>0,"initial RESTORE_LAST");
+  result.initialRestore=true;
   titleElement.textContent="{PROJECT_NAME}";
   saveButton.click(); result.saveClicked=true; await new Promise(r=>setTimeout(r,300));
   submitButton.click(); result.submitClicked=true; await new Promise(r=>setTimeout(r,300));
@@ -95,7 +94,11 @@ def main():
     saved_backup=SAVED_XML.read_bytes() if SAVED_XML.exists() else None
     sidecar=server=thread=harness_path=None
     try:
-        TMP_LAST.unlink(missing_ok=True); SAVED_XML.unlink(missing_ok=True)
+        SAVED_XML.unlink(missing_ok=True)
+        # Seed a real existing last project so main.js completes its historical
+        # RESTORE_LAST_NAME -> RESTORE_LAST startup exchange before the test
+        # starts issuing new commands on the single currCommand state machine.
+        TMP_LAST.write_text(FIXTURE_NAME,encoding="utf-8")
         sidecar=subprocess.Popen([str(SIDECAR)],cwd=SUPERVISOR_DIR,text=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
         wait_for_port(8001)
         with tempfile.NamedTemporaryFile(mode="w",suffix=".html",prefix="ci-ui-",dir=WINDOW_DIR,encoding="utf-8",delete=False) as h:
@@ -104,6 +107,7 @@ def main():
         thread=threading.Thread(target=server.serve_forever,daemon=True); thread.start()
         result=run_chrome(f"http://127.0.0.1:{port}/{harness_path.name}")
         if not result.get("ok"): raise RuntimeError("browser UI flow failed: "+str(result.get("error")))
+        if not result.get("initialRestore"): raise RuntimeError("historical initial restore did not complete")
         if not all(result.get(k) for k in ("saveClicked","submitClicked","restoreClicked")): raise RuntimeError("not all real UI buttons were exercised")
         if int(result.get("restoredTopBlocks",0))<=0: raise RuntimeError("Restore did not repopulate workspace")
         if not SAVED_XML.is_file(): raise RuntimeError("Save did not create XML")
@@ -112,7 +116,7 @@ def main():
         digest=hashlib.sha256(CONTROLLER.read_bytes()).hexdigest(); expected=EXPECTED_PYTHON_SHA256[FIXTURE]
         if digest!=expected: raise RuntimeError(f"Submit Python sha256={digest}, expected={expected}")
         if not TMP_LAST.is_file() or TMP_LAST.read_text(encoding="utf-8").strip()!=PROJECT_NAME: raise RuntimeError("last-project state not updated")
-        print(f"PASS: real blockly.html/main.js Save, Submit and Restore buttons worked against real blocklyServer; submitted {FIXTURE} Python sha256 matched.")
+        print(f"PASS: real blockly.html/main.js initial restore plus Save, Submit and Restore buttons worked against real blocklyServer; submitted {FIXTURE} Python sha256 matched.")
         return 0
     finally:
         if server is not None: server.shutdown(); server.server_close()


### PR DESCRIPTION
### Motivation
The lower half of the historical workflow is already proven under real Webots R2025a: blocklyServer protocol, SEND_CODE execution, simulation reset/controller restart, and all five non-empty historical Blockly programs. The remaining integration gap is the browser-side Save/Submit/Restore path in the actual `blockly.html`/`main.js` UI.

### Description
- add a browser integration harness that loads the real vendored Blockly 2020 page and `main.js`;
- start the real rebuilt `blocklyServer` on localhost:8001;
- load the preserved `BoxWithDistSensor.xml` workspace, then click the actual Save, Submit and Restore buttons;
- require Restore to repopulate a workspace that was explicitly cleared;
- verify the saved XML exists and contains historical motor blocks;
- verify Submit writes Python whose SHA-256 exactly matches the preserved Blockly 2020 oracle;
- restore all modified files after the test.

This is deliberately a browser/DOM + real-sidecar integration gate, not a claim of full Webots Robot Window GUI automation. It exercises the actual historical UI handlers without duplicating the already-proven lower-level protocol tests.

Base: `webots-ci`. `main` is untouched.