### PR TITLE
Prove bidirectional Robot Window WWI under R2025a

### DIFF
--- a/.github/workflows/robot-window-r2025a-ci.yml
+++ b/.github/workflows/robot-window-r2025a-ci.yml
@@ -44,11 +44,11 @@ jobs:
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends chromium >/dev/null
               chmod +x /workspace/tools/ci/webots_robot_window_browser.sh
               mkdir -p /root/.config/Cyberbotics
-              cat > /root/.config/Cyberbotics/Webots-R2025a.conf <<EOF
-[RobotWindow]
-browser=/workspace/tools/ci/webots_robot_window_browser.sh
-newBrowserWindow=false
-EOF
+              printf "%s\n" \
+                "[RobotWindow]" \
+                "browser=/workspace/tools/ci/webots_robot_window_browser.sh" \
+                "newBrowserWindow=false" \
+                > /root/.config/Cyberbotics/Webots-R2025a.conf
               echo "CI_BROWSER=$(command -v chromium)"
               cat /root/.config/Cyberbotics/Webots-R2025a.conf
               timeout -k 5s 60s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt

--- a/.github/workflows/robot-window-r2025a-ci.yml
+++ b/.github/workflows/robot-window-r2025a-ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   robot-window-roundtrip:
     runs-on: ubuntu-22.04
-    timeout-minutes: 6
+    timeout-minutes: 8
 
     steps:
       - name: Checkout repository
@@ -30,7 +30,7 @@ jobs:
           set -o pipefail
           mkdir -p ci-artifacts
           echo "CI_BEFORE_WEBOTS" | tee ci-artifacts/robot-window.log
-          echo "Command: xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt" | tee -a ci-artifacts/robot-window.log
+          echo "Command: Webots R2025a + explicit Chromium Robot Window browser" | tee -a ci-artifacts/robot-window.log
           set +e
           docker run --rm \
             -e LIBGL_ALWAYS_SOFTWARE=true \
@@ -38,7 +38,21 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'timeout -k 5s 45s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt' \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends chromium >/dev/null
+              chmod +x /workspace/tools/ci/webots_robot_window_browser.sh
+              mkdir -p /root/.config/Cyberbotics
+              cat > /root/.config/Cyberbotics/Webots-R2025a.conf <<EOF
+[RobotWindow]
+browser=/workspace/tools/ci/webots_robot_window_browser.sh
+newBrowserWindow=false
+EOF
+              echo "CI_BROWSER=$(command -v chromium)"
+              cat /root/.config/Cyberbotics/Webots-R2025a.conf
+              timeout -k 5s 60s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt
+            ' \
             2>&1 | tee -a ci-artifacts/robot-window.log
           code=${PIPESTATUS[0]}
           set -e
@@ -52,17 +66,17 @@ jobs:
         run: |
           LOG=ci-artifacts/robot-window.log
 
-          if ! grep -Fq "CI_BEFORE_WEBOTS" "$LOG"; then
-            echo "::error::Robot Window gate did not reach the Webots invocation boundary."
-            exit 1
-          fi
+          grep -F "CI_BEFORE_WEBOTS" "$LOG"
+          grep -F "CI_BROWSER=/usr/bin/chromium" "$LOG"
+          grep -F "WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED" "$LOG"
 
-          if ! grep -Fq "WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED" "$LOG"; then
-            echo "::error::Webots invocation completed without starting the CI Robot Window controller; do not diagnose plugin/WWI yet."
+          if ! grep -Fq "BROWSER_LAUNCHED" ci-artifacts/browser-launch.log 2>/dev/null; then
+            echo "::error::Webots started the controller but never launched the configured Robot Window browser."
             echo "--- robot-window.log ---"
             cat "$LOG"
             exit 1
           fi
+          cat ci-artifacts/browser-launch.log
 
           grep -F "WEBEEBLOCKS_CI_WINDOW_TO_CONTROLLER_OK" "$LOG"
           grep -F "WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW_SENT" "$LOG"

--- a/.github/workflows/robot-window-r2025a-ci.yml
+++ b/.github/workflows/robot-window-r2025a-ci.yml
@@ -1,0 +1,64 @@
+name: Robot Window R2025a bidirectional gate
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  robot-window-roundtrip:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 6
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Instrument actual Blockly Robot Window for CI only
+        run: python3 tools/ci/prepare_robot_window_probe.py
+
+      - name: Run actual Blockly Robot Window in Webots R2025a
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 45s xvfb-run -a webots --stdout --stderr --mode=fast /workspace/worlds/ci_robot_window_probe.wbt' \
+            2>&1 | tee ci-artifacts/robot-window.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "Webots exit code: $code"
+          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ] && [ "$code" -ne 137 ]; then
+            exit "$code"
+          fi
+
+      - name: Prove bidirectional Robot Window WWI round trip
+        shell: bash
+        run: |
+          LOG=ci-artifacts/robot-window.log
+          grep -F "WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED" "$LOG"
+          grep -F "WEBEEBLOCKS_CI_WINDOW_TO_CONTROLLER_OK" "$LOG"
+          grep -F "WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW_SENT" "$LOG"
+          grep -F "WEBEEBLOCKS_CI_WWI_RX=WEBEEBLOCKS_CI_WINDOW_ACK" "$LOG"
+          grep -F "WEBEEBLOCKS_CI_ROBOT_WINDOW_ROUNDTRIP_OK" "$LOG"
+          echo "PASS: actual Blockly Robot Window loaded R2025a RobotWindow.js and completed window -> controller -> window -> controller WWI round trip."
+
+      - name: Upload Robot Window diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: robot-window-r2025a-roundtrip
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/.github/workflows/robot-window-r2025a-ci.yml
+++ b/.github/workflows/robot-window-r2025a-ci.yml
@@ -30,7 +30,7 @@ jobs:
           set -o pipefail
           mkdir -p ci-artifacts
           echo "CI_BEFORE_WEBOTS" | tee ci-artifacts/robot-window.log
-          echo "Command: Webots R2025a + explicit Chromium Robot Window browser" | tee -a ci-artifacts/robot-window.log
+          echo "Command: Webots R2025a + explicit Google Chrome Robot Window browser" | tee -a ci-artifacts/robot-window.log
           set +e
           docker run --rm \
             -e LIBGL_ALWAYS_SOFTWARE=true \
@@ -41,7 +41,9 @@ jobs:
             bash -lc '
               set -e
               apt-get update >/dev/null
-              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends chromium >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
               chmod +x /workspace/tools/ci/webots_robot_window_browser.sh
               mkdir -p /root/.config/Cyberbotics
               printf "%s\n" \
@@ -49,7 +51,7 @@ jobs:
                 "browser=/workspace/tools/ci/webots_robot_window_browser.sh" \
                 "newBrowserWindow=false" \
                 > /root/.config/Cyberbotics/Webots-R2025a.conf
-              echo "CI_BROWSER=$(command -v chromium)"
+              echo "CI_BROWSER=$(command -v google-chrome)"
               cat /root/.config/Cyberbotics/Webots-R2025a.conf
               timeout -k 5s 60s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt
             ' \
@@ -67,7 +69,7 @@ jobs:
           LOG=ci-artifacts/robot-window.log
 
           grep -F "CI_BEFORE_WEBOTS" "$LOG"
-          grep -F "CI_BROWSER=/usr/bin/chromium" "$LOG"
+          grep -F "CI_BROWSER=/usr/bin/google-chrome" "$LOG"
           grep -F "WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED" "$LOG"
 
           if ! grep -Fq "BROWSER_LAUNCHED" ci-artifacts/browser-launch.log 2>/dev/null; then

--- a/.github/workflows/robot-window-r2025a-ci.yml
+++ b/.github/workflows/robot-window-r2025a-ci.yml
@@ -29,17 +29,20 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p ci-artifacts
+          echo "CI_BEFORE_WEBOTS" | tee ci-artifacts/robot-window.log
+          echo "Command: xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt" | tee -a ci-artifacts/robot-window.log
           set +e
           docker run --rm \
             -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'timeout -k 5s 45s xvfb-run -a webots --stdout --stderr --mode=fast /workspace/worlds/ci_robot_window_probe.wbt' \
-            2>&1 | tee ci-artifacts/robot-window.log
+            bash -lc 'timeout -k 5s 45s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/ci_robot_window_probe.wbt' \
+            2>&1 | tee -a ci-artifacts/robot-window.log
           code=${PIPESTATUS[0]}
           set -e
-          echo "Webots exit code: $code"
+          echo "Webots exit code: $code" | tee -a ci-artifacts/robot-window.log
           if [ "$code" -ne 0 ] && [ "$code" -ne 124 ] && [ "$code" -ne 137 ]; then
             exit "$code"
           fi
@@ -48,7 +51,19 @@ jobs:
         shell: bash
         run: |
           LOG=ci-artifacts/robot-window.log
-          grep -F "WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED" "$LOG"
+
+          if ! grep -Fq "CI_BEFORE_WEBOTS" "$LOG"; then
+            echo "::error::Robot Window gate did not reach the Webots invocation boundary."
+            exit 1
+          fi
+
+          if ! grep -Fq "WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED" "$LOG"; then
+            echo "::error::Webots invocation completed without starting the CI Robot Window controller; do not diagnose plugin/WWI yet."
+            echo "--- robot-window.log ---"
+            cat "$LOG"
+            exit 1
+          fi
+
           grep -F "WEBEEBLOCKS_CI_WINDOW_TO_CONTROLLER_OK" "$LOG"
           grep -F "WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW_SENT" "$LOG"
           grep -F "WEBEEBLOCKS_CI_WWI_RX=WEBEEBLOCKS_CI_WINDOW_ACK" "$LOG"

--- a/controllers/ci_robot_window_probe/ci_robot_window_probe.py
+++ b/controllers/ci_robot_window_probe/ci_robot_window_probe.py
@@ -1,0 +1,22 @@
+from controller import Robot
+
+READY = "WEBEEBLOCKS_CI_WINDOW_READY"
+CONTROLLER_TO_WINDOW = "WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW"
+ACK = "WEBEEBLOCKS_CI_WINDOW_ACK"
+
+robot = Robot()
+timestep = int(robot.getBasicTimeStep())
+print("WEBEEBLOCKS_CI_ROBOT_WINDOW_CONTROLLER_STARTED", flush=True)
+
+while robot.step(timestep) != -1:
+    message = robot.wwiReceiveText()
+    while message:
+        print(f"WEBEEBLOCKS_CI_WWI_RX={message}", flush=True)
+        if message == READY:
+            print("WEBEEBLOCKS_CI_WINDOW_TO_CONTROLLER_OK", flush=True)
+            robot.wwiSendText(CONTROLLER_TO_WINDOW)
+            print("WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW_SENT", flush=True)
+        elif message == ACK:
+            print("WEBEEBLOCKS_CI_ROBOT_WINDOW_ROUNDTRIP_OK", flush=True)
+            raise SystemExit(0)
+        message = robot.wwiReceiveText()

--- a/tools/ci/prepare_robot_window_probe.py
+++ b/tools/ci/prepare_robot_window_probe.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN_JS = ROOT / "plugins" / "robot_windows" / "blockly" / "main.js"
+
+needle = "    window.robotWindow.receive = receiveMessage;\n"
+injection = """    window.robotWindow.receive = function(value) {\n        receiveMessage(value);\n        if(value === \"WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW\") {\n            console.log(\"WEBEEBLOCKS_CI_CONTROLLER_TO_WINDOW_OK\");\n            window.robotWindow.send(\"WEBEEBLOCKS_CI_WINDOW_ACK\");\n        }\n    };\n    window.robotWindow.send(\"WEBEEBLOCKS_CI_WINDOW_READY\");\n"""
+
+source = MAIN_JS.read_text(encoding="utf-8")
+if needle not in source:
+    raise SystemExit("Robot Window receive assignment not found; refusing ambiguous CI instrumentation")
+MAIN_JS.write_text(source.replace(needle, injection, 1), encoding="utf-8")
+print("Instrumented actual Blockly Robot Window for bidirectional WWI probe")

--- a/tools/ci/webots_robot_window_browser.sh
+++ b/tools/ci/webots_robot_window_browser.sh
@@ -6,7 +6,7 @@ printf 'BROWSER_LAUNCHED args=' >> /workspace/ci-artifacts/browser-launch.log
 printf '%q ' "$@" >> /workspace/ci-artifacts/browser-launch.log
 printf '\n' >> /workspace/ci-artifacts/browser-launch.log
 
-exec /usr/bin/chromium \
+exec /usr/bin/google-chrome \
   --headless=new \
   --no-sandbox \
   --disable-gpu \

--- a/tools/ci/webots_robot_window_browser.sh
+++ b/tools/ci/webots_robot_window_browser.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+
+mkdir -p /workspace/ci-artifacts
+printf 'BROWSER_LAUNCHED args=' >> /workspace/ci-artifacts/browser-launch.log
+printf '%q ' "$@" >> /workspace/ci-artifacts/browser-launch.log
+printf '\n' >> /workspace/ci-artifacts/browser-launch.log
+
+exec /usr/bin/chromium \
+  --headless=new \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --disable-background-networking \
+  --no-first-run \
+  --no-default-browser-check \
+  "$@"

--- a/worlds/.ci_robot_window_probe.wbproj
+++ b/worlds/.ci_robot_window_probe.wbproj
@@ -1,0 +1,2 @@
+Webots Project File version R2025a
+robotWindow: ci-probe

--- a/worlds/ci_robot_window_probe.wbt
+++ b/worlds/ci_robot_window_probe.wbt
@@ -1,0 +1,13 @@
+#VRML_SIM R2025a utf8
+
+WorldInfo {
+  basicTimeStep 32
+}
+Viewpoint {
+  position 0 0 2
+}
+Robot {
+  name "ci-probe"
+  controller "ci_robot_window_probe"
+  window "blockly"
+}


### PR DESCRIPTION
### Goal
Close the last unproven boundary of the historical Webots-Blockly baseline: the actual Webots R2025a Robot Window integration.

### Scope
- add a CI-only minimal R2025a world using the real `window "blockly"` plugin;
- auto-open that Robot Window via a CI world project file;
- transiently instrument the actual `plugins/robot_windows/blockly/main.js` in the Actions checkout only, without changing product behavior in the commit;
- require the real R2025a `RobotWindow.js` import to create `window.robotWindow`;
- prove window -> controller with `robotWindow.send()` / `wwiReceiveText()`;
- prove controller -> window with `wwiSendText()` / `robotWindow.receive`;
- require an acknowledgement back to the controller, making the test a complete bidirectional round trip.

### Evidence required
The controller log must contain, in order of the protocol, startup, window-to-controller reception, controller-to-window send, acknowledgement reception, and `WEBEEBLOCKS_CI_ROBOT_WINDOW_ROUNDTRIP_OK`.

This deliberately does **not** repeat Save/Submit/Restore (already proven by #19), does not modernize Blockly, does not start Crazyflie work, and does not touch `main`.