### PR TITLE
Run measured Crazyflie square under R2025a

### DIFF
--- a/.github/workflows/crazyflie-square-r2025a.yml
+++ b/.github/workflows/crazyflie-square-r2025a.yml
@@ -1,0 +1,79 @@
+name: Crazyflie square R2025a gate
+
+on:
+  push:
+    branches: [webots-ci]
+  pull_request:
+    branches: [webots-ci]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  crazyflie-square:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 7
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build measured square controller
+        shell: bash
+        run: |
+          mkdir -p ci-artifacts
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_square \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/crazyflie-square-build.log
+
+      - name: Fly one measured 1 m square
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_square.wbt' \
+            2>&1 | tee ci-artifacts/crazyflie-square.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/crazyflie-square-exit-code.txt
+          exit "$code"
+
+      - name: Validate measured square result
+        shell: bash
+        run: |
+          LOG=ci-artifacts/crazyflie-square.log
+          if grep -Fq 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"; then
+            grep -F 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"
+            exit 1
+          fi
+          if grep -Fq 'ERROR:' "$LOG"; then
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+          RESULT=$(grep -F 'WEBEEBLOCKS_CF_SQUARE_RESULT status=success' "$LOG" | tail -1)
+          if [ -z "$RESULT" ]; then
+            echo '::error::Measured square completion marker missing.'
+            exit 1
+          fi
+          echo "$RESULT"
+          echo "$RESULT" | grep -Fq 'legs=4'
+
+      - name: Upload Crazyflie square diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crazyflie-square-r2025a
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/.github/workflows/crazyflie-square-r2025a.yml
+++ b/.github/workflows/crazyflie-square-r2025a.yml
@@ -24,6 +24,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ci-artifacts
+          rm -f ci-artifacts/crazyflie-square-result.txt
           set -o pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
@@ -54,6 +55,7 @@ jobs:
         shell: bash
         run: |
           LOG=ci-artifacts/crazyflie-square.log
+          RESULT_FILE=ci-artifacts/crazyflie-square-result.txt
           if grep -Fq 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"; then
             grep -F 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"
             exit 1
@@ -62,12 +64,13 @@ jobs:
             grep -F 'ERROR:' "$LOG"
             exit 1
           fi
-          RESULT=$(grep -F 'WEBEEBLOCKS_CF_SQUARE_RESULT status=success' "$LOG" | tail -1)
-          if [ -z "$RESULT" ]; then
-            echo '::error::Measured square completion marker missing.'
+          if [ ! -s "$RESULT_FILE" ]; then
+            echo '::error::Measured square result file missing.'
             exit 1
           fi
+          RESULT=$(tail -1 "$RESULT_FILE")
           echo "$RESULT"
+          echo "$RESULT" | grep -Fq 'WEBEEBLOCKS_CF_SQUARE_RESULT status=success'
           echo "$RESULT" | grep -Fq 'legs=4'
 
       - name: Upload Crazyflie square diagnostics

--- a/controllers/crazyflie_square/Makefile
+++ b/controllers/crazyflie_square/Makefile
@@ -1,0 +1,6 @@
+C_SOURCES = crazyflie_square.c pid_controller.c
+
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -1,0 +1,77 @@
+#include <math.h>
+#include <stdio.h>
+#include <webots/gps.h>
+#include <webots/gyro.h>
+#include <webots/inertial_unit.h>
+#include <webots/motor.h>
+#include <webots/robot.h>
+#include <webots/supervisor.h>
+#include "pid_controller.h"
+
+#define PI 3.14159265358979323846
+#define TARGET_Z_DELTA 1.0
+#define LEG_M 1.0
+#define VX 0.35
+#define YAW_RATE 0.7
+#define TIMEOUT 60.0
+
+typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
+
+static double wrap(double a) {
+  while (a > PI) a -= 2 * PI;
+  while (a < -PI) a += 2 * PI;
+  return a;
+}
+static double motor(double v) { return v < 0 ? 0 : (v > 600 ? 600 : v); }
+static void stop(WbDeviceTag a, WbDeviceTag b, WbDeviceTag c, WbDeviceTag d) {
+  wb_motor_set_velocity(a,0); wb_motor_set_velocity(b,0); wb_motor_set_velocity(c,0); wb_motor_set_velocity(d,0);
+}
+
+int main(void) {
+  wb_robot_init();
+  const int step=(int)wb_robot_get_basic_time_step();
+  WbDeviceTag m1=wb_robot_get_device("m1_motor"),m2=wb_robot_get_device("m2_motor");
+  WbDeviceTag m3=wb_robot_get_device("m3_motor"),m4=wb_robot_get_device("m4_motor");
+  WbDeviceTag gps=wb_robot_get_device("gps"),imu=wb_robot_get_device("inertial_unit"),gyro=wb_robot_get_device("gyro");
+  wb_motor_set_position(m1,INFINITY); wb_motor_set_position(m2,INFINITY); wb_motor_set_position(m3,INFINITY); wb_motor_set_position(m4,INFINITY);
+  wb_motor_set_velocity(m1,-1); wb_motor_set_velocity(m2,1); wb_motor_set_velocity(m3,-1); wb_motor_set_velocity(m4,1);
+  wb_gps_enable(gps,step); wb_inertial_unit_enable(imu,step); wb_gyro_enable(gyro,step);
+  while(wb_robot_step(step)!=-1 && wb_robot_get_time()<2.0){}
+
+  const double *p=wb_gps_get_values(gps),*r=wb_inertial_unit_get_roll_pitch_yaw(imu);
+  const double sx=p[0],sy=p[1],sz=p[2],syaw=r[2],target_z=sz+TARGET_Z_DELTA;
+  double min_z=sz,max_z=sz,px=sx,py=sy,pz=sz,pt=wb_robot_get_time(),leg_x=sx,leg_y=sy,prev_yaw=syaw,turn_angle=0,stable=-1;
+  const double t0=pt;
+  int leg=0; phase_t phase=TAKEOFF;
+  gains_pid_t g={0}; g.kp_att_y=1;g.kd_att_y=.5;g.kp_att_rp=.5;g.kd_att_rp=.1;g.kp_vel_xy=2;g.kd_vel_xy=.5;g.kp_z=10;g.ki_z=5;g.kd_z=5;
+  init_pid_attitude_fixed_height_controller();
+  actual_state_t a={0}; desired_state_t d={0}; motor_power_t power={0};
+  printf("WEBEEBLOCKS_CF_SQUARE_STARTED x=%.6f y=%.6f z=%.6f yaw=%.6f\n",sx,sy,sz,syaw);
+
+  while(wb_robot_step(step)!=-1){
+    double now=wb_robot_get_time(),dt=now-pt; if(dt<=0) continue;
+    p=wb_gps_get_values(gps);r=wb_inertial_unit_get_roll_pitch_yaw(imu);const double *gv=wb_gyro_get_values(gyro);
+    double x=p[0],y=p[1],z=p[2],yaw=r[2],vz=(z-pz)/dt,vxg=(x-px)/dt,vyg=(y-py)/dt,cy=cos(yaw),syy=sin(yaw);
+    if(z<min_z)min_z=z;if(z>max_z)max_z=z;
+    a.roll=r[0];a.pitch=r[1];a.yaw_rate=gv[2];a.altitude=z;a.vx=vxg*cy+vyg*syy;a.vy=-vxg*syy+vyg*cy;
+    d.roll=0;d.pitch=0;d.vx=0;d.vy=0;d.yaw_rate=0;d.altitude=target_z;
+    if(fabs(a.roll)>1.2||fabs(a.pitch)>1.2||now-t0>TIMEOUT){
+      printf("WEBEEBLOCKS_CF_SQUARE_FAILED phase=%d leg=%d t=%.3f\n",phase,leg,now-t0);stop(m1,m2,m3,m4);fflush(stdout);wb_supervisor_simulation_quit(2);break;
+    }
+    if(phase==TAKEOFF){
+      if(fabs(z-target_z)<.05&&fabs(vz)<.15){if(stable<0)stable=now;if(now-stable>.5){phase=LEG;leg_x=x;leg_y=y;stable=-1;}}else stable=-1;
+    }else if(phase==LEG){
+      d.vx=VX;if(hypot(x-leg_x,y-leg_y)>=LEG_M){phase=TURN;turn_angle=0;prev_yaw=yaw;}
+    }else if(phase==TURN){
+      d.yaw_rate=YAW_RATE;turn_angle+=wrap(yaw-prev_yaw);prev_yaw=yaw;
+      if(turn_angle>=PI/2){leg++;if(leg==4){phase=LAND;stable=-1;}else{phase=LEG;leg_x=x;leg_y=y;}}
+    }else{
+      d.altitude=sz;
+      if(z<=sz+.05&&fabs(vz)<.15){if(stable<0)stable=now;if(now-stable>.5){double err=hypot(x-sx,y-sy),yawerr=fabs(wrap(yaw-syaw))*180/PI;printf("WEBEEBLOCKS_CF_SQUARE_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",err,yawerr,min_z,max_z,now-t0,leg);stop(m1,m2,m3,m4);fflush(stdout);wb_supervisor_simulation_quit(0);break;}}else stable=-1;
+    }
+    pid_velocity_fixed_height_controller(a,&d,g,dt,&power);
+    wb_motor_set_velocity(m1,-motor(power.m1));wb_motor_set_velocity(m2,motor(power.m2));wb_motor_set_velocity(m3,-motor(power.m3));wb_motor_set_velocity(m4,motor(power.m4));
+    pt=now;px=x;py=y;pz=z;
+  }
+  stop(m1,m2,m3,m4);wb_robot_cleanup();return 0;
+}

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -41,6 +41,21 @@ static void log_state(const char *event, phase_t phase, int leg, double t, doubl
          event, phase_name(phase), leg, t, x, y, z, yaw, roll, pitch, vz);
   fflush(stdout);
 }
+static void write_result_file(double err, double yawerr, double min_z, double max_z, double total, int legs) {
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-square-result.txt", wb_robot_get_project_path());
+  FILE *file = fopen(path, "w");
+  if (!file) {
+    printf("WEBEEBLOCKS_CF_SQUARE_RESULT_FILE_FAILED path=%s\n", path);
+    fflush(stdout);
+    return;
+  }
+  fprintf(file,
+          "WEBEEBLOCKS_CF_SQUARE_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",
+          err, yawerr, min_z, max_z, total, legs);
+  fflush(file);
+  fclose(file);
+}
 
 int main(void) {
   wb_robot_init();
@@ -114,6 +129,7 @@ int main(void) {
         if(stable<0)stable=now;
         if(now-stable>.5){
           double err=hypot(x-sx,y-sy),yawerr=fabs(wrap(yaw-syaw))*180/PI;
+          write_result_file(err,yawerr,min_z,max_z,now-t0,leg);
           printf("WEBEEBLOCKS_CF_SQUARE_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",err,yawerr,min_z,max_z,now-t0,leg);
           printf("WEBEEBLOCKS_CF_SQUARE_QUIT reason=success phase=%s leg=%d t=%.3f\n",phase_name(phase),leg,now-t0);
           stop(m1,m2,m3,m4);fflush(stdout);wb_supervisor_simulation_quit(0);break;

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -26,6 +26,21 @@ static double motor(double v) { return v < 0 ? 0 : (v > 600 ? 600 : v); }
 static void stop(WbDeviceTag a, WbDeviceTag b, WbDeviceTag c, WbDeviceTag d) {
   wb_motor_set_velocity(a,0); wb_motor_set_velocity(b,0); wb_motor_set_velocity(c,0); wb_motor_set_velocity(d,0);
 }
+static const char *phase_name(phase_t phase) {
+  switch (phase) {
+    case TAKEOFF: return "TAKEOFF";
+    case LEG: return "LEG";
+    case TURN: return "TURN";
+    case LAND: return "LAND";
+  }
+  return "UNKNOWN";
+}
+static void log_state(const char *event, phase_t phase, int leg, double t, double x, double y, double z,
+                      double yaw, double roll, double pitch, double vz) {
+  printf("WEBEEBLOCKS_CF_SQUARE_%s phase=%s leg=%d t=%.3f x=%.6f y=%.6f z=%.6f yaw=%.6f roll=%.6f pitch=%.6f vz=%.6f\n",
+         event, phase_name(phase), leg, t, x, y, z, yaw, roll, pitch, vz);
+  fflush(stdout);
+}
 
 int main(void) {
   wb_robot_init();
@@ -42,36 +57,74 @@ int main(void) {
   const double sx=p[0],sy=p[1],sz=p[2],syaw=r[2],target_z=sz+TARGET_Z_DELTA;
   double min_z=sz,max_z=sz,px=sx,py=sy,pz=sz,pt=wb_robot_get_time(),leg_x=sx,leg_y=sy,prev_yaw=syaw,turn_angle=0,stable=-1;
   const double t0=pt;
+  double next_heartbeat=t0;
   int leg=0; phase_t phase=TAKEOFF;
   gains_pid_t g={0}; g.kp_att_y=1;g.kd_att_y=.5;g.kp_att_rp=.5;g.kd_att_rp=.1;g.kp_vel_xy=2;g.kd_vel_xy=.5;g.kp_z=10;g.ki_z=5;g.kd_z=5;
   init_pid_attitude_fixed_height_controller();
   actual_state_t a={0}; desired_state_t d={0}; motor_power_t power={0};
   printf("WEBEEBLOCKS_CF_SQUARE_STARTED x=%.6f y=%.6f z=%.6f yaw=%.6f\n",sx,sy,sz,syaw);
+  fflush(stdout);
+  log_state("PHASE_ENTER", phase, leg, 0.0, sx, sy, sz, syaw, r[0], r[1], 0.0);
 
-  while(wb_robot_step(step)!=-1){
+  int step_result;
+  while((step_result=wb_robot_step(step))!=-1){
     double now=wb_robot_get_time(),dt=now-pt; if(dt<=0) continue;
     p=wb_gps_get_values(gps);r=wb_inertial_unit_get_roll_pitch_yaw(imu);const double *gv=wb_gyro_get_values(gyro);
     double x=p[0],y=p[1],z=p[2],yaw=r[2],vz=(z-pz)/dt,vxg=(x-px)/dt,vyg=(y-py)/dt,cy=cos(yaw),syy=sin(yaw);
     if(z<min_z)min_z=z;if(z>max_z)max_z=z;
     a.roll=r[0];a.pitch=r[1];a.yaw_rate=gv[2];a.altitude=z;a.vx=vxg*cy+vyg*syy;a.vy=-vxg*syy+vyg*cy;
     d.roll=0;d.pitch=0;d.vx=0;d.vy=0;d.yaw_rate=0;d.altitude=target_z;
+
+    if(now>=next_heartbeat){
+      log_state("HEARTBEAT", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
+      next_heartbeat=now+1.0;
+    }
+
     if(fabs(a.roll)>1.2||fabs(a.pitch)>1.2||now-t0>TIMEOUT){
-      printf("WEBEEBLOCKS_CF_SQUARE_FAILED phase=%d leg=%d t=%.3f\n",phase,leg,now-t0);stop(m1,m2,m3,m4);fflush(stdout);wb_supervisor_simulation_quit(2);break;
+      const char *reason=(fabs(a.roll)>1.2||fabs(a.pitch)>1.2)?"tilt":"internal-timeout";
+      printf("WEBEEBLOCKS_CF_SQUARE_QUIT reason=%s phase=%s leg=%d t=%.3f\n",reason,phase_name(phase),leg,now-t0);
+      printf("WEBEEBLOCKS_CF_SQUARE_FAILED phase=%d leg=%d t=%.3f\n",phase,leg,now-t0);
+      fflush(stdout);stop(m1,m2,m3,m4);wb_supervisor_simulation_quit(2);break;
     }
     if(phase==TAKEOFF){
-      if(fabs(z-target_z)<.05&&fabs(vz)<.15){if(stable<0)stable=now;if(now-stable>.5){phase=LEG;leg_x=x;leg_y=y;stable=-1;}}else stable=-1;
+      if(fabs(z-target_z)<.05&&fabs(vz)<.15){
+        if(stable<0)stable=now;
+        if(now-stable>.5){
+          phase=LEG;leg_x=x;leg_y=y;stable=-1;
+          log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
+        }
+      }else stable=-1;
     }else if(phase==LEG){
-      d.vx=VX;if(hypot(x-leg_x,y-leg_y)>=LEG_M){phase=TURN;turn_angle=0;prev_yaw=yaw;}
+      d.vx=VX;
+      if(hypot(x-leg_x,y-leg_y)>=LEG_M){
+        phase=TURN;turn_angle=0;prev_yaw=yaw;
+        log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
+      }
     }else if(phase==TURN){
       d.yaw_rate=YAW_RATE;turn_angle+=wrap(yaw-prev_yaw);prev_yaw=yaw;
-      if(turn_angle>=PI/2){leg++;if(leg==4){phase=LAND;stable=-1;}else{phase=LEG;leg_x=x;leg_y=y;}}
+      if(turn_angle>=PI/2){
+        leg++;
+        if(leg==4){phase=LAND;stable=-1;}
+        else{phase=LEG;leg_x=x;leg_y=y;}
+        log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
+      }
     }else{
       d.altitude=sz;
-      if(z<=sz+.05&&fabs(vz)<.15){if(stable<0)stable=now;if(now-stable>.5){double err=hypot(x-sx,y-sy),yawerr=fabs(wrap(yaw-syaw))*180/PI;printf("WEBEEBLOCKS_CF_SQUARE_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",err,yawerr,min_z,max_z,now-t0,leg);stop(m1,m2,m3,m4);fflush(stdout);wb_supervisor_simulation_quit(0);break;}}else stable=-1;
+      if(z<=sz+.05&&fabs(vz)<.15){
+        if(stable<0)stable=now;
+        if(now-stable>.5){
+          double err=hypot(x-sx,y-sy),yawerr=fabs(wrap(yaw-syaw))*180/PI;
+          printf("WEBEEBLOCKS_CF_SQUARE_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",err,yawerr,min_z,max_z,now-t0,leg);
+          printf("WEBEEBLOCKS_CF_SQUARE_QUIT reason=success phase=%s leg=%d t=%.3f\n",phase_name(phase),leg,now-t0);
+          stop(m1,m2,m3,m4);fflush(stdout);wb_supervisor_simulation_quit(0);break;
+        }
+      }else stable=-1;
     }
     pid_velocity_fixed_height_controller(a,&d,g,dt,&power);
     wb_motor_set_velocity(m1,-motor(power.m1));wb_motor_set_velocity(m2,motor(power.m2));wb_motor_set_velocity(m3,-motor(power.m3));wb_motor_set_velocity(m4,motor(power.m4));
     pt=now;px=x;py=y;pz=z;
   }
+  printf("WEBEEBLOCKS_CF_SQUARE_LOOP_EXIT step_result=%d t=%.3f phase=%s leg=%d\n",step_result,wb_robot_get_time()-t0,phase_name(phase),leg);
+  fflush(stdout);
   stop(m1,m2,m3,m4);wb_robot_cleanup();return 0;
 }

--- a/controllers/crazyflie_square/pid_controller.c
+++ b/controllers/crazyflie_square/pid_controller.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Bitcraze AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "pid_controller.h"
+
+float constrain(float value, const float minVal, const float maxVal) {
+  return fminf(maxVal, fmaxf(minVal, value));
+}
+
+double pastAltitudeError, pastPitchError, pastRollError, pastYawRateError;
+double pastVxError, pastVyError;
+double altitudeIntegrator;
+
+void init_pid_attitude_fixed_height_controller() {
+  pastAltitudeError = 0;
+  pastYawRateError = 0;
+  pastPitchError = 0;
+  pastRollError = 0;
+  pastVxError = 0;
+  pastVyError = 0;
+  altitudeIntegrator = 0;
+}
+
+void pid_attitude_fixed_height_controller(actual_state_t actual_state, const desired_state_t *desired_state,
+                                          gains_pid_t gains_pid, double dt, motor_power_t *motorCommands) {
+  control_commands_t control_commands = {0};
+  pid_fixed_height_controller(actual_state, desired_state, gains_pid, dt, &control_commands);
+  pid_attitude_controller(actual_state, desired_state, gains_pid, dt, &control_commands);
+  motor_mixing(control_commands, motorCommands);
+}
+
+void pid_velocity_fixed_height_controller(actual_state_t actual_state, desired_state_t *desired_state,
+                                          gains_pid_t gains_pid, double dt, motor_power_t *motorCommands) {
+  control_commands_t control_commands = {0};
+  pid_horizontal_velocity_controller(actual_state, desired_state, gains_pid, dt);
+  pid_fixed_height_controller(actual_state, desired_state, gains_pid, dt, &control_commands);
+  pid_attitude_controller(actual_state, desired_state, gains_pid, dt, &control_commands);
+  motor_mixing(control_commands, motorCommands);
+}
+
+void pid_fixed_height_controller(actual_state_t actual_state, const desired_state_t *desired_state,
+                                 gains_pid_t gains_pid, double dt, control_commands_t *control_commands) {
+  double altitudeError = desired_state->altitude - actual_state.altitude;
+  double altitudeDerivativeError = (altitudeError - pastAltitudeError) / dt;
+
+  altitudeIntegrator += altitudeError * dt;
+  control_commands->altitude = gains_pid.kp_z * constrain(altitudeError, -1, 1) +
+                               gains_pid.kd_z * altitudeDerivativeError +
+                               gains_pid.ki_z * altitudeIntegrator + 48;
+  pastAltitudeError = altitudeError;
+}
+
+void motor_mixing(control_commands_t control_commands, motor_power_t *motorCommands) {
+  motorCommands->m1 = control_commands.altitude - control_commands.roll + control_commands.pitch + control_commands.yaw;
+  motorCommands->m2 = control_commands.altitude - control_commands.roll - control_commands.pitch - control_commands.yaw;
+  motorCommands->m3 = control_commands.altitude + control_commands.roll - control_commands.pitch + control_commands.yaw;
+  motorCommands->m4 = control_commands.altitude + control_commands.roll + control_commands.pitch - control_commands.yaw;
+}
+
+void pid_attitude_controller(actual_state_t actual_state, const desired_state_t *desired_state,
+                             gains_pid_t gains_pid, double dt, control_commands_t *control_commands) {
+  double pitchError = desired_state->pitch - actual_state.pitch;
+  double pitchDerivativeError = (pitchError - pastPitchError) / dt;
+  double rollError = desired_state->roll - actual_state.roll;
+  double rollDerivativeError = (rollError - pastRollError) / dt;
+  double yawRateError = desired_state->yaw_rate - actual_state.yaw_rate;
+
+  control_commands->roll = gains_pid.kp_att_rp * constrain(rollError, -1, 1) +
+                           gains_pid.kd_att_rp * rollDerivativeError;
+  control_commands->pitch = -gains_pid.kp_att_rp * constrain(pitchError, -1, 1) -
+                            gains_pid.kd_att_rp * pitchDerivativeError;
+  control_commands->yaw = gains_pid.kp_att_y * constrain(yawRateError, -1, 1);
+
+  pastPitchError = pitchError;
+  pastRollError = rollError;
+  pastYawRateError = yawRateError;
+}
+
+void pid_horizontal_velocity_controller(actual_state_t actual_state, desired_state_t *desired_state,
+                                        gains_pid_t gains_pid, double dt) {
+  double vxError = desired_state->vx - actual_state.vx;
+  double vxDerivative = (vxError - pastVxError) / dt;
+  double vyError = desired_state->vy - actual_state.vy;
+  double vyDerivative = (vyError - pastVyError) / dt;
+
+  double pitchCommand = gains_pid.kp_vel_xy * constrain(vxError, -1, 1) + gains_pid.kd_vel_xy * vxDerivative;
+  double rollCommand = -gains_pid.kp_vel_xy * constrain(vyError, -1, 1) - gains_pid.kd_vel_xy * vyDerivative;
+
+  desired_state->pitch = pitchCommand;
+  desired_state->roll = rollCommand;
+
+  pastVxError = vxError;
+  pastVyError = vyError;
+}

--- a/controllers/crazyflie_square/pid_controller.h
+++ b/controllers/crazyflie_square/pid_controller.h
@@ -1,0 +1,75 @@
+#pragma once
+
+/*
+ * Copyright 2022 Bitcraze AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef struct motor_power_s {
+  double m1;
+  double m2;
+  double m3;
+  double m4;
+} motor_power_t;
+
+typedef struct control_commands_s {
+  double roll;
+  double pitch;
+  double yaw;
+  double altitude;
+} control_commands_t;
+
+typedef struct desired_state_s {
+  double roll;
+  double pitch;
+  double yaw_rate;
+  double altitude;
+  double vx;
+  double vy;
+} desired_state_t;
+
+typedef struct actual_state_s {
+  double roll;
+  double pitch;
+  double yaw_rate;
+  double altitude;
+  double vx;
+  double vy;
+} actual_state_t;
+
+typedef struct gains_pid_s {
+  double kp_att_rp;
+  double kd_att_rp;
+  double kp_att_y;
+  double kd_att_y;
+  double kp_vel_xy;
+  double kd_vel_xy;
+  double kp_z;
+  double kd_z;
+  double ki_z;
+} gains_pid_t;
+
+float constrain(float value, const float minVal, const float maxVal);
+void init_pid_attitude_fixed_height_controller();
+void pid_attitude_fixed_height_controller(actual_state_t actual_state, const desired_state_t *desired_state,
+                                          gains_pid_t gains_pid, double dt, motor_power_t *motorCommands);
+void pid_velocity_fixed_height_controller(actual_state_t actual_state, desired_state_t *desired_state,
+                                          gains_pid_t gains_pid, double dt, motor_power_t *motorCommands);
+void pid_fixed_height_controller(actual_state_t actual_state, const desired_state_t *desired_state,
+                                 gains_pid_t gains_pid, double dt, control_commands_t *control_commands);
+void motor_mixing(control_commands_t control_commands, motor_power_t *motorCommands);
+void pid_attitude_controller(actual_state_t actual_state, const desired_state_t *desired_state,
+                             gains_pid_t gains_pid, double dt, control_commands_t *control_commands);
+void pid_horizontal_velocity_controller(actual_state_t actual_state, desired_state_t *desired_state,
+                                        gains_pid_t gains_pid, double dt);

--- a/worlds/crazyflie_square.wbt
+++ b/worlds/crazyflie_square.wbt
@@ -1,0 +1,28 @@
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "webots://projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "webots://projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "webots://projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "webots://projects/objects/floors/protos/Floor.proto"
+
+WorldInfo {
+  basicTimeStep 32
+  title "WebeeBlocks Crazyflie square experiment"
+}
+Viewpoint {
+  orientation -0.45 0.47 0.76 1.05
+  position -3 -3 3
+  follow "Crazyflie"
+}
+TexturedBackground {
+}
+TexturedBackgroundLight {
+}
+Floor {
+  size 6 6
+}
+Crazyflie {
+  name "Crazyflie"
+  controller "crazyflie_square"
+  supervisor TRUE
+}

--- a/worlds/crazyflie_square.wbt
+++ b/worlds/crazyflie_square.wbt
@@ -1,9 +1,9 @@
 #VRML_SIM R2025a utf8
 
-EXTERNPROTO "webots://projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
-EXTERNPROTO "webots://projects/objects/backgrounds/protos/TexturedBackground.proto"
-EXTERNPROTO "webots://projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
-EXTERNPROTO "webots://projects/objects/floors/protos/Floor.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
 
 WorldInfo {
   basicTimeStep 32


### PR DESCRIPTION
## Goal
Start the simulated Crazyflie phase with the smallest discriminating experiment requested by Lead: one measured 1 m × 1 m square under real Webots R2025a.

## Changes
- use the native R2025a `Crazyflie.proto` through `webots://`;
- reuse the Bitcraze/Cyberbotics reference velocity + fixed-altitude PID;
- replace only the keyboard with a measured mission state machine: takeoff, four 1 m legs, four measured 90° turns, land;
- terminate legs from measured GPS displacement and turns from measured IMU yaw, not from blind timing;
- emit measured closure error, yaw error, altitude min/max and total time;
- add an isolated GitHub Actions gate using `cyberbotics/webots:R2025a-ubuntu22.04`.

## Scope
This is backend A only (relative/body-velocity semantics). It does not add Blockly product UI, obstacles, cflib, ROS, firmware SITL, or backend B. No changes to `main`.

## Acceptance
The first gate must complete one full measured square and land without Webots errors, timeout, excessive-tilt failure, or missing completion marker. Accuracy thresholds are deliberately not fixed yet; the first real run establishes the measured baseline before the 10-run repeatability experiment.