### PR TITLE
Measure Crazyflie square repeatability under R2025a

### DIFF
--- a/.github/workflows/crazyflie-square-r2025a.yml
+++ b/.github/workflows/crazyflie-square-r2025a.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   crazyflie-square:
     runs-on: ubuntu-22.04
-    timeout-minutes: 7
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
 
@@ -23,8 +23,9 @@ jobs:
       - name: Build measured square controller
         shell: bash
         run: |
-          mkdir -p ci-artifacts
+          mkdir -p ci-artifacts/crazyflie-repeatability
           rm -f ci-artifacts/crazyflie-square-result.txt
+          rm -f ci-artifacts/crazyflie-repeatability/*
           set -o pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
@@ -33,45 +34,65 @@ jobs:
             bash -lc 'make clean && make' \
             2>&1 | tee ci-artifacts/crazyflie-square-build.log
 
-      - name: Fly one measured 1 m square
+      - name: Fly ten identical measured 1 m squares
         shell: bash
         run: |
-          set +e
-          set -o pipefail
-          docker run --rm \
-            -e LIBGL_ALWAYS_SOFTWARE=true \
-            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_square.wbt' \
-            2>&1 | tee ci-artifacts/crazyflie-square.log
-          code=${PIPESTATUS[0]}
-          set -e
-          echo "$code" > ci-artifacts/crazyflie-square-exit-code.txt
-          exit "$code"
+          set -euo pipefail
+          for run in $(seq 1 10); do
+            printf -v run_id '%02d' "$run"
+            LOG="ci-artifacts/crazyflie-repeatability/run-${run_id}.log"
+            EXIT_FILE="ci-artifacts/crazyflie-repeatability/run-${run_id}-exit-code.txt"
+            RESULT_COPY="ci-artifacts/crazyflie-repeatability/run-${run_id}-result.txt"
+            RESULT_FILE="ci-artifacts/crazyflie-square-result.txt"
 
-      - name: Validate measured square result
+            # Fail closed against stale output: every Webots process must create
+            # its own fresh persisted result.
+            rm -f "$RESULT_FILE"
+
+            set +e
+            docker run --rm \
+              -e LIBGL_ALWAYS_SOFTWARE=true \
+              -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+              -v "${{ github.workspace }}:/workspace" \
+              -w /workspace \
+              cyberbotics/webots:R2025a-ubuntu22.04 \
+              bash -lc 'timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_square.wbt' \
+              2>&1 | tee "$LOG"
+            code=${PIPESTATUS[0]}
+            set -e
+            echo "$code" > "$EXIT_FILE"
+
+            if [ "$code" -ne 0 ]; then
+              echo "::error::Crazyflie repeatability run $run exited with code $code"
+              exit "$code"
+            fi
+            if grep -Fq 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"; then
+              grep -F 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"
+              exit 1
+            fi
+            if grep -Fq 'ERROR:' "$LOG"; then
+              grep -F 'ERROR:' "$LOG"
+              exit 1
+            fi
+            if [ ! -s "$RESULT_FILE" ]; then
+              echo "::error::Crazyflie repeatability run $run produced no fresh result file"
+              exit 1
+            fi
+
+            RESULT=$(tail -1 "$RESULT_FILE")
+            echo "run=$run $RESULT"
+            echo "$RESULT" | grep -Fq 'WEBEEBLOCKS_CF_SQUARE_RESULT status=success'
+            echo "$RESULT" | grep -Fq 'legs=4'
+            cp "$RESULT_FILE" "$RESULT_COPY"
+          done
+
+      - name: Summarize repeatability distribution
         shell: bash
         run: |
-          LOG=ci-artifacts/crazyflie-square.log
-          RESULT_FILE=ci-artifacts/crazyflie-square-result.txt
-          if grep -Fq 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"; then
-            grep -F 'WEBEEBLOCKS_CF_SQUARE_FAILED' "$LOG"
-            exit 1
-          fi
-          if grep -Fq 'ERROR:' "$LOG"; then
-            grep -F 'ERROR:' "$LOG"
-            exit 1
-          fi
-          if [ ! -s "$RESULT_FILE" ]; then
-            echo '::error::Measured square result file missing.'
-            exit 1
-          fi
-          RESULT=$(tail -1 "$RESULT_FILE")
-          echo "$RESULT"
-          echo "$RESULT" | grep -Fq 'WEBEEBLOCKS_CF_SQUARE_RESULT status=success'
-          echo "$RESULT" | grep -Fq 'legs=4'
+          python3 tools/ci/summarize_crazyflie_repeatability.py \
+            ci-artifacts/crazyflie-repeatability/run-??-result.txt \
+            --json ci-artifacts/crazyflie-repeatability-summary.json \
+            --text ci-artifacts/crazyflie-repeatability-summary.txt
 
       - name: Upload Crazyflie square diagnostics
         if: always()

--- a/.github/workflows/crazyflie-square-r2025a.yml
+++ b/.github/workflows/crazyflie-square-r2025a.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   crazyflie-square:
     runs-on: ubuntu-22.04
-    timeout-minutes: 12
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/ci/summarize_crazyflie_repeatability.py
+++ b/tools/ci/summarize_crazyflie_repeatability.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import math
+import statistics
+from pathlib import Path
+
+METRICS = (
+    "error_xy",
+    "yaw_error_deg",
+    "altitude_min",
+    "altitude_max",
+    "total_s",
+)
+
+
+def parse_result(path: Path):
+    line = path.read_text(encoding="utf-8").strip().splitlines()[-1]
+    tokens = line.split()
+    if not tokens or tokens[0] != "WEBEEBLOCKS_CF_SQUARE_RESULT":
+        raise ValueError(f"{path}: invalid result prefix")
+
+    values = {}
+    for token in tokens[1:]:
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        values[key] = value
+
+    if values.get("status") != "success":
+        raise ValueError(f"{path}: status is not success")
+    if values.get("legs") != "4":
+        raise ValueError(f"{path}: legs is not 4")
+
+    parsed = {"file": str(path), "status": "success", "legs": 4}
+    for metric in METRICS:
+        if metric not in values:
+            raise ValueError(f"{path}: missing metric {metric}")
+        number = float(values[metric])
+        if not math.isfinite(number):
+            raise ValueError(f"{path}: non-finite metric {metric}")
+        parsed[metric] = number
+    return parsed
+
+
+def stats(values):
+    return {
+        "mean": statistics.fmean(values),
+        "min": min(values),
+        "max": max(values),
+        "stdev": statistics.pstdev(values),
+    }
+
+
+def summarize(paths):
+    runs = [parse_result(path) for path in paths]
+    if len(runs) != 10:
+        raise ValueError(f"expected exactly 10 results, got {len(runs)}")
+
+    aggregate = {
+        metric: stats([run[metric] for run in runs])
+        for metric in METRICS
+    }
+    return {
+        "success_count": len(runs),
+        "run_count": len(runs),
+        "runs": runs,
+        "aggregate": aggregate,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results", nargs="+")
+    parser.add_argument("--json", required=True, dest="json_path")
+    parser.add_argument("--text", required=True, dest="text_path")
+    args = parser.parse_args()
+
+    paths = [Path(p) for p in args.results]
+    summary = summarize(paths)
+
+    Path(args.json_path).write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    lines = [f"success_count={summary['success_count']} run_count={summary['run_count']}"]
+    for metric in METRICS:
+        item = summary["aggregate"][metric]
+        lines.append(
+            f"{metric} mean={item['mean']:.6f} min={item['min']:.6f} "
+            f"max={item['max']:.6f} stdev={item['stdev']:.6f}"
+        )
+    Path(args.text_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Goal
Measure backend A repeatability with the exact controller/world/PID already proven by PR #24.

## Changes
- keep `controllers/crazyflie_square`, its PID, thresholds, world and mission unchanged;
- run ten independent Webots R2025a processes with the same measured 1 m square;
- delete the persisted result before every run so stale output cannot satisfy a later run;
- fail closed on non-zero exit, timeout, `WEBEEBLOCKS_CF_SQUARE_FAILED`, Webots `ERROR:`, missing result, non-success result or `legs != 4`;
- preserve one log/result/exit-code per run;
- aggregate XY closure error, final yaw error, altitude min/max and duration with mean/min/max/population standard deviation.

## Scope
Harness/measurement only. No PID, navigation, setpoint, threshold, model, world, Blockly, backend B or obstacle change. `main` is untouched.

## Acceptance
All 10 fresh Webots runs must succeed independently. The aggregate distribution is evidence, not yet a product-quality threshold.