### PR TITLE
Add nominal global-target Crazyflie backend B

### DIFF
--- a/.github/workflows/crazyflie-square-position-r2025a.yml
+++ b/.github/workflows/crazyflie-square-position-r2025a.yml
@@ -1,0 +1,82 @@
+name: Crazyflie square position-target R2025a gate
+
+on:
+  push:
+    branches: [webots-ci]
+  pull_request:
+    branches: [webots-ci]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  crazyflie-square-position:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 7
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build position-target square controller
+        shell: bash
+        run: |
+          mkdir -p ci-artifacts
+          rm -f ci-artifacts/crazyflie-square-position-result.txt
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_square_position \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/crazyflie-square-position-build.log
+
+      - name: Fly one measured global-target 1 m square
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_square_position.wbt' \
+            2>&1 | tee ci-artifacts/crazyflie-square-position.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/crazyflie-square-position-exit-code.txt
+          exit "$code"
+
+      - name: Validate measured position-target result
+        shell: bash
+        run: |
+          LOG=ci-artifacts/crazyflie-square-position.log
+          RESULT_FILE=ci-artifacts/crazyflie-square-position-result.txt
+          if grep -Fq 'WEBEEBLOCKS_CF_POSITION_FAILED' "$LOG"; then
+            grep -F 'WEBEEBLOCKS_CF_POSITION_FAILED' "$LOG"
+            exit 1
+          fi
+          if grep -Fq 'ERROR:' "$LOG"; then
+            grep -F 'ERROR:' "$LOG"
+            exit 1
+          fi
+          if [ ! -s "$RESULT_FILE" ]; then
+            echo '::error::Position-target square result file missing.'
+            exit 1
+          fi
+          RESULT=$(tail -1 "$RESULT_FILE")
+          echo "$RESULT"
+          echo "$RESULT" | grep -Fq 'WEBEEBLOCKS_CF_POSITION_RESULT status=success'
+          echo "$RESULT" | grep -Fq 'legs=4'
+
+      - name: Upload position-target diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crazyflie-square-position-r2025a
+          path: ci-artifacts/
+          if-no-files-found: error

--- a/controllers/crazyflie_square_position/Makefile
+++ b/controllers/crazyflie_square_position/Makefile
@@ -1,0 +1,7 @@
+C_SOURCES = crazyflie_square_position.c ../crazyflie_square/pid_controller.c
+CFLAGS = -I../crazyflie_square
+
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/controllers/crazyflie_square_position/crazyflie_square_position.c
+++ b/controllers/crazyflie_square_position/crazyflie_square_position.c
@@ -33,6 +33,14 @@ static double clip(double v, double limit) {
   if (v < -limit) return -limit;
   return v;
 }
+static void clip_vector(double *x, double *y, double limit) {
+  const double magnitude = hypot(*x, *y);
+  if (magnitude > limit && magnitude > 0) {
+    const double scale = limit / magnitude;
+    *x *= scale;
+    *y *= scale;
+  }
+}
 static double motor(double v) { return v < 0 ? 0 : (v > 600 ? 600 : v); }
 static void stop(WbDeviceTag a, WbDeviceTag b, WbDeviceTag c, WbDeviceTag d) {
   wb_motor_set_velocity(a, 0); wb_motor_set_velocity(b, 0); wb_motor_set_velocity(c, 0); wb_motor_set_velocity(d, 0);
@@ -116,8 +124,9 @@ int main(void) {
     } else if (phase == LEG) {
       double ex = target_x - x, ey = target_y - y;
       double bx = ex * cy + ey * syy, by = -ex * syy + ey * cy;
-      d.vx = clip(POSITION_KP * bx, VX_MAX);
-      d.vy = clip(POSITION_KP * by, VX_MAX);
+      d.vx = POSITION_KP * bx;
+      d.vy = POSITION_KP * by;
+      clip_vector(&d.vx, &d.vy, VX_MAX);
       if (hypot(ex, ey) <= POSITION_TOL && hypot(a.vx, a.vy) <= SPEED_TOL) {
         if (stable < 0) stable = now;
         if (now - stable > .2) {

--- a/controllers/crazyflie_square_position/crazyflie_square_position.c
+++ b/controllers/crazyflie_square_position/crazyflie_square_position.c
@@ -1,0 +1,165 @@
+#include <math.h>
+#include <stdio.h>
+#include <webots/gps.h>
+#include <webots/gyro.h>
+#include <webots/inertial_unit.h>
+#include <webots/motor.h>
+#include <webots/robot.h>
+#include <webots/supervisor.h>
+#include "pid_controller.h"
+
+#define PI 3.14159265358979323846
+#define TARGET_Z_DELTA 1.0
+#define LEG_M 1.0
+#define VX_MAX 0.35
+#define YAW_RATE_MAX 0.7
+#define POSITION_KP 1.0
+#define YAW_KP 1.5
+#define POSITION_TOL 0.03
+#define YAW_TOL (2.0 * PI / 180.0)
+#define SPEED_TOL 0.12
+#define YAW_RATE_TOL 0.10
+#define TIMEOUT 60.0
+
+typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
+
+static double wrap(double a) {
+  while (a > PI) a -= 2 * PI;
+  while (a < -PI) a += 2 * PI;
+  return a;
+}
+static double clip(double v, double limit) {
+  if (v > limit) return limit;
+  if (v < -limit) return -limit;
+  return v;
+}
+static double motor(double v) { return v < 0 ? 0 : (v > 600 ? 600 : v); }
+static void stop(WbDeviceTag a, WbDeviceTag b, WbDeviceTag c, WbDeviceTag d) {
+  wb_motor_set_velocity(a, 0); wb_motor_set_velocity(b, 0); wb_motor_set_velocity(c, 0); wb_motor_set_velocity(d, 0);
+}
+static const char *phase_name(phase_t phase) {
+  switch (phase) {
+    case TAKEOFF: return "TAKEOFF";
+    case LEG: return "LEG";
+    case TURN: return "TURN";
+    case LAND: return "LAND";
+  }
+  return "UNKNOWN";
+}
+static void write_result_file(double err, double yawerr, double min_z, double max_z, double total, int legs) {
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-square-position-result.txt", wb_robot_get_project_path());
+  FILE *file = fopen(path, "w");
+  if (!file) return;
+  fprintf(file,
+          "WEBEEBLOCKS_CF_POSITION_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",
+          err, yawerr, min_z, max_z, total, legs);
+  fflush(file);
+  fclose(file);
+}
+
+int main(void) {
+  wb_robot_init();
+  const int step = (int)wb_robot_get_basic_time_step();
+  WbDeviceTag m1 = wb_robot_get_device("m1_motor"), m2 = wb_robot_get_device("m2_motor");
+  WbDeviceTag m3 = wb_robot_get_device("m3_motor"), m4 = wb_robot_get_device("m4_motor");
+  WbDeviceTag gps = wb_robot_get_device("gps"), imu = wb_robot_get_device("inertial_unit"), gyro = wb_robot_get_device("gyro");
+  wb_motor_set_position(m1, INFINITY); wb_motor_set_position(m2, INFINITY); wb_motor_set_position(m3, INFINITY); wb_motor_set_position(m4, INFINITY);
+  wb_motor_set_velocity(m1, -1); wb_motor_set_velocity(m2, 1); wb_motor_set_velocity(m3, -1); wb_motor_set_velocity(m4, 1);
+  wb_gps_enable(gps, step); wb_inertial_unit_enable(imu, step); wb_gyro_enable(gyro, step);
+  while (wb_robot_step(step) != -1 && wb_robot_get_time() < 2.0) {}
+
+  const double *p = wb_gps_get_values(gps), *r = wb_inertial_unit_get_roll_pitch_yaw(imu);
+  const double sx = p[0], sy = p[1], sz = p[2], syaw = r[2], target_z = sz + TARGET_Z_DELTA;
+  double target_x = sx, target_y = sy, target_yaw = syaw;
+  double min_z = sz, max_z = sz, px = sx, py = sy, pz = sz, pt = wb_robot_get_time(), stable = -1;
+  const double t0 = pt;
+  int leg = 0;
+  phase_t phase = TAKEOFF;
+
+  gains_pid_t g = {0};
+  g.kp_att_y = 1; g.kd_att_y = .5; g.kp_att_rp = .5; g.kd_att_rp = .1;
+  g.kp_vel_xy = 2; g.kd_vel_xy = .5; g.kp_z = 10; g.ki_z = 5; g.kd_z = 5;
+  init_pid_attitude_fixed_height_controller();
+  actual_state_t a = {0}; desired_state_t d = {0}; motor_power_t power = {0};
+
+  printf("WEBEEBLOCKS_CF_POSITION_STARTED x=%.6f y=%.6f z=%.6f yaw=%.6f\n", sx, sy, sz, syaw);
+  fflush(stdout);
+
+  int step_result;
+  while ((step_result = wb_robot_step(step)) != -1) {
+    double now = wb_robot_get_time(), dt = now - pt;
+    if (dt <= 0) continue;
+    p = wb_gps_get_values(gps); r = wb_inertial_unit_get_roll_pitch_yaw(imu); const double *gv = wb_gyro_get_values(gyro);
+    double x = p[0], y = p[1], z = p[2], yaw = r[2], vz = (z - pz) / dt, vxg = (x - px) / dt, vyg = (y - py) / dt;
+    double cy = cos(yaw), syy = sin(yaw);
+    if (z < min_z) min_z = z;
+    if (z > max_z) max_z = z;
+    a.roll = r[0]; a.pitch = r[1]; a.yaw_rate = gv[2]; a.altitude = z;
+    a.vx = vxg * cy + vyg * syy; a.vy = -vxg * syy + vyg * cy;
+    d.roll = 0; d.pitch = 0; d.vx = 0; d.vy = 0; d.yaw_rate = 0; d.altitude = target_z;
+
+    if (fabs(a.roll) > 1.2 || fabs(a.pitch) > 1.2 || now - t0 > TIMEOUT) {
+      printf("WEBEEBLOCKS_CF_POSITION_FAILED phase=%s leg=%d t=%.3f\n", phase_name(phase), leg, now - t0);
+      fflush(stdout); stop(m1, m2, m3, m4); wb_supervisor_simulation_quit(2); break;
+    }
+
+    if (phase == TAKEOFF) {
+      if (fabs(z - target_z) < .05 && fabs(vz) < .15) {
+        if (stable < 0) stable = now;
+        if (now - stable > .5) {
+          phase = LEG; stable = -1;
+          target_x += LEG_M * cos(target_yaw);
+          target_y += LEG_M * sin(target_yaw);
+        }
+      } else stable = -1;
+    } else if (phase == LEG) {
+      double ex = target_x - x, ey = target_y - y;
+      double bx = ex * cy + ey * syy, by = -ex * syy + ey * cy;
+      d.vx = clip(POSITION_KP * bx, VX_MAX);
+      d.vy = clip(POSITION_KP * by, VX_MAX);
+      if (hypot(ex, ey) <= POSITION_TOL && hypot(a.vx, a.vy) <= SPEED_TOL) {
+        if (stable < 0) stable = now;
+        if (now - stable > .2) {
+          phase = TURN; stable = -1;
+          target_yaw = wrap(target_yaw + PI / 2);
+        }
+      } else stable = -1;
+    } else if (phase == TURN) {
+      double eyaw = wrap(target_yaw - yaw);
+      d.yaw_rate = clip(YAW_KP * eyaw, YAW_RATE_MAX);
+      if (fabs(eyaw) <= YAW_TOL && fabs(a.yaw_rate) <= YAW_RATE_TOL) {
+        if (stable < 0) stable = now;
+        if (now - stable > .2) {
+          leg++;
+          stable = -1;
+          if (leg == 4) phase = LAND;
+          else {
+            phase = LEG;
+            target_x += LEG_M * cos(target_yaw);
+            target_y += LEG_M * sin(target_yaw);
+          }
+        }
+      } else stable = -1;
+    } else {
+      d.altitude = sz;
+      if (z <= sz + .05 && fabs(vz) < .15) {
+        if (stable < 0) stable = now;
+        if (now - stable > .5) {
+          double err = hypot(x - sx, y - sy), yawerr = fabs(wrap(yaw - syaw)) * 180 / PI;
+          write_result_file(err, yawerr, min_z, max_z, now - t0, leg);
+          printf("WEBEEBLOCKS_CF_POSITION_RESULT status=success error_xy=%.6f yaw_error_deg=%.6f altitude_min=%.6f altitude_max=%.6f total_s=%.3f legs=%d\n",
+                 err, yawerr, min_z, max_z, now - t0, leg);
+          fflush(stdout); stop(m1, m2, m3, m4); wb_supervisor_simulation_quit(0); break;
+        }
+      } else stable = -1;
+    }
+
+    pid_velocity_fixed_height_controller(a, &d, g, dt, &power);
+    wb_motor_set_velocity(m1, -motor(power.m1)); wb_motor_set_velocity(m2, motor(power.m2));
+    wb_motor_set_velocity(m3, -motor(power.m3)); wb_motor_set_velocity(m4, motor(power.m4));
+    pt = now; px = x; py = y; pz = z;
+  }
+
+  stop(m1, m2, m3, m4); wb_robot_cleanup(); return 0;
+}

--- a/worlds/crazyflie_square_position.wbt
+++ b/worlds/crazyflie_square_position.wbt
@@ -1,0 +1,28 @@
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
+
+WorldInfo {
+  basicTimeStep 32
+  title "WebeeBlocks Crazyflie square position-target experiment"
+}
+Viewpoint {
+  orientation -0.45 0.47 0.76 1.05
+  position -3 -3 3
+  follow "Crazyflie"
+}
+TexturedBackground {
+}
+TexturedBackgroundLight {
+}
+Floor {
+  size 6 6
+}
+Crazyflie {
+  name "Crazyflie"
+  controller "crazyflie_square_position"
+  supervisor TRUE
+}


### PR DESCRIPTION
## Goal
Implement the minimal backend B experiment requested by the Lead: keep the same Webots R2025a Crazyflie model, PID, altitude, 1 m square mission, metrics and fail-closed rules as backend A, while changing only the navigation layer from body-relative velocity/yaw-rate sequencing to global `x/y/z/yaw` targets translated into bounded body velocity and yaw-rate setpoints.

## Changes
- add `crazyflie_square_position`, reusing the exact existing Bitcraze PID source/header from backend A;
- keep the same PID gains and motor mapping;
- define the same 1 m square as successive global XY targets and successive absolute yaw targets;
- use a minimal proportional outer navigation loop, bounded by the same `0.35 m/s` horizontal speed and `0.7 rad/s` yaw-rate caps as A;
- add a world identical in geometry/model/initial state to A, differing only in controller name/title;
- add one nominal Webots R2025a gate producing the same metrics: closure XY, final yaw error, altitude min/max, duration, legs.

## Scope
This is a single nominal experiment only. No Blockly, obstacles, PID tuning, backend A modification, product thresholds or real-drone work. `main` is untouched.

## Acceptance
One fresh Webots R2025a run must finish `status=success legs=4` without Webots errors or controller failure. The resulting metrics are evidence for the next common A/B perturbation matrix, not yet a product-quality judgment.