### PR TITLE
Measure Crazyflie primitive semantics across A/B

### DIFF
--- a/.github/workflows/crazyflie-primitive-matrix-r2025a.yml
+++ b/.github/workflows/crazyflie-primitive-matrix-r2025a.yml
@@ -1,0 +1,57 @@
+name: Crazyflie primitive A/B matrix R2025a
+
+on:
+  push:
+    branches: [webots-ci]
+  pull_request:
+    branches: [webots-ci]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  crazyflie-primitive-matrix:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build backend A and backend B controllers
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/crazyflie-primitive-matrix
+          for controller in crazyflie_square crazyflie_square_position; do
+            docker run --rm \
+              -v "${{ github.workspace }}:/workspace" \
+              -w "/workspace/controllers/${controller}" \
+              cyberbotics/webots:R2025a-ubuntu22.04 \
+              bash -lc 'make clean && make' \
+              2>&1 | tee "ci-artifacts/crazyflie-primitive-matrix/build-${controller}.log"
+          done
+
+      - name: Run primitive missions for A and B
+        shell: bash
+        run: |
+          set -o pipefail
+          python3 tools/ci/run_crazyflie_primitive_matrix.py
+
+      - name: Publish primitive matrix summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ci-artifacts/crazyflie-primitive-matrix/matrix.md ]; then
+            cat ci-artifacts/crazyflie-primitive-matrix/matrix.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload primitive diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crazyflie-primitive-matrix-r2025a
+          path: ci-artifacts/crazyflie-primitive-matrix/
+          if-no-files-found: error

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -16,6 +16,10 @@
 #define VX 0.35
 #define YAW_RATE 0.7
 #define PRIMITIVE_STABLE_WINDOW 0.5
+#define PRIMITIVE_SPEED_TOL 0.12
+#define PRIMITIVE_YAW_RATE_TOL 0.10
+#define PRIMITIVE_VZ_TOL 0.15
+#define PRIMITIVE_ALTITUDE_TOL 0.05
 #define TIMEOUT 60.0
 
 typedef enum { TAKEOFF, LEG, TURN, SETTLE, LAND } phase_t;
@@ -62,14 +66,19 @@ static void write_result_file(double err, double yawerr, double min_z, double ma
   fclose(file);
 }
 static void write_primitive_result(const char *kind, double command, double longitudinal, double lateral,
-                                   double yaw_error_deg, double drift_xy, double duration) {
+                                   double yaw_error_deg, double drift_xy, double duration,
+                                   double threshold_error, double max_overshoot,
+                                   double residual_speed, double residual_yaw_rate, double residual_vz,
+                                   double final_x, double final_y, double final_z, double final_yaw) {
   char path[4096];
   snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-primitive-A.txt", wb_robot_get_project_path());
   FILE *file = fopen(path, "w");
   if (!file) return;
   fprintf(file,
-          "WEBEEBLOCKS_CF_PRIMITIVE_A status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f\n",
-          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration);
+          "WEBEEBLOCKS_CF_PRIMITIVE_A status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f threshold_error=%.6f max_overshoot=%.6f residual_speed=%.6f residual_yaw_rate=%.6f residual_vz=%.6f final_x=%.6f final_y=%.6f final_z=%.6f final_yaw=%.6f\n",
+          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration,
+          threshold_error, max_overshoot, residual_speed, residual_yaw_rate, residual_vz,
+          final_x, final_y, final_z, final_yaw);
   fflush(file);
   fclose(file);
 }
@@ -107,6 +116,7 @@ int main(int argc, char **argv) {
   const double sx=p[0],sy=p[1],sz=p[2],syaw=r[2],target_z=sz+TARGET_Z_DELTA;
   double min_z=sz,max_z=sz,px=sx,py=sy,pz=sz,pt=wb_robot_get_time(),leg_x=sx,leg_y=sy,prev_yaw=syaw,turn_angle=0,stable=-1;
   double primitive_start_x=sx,primitive_start_y=sy,primitive_start_yaw=syaw;
+  double threshold_error=0.0,max_overshoot=0.0;
   const double t0=pt;
   double primitive_t0=pt;
   double next_heartbeat=t0;
@@ -146,6 +156,7 @@ int main(int argc, char **argv) {
           stable=-1;
           primitive_t0=now;
           primitive_start_x=x;primitive_start_y=y;primitive_start_yaw=yaw;
+          threshold_error=0.0;max_overshoot=0.0;
           if(mission==MISSION_TURN){
             phase=TURN;turn_angle=0;prev_yaw=yaw;
           }else{
@@ -159,6 +170,10 @@ int main(int argc, char **argv) {
       const double leg_target = mission==MISSION_FORWARD ? mission_value : LEG_M;
       if(hypot(x-leg_x,y-leg_y)>=leg_target){
         if(mission==MISSION_FORWARD){
+          const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
+          const double along=dx*cy0+dy*sy0;
+          threshold_error=along-mission_value;
+          max_overshoot=threshold_error>0.0?threshold_error:0.0;
           phase=SETTLE;stable=-1;
         }else{
           phase=TURN;turn_angle=0;prev_yaw=yaw;primitive_t0=now;
@@ -171,6 +186,8 @@ int main(int argc, char **argv) {
       turn_angle+=wrap(yaw-prev_yaw);prev_yaw=yaw;
       if(fabs(turn_angle)>=fabs(target_turn)){
         if(mission==MISSION_TURN){
+          threshold_error=(fabs(turn_angle)-fabs(target_turn))*180/PI;
+          max_overshoot=threshold_error>0.0?threshold_error:0.0;
           phase=SETTLE;stable=-1;
         }else{
           leg++;
@@ -180,18 +197,31 @@ int main(int argc, char **argv) {
         log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
       }
     }else if(phase==SETTLE){
-      if(hypot(a.vx,a.vy)<.12 && fabs(a.yaw_rate)<.10){
+      if(mission==MISSION_FORWARD){
+        const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
+        const double along=dx*cy0+dy*sy0;
+        const double overshoot=along-mission_value;
+        if(overshoot>max_overshoot)max_overshoot=overshoot;
+      }else if(mission==MISSION_TURN){
+        const double overshoot=(fabs(wrap(yaw-primitive_start_yaw))-fabs(mission_value))*180/PI;
+        if(overshoot>max_overshoot)max_overshoot=overshoot;
+      }
+      if(hypot(a.vx,a.vy)<PRIMITIVE_SPEED_TOL && fabs(a.yaw_rate)<PRIMITIVE_YAW_RATE_TOL &&
+         fabs(vz)<PRIMITIVE_VZ_TOL && fabs(z-target_z)<PRIMITIVE_ALTITUDE_TOL){
         if(stable<0)stable=now;
         if(now-stable>PRIMITIVE_STABLE_WINDOW){
+          const double residual_speed=hypot(a.vx,a.vy);
           if(mission==MISSION_FORWARD){
             const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
             const double along=dx*cy0+dy*sy0,lateral=-dx*sy0+dy*cy0;
             write_primitive_result("forward",mission_value,along-mission_value,lateral,
-                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0);
+                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0,
+                                   threshold_error,max_overshoot,residual_speed,a.yaw_rate,vz,x,y,z,yaw);
           }else if(mission==MISSION_TURN){
             write_primitive_result("turn",mission_value*180/PI,0.0,0.0,
                                    wrap(yaw-primitive_start_yaw-mission_value)*180/PI,
-                                   hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0);
+                                   hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0,
+                                   threshold_error,max_overshoot,residual_speed,a.yaw_rate,vz,x,y,z,yaw);
           }
           phase=LAND;stable=-1;
           log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -17,7 +17,7 @@
 #define YAW_RATE 0.7
 #define TIMEOUT 60.0
 
-typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
+typedef enum { TAKEOFF, LEG, TURN, SETTLE, LAND } phase_t;
 typedef enum { MISSION_SQUARE, MISSION_FORWARD, MISSION_TURN } mission_t;
 
 static double wrap(double a) {
@@ -34,6 +34,7 @@ static const char *phase_name(phase_t phase) {
     case TAKEOFF: return "TAKEOFF";
     case LEG: return "LEG";
     case TURN: return "TURN";
+    case SETTLE: return "SETTLE";
     case LAND: return "LAND";
   }
   return "UNKNOWN";
@@ -158,7 +159,7 @@ int main(int argc, char **argv) {
           const double dx=x-leg_x,dy=y-leg_y,cy0=cos(syaw),sy0=sin(syaw);
           const double along=dx*cy0+dy*sy0, lateral=-dx*sy0+dy*cy0;
           write_primitive_result("forward",mission_value,along-mission_value,lateral,wrap(yaw-syaw)*180/PI,0.0,now-primitive_t0);
-          phase=LAND;stable=-1;
+          phase=SETTLE;stable=-1;
         }else{
           phase=TURN;turn_angle=0;prev_yaw=yaw;primitive_t0=now;
         }
@@ -171,7 +172,7 @@ int main(int argc, char **argv) {
       if(fabs(turn_angle)>=fabs(target_turn)){
         if(mission==MISSION_TURN){
           write_primitive_result("turn",mission_value*180/PI,0.0,0.0,(turn_angle-mission_value)*180/PI,hypot(x-sx,y-sy),now-primitive_t0);
-          phase=LAND;stable=-1;
+          phase=SETTLE;stable=-1;
         }else{
           leg++;
           if(leg==4){phase=LAND;stable=-1;}
@@ -179,6 +180,14 @@ int main(int argc, char **argv) {
         }
         log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
       }
+    }else if(phase==SETTLE){
+      if(hypot(a.vx,a.vy)<.12 && fabs(a.yaw_rate)<.10){
+        if(stable<0)stable=now;
+        if(now-stable>.5){
+          phase=LAND;stable=-1;
+          log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
+        }
+      }else stable=-1;
     }else{
       d.altitude=sz;
       if(z<=sz+.05&&fabs(vz)<.15){

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -1,5 +1,7 @@
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <webots/gps.h>
 #include <webots/gyro.h>
 #include <webots/inertial_unit.h>
@@ -16,6 +18,7 @@
 #define TIMEOUT 60.0
 
 typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
+typedef enum { MISSION_SQUARE, MISSION_FORWARD, MISSION_TURN } mission_t;
 
 static double wrap(double a) {
   while (a > PI) a -= 2 * PI;
@@ -56,8 +59,38 @@ static void write_result_file(double err, double yawerr, double min_z, double ma
   fflush(file);
   fclose(file);
 }
+static void write_primitive_result(const char *kind, double command, double longitudinal, double lateral,
+                                   double yaw_error_deg, double drift_xy, double duration) {
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-primitive-A.txt", wb_robot_get_project_path());
+  FILE *file = fopen(path, "w");
+  if (!file) return;
+  fprintf(file,
+          "WEBEEBLOCKS_CF_PRIMITIVE_A status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f\n",
+          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration);
+  fflush(file);
+  fclose(file);
+}
 
-int main(void) {
+int main(int argc, char **argv) {
+  mission_t mission = MISSION_SQUARE;
+  double mission_value = 0.0;
+  if (argc == 3 && strcmp(argv[1], "forward") == 0) {
+    mission = MISSION_FORWARD;
+    mission_value = strtod(argv[2], NULL);
+  } else if (argc == 3 && strcmp(argv[1], "turn") == 0) {
+    mission = MISSION_TURN;
+    mission_value = strtod(argv[2], NULL) * PI / 180.0;
+  } else if (argc != 1) {
+    fprintf(stderr, "WEBEEBLOCKS_CF_SQUARE_FAILED invalid controllerArgs\n");
+    return 2;
+  }
+  if ((mission == MISSION_FORWARD && mission_value <= 0.0) ||
+      (mission == MISSION_TURN && fabs(mission_value) <= 0.0)) {
+    fprintf(stderr, "WEBEEBLOCKS_CF_SQUARE_FAILED invalid mission value\n");
+    return 2;
+  }
+
   wb_robot_init();
   const int step=(int)wb_robot_get_basic_time_step();
   WbDeviceTag m1=wb_robot_get_device("m1_motor"),m2=wb_robot_get_device("m2_motor");
@@ -72,6 +105,7 @@ int main(void) {
   const double sx=p[0],sy=p[1],sz=p[2],syaw=r[2],target_z=sz+TARGET_Z_DELTA;
   double min_z=sz,max_z=sz,px=sx,py=sy,pz=sz,pt=wb_robot_get_time(),leg_x=sx,leg_y=sy,prev_yaw=syaw,turn_angle=0,stable=-1;
   const double t0=pt;
+  double primitive_t0=pt;
   double next_heartbeat=t0;
   int leg=0; phase_t phase=TAKEOFF;
   gains_pid_t g={0}; g.kp_att_y=1;g.kd_att_y=.5;g.kp_att_rp=.5;g.kd_att_rp=.1;g.kp_vel_xy=2;g.kd_vel_xy=.5;g.kp_z=10;g.ki_z=5;g.kd_z=5;
@@ -86,7 +120,8 @@ int main(void) {
     double now=wb_robot_get_time(),dt=now-pt; if(dt<=0) continue;
     p=wb_gps_get_values(gps);r=wb_inertial_unit_get_roll_pitch_yaw(imu);const double *gv=wb_gyro_get_values(gyro);
     double x=p[0],y=p[1],z=p[2],yaw=r[2],vz=(z-pz)/dt,vxg=(x-px)/dt,vyg=(y-py)/dt,cy=cos(yaw),syy=sin(yaw);
-    if(z<min_z)min_z=z;if(z>max_z)max_z=z;
+    if(z<min_z) min_z=z;
+    if(z>max_z) max_z=z;
     a.roll=r[0];a.pitch=r[1];a.yaw_rate=gv[2];a.altitude=z;a.vx=vxg*cy+vyg*syy;a.vy=-vxg*syy+vyg*cy;
     d.roll=0;d.pitch=0;d.vx=0;d.vy=0;d.yaw_rate=0;d.altitude=target_z;
 
@@ -105,22 +140,43 @@ int main(void) {
       if(fabs(z-target_z)<.05&&fabs(vz)<.15){
         if(stable<0)stable=now;
         if(now-stable>.5){
-          phase=LEG;leg_x=x;leg_y=y;stable=-1;
+          stable=-1;
+          primitive_t0=now;
+          if(mission==MISSION_TURN){
+            phase=TURN;turn_angle=0;prev_yaw=yaw;
+          }else{
+            phase=LEG;leg_x=x;leg_y=y;
+          }
           log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
         }
       }else stable=-1;
     }else if(phase==LEG){
       d.vx=VX;
-      if(hypot(x-leg_x,y-leg_y)>=LEG_M){
-        phase=TURN;turn_angle=0;prev_yaw=yaw;
+      const double leg_target = mission==MISSION_FORWARD ? mission_value : LEG_M;
+      if(hypot(x-leg_x,y-leg_y)>=leg_target){
+        if(mission==MISSION_FORWARD){
+          const double dx=x-leg_x,dy=y-leg_y,cy0=cos(syaw),sy0=sin(syaw);
+          const double along=dx*cy0+dy*sy0, lateral=-dx*sy0+dy*cy0;
+          write_primitive_result("forward",mission_value,along-mission_value,lateral,wrap(yaw-syaw)*180/PI,0.0,now-primitive_t0);
+          phase=LAND;stable=-1;
+        }else{
+          phase=TURN;turn_angle=0;prev_yaw=yaw;primitive_t0=now;
+        }
         log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
       }
     }else if(phase==TURN){
-      d.yaw_rate=YAW_RATE;turn_angle+=wrap(yaw-prev_yaw);prev_yaw=yaw;
-      if(turn_angle>=PI/2){
-        leg++;
-        if(leg==4){phase=LAND;stable=-1;}
-        else{phase=LEG;leg_x=x;leg_y=y;}
+      const double target_turn = mission==MISSION_TURN ? mission_value : PI/2;
+      d.yaw_rate=target_turn>=0 ? YAW_RATE : -YAW_RATE;
+      turn_angle+=wrap(yaw-prev_yaw);prev_yaw=yaw;
+      if(fabs(turn_angle)>=fabs(target_turn)){
+        if(mission==MISSION_TURN){
+          write_primitive_result("turn",mission_value*180/PI,0.0,0.0,(turn_angle-mission_value)*180/PI,hypot(x-sx,y-sy),now-primitive_t0);
+          phase=LAND;stable=-1;
+        }else{
+          leg++;
+          if(leg==4){phase=LAND;stable=-1;}
+          else{phase=LEG;leg_x=x;leg_y=y;}
+        }
         log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
       }
     }else{

--- a/controllers/crazyflie_square/crazyflie_square.c
+++ b/controllers/crazyflie_square/crazyflie_square.c
@@ -15,6 +15,7 @@
 #define LEG_M 1.0
 #define VX 0.35
 #define YAW_RATE 0.7
+#define PRIMITIVE_STABLE_WINDOW 0.5
 #define TIMEOUT 60.0
 
 typedef enum { TAKEOFF, LEG, TURN, SETTLE, LAND } phase_t;
@@ -105,6 +106,7 @@ int main(int argc, char **argv) {
   const double *p=wb_gps_get_values(gps),*r=wb_inertial_unit_get_roll_pitch_yaw(imu);
   const double sx=p[0],sy=p[1],sz=p[2],syaw=r[2],target_z=sz+TARGET_Z_DELTA;
   double min_z=sz,max_z=sz,px=sx,py=sy,pz=sz,pt=wb_robot_get_time(),leg_x=sx,leg_y=sy,prev_yaw=syaw,turn_angle=0,stable=-1;
+  double primitive_start_x=sx,primitive_start_y=sy,primitive_start_yaw=syaw;
   const double t0=pt;
   double primitive_t0=pt;
   double next_heartbeat=t0;
@@ -143,6 +145,7 @@ int main(int argc, char **argv) {
         if(now-stable>.5){
           stable=-1;
           primitive_t0=now;
+          primitive_start_x=x;primitive_start_y=y;primitive_start_yaw=yaw;
           if(mission==MISSION_TURN){
             phase=TURN;turn_angle=0;prev_yaw=yaw;
           }else{
@@ -156,9 +159,6 @@ int main(int argc, char **argv) {
       const double leg_target = mission==MISSION_FORWARD ? mission_value : LEG_M;
       if(hypot(x-leg_x,y-leg_y)>=leg_target){
         if(mission==MISSION_FORWARD){
-          const double dx=x-leg_x,dy=y-leg_y,cy0=cos(syaw),sy0=sin(syaw);
-          const double along=dx*cy0+dy*sy0, lateral=-dx*sy0+dy*cy0;
-          write_primitive_result("forward",mission_value,along-mission_value,lateral,wrap(yaw-syaw)*180/PI,0.0,now-primitive_t0);
           phase=SETTLE;stable=-1;
         }else{
           phase=TURN;turn_angle=0;prev_yaw=yaw;primitive_t0=now;
@@ -171,7 +171,6 @@ int main(int argc, char **argv) {
       turn_angle+=wrap(yaw-prev_yaw);prev_yaw=yaw;
       if(fabs(turn_angle)>=fabs(target_turn)){
         if(mission==MISSION_TURN){
-          write_primitive_result("turn",mission_value*180/PI,0.0,0.0,(turn_angle-mission_value)*180/PI,hypot(x-sx,y-sy),now-primitive_t0);
           phase=SETTLE;stable=-1;
         }else{
           leg++;
@@ -183,7 +182,17 @@ int main(int argc, char **argv) {
     }else if(phase==SETTLE){
       if(hypot(a.vx,a.vy)<.12 && fabs(a.yaw_rate)<.10){
         if(stable<0)stable=now;
-        if(now-stable>.5){
+        if(now-stable>PRIMITIVE_STABLE_WINDOW){
+          if(mission==MISSION_FORWARD){
+            const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
+            const double along=dx*cy0+dy*sy0,lateral=-dx*sy0+dy*cy0;
+            write_primitive_result("forward",mission_value,along-mission_value,lateral,
+                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0);
+          }else if(mission==MISSION_TURN){
+            write_primitive_result("turn",mission_value*180/PI,0.0,0.0,
+                                   wrap(yaw-primitive_start_yaw-mission_value)*180/PI,
+                                   hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0);
+          }
           phase=LAND;stable=-1;
           log_state("PHASE_ENTER", phase, leg, now-t0, x, y, z, yaw, a.roll, a.pitch, vz);
         }

--- a/controllers/crazyflie_square_position/crazyflie_square_position.c
+++ b/controllers/crazyflie_square_position/crazyflie_square_position.c
@@ -21,6 +21,7 @@
 #define YAW_TOL (2.0 * PI / 180.0)
 #define SPEED_TOL 0.12
 #define YAW_RATE_TOL 0.10
+#define PRIMITIVE_STABLE_WINDOW 0.5
 #define TIMEOUT 60.0
 
 typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
@@ -113,6 +114,7 @@ int main(int argc, char **argv) {
   const double *p = wb_gps_get_values(gps), *r = wb_inertial_unit_get_roll_pitch_yaw(imu);
   const double sx = p[0], sy = p[1], sz = p[2], syaw = r[2], target_z = sz + TARGET_Z_DELTA;
   double target_x = sx, target_y = sy, target_yaw = syaw;
+  double primitive_start_x = sx, primitive_start_y = sy, primitive_start_yaw = syaw;
   double min_z = sz, max_z = sz, px = sx, py = sy, pz = sz, pt = wb_robot_get_time(), stable = -1;
   const double t0 = pt;
   double primitive_t0 = pt;
@@ -152,14 +154,16 @@ int main(int argc, char **argv) {
         if (now - stable > .5) {
           stable = -1;
           primitive_t0 = now;
+          primitive_start_x = x; primitive_start_y = y; primitive_start_yaw = yaw;
           if (mission == MISSION_TURN) {
             phase = TURN;
-            target_yaw = wrap(syaw + mission_value);
+            target_yaw = wrap(yaw + mission_value);
           } else {
             phase = LEG;
             const double distance = mission == MISSION_FORWARD ? mission_value : LEG_M;
-            target_x += distance * cos(target_yaw);
-            target_y += distance * sin(target_yaw);
+            target_x = x + distance * cos(yaw);
+            target_y = y + distance * sin(yaw);
+            if (mission == MISSION_FORWARD) target_yaw = yaw;
           }
         }
       } else stable = -1;
@@ -171,12 +175,13 @@ int main(int argc, char **argv) {
       clip_vector(&d.vx, &d.vy, VX_MAX);
       if (hypot(ex, ey) <= POSITION_TOL && hypot(a.vx, a.vy) <= SPEED_TOL) {
         if (stable < 0) stable = now;
-        if (now - stable > .2) {
+        if (now - stable > PRIMITIVE_STABLE_WINDOW) {
           stable = -1;
           if (mission == MISSION_FORWARD) {
-            const double dx=x-sx,dy=y-sy,cy0=cos(syaw),sy0=sin(syaw);
-            const double along=dx*cy0+dy*sy0, lateral=-dx*sy0+dy*cy0;
-            write_primitive_result("forward",mission_value,along-mission_value,lateral,wrap(yaw-syaw)*180/PI,0.0,now-primitive_t0);
+            const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
+            const double along=dx*cy0+dy*sy0,lateral=-dx*sy0+dy*cy0;
+            write_primitive_result("forward",mission_value,along-mission_value,lateral,
+                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0);
             phase = LAND;
           } else {
             phase = TURN;
@@ -189,10 +194,12 @@ int main(int argc, char **argv) {
       d.yaw_rate = clip(YAW_KP * eyaw, YAW_RATE_MAX);
       if (fabs(eyaw) <= YAW_TOL && fabs(a.yaw_rate) <= YAW_RATE_TOL) {
         if (stable < 0) stable = now;
-        if (now - stable > .2) {
+        if (now - stable > PRIMITIVE_STABLE_WINDOW) {
           stable = -1;
           if (mission == MISSION_TURN) {
-            write_primitive_result("turn",mission_value*180/PI,0.0,0.0,wrap(yaw-syaw-mission_value)*180/PI,hypot(x-sx,y-sy),now-primitive_t0);
+            write_primitive_result("turn",mission_value*180/PI,0.0,0.0,
+                                   wrap(yaw-primitive_start_yaw-mission_value)*180/PI,
+                                   hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0);
             phase = LAND;
           } else {
             leg++;

--- a/controllers/crazyflie_square_position/crazyflie_square_position.c
+++ b/controllers/crazyflie_square_position/crazyflie_square_position.c
@@ -1,5 +1,7 @@
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <webots/gps.h>
 #include <webots/gyro.h>
 #include <webots/inertial_unit.h>
@@ -22,6 +24,7 @@
 #define TIMEOUT 60.0
 
 typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
+typedef enum { MISSION_SQUARE, MISSION_FORWARD, MISSION_TURN } mission_t;
 
 static double wrap(double a) {
   while (a > PI) a -= 2 * PI;
@@ -65,8 +68,38 @@ static void write_result_file(double err, double yawerr, double min_z, double ma
   fflush(file);
   fclose(file);
 }
+static void write_primitive_result(const char *kind, double command, double longitudinal, double lateral,
+                                   double yaw_error_deg, double drift_xy, double duration) {
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-primitive-B.txt", wb_robot_get_project_path());
+  FILE *file = fopen(path, "w");
+  if (!file) return;
+  fprintf(file,
+          "WEBEEBLOCKS_CF_PRIMITIVE_B status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f\n",
+          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration);
+  fflush(file);
+  fclose(file);
+}
 
-int main(void) {
+int main(int argc, char **argv) {
+  mission_t mission = MISSION_SQUARE;
+  double mission_value = 0.0;
+  if (argc == 3 && strcmp(argv[1], "forward") == 0) {
+    mission = MISSION_FORWARD;
+    mission_value = strtod(argv[2], NULL);
+  } else if (argc == 3 && strcmp(argv[1], "turn") == 0) {
+    mission = MISSION_TURN;
+    mission_value = strtod(argv[2], NULL) * PI / 180.0;
+  } else if (argc != 1) {
+    fprintf(stderr, "WEBEEBLOCKS_CF_POSITION_FAILED invalid controllerArgs\n");
+    return 2;
+  }
+  if ((mission == MISSION_FORWARD && mission_value <= 0.0) ||
+      (mission == MISSION_TURN && fabs(mission_value) <= 0.0)) {
+    fprintf(stderr, "WEBEEBLOCKS_CF_POSITION_FAILED invalid mission value\n");
+    return 2;
+  }
+
   wb_robot_init();
   const int step = (int)wb_robot_get_basic_time_step();
   WbDeviceTag m1 = wb_robot_get_device("m1_motor"), m2 = wb_robot_get_device("m2_motor");
@@ -82,6 +115,7 @@ int main(void) {
   double target_x = sx, target_y = sy, target_yaw = syaw;
   double min_z = sz, max_z = sz, px = sx, py = sy, pz = sz, pt = wb_robot_get_time(), stable = -1;
   const double t0 = pt;
+  double primitive_t0 = pt;
   int leg = 0;
   phase_t phase = TAKEOFF;
 
@@ -116,9 +150,17 @@ int main(void) {
       if (fabs(z - target_z) < .05 && fabs(vz) < .15) {
         if (stable < 0) stable = now;
         if (now - stable > .5) {
-          phase = LEG; stable = -1;
-          target_x += LEG_M * cos(target_yaw);
-          target_y += LEG_M * sin(target_yaw);
+          stable = -1;
+          primitive_t0 = now;
+          if (mission == MISSION_TURN) {
+            phase = TURN;
+            target_yaw = wrap(syaw + mission_value);
+          } else {
+            phase = LEG;
+            const double distance = mission == MISSION_FORWARD ? mission_value : LEG_M;
+            target_x += distance * cos(target_yaw);
+            target_y += distance * sin(target_yaw);
+          }
         }
       } else stable = -1;
     } else if (phase == LEG) {
@@ -130,8 +172,16 @@ int main(void) {
       if (hypot(ex, ey) <= POSITION_TOL && hypot(a.vx, a.vy) <= SPEED_TOL) {
         if (stable < 0) stable = now;
         if (now - stable > .2) {
-          phase = TURN; stable = -1;
-          target_yaw = wrap(target_yaw + PI / 2);
+          stable = -1;
+          if (mission == MISSION_FORWARD) {
+            const double dx=x-sx,dy=y-sy,cy0=cos(syaw),sy0=sin(syaw);
+            const double along=dx*cy0+dy*sy0, lateral=-dx*sy0+dy*cy0;
+            write_primitive_result("forward",mission_value,along-mission_value,lateral,wrap(yaw-syaw)*180/PI,0.0,now-primitive_t0);
+            phase = LAND;
+          } else {
+            phase = TURN;
+            target_yaw = wrap(target_yaw + PI / 2);
+          }
         }
       } else stable = -1;
     } else if (phase == TURN) {
@@ -140,13 +190,18 @@ int main(void) {
       if (fabs(eyaw) <= YAW_TOL && fabs(a.yaw_rate) <= YAW_RATE_TOL) {
         if (stable < 0) stable = now;
         if (now - stable > .2) {
-          leg++;
           stable = -1;
-          if (leg == 4) phase = LAND;
-          else {
-            phase = LEG;
-            target_x += LEG_M * cos(target_yaw);
-            target_y += LEG_M * sin(target_yaw);
+          if (mission == MISSION_TURN) {
+            write_primitive_result("turn",mission_value*180/PI,0.0,0.0,wrap(yaw-syaw-mission_value)*180/PI,hypot(x-sx,y-sy),now-primitive_t0);
+            phase = LAND;
+          } else {
+            leg++;
+            if (leg == 4) phase = LAND;
+            else {
+              phase = LEG;
+              target_x += LEG_M * cos(target_yaw);
+              target_y += LEG_M * sin(target_yaw);
+            }
           }
         }
       } else stable = -1;

--- a/controllers/crazyflie_square_position/crazyflie_square_position.c
+++ b/controllers/crazyflie_square_position/crazyflie_square_position.c
@@ -22,9 +22,11 @@
 #define SPEED_TOL 0.12
 #define YAW_RATE_TOL 0.10
 #define PRIMITIVE_STABLE_WINDOW 0.5
+#define PRIMITIVE_VZ_TOL 0.15
+#define PRIMITIVE_ALTITUDE_TOL 0.05
 #define TIMEOUT 60.0
 
-typedef enum { TAKEOFF, LEG, TURN, LAND } phase_t;
+typedef enum { TAKEOFF, LEG, TURN, SETTLE, LAND } phase_t;
 typedef enum { MISSION_SQUARE, MISSION_FORWARD, MISSION_TURN } mission_t;
 
 static double wrap(double a) {
@@ -54,6 +56,7 @@ static const char *phase_name(phase_t phase) {
     case TAKEOFF: return "TAKEOFF";
     case LEG: return "LEG";
     case TURN: return "TURN";
+    case SETTLE: return "SETTLE";
     case LAND: return "LAND";
   }
   return "UNKNOWN";
@@ -70,14 +73,17 @@ static void write_result_file(double err, double yawerr, double min_z, double ma
   fclose(file);
 }
 static void write_primitive_result(const char *kind, double command, double longitudinal, double lateral,
-                                   double yaw_error_deg, double drift_xy, double duration) {
+                                   double yaw_error_deg, double drift_xy, double duration,
+                                   double residual_speed, double residual_yaw_rate, double residual_vz,
+                                   double final_x, double final_y, double final_z, double final_yaw) {
   char path[4096];
   snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-primitive-B.txt", wb_robot_get_project_path());
   FILE *file = fopen(path, "w");
   if (!file) return;
   fprintf(file,
-          "WEBEEBLOCKS_CF_PRIMITIVE_B status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f\n",
-          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration);
+          "WEBEEBLOCKS_CF_PRIMITIVE_B status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f residual_speed=%.6f residual_yaw_rate=%.6f residual_vz=%.6f final_x=%.6f final_y=%.6f final_z=%.6f final_yaw=%.6f\n",
+          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration,
+          residual_speed, residual_yaw_rate, residual_vz, final_x, final_y, final_z, final_yaw);
   fflush(file);
   fclose(file);
 }
@@ -178,11 +184,7 @@ int main(int argc, char **argv) {
         if (now - stable > PRIMITIVE_STABLE_WINDOW) {
           stable = -1;
           if (mission == MISSION_FORWARD) {
-            const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
-            const double along=dx*cy0+dy*sy0,lateral=-dx*sy0+dy*cy0;
-            write_primitive_result("forward",mission_value,along-mission_value,lateral,
-                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0);
-            phase = LAND;
+            phase = SETTLE;
           } else {
             phase = TURN;
             target_yaw = wrap(target_yaw + PI / 2);
@@ -197,10 +199,7 @@ int main(int argc, char **argv) {
         if (now - stable > PRIMITIVE_STABLE_WINDOW) {
           stable = -1;
           if (mission == MISSION_TURN) {
-            write_primitive_result("turn",mission_value*180/PI,0.0,0.0,
-                                   wrap(yaw-primitive_start_yaw-mission_value)*180/PI,
-                                   hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0);
-            phase = LAND;
+            phase = SETTLE;
           } else {
             leg++;
             if (leg == 4) phase = LAND;
@@ -210,6 +209,28 @@ int main(int argc, char **argv) {
               target_y += LEG_M * sin(target_yaw);
             }
           }
+        }
+      } else stable = -1;
+    } else if (phase == SETTLE) {
+      if (hypot(a.vx, a.vy) < SPEED_TOL && fabs(a.yaw_rate) < YAW_RATE_TOL &&
+          fabs(vz) < PRIMITIVE_VZ_TOL && fabs(z - target_z) < PRIMITIVE_ALTITUDE_TOL) {
+        if (stable < 0) stable = now;
+        if (now - stable > PRIMITIVE_STABLE_WINDOW) {
+          const double residual_speed = hypot(a.vx, a.vy);
+          if (mission == MISSION_FORWARD) {
+            const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
+            const double along=dx*cy0+dy*sy0,lateral=-dx*sy0+dy*cy0;
+            write_primitive_result("forward",mission_value,along-mission_value,lateral,
+                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0,
+                                   residual_speed,a.yaw_rate,vz,x,y,z,yaw);
+          } else if (mission == MISSION_TURN) {
+            write_primitive_result("turn",mission_value*180/PI,0.0,0.0,
+                                   wrap(yaw-primitive_start_yaw-mission_value)*180/PI,
+                                   hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0,
+                                   residual_speed,a.yaw_rate,vz,x,y,z,yaw);
+          }
+          phase = LAND;
+          stable = -1;
         }
       } else stable = -1;
     } else {

--- a/tools/ci/run_crazyflie_primitive_matrix.py
+++ b/tools/ci/run_crazyflie_primitive_matrix.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+IMAGE = "cyberbotics/webots:R2025a-ubuntu22.04"
+MISSIONS = [
+    ("T-short", "forward", "0.50"),
+    ("T-long", "forward", "1.50"),
+    ("Y-small", "turn", "45"),
+    ("Y-large", "turn", "135"),
+    ("S-ref", None, None),
+]
+BACKENDS = {
+    "A": {
+        "world": "worlds/crazyflie_square.wbt",
+        "controller": "crazyflie_square",
+        "primitive_result": "ci-artifacts/crazyflie-primitive-A.txt",
+        "primitive_prefix": "WEBEEBLOCKS_CF_PRIMITIVE_A",
+        "square_result": "ci-artifacts/crazyflie-square-result.txt",
+        "square_prefix": "WEBEEBLOCKS_CF_SQUARE_RESULT",
+    },
+    "B": {
+        "world": "worlds/crazyflie_square_position.wbt",
+        "controller": "crazyflie_square_position",
+        "primitive_result": "ci-artifacts/crazyflie-primitive-B.txt",
+        "primitive_prefix": "WEBEEBLOCKS_CF_PRIMITIVE_B",
+        "square_result": "ci-artifacts/crazyflie-square-position-result.txt",
+        "square_prefix": "WEBEEBLOCKS_CF_POSITION_RESULT",
+    },
+}
+
+
+def render_world(source: str, controller: str, kind: str | None, value: str | None, label: str) -> str:
+    needle = f'  controller "{controller}"\n'
+    if needle not in source:
+        raise RuntimeError(f"controller field not found for {controller}")
+    if kind is not None:
+        args = f'  controllerArgs [\n    "{kind}"\n    "{value}"\n  ]\n'
+        source = source.replace(needle, needle + args, 1)
+    source = source.replace("WorldInfo {", "WorldInfo {\n  randomSeed 1\n  optimalThreadCount 1", 1)
+    source = source.replace('name "Crazyflie"', 'name "Crazyflie"\n  synchronization TRUE', 1)
+    return source.replace('experiment"', f'experiment — {label}"', 1)
+
+
+def parse_pairs(line: str, prefix: str) -> dict:
+    if prefix not in line:
+        raise RuntimeError(f"unexpected result line: {line}")
+    pairs = dict(re.findall(r"([A-Za-z_]+)=([^\s]+)", line))
+    if pairs.get("status") != "success":
+        raise RuntimeError(f"non-success result: {line}")
+    return pairs
+
+
+def run_case(root: Path, artifacts: Path, backend: str, mission: str, kind: str | None, value: str | None) -> dict:
+    cfg = BACKENDS[backend]
+    source = (root / cfg["world"]).read_text(encoding="utf-8")
+    generated = root / "worlds" / f".ci-primitive-{backend}-{mission}.wbt"
+    generated.write_text(render_world(source, cfg["controller"], kind, value, f"{backend} {mission}"), encoding="utf-8")
+
+    primitive_path = root / cfg["primitive_result"]
+    square_path = root / cfg["square_result"]
+    primitive_path.unlink(missing_ok=True)
+    square_path.unlink(missing_ok=True)
+    log_path = artifacts / f"{backend}-{mission}.log"
+    relative_world = generated.relative_to(root).as_posix()
+    inner = (
+        "timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast "
+        f"/workspace/{relative_world}"
+    )
+    command = [
+        "docker", "run", "--rm",
+        "-e", "LIBGL_ALWAYS_SOFTWARE=true",
+        "-e", "WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true",
+        "-v", f"{root}:/workspace",
+        "-w", "/workspace",
+        IMAGE,
+        "bash", "-lc", inner,
+    ]
+    try:
+        completed = subprocess.run(command, cwd=root, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=105)
+        log_path.write_text(completed.stdout, encoding="utf-8")
+        if completed.returncode != 0:
+            raise RuntimeError(f"{backend}/{mission}: Webots exit={completed.returncode}; see {log_path}")
+        if "ERROR:" in completed.stdout or "FAILED" in completed.stdout:
+            raise RuntimeError(f"{backend}/{mission}: Webots/controller error; see {log_path}")
+
+        if kind is None:
+            if not square_path.is_file() or square_path.stat().st_size == 0:
+                raise RuntimeError(f"{backend}/{mission}: fresh square result missing")
+            pairs = parse_pairs(square_path.read_text(encoding="utf-8").strip().splitlines()[-1], cfg["square_prefix"])
+            return {
+                "backend": backend,
+                "mission": mission,
+                "kind": "square",
+                "error_xy": float(pairs["error_xy"]),
+                "yaw_error_deg": float(pairs["yaw_error_deg"]),
+                "duration_s": float(pairs["total_s"]),
+            }
+
+        if not primitive_path.is_file() or primitive_path.stat().st_size == 0:
+            raise RuntimeError(f"{backend}/{mission}: fresh primitive result missing")
+        pairs = parse_pairs(primitive_path.read_text(encoding="utf-8").strip().splitlines()[-1], cfg["primitive_prefix"])
+        row = {
+            "backend": backend,
+            "mission": mission,
+            "kind": pairs["kind"],
+            "command": float(pairs["command"]),
+            "yaw_error_deg": float(pairs["yaw_error_deg"]),
+            "duration_s": float(pairs["primitive_s"]),
+        }
+        if kind == "forward":
+            row["longitudinal_error_m"] = float(pairs["longitudinal_error"])
+            row["lateral_error_m"] = float(pairs["lateral_error"])
+        else:
+            row["drift_xy_m"] = float(pairs["drift_xy"])
+        return row
+    finally:
+        generated.unlink(missing_ok=True)
+
+
+def write_markdown(path: Path, rows: list[dict]) -> None:
+    lines = [
+        "# Crazyflie primitive A/B matrix",
+        "",
+        "Metrics for T/Y are captured at primitive completion, before LAND.",
+        "",
+        "| Backend | Mission | Kind | Command | Long err (m) | Lateral err (m) | Yaw err (deg) | Drift XY (m) | Primitive/mission (s) |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row['backend']} | {row['mission']} | {row['kind']} | {row.get('command', 0):.3f} | "
+            f"{row.get('longitudinal_error_m', 0):.6f} | {row.get('lateral_error_m', 0):.6f} | "
+            f"{row['yaw_error_deg']:.6f} | {row.get('drift_xy_m', row.get('error_xy', 0)):.6f} | {row['duration_s']:.3f} |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    artifacts = root / "ci-artifacts" / "crazyflie-primitive-matrix"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    rows = []
+    try:
+        for mission, kind, value in MISSIONS:
+            for backend in ("A", "B"):
+                print(f"=== {backend} / {mission} ===", flush=True)
+                row = run_case(root, artifacts, backend, mission, kind, value)
+                rows.append(row)
+                print(json.dumps(row, sort_keys=True), flush=True)
+    except Exception as exc:
+        (artifacts / "failure.txt").write_text(str(exc) + "\n", encoding="utf-8")
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    (artifacts / "matrix.json").write_text(json.dumps({"rows": rows}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(artifacts / "matrix.md", rows)
+    print((artifacts / "matrix.md").read_text(encoding="utf-8"), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/run_crazyflie_primitive_matrix.py
+++ b/tools/ci/run_crazyflie_primitive_matrix.py
@@ -54,6 +54,22 @@ def parse_pairs(line: str, prefix: str) -> dict:
     return pairs
 
 
+def require_common_endpoint(pairs: dict, backend: str, mission: str) -> None:
+    required = (
+        "residual_speed", "residual_yaw_rate", "residual_vz",
+        "final_x", "final_y", "final_z", "final_yaw",
+    )
+    missing = [key for key in required if key not in pairs]
+    if missing:
+        raise RuntimeError(f"{backend}/{mission}: common endpoint fields missing: {missing}")
+    if float(pairs["residual_speed"]) >= 0.12:
+        raise RuntimeError(f"{backend}/{mission}: residual horizontal speed not settled")
+    if abs(float(pairs["residual_yaw_rate"])) >= 0.10:
+        raise RuntimeError(f"{backend}/{mission}: residual yaw rate not settled")
+    if abs(float(pairs["residual_vz"])) >= 0.15:
+        raise RuntimeError(f"{backend}/{mission}: residual vertical speed not settled")
+
+
 def run_case(root: Path, artifacts: Path, backend: str, mission: str, kind: str | None, value: str | None) -> dict:
     cfg = BACKENDS[backend]
     source = (root / cfg["world"]).read_text(encoding="utf-8")
@@ -103,6 +119,7 @@ def run_case(root: Path, artifacts: Path, backend: str, mission: str, kind: str 
         if not primitive_path.is_file() or primitive_path.stat().st_size == 0:
             raise RuntimeError(f"{backend}/{mission}: fresh primitive result missing")
         pairs = parse_pairs(primitive_path.read_text(encoding="utf-8").strip().splitlines()[-1], cfg["primitive_prefix"])
+        require_common_endpoint(pairs, backend, mission)
         row = {
             "backend": backend,
             "mission": mission,
@@ -110,7 +127,17 @@ def run_case(root: Path, artifacts: Path, backend: str, mission: str, kind: str 
             "command": float(pairs["command"]),
             "yaw_error_deg": float(pairs["yaw_error_deg"]),
             "duration_s": float(pairs["primitive_s"]),
+            "residual_speed_m_s": float(pairs["residual_speed"]),
+            "residual_yaw_rate_rad_s": float(pairs["residual_yaw_rate"]),
+            "residual_vz_m_s": float(pairs["residual_vz"]),
+            "final_x_m": float(pairs["final_x"]),
+            "final_y_m": float(pairs["final_y"]),
+            "final_z_m": float(pairs["final_z"]),
+            "final_yaw_rad": float(pairs["final_yaw"]),
         }
+        if backend == "A":
+            row["threshold_error"] = float(pairs["threshold_error"])
+            row["max_overshoot"] = float(pairs["max_overshoot"])
         if kind == "forward":
             row["longitudinal_error_m"] = float(pairs["longitudinal_error"])
             row["lateral_error_m"] = float(pairs["lateral_error"])
@@ -125,16 +152,18 @@ def write_markdown(path: Path, rows: list[dict]) -> None:
     lines = [
         "# Crazyflie primitive A/B matrix",
         "",
-        "Metrics for T/Y are captured at primitive completion, before LAND.",
+        "T/Y metrics are captured only after the common 0.5 s kinematic stability boundary, before LAND.",
         "",
-        "| Backend | Mission | Kind | Command | Long err (m) | Lateral err (m) | Yaw err (deg) | Drift XY (m) | Primitive/mission (s) |",
-        "|---|---|---|---:|---:|---:|---:|---:|---:|",
+        "| Backend | Mission | Kind | Command | Long err (m) | Lateral err (m) | Yaw err (deg) | Drift XY (m) | Residual speed | Residual yaw rate | Residual vz | Time (s) |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in rows:
         lines.append(
             f"| {row['backend']} | {row['mission']} | {row['kind']} | {row.get('command', 0):.3f} | "
             f"{row.get('longitudinal_error_m', 0):.6f} | {row.get('lateral_error_m', 0):.6f} | "
-            f"{row['yaw_error_deg']:.6f} | {row.get('drift_xy_m', row.get('error_xy', 0)):.6f} | {row['duration_s']:.3f} |"
+            f"{row['yaw_error_deg']:.6f} | {row.get('drift_xy_m', row.get('error_xy', 0)):.6f} | "
+            f"{row.get('residual_speed_m_s', 0):.6f} | {row.get('residual_yaw_rate_rad_s', 0):.6f} | "
+            f"{row.get('residual_vz_m_s', 0):.6f} | {row['duration_s']:.3f} |"
         )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
## Goal
Measure the exact future student-facing primitives before introducing obstacles or product thresholds.

## Lab-defined matrix
- T-short: `takeoff -> forward(0.50 m) -> land`
- T-long: `takeoff -> forward(1.50 m) -> land`
- Y-small: `takeoff -> turn(+45 deg) -> land`
- Y-large: `takeoff -> turn(+135 deg) -> land`
- S-ref: existing `4 x [forward(1.00 m), turn(+90 deg)] -> land`

For T/Y, the primary metric is captured **at primitive completion before LAND**.

## Scope
- same native Webots R2025a Crazyflie model;
- same PID, gains, velocity/yaw caps, altitude and landing rule;
- existing square behavior remains the default when no `controllerArgs` are supplied, so all current A/B gates remain direct non-regression checks;
- the only new controller interface is CI mission selection (`forward <distance>` or `turn <degrees>`);
- no Blockly, obstacles, random perturbations or tuning.

## Metrics
Forward: longitudinal error, lateral error, heading error, primitive duration.
Turn: signed yaw error, XY drift, primitive duration.
Square: existing closure XY, final yaw error and mission duration.

## Acceptance
All 10 fresh Webots R2025a runs must complete fail-closed and produce fresh primitive/square result files. Existing historical, backend A, backend B and invariance gates must remain green. The results are characterization evidence only; no backend choice or pedagogical threshold is made in this PR.