### PR TITLE
Characterize backend B edge primitives under R2025a

### DIFF
--- a/.github/workflows/crazyflie-b-edges-r2025a.yml
+++ b/.github/workflows/crazyflie-b-edges-r2025a.yml
@@ -1,0 +1,53 @@
+name: Crazyflie backend B edge characterization R2025a
+
+on:
+  pull_request:
+    branches: [webots-ci]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  crazyflie-b-edges:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build backend B controller
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/crazyflie-b-edge-matrix
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_square_position \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/crazyflie-b-edge-matrix/build.log
+
+      - name: Run four backend B edge cases
+        shell: bash
+        run: |
+          set -o pipefail
+          python3 tools/ci/run_crazyflie_b_edge_matrix.py
+
+      - name: Publish edge characterization
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ci-artifacts/crazyflie-b-edge-matrix/matrix.md ]; then
+            cat ci-artifacts/crazyflie-b-edge-matrix/matrix.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crazyflie-b-edge-characterization-r2025a
+          path: ci-artifacts/crazyflie-b-edge-matrix/
+          if-no-files-found: error

--- a/controllers/crazyflie_square_position/crazyflie_square_position.c
+++ b/controllers/crazyflie_square_position/crazyflie_square_position.c
@@ -70,7 +70,8 @@ static void write_result_file(double err, double yawerr, double min_z, double ma
   fclose(file);
 }
 static void write_primitive_result(const char *kind, double command, double longitudinal, double lateral,
-                                   double yaw_error_deg, double drift_xy, double duration,
+                                   double yaw_error_deg, double signed_yaw_travel_deg,
+                                   double drift_xy, double duration,
                                    double residual_speed, double residual_yaw_rate, double residual_vz,
                                    double residual_altitude_error,
                                    double final_x, double final_y, double final_z, double final_yaw) {
@@ -79,10 +80,10 @@ static void write_primitive_result(const char *kind, double command, double long
   FILE *file = fopen(path, "w");
   if (!file) return;
   fprintf(file,
-          "WEBEEBLOCKS_CF_PRIMITIVE_B status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f drift_xy=%.6f primitive_s=%.3f residual_speed=%.6f residual_yaw_rate=%.6f residual_vz=%.6f residual_altitude_error=%.6f final_x=%.6f final_y=%.6f final_z=%.6f final_yaw=%.6f\n",
-          kind, command, longitudinal, lateral, yaw_error_deg, drift_xy, duration,
-          residual_speed, residual_yaw_rate, residual_vz, residual_altitude_error,
-          final_x, final_y, final_z, final_yaw);
+          "WEBEEBLOCKS_CF_PRIMITIVE_B status=success kind=%s command=%.6f longitudinal_error=%.6f lateral_error=%.6f yaw_error_deg=%.6f signed_yaw_travel_deg=%.6f drift_xy=%.6f primitive_s=%.3f residual_speed=%.6f residual_yaw_rate=%.6f residual_vz=%.6f residual_altitude_error=%.6f final_x=%.6f final_y=%.6f final_z=%.6f final_yaw=%.6f\n",
+          kind, command, longitudinal, lateral, yaw_error_deg, signed_yaw_travel_deg,
+          drift_xy, duration, residual_speed, residual_yaw_rate, residual_vz,
+          residual_altitude_error, final_x, final_y, final_z, final_yaw);
   fflush(file);
   fclose(file);
 }
@@ -125,6 +126,7 @@ int main(int argc, char **argv) {
   double min_z = sz, max_z = sz, px = sx, py = sy, pz = sz, pt = wb_robot_get_time(), stable = -1;
   const double t0 = pt;
   double primitive_t0 = pt;
+  double primitive_yaw_previous = syaw, primitive_yaw_travel = 0.0;
   int leg = 0;
   phase_t phase = TAKEOFF;
 
@@ -150,6 +152,11 @@ int main(int argc, char **argv) {
     a.vx = vxg * cy + vyg * syy; a.vy = -vxg * syy + vyg * cy;
     d.roll = 0; d.pitch = 0; d.vx = 0; d.vy = 0; d.yaw_rate = 0; d.altitude = target_z;
 
+    if (mission == MISSION_TURN && (phase == TURN || phase == SETTLE)) {
+      primitive_yaw_travel += wrap(yaw - primitive_yaw_previous);
+      primitive_yaw_previous = yaw;
+    }
+
     if (fabs(a.roll) > 1.2 || fabs(a.pitch) > 1.2 || now - t0 > TIMEOUT) {
       printf("WEBEEBLOCKS_CF_POSITION_FAILED phase=%s leg=%d t=%.3f\n", phase_name(phase), leg, now - t0);
       fflush(stdout); stop(m1, m2, m3, m4); wb_supervisor_simulation_quit(2); break;
@@ -162,6 +169,7 @@ int main(int argc, char **argv) {
           stable = -1;
           primitive_t0 = now;
           primitive_start_x = x; primitive_start_y = y; primitive_start_yaw = yaw;
+          primitive_yaw_previous = yaw; primitive_yaw_travel = 0.0;
           if (mission == MISSION_TURN) {
             phase = TURN;
             target = webeeblocks_turn(x, y, target_z, yaw, mission_value);
@@ -229,11 +237,12 @@ int main(int argc, char **argv) {
             const double dx=x-primitive_start_x,dy=y-primitive_start_y,cy0=cos(primitive_start_yaw),sy0=sin(primitive_start_yaw);
             const double along=dx*cy0+dy*sy0,lateral=-dx*sy0+dy*cy0;
             write_primitive_result("forward",mission_value,along-mission_value,lateral,
-                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,now-primitive_t0,
+                                   wrap(yaw-primitive_start_yaw)*180/PI,0.0,0.0,now-primitive_t0,
                                    residual_speed,a.yaw_rate,vz,residual_altitude_error,x,y,z,yaw);
           } else if (mission == MISSION_TURN) {
             write_primitive_result("turn",mission_value*180/PI,0.0,0.0,
                                    wrap(yaw-primitive_start_yaw-mission_value)*180/PI,
+                                   primitive_yaw_travel*180/PI,
                                    hypot(x-primitive_start_x,y-primitive_start_y),now-primitive_t0,
                                    residual_speed,a.yaw_rate,vz,residual_altitude_error,x,y,z,yaw);
           }

--- a/tools/ci/run_crazyflie_b_edge_matrix.py
+++ b/tools/ci/run_crazyflie_b_edge_matrix.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+import json
+import math
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+IMAGE = "cyberbotics/webots:R2025a-ubuntu22.04"
+WORLD = "worlds/crazyflie_square_position.wbt"
+CONTROLLER = "crazyflie_square_position"
+RESULT = "ci-artifacts/crazyflie-primitive-B.txt"
+PREFIX = "WEBEEBLOCKS_CF_PRIMITIVE_B"
+CASES = [
+    ("F-0.10", "forward", "0.10"),
+    ("F-2.00", "forward", "2.00"),
+    ("Y--90", "turn", "-90"),
+    ("Y-180", "turn", "180"),
+]
+
+
+def render_world(source: str, kind: str, value: str, label: str) -> str:
+    needle = f'  controller "{CONTROLLER}"\n'
+    if needle not in source:
+        raise RuntimeError("backend B controller field not found")
+    args = f'  controllerArgs [\n    "{kind}"\n    "{value}"\n  ]\n'
+    source = source.replace(needle, needle + args, 1)
+    source = source.replace("WorldInfo {", "WorldInfo {\n  randomSeed 1\n  optimalThreadCount 1", 1)
+    source = source.replace('name "Crazyflie"', 'name "Crazyflie"\n  synchronization TRUE', 1)
+    return source.replace('experiment"', f'experiment — B edge {label}"', 1)
+
+
+def parse_pairs(line: str) -> dict:
+    if PREFIX not in line:
+        raise RuntimeError(f"unexpected result line: {line}")
+    pairs = dict(re.findall(r"([A-Za-z_]+)=([^\s]+)", line))
+    if pairs.get("status") != "success":
+        raise RuntimeError(f"non-success result: {line}")
+    return pairs
+
+
+def require_endpoint(pairs: dict, label: str) -> None:
+    required = (
+        "kind", "command", "yaw_error_deg", "primitive_s",
+        "residual_speed", "residual_yaw_rate", "residual_vz",
+        "residual_altitude_error", "final_x", "final_y", "final_z", "final_yaw",
+    )
+    missing = [key for key in required if key not in pairs]
+    if missing:
+        raise RuntimeError(f"{label}: endpoint fields missing: {missing}")
+    if float(pairs["residual_speed"]) >= 0.12:
+        raise RuntimeError(f"{label}: residual horizontal speed not settled")
+    if abs(float(pairs["residual_yaw_rate"])) >= 0.10:
+        raise RuntimeError(f"{label}: residual yaw rate not settled")
+    if abs(float(pairs["residual_vz"])) >= 0.15:
+        raise RuntimeError(f"{label}: residual vertical speed not settled")
+    if abs(float(pairs["residual_altitude_error"])) >= 0.05:
+        raise RuntimeError(f"{label}: residual altitude error not settled")
+
+
+def result_row(label: str, kind: str, pairs: dict) -> dict:
+    require_endpoint(pairs, label)
+    command = float(pairs["command"])
+    row = {
+        "case": label,
+        "kind": kind,
+        "command": command,
+        "termination": "SUCCESS",
+        "duration_s": float(pairs["primitive_s"]),
+        "yaw_error_deg": float(pairs["yaw_error_deg"]),
+        "residual_speed_m_s": float(pairs["residual_speed"]),
+        "residual_yaw_rate_rad_s": float(pairs["residual_yaw_rate"]),
+        "residual_vz_m_s": float(pairs["residual_vz"]),
+        "residual_altitude_error_m": float(pairs["residual_altitude_error"]),
+        "final_x_m": float(pairs["final_x"]),
+        "final_y_m": float(pairs["final_y"]),
+        "final_z_m": float(pairs["final_z"]),
+        "final_yaw_rad": float(pairs["final_yaw"]),
+    }
+    if kind == "forward":
+        signed_error = float(pairs["longitudinal_error"])
+        lateral = float(pairs["lateral_error"])
+        achieved = command + signed_error
+        row.update({
+            "signed_error": signed_error,
+            "parasitic_motion": lateral,
+            "endpoint_overshoot": max(0.0, signed_error),
+            "achieved": achieved,
+        })
+        if achieved <= 0.0:
+            row["termination"] = "PATHOLOGICAL_WRONG_SIGN"
+    else:
+        signed_error = float(pairs["yaw_error_deg"])
+        drift = float(pairs["drift_xy"])
+        achieved = command + signed_error
+        direction = 1.0 if command > 0.0 else -1.0
+        row.update({
+            "signed_error": signed_error,
+            "parasitic_motion": drift,
+            "endpoint_overshoot": max(0.0, direction * signed_error),
+            "achieved": achieved,
+        })
+        if direction * achieved <= 0.0:
+            row["termination"] = "PATHOLOGICAL_WRONG_SIGN"
+    return row
+
+
+def run_case(root: Path, artifacts: Path, label: str, kind: str, value: str) -> dict:
+    source = (root / WORLD).read_text(encoding="utf-8")
+    generated = root / "worlds" / f".ci-b-edge-{label}.wbt"
+    generated.write_text(render_world(source, kind, value, label), encoding="utf-8")
+    result_path = root / RESULT
+    result_path.unlink(missing_ok=True)
+    log_path = artifacts / f"{label}.log"
+    relative_world = generated.relative_to(root).as_posix()
+    inner = (
+        "timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast "
+        f"/workspace/{relative_world}"
+    )
+    command = [
+        "docker", "run", "--rm",
+        "-e", "LIBGL_ALWAYS_SOFTWARE=true",
+        "-e", "WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true",
+        "-v", f"{root}:/workspace",
+        "-w", "/workspace",
+        IMAGE,
+        "bash", "-lc", inner,
+    ]
+    try:
+        completed = subprocess.run(command, cwd=root, text=True, stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT, timeout=105)
+        log_path.write_text(completed.stdout, encoding="utf-8")
+        if completed.returncode != 0:
+            return {"case": label, "kind": kind, "command": float(value),
+                    "termination": f"PATHOLOGICAL_WEBOTS_EXIT_{completed.returncode}"}
+        if "ERROR:" in completed.stdout or "WEBEEBLOCKS_CF_POSITION_FAILED" in completed.stdout:
+            return {"case": label, "kind": kind, "command": float(value),
+                    "termination": "PATHOLOGICAL_CONTROLLER_FAILURE"}
+        if not result_path.is_file() or result_path.stat().st_size == 0:
+            return {"case": label, "kind": kind, "command": float(value),
+                    "termination": "PATHOLOGICAL_MISSING_RESULT"}
+        pairs = parse_pairs(result_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+        return result_row(label, kind, pairs)
+    except subprocess.TimeoutExpired:
+        return {"case": label, "kind": kind, "command": float(value),
+                "termination": "PATHOLOGICAL_HARNESS_TIMEOUT"}
+    except Exception as exc:
+        return {"case": label, "kind": kind, "command": float(value),
+                "termination": "PATHOLOGICAL_INVALID_RESULT", "detail": str(exc)}
+    finally:
+        generated.unlink(missing_ok=True)
+
+
+def write_markdown(path: Path, rows: list[dict]) -> None:
+    lines = [
+        "# Backend B edge characterization",
+        "",
+        "No PID/gain/cap/navigation tuning. Each case is a fresh Webots R2025a process.",
+        "`endpoint_overshoot` is overshoot remaining at the common stabilized endpoint; transient peak overshoot is not instrumented by this gate.",
+        "",
+        "| Case | Kind | Command | Termination | Achieved | Signed err | Parasitic motion | Endpoint overshoot | Alt err | Time (s) |",
+        "|---|---|---:|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        def f(key: str) -> str:
+            value = row.get(key)
+            return "N/A" if value is None else f"{value:.6f}"
+        lines.append(
+            f"| {row['case']} | {row['kind']} | {row['command']:.3f} | {row['termination']} | "
+            f"{f('achieved')} | {f('signed_error')} | {f('parasitic_motion')} | "
+            f"{f('endpoint_overshoot')} | {f('residual_altitude_error_m')} | {f('duration_s')} |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    artifacts = root / "ci-artifacts" / "crazyflie-b-edge-matrix"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for label, kind, value in CASES:
+        print(f"=== B / {label} ===", flush=True)
+        row = run_case(root, artifacts, label, kind, value)
+        rows.append(row)
+        print(json.dumps(row, sort_keys=True), flush=True)
+
+    payload = {"rows": rows}
+    (artifacts / "matrix.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(artifacts / "matrix.md", rows)
+    print((artifacts / "matrix.md").read_text(encoding="utf-8"), flush=True)
+
+    pathological = [row for row in rows if row["termination"] != "SUCCESS"]
+    if pathological:
+        (artifacts / "failure.txt").write_text(json.dumps(pathological, indent=2) + "\n", encoding="utf-8")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/run_crazyflie_b_edge_matrix.py
+++ b/tools/ci/run_crazyflie_b_edge_matrix.py
@@ -39,12 +39,14 @@ def parse_pairs(line: str) -> dict:
     return pairs
 
 
-def require_endpoint(pairs: dict, label: str) -> None:
-    required = (
+def require_endpoint(pairs: dict, label: str, kind: str) -> None:
+    required = [
         "kind", "command", "yaw_error_deg", "primitive_s",
         "residual_speed", "residual_yaw_rate", "residual_vz",
         "residual_altitude_error", "final_x", "final_y", "final_z", "final_yaw",
-    )
+    ]
+    if kind == "turn":
+        required.append("signed_yaw_travel_deg")
     missing = [key for key in required if key not in pairs]
     if missing:
         raise RuntimeError(f"{label}: endpoint fields missing: {missing}")
@@ -59,7 +61,7 @@ def require_endpoint(pairs: dict, label: str) -> None:
 
 
 def result_row(label: str, kind: str, pairs: dict) -> dict:
-    require_endpoint(pairs, label)
+    require_endpoint(pairs, label, kind)
     command = float(pairs["command"])
     row = {
         "case": label,
@@ -93,15 +95,21 @@ def result_row(label: str, kind: str, pairs: dict) -> dict:
         signed_error = float(pairs["yaw_error_deg"])
         drift = float(pairs["drift_xy"])
         achieved = command + signed_error
+        signed_yaw_travel = float(pairs["signed_yaw_travel_deg"])
         direction = 1.0 if command > 0.0 else -1.0
+        yaw_travel_tolerance = max(15.0, 0.25 * abs(command))
         row.update({
             "signed_error": signed_error,
             "parasitic_motion": drift,
             "endpoint_overshoot": max(0.0, direction * signed_error),
             "achieved": achieved,
+            "signed_yaw_travel_deg": signed_yaw_travel,
+            "yaw_travel_error_deg": signed_yaw_travel - command,
         })
-        if direction * achieved <= 0.0:
-            row["termination"] = "PATHOLOGICAL_WRONG_SIGN"
+        if direction * signed_yaw_travel <= 0.0:
+            row["termination"] = "PATHOLOGICAL_WRONG_TURN_DIRECTION"
+        elif abs(signed_yaw_travel - command) > yaw_travel_tolerance:
+            row["termination"] = "PATHOLOGICAL_YAW_TRAVEL"
     return row
 
 
@@ -157,9 +165,10 @@ def write_markdown(path: Path, rows: list[dict]) -> None:
         "",
         "No PID/gain/cap/navigation tuning. Each case is a fresh Webots R2025a process.",
         "`endpoint_overshoot` is overshoot remaining at the common stabilized endpoint; transient peak overshoot is not instrumented by this gate.",
+        "For turns, `signed_yaw_travel_deg` is the unwrapped yaw actually traversed from TURN start through the stabilized endpoint.",
         "",
-        "| Case | Kind | Command | Termination | Achieved | Signed err | Parasitic motion | Endpoint overshoot | Alt err | Time (s) |",
-        "|---|---|---:|---|---:|---:|---:|---:|---:|---:|",
+        "| Case | Kind | Command | Termination | Achieved | Signed err | Yaw travel | Parasitic motion | Endpoint overshoot | Alt err | Time (s) |",
+        "|---|---|---:|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in rows:
         def f(key: str) -> str:
@@ -167,8 +176,9 @@ def write_markdown(path: Path, rows: list[dict]) -> None:
             return "N/A" if value is None else f"{value:.6f}"
         lines.append(
             f"| {row['case']} | {row['kind']} | {row['command']:.3f} | {row['termination']} | "
-            f"{f('achieved')} | {f('signed_error')} | {f('parasitic_motion')} | "
-            f"{f('endpoint_overshoot')} | {f('residual_altitude_error_m')} | {f('duration_s')} |"
+            f"{f('achieved')} | {f('signed_error')} | {f('signed_yaw_travel_deg')} | "
+            f"{f('parasitic_motion')} | {f('endpoint_overshoot')} | "
+            f"{f('residual_altitude_error_m')} | {f('duration_s')} |"
         )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
## Goal
Characterize the four edge cases fixed by Lab/Lead before building the first composed L course, with **no tuning** and no product/UI changes.

## Matrix
- `forward(0.10 m)`
- `forward(2.00 m)`
- `turn(-90 deg)`
- `turn(180 deg)`

Each case runs in a fresh Webots R2025a process using the already selected/factored backend B from #29.

## Evidence
For successful stabilized endpoints the harness publishes command, achieved value, signed endpoint error, parasitic motion (lateral error for forward / XY drift for turn), residual altitude error, endpoint overshoot, duration and explicit termination cause. `endpoint_overshoot` is deliberately named: transient peak overshoot is not instrumented by this minimal gate and is not claimed.

The harness continues through all four cases so a pathological case still leaves the full diagnostic matrix, then fails closed if any termination is not `SUCCESS`. Existing backend B endpoint limits remain enforced (`speed < 0.12 m/s`, `|yaw_rate| < 0.10 rad/s`, `|vz| < 0.15 m/s`, altitude error `< 0.05 m`).

## Scope
Harness/workflow only. No PID, gains, caps, navigation tolerances, model, primitive API, Blockly, obstacles, score, sensors or `main` changes.

Base: `webots-ci`.