### PR TITLE
Factor minimal STOP executor for Crazyflie L course

### DIFF
--- a/controllers/crazyflie_l_course/crazyflie_l_course.c
+++ b/controllers/crazyflie_l_course/crazyflie_l_course.c
@@ -19,9 +19,6 @@
 #define YAW_KP 1.5
 #define POSITION_TOL 0.03
 #define YAW_TOL (2.0 * PI / 180.0)
-#define SPEED_TOL 0.12
-#define YAW_RATE_TOL 0.10
-#define STABLE_WINDOW 0.5
 #define TIMEOUT 60.0
 #define GATE_ALONG_M 0.90
 #define GATE_HALF_WIDTH_M 0.30
@@ -160,7 +157,6 @@ int main(void) {
   double target_x = target.x, target_y = target.y, target_yaw = target.yaw;
   double min_z = sz, max_z = sz, px = sx, py = sy, pz = sz, pt = wb_robot_get_time();
   const double t0 = pt;
-  double stable = -1.0;
   gate_result_t gate1 = {0}, gate2 = {0};
 
   gains_pid_t g = {0};
@@ -212,82 +208,73 @@ int main(void) {
     }
 
     if (command->type == WEBEEBLOCKS_COMMAND_TAKEOFF) {
-      const int stabilized = fabs(z-target_z) < .05 && fabs(vz) < .15;
-      if (stabilized) {
-        if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
-          stable = -1;
-          webeeblocks_runner_advance(&runner);
-          command = webeeblocks_runner_current(&runner);
-          target = webeeblocks_forward(x,y,target_z,yaw,command->value);
-          target_x = target.x; target_y = target.y; target_yaw = syaw;
-        }
-      } else stable = -1;
+      const int geometric_ready = fabs(z - target_z) < WEBEEBLOCKS_STOP_ALTITUDE_ERROR_MAX;
+      if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
+                                              hypot(a.vx, a.vy), a.yaw_rate, vz,
+                                              z - target_z, now)) {
+        webeeblocks_runner_advance(&runner);
+        command = webeeblocks_runner_current(&runner);
+        target = webeeblocks_forward(x,y,target_z,yaw,command->value);
+        target_x = target.x; target_y = target.y; target_yaw = syaw;
+      }
     } else if (command->type == WEBEEBLOCKS_COMMAND_FORWARD) {
       const double ex = target_x-x, ey = target_y-y;
       double bx = ex*cy + ey*syy, by = -ex*syy + ey*cy;
       d.vx = POSITION_KP*bx; d.vy = POSITION_KP*by;
       clip_vector(&d.vx,&d.vy,VX_MAX);
-      const int geometric_reached = hypot(ex,ey) <= POSITION_TOL;
-      const int stabilized = geometric_reached && hypot(a.vx,a.vy) <= SPEED_TOL;
-      if (stabilized) {
-        if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
-          stable = -1;
-          if (runner.index == 1) {
-            if (!gate1.passed) {
-              write_failure("GATE1_NOT_CROSSED", &runner, gates);
-              stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
-            }
-            webeeblocks_runner_advance(&runner);
-            command = webeeblocks_runner_current(&runner);
-            target = webeeblocks_turn(target_x,target_y,target_z,target_yaw,command->value);
-            target_yaw = target.yaw;
-          } else {
-            if (!gate2.passed) {
-              write_failure("GATE2_NOT_CROSSED", &runner, gates);
-              stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
-            }
-            webeeblocks_runner_advance(&runner);
+      const int geometric_ready = hypot(ex,ey) <= POSITION_TOL;
+      if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
+                                              hypot(a.vx, a.vy), a.yaw_rate, vz,
+                                              z - target_z, now)) {
+        if (runner.index == 1) {
+          if (!gate1.passed) {
+            write_failure("GATE1_NOT_CROSSED", &runner, gates);
+            stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
           }
+          webeeblocks_runner_advance(&runner);
+          command = webeeblocks_runner_current(&runner);
+          target = webeeblocks_turn(target_x,target_y,target_z,target_yaw,command->value);
+          target_yaw = target.yaw;
+        } else {
+          if (!gate2.passed) {
+            write_failure("GATE2_NOT_CROSSED", &runner, gates);
+            stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
+          }
+          webeeblocks_runner_advance(&runner);
         }
-      } else stable = -1;
+      }
     } else if (command->type == WEBEEBLOCKS_COMMAND_TURN) {
       const double eyaw = wrap(target_yaw-yaw);
       d.yaw_rate = clip(YAW_KP*eyaw,YAW_RATE_MAX);
-      const int geometric_reached = fabs(eyaw) <= YAW_TOL;
-      const int stabilized = geometric_reached && fabs(a.yaw_rate) <= YAW_RATE_TOL;
-      if (stabilized) {
-        if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
-          stable = -1;
-          webeeblocks_runner_advance(&runner);
-          command = webeeblocks_runner_current(&runner);
-          target = webeeblocks_forward(target_x,target_y,target_z,target_yaw,command->value);
-          target_x = target.x; target_y = target.y;
-        }
-      } else stable = -1;
+      const int geometric_ready = fabs(eyaw) <= YAW_TOL;
+      if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
+                                              hypot(a.vx, a.vy), a.yaw_rate, vz,
+                                              z - target_z, now)) {
+        webeeblocks_runner_advance(&runner);
+        command = webeeblocks_runner_current(&runner);
+        target = webeeblocks_forward(target_x,target_y,target_z,target_yaw,command->value);
+        target_x = target.x; target_y = target.y;
+      }
     } else if (command->type == WEBEEBLOCKS_COMMAND_LAND) {
       const webeeblocks_target_t landing = webeeblocks_land(x,y,sz,yaw);
       d.altitude = landing.z;
-      const int stabilized = z <= landing.z + .05 && fabs(vz) < .15;
-      if (stabilized) {
-        if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
-          if (!(gate1.passed && gate2.passed)) {
-            write_failure("GATES_INCOMPLETE", &runner, gate1.passed+gate2.passed);
-            stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
-          }
-          const double endpoint_error = hypot(x-expected_x,y-expected_y);
-          const double yaw_error = fabs(wrap(yaw-expected_yaw))*180.0/PI;
-          write_success(&gate1,&gate2,endpoint_error,yaw_error,min_z,max_z,now-t0);
-          printf("WEBEEBLOCKS_CF_L_RESULT status=success gates=2 endpoint_error_xy=%.6f yaw_error_deg=%.6f total_s=%.3f\n",
-                 endpoint_error,yaw_error,now-t0);
-          fflush(stdout);
-          webeeblocks_runner_advance(&runner);
-          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(0); break;
+      const int geometric_ready = z <= landing.z + WEBEEBLOCKS_STOP_ALTITUDE_ERROR_MAX;
+      if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
+                                              hypot(a.vx, a.vy), a.yaw_rate, vz,
+                                              z - landing.z, now)) {
+        if (!(gate1.passed && gate2.passed)) {
+          write_failure("GATES_INCOMPLETE", &runner, gate1.passed+gate2.passed);
+          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
         }
-      } else stable = -1;
+        const double endpoint_error = hypot(x-expected_x,y-expected_y);
+        const double yaw_error = fabs(wrap(yaw-expected_yaw))*180.0/PI;
+        write_success(&gate1,&gate2,endpoint_error,yaw_error,min_z,max_z,now-t0);
+        printf("WEBEEBLOCKS_CF_L_RESULT status=success gates=2 endpoint_error_xy=%.6f yaw_error_deg=%.6f total_s=%.3f\n",
+               endpoint_error,yaw_error,now-t0);
+        fflush(stdout);
+        webeeblocks_runner_advance(&runner);
+        stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(0); break;
+      }
     }
 
     pid_velocity_fixed_height_controller(a,&d,g,dt,&power);

--- a/controllers/crazyflie_l_course/crazyflie_l_course.c
+++ b/controllers/crazyflie_l_course/crazyflie_l_course.c
@@ -8,6 +8,7 @@
 #include <webots/supervisor.h>
 #include "pid_controller.h"
 #include "webeeblocks_primitives.h"
+#include "webeeblocks_executor.h"
 
 #define PI 3.14159265358979323846
 #define TARGET_Z_DELTA 1.0
@@ -25,8 +26,6 @@
 #define GATE_ALONG_M 0.90
 #define GATE_HALF_WIDTH_M 0.30
 #define GATE_HALF_HEIGHT_M 0.20
-
-typedef enum { TAKEOFF, LEG1, TURN, LEG2, LAND } phase_t;
 
 typedef struct {
   int passed;
@@ -57,15 +56,14 @@ static void stop(WbDeviceTag a, WbDeviceTag b, WbDeviceTag c, WbDeviceTag d) {
   wb_motor_set_velocity(a, 0); wb_motor_set_velocity(b, 0);
   wb_motor_set_velocity(c, 0); wb_motor_set_velocity(d, 0);
 }
-static const char *phase_name(phase_t p) {
-  switch (p) {
-    case TAKEOFF: return "TAKEOFF";
-    case LEG1: return "LEG1";
-    case TURN: return "TURN";
-    case LEG2: return "LEG2";
-    case LAND: return "LAND";
-  }
-  return "UNKNOWN";
+
+static const char *runner_phase_name(const webeeblocks_runner_t *runner) {
+  const webeeblocks_command_t *command = webeeblocks_runner_current(runner);
+  if (!command)
+    return "DONE";
+  if (command->type == WEBEEBLOCKS_COMMAND_FORWARD)
+    return runner->index == 1 ? "LEG1" : "LEG2";
+  return webeeblocks_command_name(command->type);
 }
 
 static int check_gate(double px, double py, double pz,
@@ -97,13 +95,13 @@ static int check_gate(double px, double py, double pz,
   return 1;
 }
 
-static void write_failure(const char *reason, phase_t phase, int gates) {
+static void write_failure(const char *reason, const webeeblocks_runner_t *runner, int gates) {
   char path[4096];
   snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-l-course-result.txt", wb_robot_get_project_path());
   FILE *file = fopen(path, "w");
   if (file) {
     fprintf(file, "WEBEEBLOCKS_CF_L_RESULT status=failure reason=%s phase=%s gates=%d\n",
-            reason, phase_name(phase), gates);
+            reason, runner_phase_name(runner), gates);
     fflush(file);
     fclose(file);
   }
@@ -126,6 +124,14 @@ static void write_success(const gate_result_t *g1, const gate_result_t *g2,
 }
 
 int main(void) {
+  static const webeeblocks_command_t mission[] = {
+    {WEBEEBLOCKS_COMMAND_TAKEOFF, TARGET_Z_DELTA},
+    {WEBEEBLOCKS_COMMAND_FORWARD, LEG_M},
+    {WEBEEBLOCKS_COMMAND_TURN, PI / 2.0},
+    {WEBEEBLOCKS_COMMAND_FORWARD, LEG_M},
+    {WEBEEBLOCKS_COMMAND_LAND, 0.0},
+  };
+
   wb_robot_init();
   const int step = (int)wb_robot_get_basic_time_step();
   WbDeviceTag m1 = wb_robot_get_device("m1_motor"), m2 = wb_robot_get_device("m2_motor");
@@ -147,13 +153,14 @@ int main(void) {
   const double expected_x = corner_x + LEG_M * vx, expected_y = corner_y + LEG_M * vy;
   const double expected_yaw = wrap(syaw + PI / 2.0);
 
-  webeeblocks_target_t target = webeeblocks_takeoff(sx, sy, sz, syaw, TARGET_Z_DELTA);
+  webeeblocks_runner_t runner;
+  webeeblocks_runner_init(&runner, mission, sizeof(mission) / sizeof(mission[0]));
+  webeeblocks_target_t target = webeeblocks_takeoff(sx, sy, sz, syaw, mission[0].value);
   const double target_z = target.z;
   double target_x = target.x, target_y = target.y, target_yaw = target.yaw;
   double min_z = sz, max_z = sz, px = sx, py = sy, pz = sz, pt = wb_robot_get_time();
   const double t0 = pt;
   double stable = -1.0;
-  phase_t phase = TAKEOFF;
   gate_result_t gate1 = {0}, gate2 = {0};
 
   gains_pid_t g = {0};
@@ -178,82 +185,97 @@ int main(void) {
     a.vx = vxg * cy + vyg * syy; a.vy = -vxg * syy + vyg * cy;
     d.roll = 0; d.pitch = 0; d.vx = 0; d.vy = 0; d.yaw_rate = 0; d.altitude = target_z;
 
-    const int gates = gate1.passed + gate2.passed;
-    if (fabs(a.roll) > 1.2 || fabs(a.pitch) > 1.2 || now - t0 > TIMEOUT) {
-      write_failure(now - t0 > TIMEOUT ? "TIMEOUT" : "UNSAFE_STATE", phase, gates);
+    const webeeblocks_command_t *command = webeeblocks_runner_current(&runner);
+    if (!command) {
+      write_failure("RUNNER_EXHAUSTED", &runner, gate1.passed + gate2.passed);
       stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
     }
 
-    if (phase == LEG1) {
+    const int gates = gate1.passed + gate2.passed;
+    if (fabs(a.roll) > 1.2 || fabs(a.pitch) > 1.2 || now - t0 > TIMEOUT) {
+      write_failure(now - t0 > TIMEOUT ? "TIMEOUT" : "UNSAFE_STATE", &runner, gates);
+      stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
+    }
+
+    if (command->type == WEBEEBLOCKS_COMMAND_FORWARD && runner.index == 1) {
       const int crossed = check_gate(px,py,pz,x,y,z,pt,now,t0,g1x,g1y,ux,uy,vx,vy,target_z,&gate1);
       if (crossed < 0) {
-        write_failure("GATE1_MISS", phase, gates);
+        write_failure("GATE1_MISS", &runner, gates);
         stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
       }
-    } else if (phase == LEG2) {
+    } else if (command->type == WEBEEBLOCKS_COMMAND_FORWARD && runner.index == 3) {
       const int crossed = check_gate(px,py,pz,x,y,z,pt,now,t0,g2x,g2y,vx,vy,ux,uy,target_z,&gate2);
       if (crossed < 0 || (crossed > 0 && !gate1.passed)) {
-        write_failure(crossed < 0 ? "GATE2_MISS" : "GATE_ORDER", phase, gates);
+        write_failure(crossed < 0 ? "GATE2_MISS" : "GATE_ORDER", &runner, gates);
         stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
       }
     }
 
-    if (phase == TAKEOFF) {
-      if (fabs(z-target_z) < .05 && fabs(vz) < .15) {
+    if (command->type == WEBEEBLOCKS_COMMAND_TAKEOFF) {
+      const int stabilized = fabs(z-target_z) < .05 && fabs(vz) < .15;
+      if (stabilized) {
         if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW) {
+        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
           stable = -1;
-          phase = LEG1;
-          target = webeeblocks_forward(x,y,target_z,yaw,LEG_M);
+          webeeblocks_runner_advance(&runner);
+          command = webeeblocks_runner_current(&runner);
+          target = webeeblocks_forward(x,y,target_z,yaw,command->value);
           target_x = target.x; target_y = target.y; target_yaw = syaw;
         }
       } else stable = -1;
-    } else if (phase == LEG1 || phase == LEG2) {
+    } else if (command->type == WEBEEBLOCKS_COMMAND_FORWARD) {
       const double ex = target_x-x, ey = target_y-y;
       double bx = ex*cy + ey*syy, by = -ex*syy + ey*cy;
       d.vx = POSITION_KP*bx; d.vy = POSITION_KP*by;
       clip_vector(&d.vx,&d.vy,VX_MAX);
-      if (hypot(ex,ey) <= POSITION_TOL && hypot(a.vx,a.vy) <= SPEED_TOL) {
+      const int geometric_reached = hypot(ex,ey) <= POSITION_TOL;
+      const int stabilized = geometric_reached && hypot(a.vx,a.vy) <= SPEED_TOL;
+      if (stabilized) {
         if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW) {
+        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
           stable = -1;
-          if (phase == LEG1) {
+          if (runner.index == 1) {
             if (!gate1.passed) {
-              write_failure("GATE1_NOT_CROSSED", phase, gates);
+              write_failure("GATE1_NOT_CROSSED", &runner, gates);
               stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
             }
-            phase = TURN;
-            target = webeeblocks_turn(target_x,target_y,target_z,target_yaw,PI/2.0);
+            webeeblocks_runner_advance(&runner);
+            command = webeeblocks_runner_current(&runner);
+            target = webeeblocks_turn(target_x,target_y,target_z,target_yaw,command->value);
             target_yaw = target.yaw;
           } else {
             if (!gate2.passed) {
-              write_failure("GATE2_NOT_CROSSED", phase, gates);
+              write_failure("GATE2_NOT_CROSSED", &runner, gates);
               stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
             }
-            phase = LAND;
+            webeeblocks_runner_advance(&runner);
           }
         }
       } else stable = -1;
-    } else if (phase == TURN) {
+    } else if (command->type == WEBEEBLOCKS_COMMAND_TURN) {
       const double eyaw = wrap(target_yaw-yaw);
       d.yaw_rate = clip(YAW_KP*eyaw,YAW_RATE_MAX);
-      if (fabs(eyaw) <= YAW_TOL && fabs(a.yaw_rate) <= YAW_RATE_TOL) {
+      const int geometric_reached = fabs(eyaw) <= YAW_TOL;
+      const int stabilized = geometric_reached && fabs(a.yaw_rate) <= YAW_RATE_TOL;
+      if (stabilized) {
         if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW) {
+        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
           stable = -1;
-          phase = LEG2;
-          target = webeeblocks_forward(target_x,target_y,target_z,target_yaw,LEG_M);
+          webeeblocks_runner_advance(&runner);
+          command = webeeblocks_runner_current(&runner);
+          target = webeeblocks_forward(target_x,target_y,target_z,target_yaw,command->value);
           target_x = target.x; target_y = target.y;
         }
       } else stable = -1;
-    } else if (phase == LAND) {
+    } else if (command->type == WEBEEBLOCKS_COMMAND_LAND) {
       const webeeblocks_target_t landing = webeeblocks_land(x,y,sz,yaw);
       d.altitude = landing.z;
-      if (z <= landing.z + .05 && fabs(vz) < .15) {
+      const int stabilized = z <= landing.z + .05 && fabs(vz) < .15;
+      if (stabilized) {
         if (stable < 0) stable = now;
-        if (now-stable > STABLE_WINDOW) {
+        if (now-stable > STABLE_WINDOW && webeeblocks_runner_completion_stop(1)) {
           if (!(gate1.passed && gate2.passed)) {
-            write_failure("GATES_INCOMPLETE", phase, gate1.passed+gate2.passed);
+            write_failure("GATES_INCOMPLETE", &runner, gate1.passed+gate2.passed);
             stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
           }
           const double endpoint_error = hypot(x-expected_x,y-expected_y);
@@ -262,6 +284,7 @@ int main(void) {
           printf("WEBEEBLOCKS_CF_L_RESULT status=success gates=2 endpoint_error_xy=%.6f yaw_error_deg=%.6f total_s=%.3f\n",
                  endpoint_error,yaw_error,now-t0);
           fflush(stdout);
+          webeeblocks_runner_advance(&runner);
           stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(0); break;
         }
       } else stable = -1;

--- a/controllers/crazyflie_square_position/webeeblocks_executor.h
+++ b/controllers/crazyflie_square_position/webeeblocks_executor.h
@@ -1,7 +1,14 @@
 #ifndef WEBEEBLOCKS_EXECUTOR_H
 #define WEBEEBLOCKS_EXECUTOR_H
 
+#include <math.h>
 #include <stddef.h>
+
+#define WEBEEBLOCKS_STOP_SPEED_XY_MAX 0.12
+#define WEBEEBLOCKS_STOP_YAW_RATE_MAX 0.10
+#define WEBEEBLOCKS_STOP_VZ_MAX 0.15
+#define WEBEEBLOCKS_STOP_ALTITUDE_ERROR_MAX 0.05
+#define WEBEEBLOCKS_STOP_WINDOW_S 0.5
 
 typedef enum {
   WEBEEBLOCKS_COMMAND_TAKEOFF,
@@ -19,6 +26,7 @@ typedef struct {
   const webeeblocks_command_t *commands;
   size_t count;
   size_t index;
+  double stop_stable_since;
 } webeeblocks_runner_t;
 
 static inline void webeeblocks_runner_init(webeeblocks_runner_t *runner,
@@ -27,6 +35,7 @@ static inline void webeeblocks_runner_init(webeeblocks_runner_t *runner,
   runner->commands = commands;
   runner->count = count;
   runner->index = 0;
+  runner->stop_stable_since = -1.0;
 }
 
 static inline const webeeblocks_command_t *webeeblocks_runner_current(const webeeblocks_runner_t *runner) {
@@ -39,14 +48,40 @@ static inline int webeeblocks_runner_finished(const webeeblocks_runner_t *runner
   return !runner || runner->index >= runner->count;
 }
 
-static inline int webeeblocks_runner_completion_stop(int stabilized) {
-  return stabilized;
+static inline int webeeblocks_runner_completion_stop(webeeblocks_runner_t *runner,
+                                                       int geometric_ready,
+                                                       double speed_xy,
+                                                       double yaw_rate,
+                                                       double vz,
+                                                       double altitude_error,
+                                                       double now) {
+  if (!runner)
+    return 0;
+
+  const int stop_ready = geometric_ready &&
+                         speed_xy < WEBEEBLOCKS_STOP_SPEED_XY_MAX &&
+                         fabs(yaw_rate) < WEBEEBLOCKS_STOP_YAW_RATE_MAX &&
+                         fabs(vz) < WEBEEBLOCKS_STOP_VZ_MAX &&
+                         fabs(altitude_error) < WEBEEBLOCKS_STOP_ALTITUDE_ERROR_MAX;
+
+  if (!stop_ready) {
+    runner->stop_stable_since = -1.0;
+    return 0;
+  }
+
+  if (runner->stop_stable_since < 0.0) {
+    runner->stop_stable_since = now;
+    return 0;
+  }
+
+  return now - runner->stop_stable_since >= WEBEEBLOCKS_STOP_WINDOW_S;
 }
 
 static inline int webeeblocks_runner_advance(webeeblocks_runner_t *runner) {
   if (!runner || runner->index >= runner->count)
     return 0;
   ++runner->index;
+  runner->stop_stable_since = -1.0;
   return runner->index < runner->count;
 }
 

--- a/controllers/crazyflie_square_position/webeeblocks_executor.h
+++ b/controllers/crazyflie_square_position/webeeblocks_executor.h
@@ -1,0 +1,63 @@
+#ifndef WEBEEBLOCKS_EXECUTOR_H
+#define WEBEEBLOCKS_EXECUTOR_H
+
+#include <stddef.h>
+
+typedef enum {
+  WEBEEBLOCKS_COMMAND_TAKEOFF,
+  WEBEEBLOCKS_COMMAND_FORWARD,
+  WEBEEBLOCKS_COMMAND_TURN,
+  WEBEEBLOCKS_COMMAND_LAND
+} webeeblocks_command_type_t;
+
+typedef struct {
+  webeeblocks_command_type_t type;
+  double value;
+} webeeblocks_command_t;
+
+typedef struct {
+  const webeeblocks_command_t *commands;
+  size_t count;
+  size_t index;
+} webeeblocks_runner_t;
+
+static inline void webeeblocks_runner_init(webeeblocks_runner_t *runner,
+                                            const webeeblocks_command_t *commands,
+                                            size_t count) {
+  runner->commands = commands;
+  runner->count = count;
+  runner->index = 0;
+}
+
+static inline const webeeblocks_command_t *webeeblocks_runner_current(const webeeblocks_runner_t *runner) {
+  if (!runner || runner->index >= runner->count)
+    return NULL;
+  return &runner->commands[runner->index];
+}
+
+static inline int webeeblocks_runner_finished(const webeeblocks_runner_t *runner) {
+  return !runner || runner->index >= runner->count;
+}
+
+static inline int webeeblocks_runner_completion_stop(int stabilized) {
+  return stabilized;
+}
+
+static inline int webeeblocks_runner_advance(webeeblocks_runner_t *runner) {
+  if (!runner || runner->index >= runner->count)
+    return 0;
+  ++runner->index;
+  return runner->index < runner->count;
+}
+
+static inline const char *webeeblocks_command_name(webeeblocks_command_type_t type) {
+  switch (type) {
+    case WEBEEBLOCKS_COMMAND_TAKEOFF: return "TAKEOFF";
+    case WEBEEBLOCKS_COMMAND_FORWARD: return "FORWARD";
+    case WEBEEBLOCKS_COMMAND_TURN: return "TURN";
+    case WEBEEBLOCKS_COMMAND_LAND: return "LAND";
+  }
+  return "UNKNOWN";
+}
+
+#endif


### PR DESCRIPTION
## Goal
Factor the already-proven pedagogical v0 completion policy (`STOP`) into the smallest shared sequential executor, without changing navigation behavior.

## Scope
- add a tiny immutable command/runner contract for `TAKEOFF`, `FORWARD(distance)`, `TURN(angle)`, `LAND`;
- make the existing L-course controller consume that sequence through the runner;
- keep the same backend B primitives, PID, gains, speed/yaw caps, world, mission, virtual gates, stabilization window and fail-closed rules;
- preserve the existing anchoring semantics: first forward begins from the measured post-takeoff pose, turn/second forward continue from the intended target chain;
- keep Blockly, obstacles, scoring, sensors, CHAIN optimization and `main` out of this lot.

## Completion policy
`webeeblocks_runner_completion_stop()` deliberately completes a primitive only after the controller's existing stabilized condition has held for the same 0.5 s window. Geometric reachability remains observable separately inside the controller and does not advance the sequence by itself.

## Acceptance
The existing real Webots R2025a L-course gate must remain green through the factorized runner, with G1 then G2, successful landing and endpoint/yaw/duration compatible with the STOP reference from #31/#32. All historical and Crazyflie non-regression gates must remain green. No tuning is permitted in response to the result.