### PR TITLE
Prove first collision obstacle with current Crazyflie blocks

### DIFF
--- a/.github/workflows/crazyflie-first-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-first-obstacle-r2025a.yml
@@ -1,0 +1,60 @@
+name: Crazyflie first collision obstacle R2025a
+
+on:
+  push:
+    branches: [webots-ci]
+  pull_request:
+    branches: [webots-ci]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  first-collision-obstacle:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build flight controllers and collision observer
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/crazyflie-first-obstacle
+          for controller in crazyflie_square_position crazyflie_l_course crazyflie_collision_observer; do
+            docker run --rm \
+              -v "${{ github.workspace }}:/workspace" \
+              -w "/workspace/controllers/${controller}" \
+              cyberbotics/webots:R2025a-ubuntu22.04 \
+              bash -lc 'make clean && make' \
+              2>&1 | tee "ci-artifacts/crazyflie-first-obstacle/build-${controller}.log"
+          done
+
+      - name: Run direct collision witness and STOP L detour
+        shell: bash
+        run: |
+          set -o pipefail
+          python3 tools/ci/run_crazyflie_first_obstacle.py
+
+      - name: Publish obstacle summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f ci-artifacts/crazyflie-first-obstacle/summary.md ]; then
+            cat ci-artifacts/crazyflie-first-obstacle/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload obstacle diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crazyflie-first-collision-obstacle-r2025a
+          path: |
+            ci-artifacts/crazyflie-first-obstacle/
+            ci-artifacts/crazyflie-obstacle-contact.txt
+            ci-artifacts/crazyflie-l-course-result.txt
+          if-no-files-found: warn

--- a/controllers/crazyflie_collision_observer/Makefile
+++ b/controllers/crazyflie_collision_observer/Makefile
@@ -1,0 +1,6 @@
+C_SOURCES = crazyflie_collision_observer.c
+
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/controllers/crazyflie_collision_observer/crazyflie_collision_observer.c
+++ b/controllers/crazyflie_collision_observer/crazyflie_collision_observer.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <webots/contact_point.h>
+#include <webots/robot.h>
+#include <webots/supervisor.h>
+
+static int belongs_to(WbNodeRef node, WbNodeRef ancestor) {
+  while (node) {
+    if (node == ancestor)
+      return 1;
+    node = wb_supervisor_node_get_parent_node(node);
+  }
+  return 0;
+}
+
+int main(void) {
+  wb_robot_init();
+  const int step = (int)wb_robot_get_basic_time_step();
+  WbNodeRef obstacle = wb_supervisor_node_get_from_def("OBSTACLE");
+  WbNodeRef crazyflie = wb_supervisor_node_get_from_def("CRAZYFLIE");
+  if (!obstacle || !crazyflie) {
+    fprintf(stderr, "WEBEEBLOCKS_OBSTACLE_OBSERVER_ERROR missing DEF node\n");
+    wb_robot_cleanup();
+    return 2;
+  }
+
+  wb_supervisor_node_enable_contact_points_tracking(obstacle, step, true);
+  printf("WEBEEBLOCKS_OBSTACLE_OBSERVER_READY\n");
+  fflush(stdout);
+
+  while (wb_robot_step(step) != -1) {
+    int count = 0;
+    WbContactPoint *points = wb_supervisor_node_get_contact_points(obstacle, true, &count);
+    for (int i = 0; i < count; ++i) {
+      WbNodeRef contacting = wb_supervisor_node_get_from_id(points[i].node_id);
+      if (!contacting || !belongs_to(contacting, crazyflie))
+        continue;
+
+      char path[4096];
+      snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-obstacle-contact.txt",
+               wb_robot_get_project_path());
+      FILE *file = fopen(path, "w");
+      if (file) {
+        fprintf(file,
+                "WEBEEBLOCKS_OBSTACLE_RESULT status=COLLISION time=%.3f x=%.6f y=%.6f z=%.6f node_id=%d\n",
+                wb_robot_get_time(),
+                points[i].point[0], points[i].point[1], points[i].point[2],
+                points[i].node_id);
+        fflush(file);
+        fclose(file);
+      }
+      printf("WEBEEBLOCKS_OBSTACLE_RESULT status=COLLISION time=%.3f\n", wb_robot_get_time());
+      fflush(stdout);
+      wb_supervisor_simulation_quit(0);
+      wb_robot_cleanup();
+      return 0;
+    }
+  }
+
+  wb_robot_cleanup();
+  return 0;
+}

--- a/controllers/crazyflie_collision_observer/crazyflie_collision_observer.c
+++ b/controllers/crazyflie_collision_observer/crazyflie_collision_observer.c
@@ -1,15 +1,21 @@
+#include <math.h>
 #include <stdio.h>
 #include <webots/contact_point.h>
 #include <webots/robot.h>
 #include <webots/supervisor.h>
 
-static int belongs_to(WbNodeRef node, WbNodeRef ancestor) {
-  while (node) {
-    if (node == ancestor)
-      return 1;
-    node = wb_supervisor_node_get_parent_node(node);
-  }
-  return 0;
+#define OBSTACLE_X 1.25
+#define OBSTACLE_HALF_THICKNESS 0.025
+#define OBSTACLE_HALF_WIDTH 0.15
+#define OBSTACLE_MIN_Z 0.0
+#define OBSTACLE_MAX_Z 1.40
+#define CONTACT_TOLERANCE 0.003
+
+static int point_is_on_obstacle(const double point[3]) {
+  return fabs(point[0] - OBSTACLE_X) <= OBSTACLE_HALF_THICKNESS + CONTACT_TOLERANCE &&
+         fabs(point[1]) <= OBSTACLE_HALF_WIDTH + CONTACT_TOLERANCE &&
+         point[2] >= OBSTACLE_MIN_Z - CONTACT_TOLERANCE &&
+         point[2] <= OBSTACLE_MAX_Z + CONTACT_TOLERANCE;
 }
 
 int main(void) {
@@ -23,16 +29,21 @@ int main(void) {
     return 2;
   }
 
-  wb_supervisor_node_enable_contact_points_tracking(obstacle, step, true);
+  /*
+   * Track the dynamic Crazyflie rather than the static obstacle.  The Webots
+   * contact-point API guarantees that these are physical collision contacts;
+   * the point location then identifies the pre-registered obstacle and filters
+   * normal floor contacts during takeoff/landing.
+   */
+  wb_supervisor_node_enable_contact_points_tracking(crazyflie, step, true);
   printf("WEBEEBLOCKS_OBSTACLE_OBSERVER_READY\n");
   fflush(stdout);
 
   while (wb_robot_step(step) != -1) {
     int count = 0;
-    WbContactPoint *points = wb_supervisor_node_get_contact_points(obstacle, true, &count);
+    WbContactPoint *points = wb_supervisor_node_get_contact_points(crazyflie, true, &count);
     for (int i = 0; i < count; ++i) {
-      WbNodeRef contacting = wb_supervisor_node_get_from_id(points[i].node_id);
-      if (!contacting || !belongs_to(contacting, crazyflie))
+      if (!point_is_on_obstacle(points[i].point))
         continue;
 
       char path[4096];
@@ -48,7 +59,8 @@ int main(void) {
         fflush(file);
         fclose(file);
       }
-      printf("WEBEEBLOCKS_OBSTACLE_RESULT status=COLLISION time=%.3f\n", wb_robot_get_time());
+      printf("WEBEEBLOCKS_OBSTACLE_RESULT status=COLLISION time=%.3f x=%.6f y=%.6f z=%.6f\n",
+             wb_robot_get_time(), points[i].point[0], points[i].point[1], points[i].point[2]);
       fflush(stdout);
       wb_supervisor_simulation_quit(0);
       wb_robot_cleanup();

--- a/tools/ci/run_crazyflie_first_obstacle.py
+++ b/tools/ci/run_crazyflie_first_obstacle.py
@@ -82,6 +82,13 @@ def main() -> int:
         direct = parse_last_result(contact, "WEBEEBLOCKS_OBSTACLE_RESULT")
         if direct.get("status") != "COLLISION":
             raise RuntimeError(f"direct witness did not classify COLLISION: {direct}")
+
+        # Preserve the raw physical-contact witness before the shared result path
+        # is cleared for the no-collision detour. This is the auditable evidence
+        # containing the exact contact coordinates and Webots node id.
+        (artifacts / "direct-contact.txt").write_text(
+            contact.read_text(encoding="utf-8"), encoding="utf-8"
+        )
         summary["direct"] = {
             "expected": "COLLISION",
             "observed": "COLLISION",
@@ -133,7 +140,7 @@ def main() -> int:
         "",
         "| Mission | Expected | Observed | Evidence |",
         "|---|---|---|---|",
-        f"| direct forward 2.0 m | COLLISION | {summary['direct']['observed']} | contact t={summary['direct']['contact_time_s']:.3f} s |",
+        f"| direct forward 2.0 m | COLLISION | {summary['direct']['observed']} | contact t={summary['direct']['contact_time_s']:.3f} s; raw witness `direct-contact.txt` |",
         f"| STOP L detour | SUCCESS | {summary['detour']['observed']} | G1→G2→LAND; endpoint={summary['detour']['endpoint_error_xy_m']:.6f} m; yaw={summary['detour']['yaw_error_deg']:.6f}° |",
         "",
         "No sensor block, condition, scoring rule, avoidance algorithm or PID/navigation tuning is part of this experiment.",

--- a/tools/ci/run_crazyflie_first_obstacle.py
+++ b/tools/ci/run_crazyflie_first_obstacle.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+IMAGE = "cyberbotics/webots:R2025a-ubuntu22.04"
+CONTACT_RESULT = "ci-artifacts/crazyflie-obstacle-contact.txt"
+L_RESULT = "ci-artifacts/crazyflie-l-course-result.txt"
+
+
+def run_world(root: Path, artifacts: Path, label: str, world: str) -> tuple[int, str]:
+    log_path = artifacts / f"{label}.log"
+    inner = (
+        "timeout -k 5s 90s xvfb-run -a webots --stdout --stderr --batch --mode=fast "
+        f"/workspace/{world}"
+    )
+    command = [
+        "docker", "run", "--rm",
+        "-e", "LIBGL_ALWAYS_SOFTWARE=true",
+        "-e", "WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true",
+        "-v", f"{root}:/workspace",
+        "-w", "/workspace",
+        IMAGE,
+        "bash", "-lc", inner,
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=105,
+    )
+    log_path.write_text(completed.stdout, encoding="utf-8")
+    return completed.returncode, completed.stdout
+
+
+def parse_last_result(path: Path, prefix: str) -> dict[str, str]:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise RuntimeError(f"result missing: {path}")
+    line = path.read_text(encoding="utf-8").strip().splitlines()[-1]
+    if prefix not in line:
+        raise RuntimeError(f"unexpected result: {line}")
+    pairs = {}
+    for token in line.split():
+        if "=" in token:
+            key, value = token.split("=", 1)
+            pairs[key] = value
+    return pairs
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    artifacts = root / "ci-artifacts" / "crazyflie-first-obstacle"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    contact = root / CONTACT_RESULT
+    l_result = root / L_RESULT
+
+    summary = {
+        "obstacle": {
+            "center_x_m": 1.25,
+            "transverse_m": 0.30,
+            "thickness_m": 0.05,
+            "height_m": 1.40,
+            "crazyflie_radius_m": 0.05,
+            "detour_nominal_clearance_m": 0.175,
+        }
+    }
+
+    try:
+        # Witness: a characterized 2 m forward primitive must hit the obstacle.
+        contact.unlink(missing_ok=True)
+        l_result.unlink(missing_ok=True)
+        direct_code, direct_log = run_world(
+            root, artifacts, "direct", "worlds/crazyflie_obstacle_direct.wbt"
+        )
+        if direct_code == 124:
+            raise RuntimeError("direct witness timed out before collision")
+        if "ERROR:" in direct_log:
+            raise RuntimeError("direct witness contains a Webots ERROR; see direct.log")
+        direct = parse_last_result(contact, "WEBEEBLOCKS_OBSTACLE_RESULT")
+        if direct.get("status") != "COLLISION":
+            raise RuntimeError(f"direct witness did not classify COLLISION: {direct}")
+        summary["direct"] = {
+            "expected": "COLLISION",
+            "observed": "COLLISION",
+            "webots_exit": direct_code,
+            "contact_time_s": float(direct["time"]),
+            "contact_xyz_m": [float(direct["x"]), float(direct["y"]), float(direct["z"])],
+        }
+
+        # Detour: the already-proven STOP L must clear the exact same obstacle,
+        # cross both virtual gates and land successfully.
+        contact.unlink(missing_ok=True)
+        l_result.unlink(missing_ok=True)
+        detour_code, detour_log = run_world(
+            root, artifacts, "detour", "worlds/crazyflie_obstacle_detour.wbt"
+        )
+        if detour_code != 0:
+            raise RuntimeError(f"detour Webots exit={detour_code}; see detour.log")
+        if "ERROR:" in detour_log or "Traceback" in detour_log:
+            raise RuntimeError("detour contains a Webots/Python error; see detour.log")
+        if contact.exists():
+            collision = parse_last_result(contact, "WEBEEBLOCKS_OBSTACLE_RESULT")
+            raise RuntimeError(f"detour collided with obstacle: {collision}")
+        detour = parse_last_result(l_result, "WEBEEBLOCKS_CF_L_RESULT")
+        if detour.get("status") != "success" or detour.get("gates") != "2":
+            raise RuntimeError(f"detour did not complete G1/G2/LAND: {detour}")
+        summary["detour"] = {
+            "expected": "SUCCESS",
+            "observed": "SUCCESS",
+            "webots_exit": detour_code,
+            "gates": int(detour["gates"]),
+            "endpoint_error_xy_m": float(detour["endpoint_error_xy"]),
+            "yaw_error_deg": float(detour["yaw_error_deg"]),
+            "total_s": float(detour["total_s"]),
+        }
+
+    except Exception as exc:
+        (artifacts / "failure.txt").write_text(str(exc) + "\n", encoding="utf-8")
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    (artifacts / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    markdown = [
+        "# First collision obstacle experiment",
+        "",
+        "Same physical obstacle in both runs: 0.30 m transverse × 0.05 m thick × 1.40 m high, center x=1.25 m.",
+        "Nominal STOP-L clearance at the first corner: 0.175 m between the Crazyflie collision envelope and the obstacle.",
+        "",
+        "| Mission | Expected | Observed | Evidence |",
+        "|---|---|---|---|",
+        f"| direct forward 2.0 m | COLLISION | {summary['direct']['observed']} | contact t={summary['direct']['contact_time_s']:.3f} s |",
+        f"| STOP L detour | SUCCESS | {summary['detour']['observed']} | G1→G2→LAND; endpoint={summary['detour']['endpoint_error_xy_m']:.6f} m; yaw={summary['detour']['yaw_error_deg']:.6f}° |",
+        "",
+        "No sensor block, condition, scoring rule, avoidance algorithm or PID/navigation tuning is part of this experiment.",
+    ]
+    (artifacts / "summary.md").write_text("\n".join(markdown) + "\n", encoding="utf-8")
+    print((artifacts / "summary.md").read_text(encoding="utf-8"), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worlds/crazyflie_obstacle_detour.wbt
+++ b/worlds/crazyflie_obstacle_detour.wbt
@@ -1,0 +1,54 @@
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
+
+WorldInfo {
+  basicTimeStep 32
+  randomSeed 1
+  optimalThreadCount 1
+  title "WebeeBlocks first collision obstacle — STOP L detour"
+}
+Viewpoint {
+  orientation -0.45 0.47 0.76 1.05
+  position -3 -3 3
+  follow "Crazyflie"
+}
+TexturedBackground {
+}
+TexturedBackgroundLight {
+}
+Floor {
+  size 6 6
+}
+DEF OBSTACLE Solid {
+  translation 1.25 0 0.70
+  children [
+    Shape {
+      appearance PBRAppearance {
+        baseColor 0.8 0.1 0.1
+        roughness 0.6
+        metalness 0
+      }
+      geometry Box {
+        size 0.05 0.30 1.40
+      }
+    }
+  ]
+  boundingObject Box {
+    size 0.05 0.30 1.40
+  }
+}
+DEF CRAZYFLIE Crazyflie {
+  name "Crazyflie"
+  synchronization TRUE
+  controller "crazyflie_l_course"
+  supervisor TRUE
+}
+Robot {
+  name "Collision observer"
+  controller "crazyflie_collision_observer"
+  supervisor TRUE
+}

--- a/worlds/crazyflie_obstacle_direct.wbt
+++ b/worlds/crazyflie_obstacle_direct.wbt
@@ -1,0 +1,58 @@
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
+
+WorldInfo {
+  basicTimeStep 32
+  randomSeed 1
+  optimalThreadCount 1
+  title "WebeeBlocks first collision obstacle — direct witness"
+}
+Viewpoint {
+  orientation -0.45 0.47 0.76 1.05
+  position -3 -3 3
+  follow "Crazyflie"
+}
+TexturedBackground {
+}
+TexturedBackgroundLight {
+}
+Floor {
+  size 6 6
+}
+DEF OBSTACLE Solid {
+  translation 1.25 0 0.70
+  children [
+    Shape {
+      appearance PBRAppearance {
+        baseColor 0.8 0.1 0.1
+        roughness 0.6
+        metalness 0
+      }
+      geometry Box {
+        size 0.05 0.30 1.40
+      }
+    }
+  ]
+  boundingObject Box {
+    size 0.05 0.30 1.40
+  }
+}
+DEF CRAZYFLIE Crazyflie {
+  name "Crazyflie"
+  synchronization TRUE
+  controller "crazyflie_square_position"
+  controllerArgs [
+    "forward"
+    "2.0"
+  ]
+  supervisor TRUE
+}
+Robot {
+  name "Collision observer"
+  controller "crazyflie_collision_observer"
+  supervisor TRUE
+}


### PR DESCRIPTION
## Goal
Prove the first physical/collision obstacle milestone after the runtime-WWI seam was closed in #35, without adding any new student block, sensor, condition or scoring model.

## Experiment
Use the exact same static obstacle in two fresh Webots R2025a runs:
- Box collision geometry: **0.30 m transverse × 0.05 m thick × 1.40 m high**;
- obstacle center: `x=1.25 m`, directly across the initial straight path;
- native R2025a Crazyflie collision envelope is treated as ~5 cm radius for the pre-registered nominal margin calculation.

Two missions only:
1. **Direct witness** — already-characterized backend B primitive `forward(2.0 m)` must physically contact the obstacle and be classified `COLLISION`.
2. **Detour** — the already-proven shared STOP L (`forward(1) -> turn(+90°) -> forward(1)`) must clear the same obstacle, cross G1 then G2 and land successfully. The nominal clearance at the first corner is **0.175 m** between the drone collision envelope and the obstacle, matching the Lab's 15–20 cm target.

## Evaluation
A dedicated CI-only Supervisor observes Webots contact points on the obstacle and persists a collision result. Flight evaluation remains outside the student program:
- direct run: require `COLLISION`;
- detour: require **no collision** plus the existing L-course result `status=success gates=2` (G1 -> G2 -> LAND).

## Deliberate non-goals
No Blockly change, no runtime protocol generalization, no new movement primitive, no sensor/condition block, no obstacle avoidance, no score, no PID/navigation tuning, no CHAIN, and no change to `main`.

## Acceptance
- observer + existing flight controllers compile in the official Webots R2025a image;
- direct 2 m witness produces a real obstacle/Crazyflie contact;
- STOP L detour produces no contact and still completes G1 -> G2 -> LAND;
- all existing historical/Crazyflie non-regression gates remain green.

Base: `webots-ci`; `main` is untouched.