### PR TITLE
Run freely composed Blockly missions against the same obstacle

### DIFF
--- a/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
@@ -20,6 +20,7 @@ jobs:
           node --check plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/crazyflie.js
           python3 -m py_compile tools/ci/prepare_crazyflie_parametric_obstacle.py
           python3 -m py_compile tools/ci/runtime_wwi_event_server.py
+          python3 -m py_compile tools/ci/instrument_runtime_done_ack.py
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -29,6 +30,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p ci-artifacts/crazyflie-parametric-obstacle
+          python3 tools/ci/instrument_runtime_done_ack.py
           for controller in crazyflie_l_course crazyflie_collision_observer; do
             docker run --rm \
               -v "${{ github.workspace }}:/workspace" \
@@ -50,6 +52,7 @@ jobs:
           git checkout -- plugins/robot_windows/blockly/blockly.html
           python3 tools/ci/prepare_crazyflie_parametric_obstacle.py controllers/Blockly_Programs/CrazyflieDirect.xml
           rm -f ci-artifacts/crazyflie-obstacle-contact.txt ci-artifacts/crazyflie-runtime-mission-result.txt
+          rm -f ci-artifacts/crazyflie-done-ack-trace.txt
           rm -f ci-artifacts/crazyflie-parametric-obstacle/direct-events.jsonl
           set +e
           docker run --rm \
@@ -103,6 +106,7 @@ jobs:
           git checkout -- plugins/robot_windows/blockly/blockly.html
           python3 tools/ci/prepare_crazyflie_parametric_obstacle.py controllers/Blockly_Programs/CrazyflieL.xml --expect-done
           rm -f ci-artifacts/crazyflie-obstacle-contact.txt ci-artifacts/crazyflie-l-course-result.txt
+          rm -f ci-artifacts/crazyflie-done-ack-trace.txt
           rm -f ci-artifacts/crazyflie-parametric-obstacle/detour-events.jsonl
           set +e
           docker run --rm \
@@ -134,6 +138,7 @@ jobs:
           fi
           ! test -s ci-artifacts/crazyflie-obstacle-contact.txt
           test -s ci-artifacts/crazyflie-l-course-result.txt
+          test -s ci-artifacts/crazyflie-done-ack-trace.txt
           grep -Fq 'WEBEEBLOCKS_CF_L_RESULT status=success gates=2' ci-artifacts/crazyflie-l-course-result.txt
           ! grep -Fq 'reason=DONE_ACK_TIMEOUT' ci-artifacts/crazyflie-l-course-result.txt
           test "$(cat ci-artifacts/crazyflie-parametric-obstacle/detour-exit-code.txt)" = "0"
@@ -141,16 +146,33 @@ jobs:
           import json
           from pathlib import Path
           events = [json.loads(x) for x in Path('ci-artifacts/crazyflie-parametric-obstacle/detour-events.jsonl').read_text().splitlines() if x.strip()]
-          details = {(e['event'], e.get('detail')) for e in events}
+          expected = [
+              ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE'),
+              ('STATE_AFTER_DONE', 'WAITING'),
+              ('DONE_ACK_SEND_CALL', 'WAITING'),
+              ('DONE_ACK_SEND_RETURN', 'WAITING'),
+              ('DONE_ACK_SENT', 'WAITING'),
+          ]
+          cursor = 0
+          for event in events:
+              assert 'wall_ms' in event and 'performance_ms' in event, event
+              if cursor < len(expected) and event.get('event') == expected[cursor][0] and event.get('detail') == expected[cursor][1]:
+                  cursor += 1
+          assert cursor == len(expected), (cursor, expected[cursor] if cursor < len(expected) else None, events)
           assert any(e['event'] == 'BLOCKS' and 'webeeblocks_turn:90' in (e.get('detail') or '') for e in events), events
           assert any(e['event'] == 'MISSION' and 'TURN 1.5707963267948966' in (e.get('detail') or '') for e in events), events
-          assert ('RX', 'WEBEEBLOCKS_MISSION_V1 ACK') in details, events
-          assert ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE') in details, events
-          assert ('STATE_AFTER_DONE', 'WAITING') in details, events
-          assert ('DONE_ACK_SENT', 'WAITING') in details, events
+          assert any(e['event'] == 'RX' and e.get('detail') == 'WEBEEBLOCKS_MISSION_V1 ACK' for e in events), events
           assert not any(e['event'] == 'ERROR' for e in events), events
-          print('PASS: real Blockly detour -> no collision -> G1/G2/LAND -> DONE/WAITING -> DONE_ACK sent by the true handler.')
-          print('PASS: controller completed successfully; DONE_ACK timeout would overwrite the L result with reason=DONE_ACK_TIMEOUT and terminate the run as a failure.')
+          print('PASS: real Blockly detour -> no collision -> G1/G2/LAND -> browser DONE/WAITING -> synchronous DONE_ACK send.')
+          PY
+          cat ci-artifacts/crazyflie-done-ack-trace.txt
+          python3 - <<'PY'
+          from pathlib import Path
+          lines = [line for line in Path('ci-artifacts/crazyflie-done-ack-trace.txt').read_text().splitlines() if line.strip()]
+          ack = [line for line in lines if 'payload=WEBEEBLOCKS_MISSION_V1 DONE_ACK' in line]
+          assert ack, lines
+          assert any('phase=before_step ' in line or 'phase=after_step ' in line for line in ack), ack
+          print('PASS: controller terminal WWI drain observed exact DONE_ACK payload.')
           PY
 
       - name: Prove controller binary unchanged across both Submit runs
@@ -169,4 +191,5 @@ jobs:
             ci-artifacts/crazyflie-parametric-obstacle/
             ci-artifacts/crazyflie-l-course-result.txt
             ci-artifacts/crazyflie-obstacle-contact.txt
+            ci-artifacts/crazyflie-done-ack-trace.txt
           if-no-files-found: warn

--- a/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
@@ -70,7 +70,7 @@ jobs:
               event_server_pid=$!
               trap "kill $event_server_pid 2>/dev/null || true" EXIT
               sleep 0.5
-              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_runtime_obstacle.wbt
+              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_obstacle.wbt
             ' 2>&1 | tee ci-artifacts/crazyflie-parametric-obstacle/direct.log
           code=${PIPESTATUS[0]}
           set -e
@@ -123,7 +123,7 @@ jobs:
               event_server_pid=$!
               trap "kill $event_server_pid 2>/dev/null || true" EXIT
               sleep 0.5
-              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_runtime_obstacle.wbt
+              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_obstacle.wbt
             ' 2>&1 | tee ci-artifacts/crazyflie-parametric-obstacle/detour.log
           code=${PIPESTATUS[0]}
           set -e

--- a/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
@@ -135,6 +135,9 @@ jobs:
           ! test -s ci-artifacts/crazyflie-obstacle-contact.txt
           test -s ci-artifacts/crazyflie-l-course-result.txt
           grep -Fq 'WEBEEBLOCKS_CF_L_RESULT status=success gates=2' ci-artifacts/crazyflie-l-course-result.txt
+          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_SENT' ci-artifacts/crazyflie-parametric-obstacle/detour.log
+          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED' ci-artifacts/crazyflie-parametric-obstacle/detour.log
+          ! grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT' ci-artifacts/crazyflie-parametric-obstacle/detour.log
           python3 - <<'PY'
           import json
           from pathlib import Path
@@ -144,9 +147,9 @@ jobs:
           assert any(e['event'] == 'MISSION' and 'TURN 1.5707963267948966' in (e.get('detail') or '') for e in events), events
           assert ('RX', 'WEBEEBLOCKS_MISSION_V1 ACK') in details, events
           assert ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE') in details, events
-          assert ('COMPLETE', 'SUCCESS') in details, events
+          assert ('STATE_AFTER_DONE', 'WAITING') in details, events
           assert not any(e['event'] == 'ERROR' for e in events), events
-          print('PASS: Blockly detour mission -> runtime ACK -> no collision -> G1/G2/LAND -> DONE.')
+          print('PASS: Blockly detour mission -> ACK -> no collision -> G1/G2/LAND -> DONE/WAITING -> DONE_ACK.')
           PY
 
       - name: Prove controller binary unchanged across both Submit runs

--- a/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
@@ -1,0 +1,168 @@
+name: Crazyflie parametric Blockly obstacle R2025a
+
+on:
+  pull_request:
+    branches: [webots-ci]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  parametric-blockly-obstacle:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 16
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate parametric Blockly/runtime syntax
+        run: |
+          node --check plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/crazyflie.js
+          python3 -m py_compile tools/ci/prepare_crazyflie_parametric_obstacle.py
+          python3 -m py_compile tools/ci/runtime_wwi_event_server.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build shared STOP runtime and collision observer once
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/crazyflie-parametric-obstacle
+          for controller in crazyflie_l_course crazyflie_collision_observer; do
+            docker run --rm \
+              -v "${{ github.workspace }}:/workspace" \
+              -w "/workspace/controllers/${controller}" \
+              cyberbotics/webots:R2025a-ubuntu22.04 \
+              bash -lc 'make clean && make' \
+              2>&1 | tee "ci-artifacts/crazyflie-parametric-obstacle/build-${controller}.log"
+          done
+          sha256sum controllers/crazyflie_l_course/crazyflie_l_course \
+            | tee ci-artifacts/crazyflie-parametric-obstacle/controller-before.sha256
+
+      - name: Install browser helper files
+        run: chmod +x tools/ci/webots_runtime_wwi_browser.sh
+
+      - name: Run direct Blockly mission into physical obstacle
+        shell: bash
+        run: |
+          set -o pipefail
+          git checkout -- plugins/robot_windows/blockly/blockly.html
+          python3 tools/ci/prepare_crazyflie_parametric_obstacle.py controllers/Blockly_Programs/CrazyflieDirect.xml
+          rm -f ci-artifacts/crazyflie-obstacle-contact.txt ci-artifacts/crazyflie-runtime-mission-result.txt
+          rm -f ci-artifacts/crazyflie-parametric-obstacle/direct-events.jsonl
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              mkdir -p /root/.config/Cyberbotics
+              printf "%s\n" "[RobotWindow]" "browser=/workspace/tools/ci/webots_runtime_wwi_browser.sh" "newBrowserWindow=false" > /root/.config/Cyberbotics/Webots-R2025a.conf
+              python3 /workspace/tools/ci/runtime_wwi_event_server.py --output /workspace/ci-artifacts/crazyflie-parametric-obstacle/direct-events.jsonl &
+              event_server_pid=$!
+              trap "kill $event_server_pid 2>/dev/null || true" EXIT
+              sleep 0.5
+              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_runtime_obstacle.wbt
+            ' 2>&1 | tee ci-artifacts/crazyflie-parametric-obstacle/direct.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/crazyflie-parametric-obstacle/direct-exit-code.txt
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Direct runtime obstacle run exited with $code"
+            exit 1
+          fi
+          test -s ci-artifacts/crazyflie-obstacle-contact.txt
+          cp ci-artifacts/crazyflie-obstacle-contact.txt ci-artifacts/crazyflie-parametric-obstacle/direct-contact.txt
+          grep -Fq 'WEBEEBLOCKS_OBSTACLE_RESULT status=COLLISION' ci-artifacts/crazyflie-obstacle-contact.txt
+          ! test -s ci-artifacts/crazyflie-runtime-mission-result.txt
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          events = [json.loads(x) for x in Path('ci-artifacts/crazyflie-parametric-obstacle/direct-events.jsonl').read_text().splitlines() if x.strip()]
+          details = {(e['event'], e.get('detail')) for e in events}
+          assert any(e['event'] == 'BLOCKS' and 'webeeblocks_forward:2' in (e.get('detail') or '') for e in events), events
+          assert any(e['event'] == 'MISSION' and 'FORWARD 2.0000000000000000' in (e.get('detail') or '') for e in events), events
+          assert ('RX', 'WEBEEBLOCKS_MISSION_V1 ACK') in details, events
+          assert ('STATE_AFTER_ACK', 'RUNNING') in details, events
+          assert not any(e['event'] == 'ERROR' for e in events), events
+          print('PASS: Blockly direct mission -> runtime ACK -> physical collision.')
+          PY
+
+      - name: Run Blockly L detour around the same obstacle
+        shell: bash
+        run: |
+          set -o pipefail
+          git checkout -- plugins/robot_windows/blockly/blockly.html
+          python3 tools/ci/prepare_crazyflie_parametric_obstacle.py controllers/Blockly_Programs/CrazyflieL.xml --expect-done
+          rm -f ci-artifacts/crazyflie-obstacle-contact.txt ci-artifacts/crazyflie-l-course-result.txt
+          rm -f ci-artifacts/crazyflie-parametric-obstacle/detour-events.jsonl
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              mkdir -p /root/.config/Cyberbotics
+              printf "%s\n" "[RobotWindow]" "browser=/workspace/tools/ci/webots_runtime_wwi_browser.sh" "newBrowserWindow=false" > /root/.config/Cyberbotics/Webots-R2025a.conf
+              python3 /workspace/tools/ci/runtime_wwi_event_server.py --output /workspace/ci-artifacts/crazyflie-parametric-obstacle/detour-events.jsonl &
+              event_server_pid=$!
+              trap "kill $event_server_pid 2>/dev/null || true" EXIT
+              sleep 0.5
+              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_runtime_obstacle.wbt
+            ' 2>&1 | tee ci-artifacts/crazyflie-parametric-obstacle/detour.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/crazyflie-parametric-obstacle/detour-exit-code.txt
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Detour runtime obstacle run exited with $code"
+            exit 1
+          fi
+          ! test -s ci-artifacts/crazyflie-obstacle-contact.txt
+          test -s ci-artifacts/crazyflie-l-course-result.txt
+          grep -Fq 'WEBEEBLOCKS_CF_L_RESULT status=success gates=2' ci-artifacts/crazyflie-l-course-result.txt
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          events = [json.loads(x) for x in Path('ci-artifacts/crazyflie-parametric-obstacle/detour-events.jsonl').read_text().splitlines() if x.strip()]
+          details = {(e['event'], e.get('detail')) for e in events}
+          assert any(e['event'] == 'BLOCKS' and 'webeeblocks_turn:90' in (e.get('detail') or '') for e in events), events
+          assert any(e['event'] == 'MISSION' and 'TURN 1.5707963267948966' in (e.get('detail') or '') for e in events), events
+          assert ('RX', 'WEBEEBLOCKS_MISSION_V1 ACK') in details, events
+          assert ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE') in details, events
+          assert ('COMPLETE', 'SUCCESS') in details, events
+          assert not any(e['event'] == 'ERROR' for e in events), events
+          print('PASS: Blockly detour mission -> runtime ACK -> no collision -> G1/G2/LAND -> DONE.')
+          PY
+
+      - name: Prove controller binary unchanged across both Submit runs
+        run: |
+          sha256sum controllers/crazyflie_l_course/crazyflie_l_course \
+            | tee ci-artifacts/crazyflie-parametric-obstacle/controller-after.sha256
+          cmp ci-artifacts/crazyflie-parametric-obstacle/controller-before.sha256 \
+              ci-artifacts/crazyflie-parametric-obstacle/controller-after.sha256
+
+      - name: Upload parametric obstacle diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crazyflie-parametric-blockly-obstacle-r2025a
+          path: |
+            ci-artifacts/crazyflie-parametric-obstacle/
+            ci-artifacts/crazyflie-l-course-result.txt
+            ci-artifacts/crazyflie-obstacle-contact.txt
+          if-no-files-found: warn

--- a/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
@@ -135,9 +135,8 @@ jobs:
           ! test -s ci-artifacts/crazyflie-obstacle-contact.txt
           test -s ci-artifacts/crazyflie-l-course-result.txt
           grep -Fq 'WEBEEBLOCKS_CF_L_RESULT status=success gates=2' ci-artifacts/crazyflie-l-course-result.txt
-          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_SENT' ci-artifacts/crazyflie-parametric-obstacle/detour.log
-          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED' ci-artifacts/crazyflie-parametric-obstacle/detour.log
-          ! grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT' ci-artifacts/crazyflie-parametric-obstacle/detour.log
+          ! grep -Fq 'reason=DONE_ACK_TIMEOUT' ci-artifacts/crazyflie-l-course-result.txt
+          test "$(cat ci-artifacts/crazyflie-parametric-obstacle/detour-exit-code.txt)" = "0"
           python3 - <<'PY'
           import json
           from pathlib import Path
@@ -150,7 +149,8 @@ jobs:
           assert ('STATE_AFTER_DONE', 'WAITING') in details, events
           assert ('DONE_ACK_SENT', 'WAITING') in details, events
           assert not any(e['event'] == 'ERROR' for e in events), events
-          print('PASS: Blockly detour mission -> ACK -> no collision -> G1/G2/LAND -> DONE/WAITING -> DONE_ACK.')
+          print('PASS: real Blockly detour -> no collision -> G1/G2/LAND -> DONE/WAITING -> DONE_ACK sent by the true handler.')
+          print('PASS: controller completed successfully; DONE_ACK timeout would overwrite the L result with reason=DONE_ACK_TIMEOUT and terminate the run as a failure.')
           PY
 
       - name: Prove controller binary unchanged across both Submit runs

--- a/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
+++ b/.github/workflows/crazyflie-parametric-obstacle-r2025a.yml
@@ -148,6 +148,7 @@ jobs:
           assert ('RX', 'WEBEEBLOCKS_MISSION_V1 ACK') in details, events
           assert ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE') in details, events
           assert ('STATE_AFTER_DONE', 'WAITING') in details, events
+          assert ('DONE_ACK_SENT', 'WAITING') in details, events
           assert not any(e['event'] == 'ERROR' for e in events), events
           print('PASS: Blockly detour mission -> ACK -> no collision -> G1/G2/LAND -> DONE/WAITING -> DONE_ACK.')
           PY

--- a/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
+++ b/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
@@ -21,9 +21,12 @@ jobs:
           node --check plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/crazyflie.js
           python3 -m py_compile tools/ci/prepare_crazyflie_runtime_wwi.py
           python3 -m py_compile tools/ci/runtime_wwi_event_server.py
+          python3 -m py_compile tools/ci/instrument_runtime_done_ack.py
 
       - name: Prepare actual Blockly Robot Window runtime harness
-        run: python3 tools/ci/prepare_crazyflie_runtime_wwi.py
+        run: |
+          python3 tools/ci/prepare_crazyflie_runtime_wwi.py
+          python3 tools/ci/instrument_runtime_done_ack.py
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -47,6 +50,7 @@ jobs:
         run: |
           set -o pipefail
           rm -f ci-artifacts/crazyflie-l-course-result.txt
+          rm -f ci-artifacts/crazyflie-done-ack-trace.txt
           rm -f ci-artifacts/crazyflie-runtime-wwi/browser-events.jsonl
           set +e
           docker run --rm \
@@ -90,9 +94,11 @@ jobs:
           set -o pipefail
           LOG=ci-artifacts/crazyflie-runtime-wwi/webots.log
           EVENTS=ci-artifacts/crazyflie-runtime-wwi/browser-events.jsonl
+          TRACE=ci-artifacts/crazyflie-done-ack-trace.txt
           RESULT=ci-artifacts/crazyflie-l-course-result.txt
           test -s ci-artifacts/crazyflie-runtime-wwi/browser-launch.log
           test -s "$EVENTS"
+          test -s "$TRACE"
           test -s "$RESULT"
           sha256sum controllers/crazyflie_l_course/crazyflie_l_course \
             | tee ci-artifacts/crazyflie-runtime-wwi/controller-after.sha256
@@ -119,18 +125,32 @@ jobs:
               ('SECOND_SUBMIT_CLICK', None), ('SECOND_SUBMIT_BLOCKED_LOCAL', 'RUNNING'),
               ('BUSY_PROBE_SEND', None), ('RX', 'WEBEEBLOCKS_MISSION_V1 ERR BUSY'),
               ('STATE_AFTER_BUSY', 'RUNNING'), ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE'),
-              ('STATE_AFTER_DONE', 'WAITING'), ('DONE_ACK_SENT', 'WAITING'),
+              ('STATE_AFTER_DONE', 'WAITING'),
+              ('DONE_ACK_SEND_CALL', 'WAITING'), ('DONE_ACK_SEND_RETURN', 'WAITING'),
+              ('DONE_ACK_SENT', 'WAITING'),
           ]
           cursor = 0
           for event in events:
+              assert 'wall_ms' in event and 'performance_ms' in event, event
               if cursor >= len(expected):
-                  break
+                  continue
               kind, detail = expected[cursor]
               if event.get('event') == kind and (detail is None or event.get('detail') == detail):
                   cursor += 1
           assert cursor == len(expected), (cursor, expected[cursor] if cursor < len(expected) else None, events)
           assert not any(event.get('event') == 'ERROR' for event in events), events
-          print('PASS: real Robot Window applied DONE -> WAITING and sent DONE_ACK after the transition.')
+          print('PASS: real Robot Window applied DONE -> WAITING and synchronously called/returned from DONE_ACK send.')
+          PY
+
+          cat "$TRACE"
+          python3 - <<'PY'
+          from pathlib import Path
+          lines = [line for line in Path('ci-artifacts/crazyflie-done-ack-trace.txt').read_text().splitlines() if line.strip()]
+          assert any('phase=wait_begin payload=NULL' in line for line in lines), lines
+          ack = [line for line in lines if 'payload=WEBEEBLOCKS_MISSION_V1 DONE_ACK' in line]
+          assert ack, lines
+          assert any('phase=before_step ' in line or 'phase=after_step ' in line for line in ack), ack
+          print('PASS: controller drain observed the exact DONE_ACK payload with Webots timestamp and drain phase.')
           PY
 
           cat "$RESULT"
@@ -148,7 +168,6 @@ jobs:
           assert float(pairs['endpoint_error_xy']) <= 0.02
           assert float(pairs['yaw_error_deg']) <= 2.0
           assert abs(float(pairs['total_s']) - 26.144) <= 0.10
-          print('PASS: controller completed only after the DONE_ACK wait path returned successfully; timeout would overwrite this result with reason=DONE_ACK_TIMEOUT and exit non-zero.')
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course, with no rebuild after Submit.')
           PY
 
@@ -160,4 +179,5 @@ jobs:
           path: |
             ci-artifacts/crazyflie-runtime-wwi/
             ci-artifacts/crazyflie-l-course-result.txt
+            ci-artifacts/crazyflie-done-ack-trace.txt
           if-no-files-found: error

--- a/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
+++ b/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
@@ -101,9 +101,6 @@ jobs:
 
           grep -Fq 'WEBEEBLOCKS_MISSION_V1 WAITING' "$LOG"
           grep -Fq 'WEBEEBLOCKS_MISSION_V1 VALIDATED count=5' "$LOG"
-          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_SENT' "$LOG"
-          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED' "$LOG"
-          ! grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT' "$LOG"
           ! grep -Fq 'ERROR:' "$LOG"
 
           python3 - <<'PY'
@@ -133,11 +130,13 @@ jobs:
                   cursor += 1
           assert cursor == len(expected), (cursor, expected[cursor] if cursor < len(expected) else None, events)
           assert not any(event.get('event') == 'ERROR' for event in events), events
-          print('PASS: Robot Window preserved RUNNING on BUSY, applied DONE -> WAITING, emitted DONE_ACK, and controller received it before exit.')
+          print('PASS: real Robot Window applied DONE -> WAITING and sent DONE_ACK after the transition.')
           PY
 
           cat "$RESULT"
           grep -Fq 'WEBEEBLOCKS_CF_L_RESULT status=success gates=2' "$RESULT"
+          ! grep -Fq 'reason=DONE_ACK_TIMEOUT' "$RESULT"
+          test "$(cat ci-artifacts/crazyflie-runtime-wwi/exit-code.txt)" = "0"
           python3 - <<'PY'
           import re
           from pathlib import Path
@@ -149,6 +148,7 @@ jobs:
           assert float(pairs['endpoint_error_xy']) <= 0.02
           assert float(pairs['yaw_error_deg']) <= 2.0
           assert abs(float(pairs['total_s']) - 26.144) <= 0.10
+          print('PASS: controller completed only after the DONE_ACK wait path returned successfully; timeout would overwrite this result with reason=DONE_ACK_TIMEOUT and exit non-zero.')
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course, with no rebuild after Submit.')
           PY
 

--- a/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
+++ b/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
@@ -73,7 +73,7 @@ jobs:
               event_server_pid=$!
               trap "kill $event_server_pid 2>/dev/null || true" EXIT
               sleep 0.5
-              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/crazyflie_runtime_wwi.wbt
+              timeout -k 5s 95s xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_wwi.wbt
             ' \
             2>&1 | tee ci-artifacts/crazyflie-runtime-wwi/webots.log
           code=${PIPESTATUS[0]}

--- a/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
+++ b/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
@@ -101,6 +101,9 @@ jobs:
 
           grep -Fq 'WEBEEBLOCKS_MISSION_V1 WAITING' "$LOG"
           grep -Fq 'WEBEEBLOCKS_MISSION_V1 VALIDATED count=5' "$LOG"
+          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_SENT' "$LOG"
+          grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED' "$LOG"
+          ! grep -Fq 'WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT' "$LOG"
           ! grep -Fq 'ERROR:' "$LOG"
 
           python3 - <<'PY'
@@ -119,7 +122,7 @@ jobs:
               ('SECOND_SUBMIT_CLICK', None), ('SECOND_SUBMIT_BLOCKED_LOCAL', 'RUNNING'),
               ('BUSY_PROBE_SEND', None), ('RX', 'WEBEEBLOCKS_MISSION_V1 ERR BUSY'),
               ('STATE_AFTER_BUSY', 'RUNNING'), ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE'),
-              ('STATE_AFTER_DONE', 'WAITING'), ('COMPLETE', 'runtime WWI handshake proved'),
+              ('STATE_AFTER_DONE', 'WAITING'),
           ]
           cursor = 0
           for event in events:
@@ -130,7 +133,7 @@ jobs:
                   cursor += 1
           assert cursor == len(expected), (cursor, expected[cursor] if cursor < len(expected) else None, events)
           assert not any(event.get('event') == 'ERROR' for event in events), events
-          print('PASS: real Robot Window persisted negative rejects -> PENDING -> ACK/RUNNING -> local second-submit block -> BUSY -> DONE/WAITING.')
+          print('PASS: Robot Window preserved RUNNING on BUSY, applied DONE -> WAITING, and controller received DONE_ACK before exit.')
           PY
 
           cat "$RESULT"

--- a/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
+++ b/.github/workflows/crazyflie-runtime-wwi-r2025a-ci.yml
@@ -122,7 +122,7 @@ jobs:
               ('SECOND_SUBMIT_CLICK', None), ('SECOND_SUBMIT_BLOCKED_LOCAL', 'RUNNING'),
               ('BUSY_PROBE_SEND', None), ('RX', 'WEBEEBLOCKS_MISSION_V1 ERR BUSY'),
               ('STATE_AFTER_BUSY', 'RUNNING'), ('RX', 'WEBEEBLOCKS_MISSION_V1 DONE'),
-              ('STATE_AFTER_DONE', 'WAITING'),
+              ('STATE_AFTER_DONE', 'WAITING'), ('DONE_ACK_SENT', 'WAITING'),
           ]
           cursor = 0
           for event in events:
@@ -133,7 +133,7 @@ jobs:
                   cursor += 1
           assert cursor == len(expected), (cursor, expected[cursor] if cursor < len(expected) else None, events)
           assert not any(event.get('event') == 'ERROR' for event in events), events
-          print('PASS: Robot Window preserved RUNNING on BUSY, applied DONE -> WAITING, and controller received DONE_ACK before exit.')
+          print('PASS: Robot Window preserved RUNNING on BUSY, applied DONE -> WAITING, emitted DONE_ACK, and controller received it before exit.')
           PY
 
           cat "$RESULT"

--- a/controllers/Blockly_Programs/CrazyflieDirect.xml
+++ b/controllers/Blockly_Programs/CrazyflieDirect.xml
@@ -1,0 +1,1 @@
+<xml xmlns="https://developers.google.com/blockly/xml"><block type="webeeblocks_takeoff" id="cf_direct_takeoff" x="40" y="40"><next><block type="webeeblocks_forward" id="cf_direct_forward"><field name="DISTANCE">2</field><next><block type="webeeblocks_land" id="cf_direct_land"></block></next></block></next></block></xml>

--- a/controllers/crazyflie_l_course/crazyflie_l_course.c
+++ b/controllers/crazyflie_l_course/crazyflie_l_course.c
@@ -23,6 +23,7 @@
 #define POSITION_TOL 0.03
 #define YAW_TOL (2.0 * PI / 180.0)
 #define TIMEOUT 60.0
+#define DONE_ACK_TIMEOUT 10.0
 #define GATE_ALONG_M 0.90
 #define GATE_HALF_WIDTH_M 0.30
 #define GATE_HALF_HEIGHT_M 0.20
@@ -189,6 +190,24 @@ static void reject_runtime_messages_while_busy(void) {
   const char *message;
   while ((message = wb_robot_wwi_receive_text()))
     wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
+}
+
+static int wait_for_runtime_done_ack(int step) {
+  const double deadline = wb_robot_get_time() + DONE_ACK_TIMEOUT;
+  while (wb_robot_get_time() < deadline && wb_robot_step(step) != -1) {
+    const char *message;
+    while ((message = wb_robot_wwi_receive_text())) {
+      if (strcmp(message, "WEBEEBLOCKS_MISSION_V1 DONE_ACK") == 0) {
+        printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED\n");
+        fflush(stdout);
+        return 1;
+      }
+      wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
+    }
+  }
+  printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT\n");
+  fflush(stdout);
+  return 0;
 }
 
 int main(int argc, const char *argv[]) {
@@ -387,9 +406,18 @@ int main(int argc, const char *argv[]) {
         }
         fflush(stdout);
         webeeblocks_runner_advance(&runner);
-        if (runtime_mode)
+        stop(m1,m2,m3,m4);
+        if (runtime_mode) {
           wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 DONE");
-        stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(0); break;
+          printf("WEBEEBLOCKS_MISSION_V1 DONE_SENT\n");
+          fflush(stdout);
+          if (!wait_for_runtime_done_ack(step)) {
+            write_failure("DONE_ACK_TIMEOUT", &runner, gate1.passed + gate2.passed);
+            wb_supervisor_simulation_quit(2);
+            break;
+          }
+        }
+        wb_supervisor_simulation_quit(0); break;
       }
     }
 

--- a/controllers/crazyflie_l_course/crazyflie_l_course.c
+++ b/controllers/crazyflie_l_course/crazyflie_l_course.c
@@ -59,11 +59,41 @@ static void stop(WbDeviceTag a, WbDeviceTag b, WbDeviceTag c, WbDeviceTag d) {
 
 static const char *runner_phase_name(const webeeblocks_runner_t *runner) {
   const webeeblocks_command_t *command = webeeblocks_runner_current(runner);
-  if (!command)
-    return "DONE";
+  return command ? webeeblocks_command_name(command->type) : "DONE";
+}
+
+static int mission_is_reference_l(const webeeblocks_command_t *mission, size_t count) {
+  return count == 5 &&
+         mission[0].type == WEBEEBLOCKS_COMMAND_TAKEOFF &&
+         mission[1].type == WEBEEBLOCKS_COMMAND_FORWARD &&
+         mission[2].type == WEBEEBLOCKS_COMMAND_TURN &&
+         mission[3].type == WEBEEBLOCKS_COMMAND_FORWARD &&
+         mission[4].type == WEBEEBLOCKS_COMMAND_LAND &&
+         fabs(mission[0].value - 1.0) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE &&
+         fabs(mission[1].value - 1.0) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE &&
+         fabs(mission[2].value - PI / 2.0) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE &&
+         fabs(mission[3].value - 1.0) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE &&
+         fabs(mission[4].value) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE;
+}
+
+static int configure_target_for_command(const webeeblocks_command_t *command,
+                                        double anchor_x, double anchor_y,
+                                        double target_z, double anchor_yaw,
+                                        double *target_x, double *target_y,
+                                        double *target_yaw) {
+  if (!command || command->type == WEBEEBLOCKS_COMMAND_LAND)
+    return 1;
+  webeeblocks_target_t target;
   if (command->type == WEBEEBLOCKS_COMMAND_FORWARD)
-    return runner->index == 1 ? "LEG1" : "LEG2";
-  return webeeblocks_command_name(command->type);
+    target = webeeblocks_forward(anchor_x, anchor_y, target_z, anchor_yaw, command->value);
+  else if (command->type == WEBEEBLOCKS_COMMAND_TURN)
+    target = webeeblocks_turn(anchor_x, anchor_y, target_z, anchor_yaw, command->value);
+  else
+    return 0;
+  *target_x = target.x;
+  *target_y = target.y;
+  *target_yaw = target.yaw;
+  return 1;
 }
 
 static int check_gate(double px, double py, double pz,
@@ -119,6 +149,18 @@ static void write_success(const gate_result_t *g1, const gate_result_t *g2,
           g1->lateral, g1->altitude_error, g1->time,
           g2->lateral, g2->altitude_error, g2->time,
           endpoint_error, yaw_error_deg, min_z, max_z, total);
+  fflush(file);
+  fclose(file);
+}
+
+static void write_generic_success(size_t commands, double x, double y, double yaw, double total) {
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-runtime-mission-result.txt", wb_robot_get_project_path());
+  FILE *file = fopen(path, "w");
+  if (!file) return;
+  fprintf(file,
+          "WEBEEBLOCKS_RUNTIME_RESULT status=success commands=%zu x=%.6f y=%.6f yaw=%.6f total_s=%.3f\n",
+          commands, x, y, yaw, total);
   fflush(file);
   fclose(file);
 }
@@ -188,16 +230,23 @@ int main(int argc, const char *argv[]) {
     fflush(stdout);
   }
 
+  const int reference_l = mission_is_reference_l(mission, mission_count);
   const double *p = wb_gps_get_values(gps), *r = wb_inertial_unit_get_roll_pitch_yaw(imu);
   const double sx = p[0], sy = p[1], sz = p[2], syaw = r[2];
-  const double ux = cos(syaw), uy = sin(syaw), lx1 = -sin(syaw), ly1 = cos(syaw);
-  const double second_yaw = wrap(syaw + mission[2].value);
-  const double ux2 = cos(second_yaw), uy2 = sin(second_yaw), lx2 = -sin(second_yaw), ly2 = cos(second_yaw);
-  const double g1x = sx + GATE_ALONG_M * ux, g1y = sy + GATE_ALONG_M * uy;
-  const double corner_x = sx + mission[1].value * ux, corner_y = sy + mission[1].value * uy;
-  const double g2x = corner_x + GATE_ALONG_M * ux2, g2y = corner_y + GATE_ALONG_M * uy2;
-  const double expected_x = corner_x + mission[3].value * ux2, expected_y = corner_y + mission[3].value * uy2;
-  const double expected_yaw = second_yaw;
+  double ux = 0.0, uy = 0.0, lx1 = 0.0, ly1 = 0.0;
+  double ux2 = 0.0, uy2 = 0.0, lx2 = 0.0, ly2 = 0.0;
+  double g1x = 0.0, g1y = 0.0, g2x = 0.0, g2y = 0.0;
+  double expected_x = sx, expected_y = sy, expected_yaw = syaw;
+  if (reference_l) {
+    ux = cos(syaw); uy = sin(syaw); lx1 = -sin(syaw); ly1 = cos(syaw);
+    const double second_yaw = wrap(syaw + mission[2].value);
+    ux2 = cos(second_yaw); uy2 = sin(second_yaw); lx2 = -sin(second_yaw); ly2 = cos(second_yaw);
+    g1x = sx + GATE_ALONG_M * ux; g1y = sy + GATE_ALONG_M * uy;
+    const double corner_x = sx + mission[1].value * ux, corner_y = sy + mission[1].value * uy;
+    g2x = corner_x + GATE_ALONG_M * ux2; g2y = corner_y + GATE_ALONG_M * uy2;
+    expected_x = corner_x + mission[3].value * ux2; expected_y = corner_y + mission[3].value * uy2;
+    expected_yaw = second_yaw;
+  }
 
   webeeblocks_runner_t runner;
   webeeblocks_runner_init(&runner, mission, mission_count);
@@ -214,7 +263,8 @@ int main(int argc, const char *argv[]) {
   init_pid_attitude_fixed_height_controller();
   actual_state_t a = {0}; desired_state_t d = {0}; motor_power_t power = {0};
 
-  printf("WEBEEBLOCKS_CF_L_STARTED x=%.6f y=%.6f z=%.6f yaw=%.6f\n", sx, sy, sz, syaw);
+  printf("WEBEEBLOCKS_CF_MISSION_STARTED commands=%zu x=%.6f y=%.6f z=%.6f yaw=%.6f\n",
+         mission_count, sx, sy, sz, syaw);
   fflush(stdout);
 
   while (wb_robot_step(step) != -1) {
@@ -244,13 +294,13 @@ int main(int argc, const char *argv[]) {
       stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
     }
 
-    if (command->type == WEBEEBLOCKS_COMMAND_FORWARD && runner.index == 1) {
+    if (reference_l && command->type == WEBEEBLOCKS_COMMAND_FORWARD && runner.index == 1) {
       const int crossed = check_gate(px,py,pz,x,y,z,pt,now,t0,g1x,g1y,ux,uy,lx1,ly1,target_z,&gate1);
       if (crossed < 0) {
         write_failure("GATE1_MISS", &runner, gates);
         stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
       }
-    } else if (command->type == WEBEEBLOCKS_COMMAND_FORWARD && runner.index == 3) {
+    } else if (reference_l && command->type == WEBEEBLOCKS_COMMAND_FORWARD && runner.index == 3) {
       const int crossed = check_gate(px,py,pz,x,y,z,pt,now,t0,g2x,g2y,ux2,uy2,lx2,ly2,target_z,&gate2);
       if (crossed < 0 || (crossed > 0 && !gate1.passed)) {
         write_failure(crossed < 0 ? "GATE2_MISS" : "GATE_ORDER", &runner, gates);
@@ -265,8 +315,11 @@ int main(int argc, const char *argv[]) {
                                               z - target_z, now)) {
         webeeblocks_runner_advance(&runner);
         command = webeeblocks_runner_current(&runner);
-        target = webeeblocks_forward(x,y,target_z,yaw,command->value);
-        target_x = target.x; target_y = target.y; target_yaw = syaw;
+        if (!configure_target_for_command(command, x, y, target_z, yaw,
+                                          &target_x, &target_y, &target_yaw)) {
+          write_failure("INVALID_NEXT_COMMAND", &runner, gates);
+          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
+        }
       }
     } else if (command->type == WEBEEBLOCKS_COMMAND_FORWARD) {
       const double ex = target_x-x, ey = target_y-y;
@@ -277,21 +330,21 @@ int main(int argc, const char *argv[]) {
       if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
                                               hypot(a.vx, a.vy), a.yaw_rate, vz,
                                               z - target_z, now)) {
-        if (runner.index == 1) {
-          if (!gate1.passed) {
-            write_failure("GATE1_NOT_CROSSED", &runner, gates);
-            stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
-          }
-          webeeblocks_runner_advance(&runner);
-          command = webeeblocks_runner_current(&runner);
-          target = webeeblocks_turn(target_x,target_y,target_z,target_yaw,command->value);
-          target_yaw = target.yaw;
-        } else {
-          if (!gate2.passed) {
-            write_failure("GATE2_NOT_CROSSED", &runner, gates);
-            stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
-          }
-          webeeblocks_runner_advance(&runner);
+        if (reference_l && runner.index == 1 && !gate1.passed) {
+          write_failure("GATE1_NOT_CROSSED", &runner, gates);
+          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
+        }
+        if (reference_l && runner.index == 3 && !gate2.passed) {
+          write_failure("GATE2_NOT_CROSSED", &runner, gates);
+          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
+        }
+        const double anchor_x = target_x, anchor_y = target_y, anchor_yaw = target_yaw;
+        webeeblocks_runner_advance(&runner);
+        command = webeeblocks_runner_current(&runner);
+        if (!configure_target_for_command(command, anchor_x, anchor_y, target_z, anchor_yaw,
+                                          &target_x, &target_y, &target_yaw)) {
+          write_failure("INVALID_NEXT_COMMAND", &runner, gates);
+          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
         }
       }
     } else if (command->type == WEBEEBLOCKS_COMMAND_TURN) {
@@ -301,10 +354,14 @@ int main(int argc, const char *argv[]) {
       if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
                                               hypot(a.vx, a.vy), a.yaw_rate, vz,
                                               z - target_z, now)) {
+        const double anchor_x = target_x, anchor_y = target_y, anchor_yaw = target_yaw;
         webeeblocks_runner_advance(&runner);
         command = webeeblocks_runner_current(&runner);
-        target = webeeblocks_forward(target_x,target_y,target_z,target_yaw,command->value);
-        target_x = target.x; target_y = target.y;
+        if (!configure_target_for_command(command, anchor_x, anchor_y, target_z, anchor_yaw,
+                                          &target_x, &target_y, &target_yaw)) {
+          write_failure("INVALID_NEXT_COMMAND", &runner, gates);
+          stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
+        }
       }
     } else if (command->type == WEBEEBLOCKS_COMMAND_LAND) {
       const webeeblocks_target_t landing = webeeblocks_land(x,y,sz,yaw);
@@ -313,15 +370,21 @@ int main(int argc, const char *argv[]) {
       if (webeeblocks_runner_completion_stop(&runner, geometric_ready,
                                               hypot(a.vx, a.vy), a.yaw_rate, vz,
                                               z - landing.z, now)) {
-        if (!(gate1.passed && gate2.passed)) {
+        if (reference_l && !(gate1.passed && gate2.passed)) {
           write_failure("GATES_INCOMPLETE", &runner, gate1.passed+gate2.passed);
           stop(m1,m2,m3,m4); wb_supervisor_simulation_quit(2); break;
         }
-        const double endpoint_error = hypot(x-expected_x,y-expected_y);
-        const double yaw_error = fabs(wrap(yaw-expected_yaw))*180.0/PI;
-        write_success(&gate1,&gate2,endpoint_error,yaw_error,min_z,max_z,now-t0);
-        printf("WEBEEBLOCKS_CF_L_RESULT status=success gates=2 endpoint_error_xy=%.6f yaw_error_deg=%.6f total_s=%.3f\n",
-               endpoint_error,yaw_error,now-t0);
+        if (reference_l) {
+          const double endpoint_error = hypot(x-expected_x,y-expected_y);
+          const double yaw_error = fabs(wrap(yaw-expected_yaw))*180.0/PI;
+          write_success(&gate1,&gate2,endpoint_error,yaw_error,min_z,max_z,now-t0);
+          printf("WEBEEBLOCKS_CF_L_RESULT status=success gates=2 endpoint_error_xy=%.6f yaw_error_deg=%.6f total_s=%.3f\n",
+                 endpoint_error,yaw_error,now-t0);
+        } else {
+          write_generic_success(mission_count, x, y, yaw, now-t0);
+          printf("WEBEEBLOCKS_RUNTIME_RESULT status=success commands=%zu total_s=%.3f\n",
+                 mission_count, now-t0);
+        }
         fflush(stdout);
         webeeblocks_runner_advance(&runner);
         if (runtime_mode)

--- a/controllers/crazyflie_l_course/crazyflie_l_course.c
+++ b/controllers/crazyflie_l_course/crazyflie_l_course.c
@@ -192,18 +192,28 @@ static void reject_runtime_messages_while_busy(void) {
     wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
 }
 
+static int drain_runtime_done_ack(void) {
+  const char *message;
+  while ((message = wb_robot_wwi_receive_text())) {
+    if (strcmp(message, "WEBEEBLOCKS_MISSION_V1 DONE_ACK") == 0) {
+      printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED\n");
+      fflush(stdout);
+      return 1;
+    }
+    wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
+  }
+  return 0;
+}
+
 static int wait_for_runtime_done_ack(int step) {
   const double deadline = wb_robot_get_time() + DONE_ACK_TIMEOUT;
-  while (wb_robot_get_time() < deadline && wb_robot_step(step) != -1) {
-    const char *message;
-    while ((message = wb_robot_wwi_receive_text())) {
-      if (strcmp(message, "WEBEEBLOCKS_MISSION_V1 DONE_ACK") == 0) {
-        printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED\n");
-        fflush(stdout);
-        return 1;
-      }
-      wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
-    }
+  while (wb_robot_get_time() < deadline) {
+    if (drain_runtime_done_ack())
+      return 1;
+    if (wb_robot_step(step) == -1)
+      break;
+    if (drain_runtime_done_ack())
+      return 1;
   }
   printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT\n");
   fflush(stdout);

--- a/controllers/crazyflie_l_course/webeeblocks_mission_v1.h
+++ b/controllers/crazyflie_l_course/webeeblocks_mission_v1.h
@@ -13,6 +13,10 @@
 #define WEBEEBLOCKS_MISSION_V1_MAX_COMMANDS 5
 #define WEBEEBLOCKS_MISSION_V1_MAX_MESSAGE 1024
 #define WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE 1e-6
+#define WEBEEBLOCKS_MISSION_V1_FORWARD_MIN 0.10
+#define WEBEEBLOCKS_MISSION_V1_FORWARD_MAX 2.00
+#define WEBEEBLOCKS_MISSION_V1_TURN_MIN (-M_PI / 2.0)
+#define WEBEEBLOCKS_MISSION_V1_TURN_MAX (3.0 * M_PI / 4.0)
 
 typedef enum {
   WEBEEBLOCKS_MISSION_V1_OK = 0,
@@ -47,6 +51,11 @@ static int webeeblocks_mission_v1_parse_number(const char *text, double *value) 
 
 static int webeeblocks_mission_v1_matches(double actual, double expected) {
   return fabs(actual - expected) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE;
+}
+
+static int webeeblocks_mission_v1_in_range(double value, double minimum, double maximum) {
+  return value >= minimum - WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE &&
+         value <= maximum + WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE;
 }
 
 static webeeblocks_mission_v1_status_t webeeblocks_mission_v1_parse(
@@ -85,13 +94,16 @@ static webeeblocks_mission_v1_status_t webeeblocks_mission_v1_parse(
         return WEBEEBLOCKS_MISSION_V1_ERR_PARAMETER;
       commands[n++] = (webeeblocks_command_t){WEBEEBLOCKS_COMMAND_TAKEOFF, value};
     } else if (strcmp(command, "FORWARD") == 0) {
-      // Transport v1 deliberately accepts only the already-proven one-metre L.
-      // General student distances come after this runtime seam is closed.
-      if (!webeeblocks_mission_v1_matches(value, 1.0))
+      if (!webeeblocks_mission_v1_in_range(value,
+                                           WEBEEBLOCKS_MISSION_V1_FORWARD_MIN,
+                                           WEBEEBLOCKS_MISSION_V1_FORWARD_MAX))
         return WEBEEBLOCKS_MISSION_V1_ERR_PARAMETER;
       commands[n++] = (webeeblocks_command_t){WEBEEBLOCKS_COMMAND_FORWARD, value};
     } else if (strcmp(command, "TURN") == 0) {
-      if (!webeeblocks_mission_v1_matches(value, M_PI / 2.0))
+      if (fabs(value) <= WEBEEBLOCKS_MISSION_V1_VALUE_TOLERANCE ||
+          !webeeblocks_mission_v1_in_range(value,
+                                           WEBEEBLOCKS_MISSION_V1_TURN_MIN,
+                                           WEBEEBLOCKS_MISSION_V1_TURN_MAX))
         return WEBEEBLOCKS_MISSION_V1_ERR_PARAMETER;
       commands[n++] = (webeeblocks_command_t){WEBEEBLOCKS_COMMAND_TURN, value};
     } else if (strcmp(command, "LAND") == 0) {
@@ -103,15 +115,17 @@ static webeeblocks_mission_v1_status_t webeeblocks_mission_v1_parse(
     }
   }
 
-  // Runtime v1 deliberately proves exactly the L-shaped pedagogical sequence
-  // already characterized in #31-#34. Parameter generalization is a later lot.
-  if (n != 5 ||
+  // v0 is deliberately a short sequential mission: one takeoff, one landing,
+  // and only the already-characterized FORWARD/TURN primitives in between.
+  if (n < 3 ||
       commands[0].type != WEBEEBLOCKS_COMMAND_TAKEOFF ||
-      commands[1].type != WEBEEBLOCKS_COMMAND_FORWARD ||
-      commands[2].type != WEBEEBLOCKS_COMMAND_TURN ||
-      commands[3].type != WEBEEBLOCKS_COMMAND_FORWARD ||
-      commands[4].type != WEBEEBLOCKS_COMMAND_LAND)
+      commands[n - 1].type != WEBEEBLOCKS_COMMAND_LAND)
     return WEBEEBLOCKS_MISSION_V1_ERR_SEQUENCE;
+  for (size_t i = 1; i + 1 < n; ++i) {
+    if (commands[i].type != WEBEEBLOCKS_COMMAND_FORWARD &&
+        commands[i].type != WEBEEBLOCKS_COMMAND_TURN)
+      return WEBEEBLOCKS_MISSION_V1_ERR_SEQUENCE;
+  }
 
   *count = n;
   return WEBEEBLOCKS_MISSION_V1_OK;

--- a/plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/crazyflie.js
+++ b/plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/crazyflie.js
@@ -28,7 +28,7 @@ Blockly.Blocks['webeeblocks_turn'] = {
   init: function() {
     this.appendDummyInput()
         .appendField('tourner de')
-        .appendField(new Blockly.FieldNumber(90, -179, 179, 1), 'ANGLE')
+        .appendField(new Blockly.FieldNumber(90, -90, 135, 1), 'ANGLE')
         .appendField('°');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
@@ -59,6 +59,10 @@ Blockly.Blocks['webeeblocks_land'] = {
   };
   const PROTOCOL = 'WEBEEBLOCKS_MISSION_V1';
   const MAX_COMMANDS_V1 = 5;
+  const FORWARD_MIN_M = 0.1;
+  const FORWARD_MAX_M = 2.0;
+  const TURN_MIN_DEG = -90;
+  const TURN_MAX_DEG = 135;
 
   function finiteNumber(block, field) {
     const value = Number(block.getFieldValue(field));
@@ -77,14 +81,14 @@ Blockly.Blocks['webeeblocks_land'] = {
       return {type: 'LAND', value: 0.0};
     if (block.type === 'webeeblocks_forward') {
       const distance = finiteNumber(block, 'DISTANCE');
-      if (!(distance >= 0.1 && distance <= 2.0))
+      if (!(distance >= FORWARD_MIN_M && distance <= FORWARD_MAX_M))
         throw new Error('forward distance out of v0 range: ' + distance);
       return {type: 'FORWARD', value: distance};
     }
 
     const angleDeg = finiteNumber(block, 'ANGLE');
-    if (angleDeg === 0 || Math.abs(angleDeg) >= 180)
-      throw new Error('turn angle must satisfy 0 < |angle| < 180 degrees');
+    if (angleDeg === 0 || angleDeg < TURN_MIN_DEG || angleDeg > TURN_MAX_DEG)
+      throw new Error('turn angle out of characterized v0 range: ' + angleDeg);
     return {type: 'TURN', value: angleDeg * Math.PI / 180.0};
   }
 
@@ -100,7 +104,7 @@ Blockly.Blocks['webeeblocks_land'] = {
       block = block.getNextBlock();
     }
 
-    if (mission.length < 2 || mission[0].type !== 'TAKEOFF' || mission[mission.length - 1].type !== 'LAND')
+    if (mission.length < 3 || mission[0].type !== 'TAKEOFF' || mission[mission.length - 1].type !== 'LAND')
       throw new Error('Crazyflie mission must start with TAKEOFF and end with LAND');
     if (mission.length > MAX_COMMANDS_V1)
       throw new Error('Crazyflie mission is too long for runtime protocol v1');

--- a/plugins/robot_windows/blockly/main.js
+++ b/plugins/robot_windows/blockly/main.js
@@ -198,8 +198,10 @@ function receiveMessage(value) {
         }
     }
     window.dispatchEvent(new CustomEvent('webeeblocks-wwi', {detail: value}));
-    if (acknowledgeDone && window.robotWindow && typeof window.robotWindow.send === 'function')
+    if (acknowledgeDone && window.robotWindow && typeof window.robotWindow.send === 'function') {
         window.robotWindow.send('WEBEEBLOCKS_MISSION_V1 DONE_ACK');
+        window.dispatchEvent(new CustomEvent('webeeblocks-runtime', {detail: 'DONE_ACK_SENT'}));
+    }
 }
 
 function onResize(e) {
@@ -227,3 +229,11 @@ window.onload = async function() {
 }
 
 var container = document.getElementById("blocklyContainer");
+var workspace = Blockly.inject(container,
+    {
+        toolbox: document.getElementById('toolbox'),
+        scrollbars: true,
+        media: 'google-blockly-31ee4ea/media/'
+    });
+Blockly.svgResize(workspace);
+workspace.addChangeListener(realTimeUpdate);

--- a/plugins/robot_windows/blockly/main.js
+++ b/plugins/robot_windows/blockly/main.js
@@ -182,12 +182,14 @@ function restore() {
 
 function receiveMessage(value) {
     console.log(value);
+    var acknowledgeDone = false;
     if (typeof value === 'string' && value.indexOf('WEBEEBLOCKS_MISSION_V1 ') === 0) {
         if (value === 'WEBEEBLOCKS_MISSION_V1 ACK') {
             if (crazyflieRuntimeState === 'PENDING')
                 crazyflieRuntimeState = 'RUNNING';
         } else if (value === 'WEBEEBLOCKS_MISSION_V1 DONE') {
             crazyflieRuntimeState = 'WAITING';
+            acknowledgeDone = true;
         } else if (value.indexOf('WEBEEBLOCKS_MISSION_V1 ERR ') === 0) {
             // BUSY can be the response to a second transport-level probe while an
             // already accepted mission is still active. Never let it unlock Submit.
@@ -196,6 +198,8 @@ function receiveMessage(value) {
         }
     }
     window.dispatchEvent(new CustomEvent('webeeblocks-wwi', {detail: value}));
+    if (acknowledgeDone && window.robotWindow && typeof window.robotWindow.send === 'function')
+        window.robotWindow.send('WEBEEBLOCKS_MISSION_V1 DONE_ACK');
 }
 
 function onResize(e) {

--- a/tools/ci/instrument_runtime_done_ack.py
+++ b/tools/ci/instrument_runtime_done_ack.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "controllers/crazyflie_l_course/crazyflie_l_course.c"
+
+OLD = r'''static int drain_runtime_done_ack(void) {
+  const char *message;
+  while ((message = wb_robot_wwi_receive_text())) {
+    if (strcmp(message, "WEBEEBLOCKS_MISSION_V1 DONE_ACK") == 0) {
+      printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED\n");
+      fflush(stdout);
+      return 1;
+    }
+    wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
+  }
+  return 0;
+}
+
+static int wait_for_runtime_done_ack(int step) {
+  const double deadline = wb_robot_get_time() + DONE_ACK_TIMEOUT;
+  while (wb_robot_get_time() < deadline) {
+    if (drain_runtime_done_ack())
+      return 1;
+    if (wb_robot_step(step) == -1)
+      break;
+    if (drain_runtime_done_ack())
+      return 1;
+  }
+  printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT\n");
+  fflush(stdout);
+  return 0;
+}
+'''
+
+NEW = r'''static void trace_runtime_done_ack(const char *phase, const char *payload) {
+  char path[4096];
+  snprintf(path, sizeof(path), "%s/ci-artifacts/crazyflie-done-ack-trace.txt", wb_robot_get_project_path());
+  FILE *file = fopen(path, "a");
+  if (file) {
+    fprintf(file, "t=%.6f phase=%s payload=%s\n",
+            wb_robot_get_time(), phase, payload ? payload : "NULL");
+    fflush(file);
+    fclose(file);
+  }
+  printf("WEBEEBLOCKS_DONE_ACK_TRACE t=%.6f phase=%s payload=%s\n",
+         wb_robot_get_time(), phase, payload ? payload : "NULL");
+  fflush(stdout);
+}
+
+static int drain_runtime_done_ack(const char *phase) {
+  const char *message;
+  int received_any = 0;
+  while ((message = wb_robot_wwi_receive_text())) {
+    received_any = 1;
+    trace_runtime_done_ack(phase, message);
+    if (strcmp(message, "WEBEEBLOCKS_MISSION_V1 DONE_ACK") == 0) {
+      printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_RECEIVED\n");
+      fflush(stdout);
+      return 1;
+    }
+    wb_robot_wwi_send_text("WEBEEBLOCKS_MISSION_V1 ERR BUSY");
+  }
+  if (!received_any)
+    trace_runtime_done_ack(phase, NULL);
+  return 0;
+}
+
+static int wait_for_runtime_done_ack(int step) {
+  const double deadline = wb_robot_get_time() + DONE_ACK_TIMEOUT;
+  trace_runtime_done_ack("wait_begin", NULL);
+  while (wb_robot_get_time() < deadline) {
+    if (drain_runtime_done_ack("before_step"))
+      return 1;
+    if (wb_robot_step(step) == -1) {
+      trace_runtime_done_ack("step_ended", NULL);
+      break;
+    }
+    if (drain_runtime_done_ack("after_step"))
+      return 1;
+  }
+  trace_runtime_done_ack("timeout", NULL);
+  printf("WEBEEBLOCKS_MISSION_V1 DONE_ACK_TIMEOUT\n");
+  fflush(stdout);
+  return 0;
+}
+'''
+
+
+def main() -> int:
+    text = SOURCE.read_text(encoding="utf-8")
+    if NEW in text:
+        print("DONE_ACK terminal tracing already installed.")
+        return 0
+    if OLD not in text:
+        raise SystemExit("expected DONE_ACK functions not found; refusing to patch")
+    SOURCE.write_text(text.replace(OLD, NEW, 1), encoding="utf-8")
+    print("Installed CI-only terminal DONE_ACK tracing in crazyflie_l_course.c")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/prepare_crazyflie_parametric_obstacle.py
+++ b/tools/ci/prepare_crazyflie_parametric_obstacle.py
@@ -54,6 +54,9 @@ def main() -> int:
         report('STATE_AFTER_DONE', stateWhenDone);
       }
     });
+    window.addEventListener('webeeblocks-runtime', event => {
+      report(String(event.detail), crazyflieRuntimeState);
+    });
 
     await waitFor(() => window.robotWindow && typeof window.robotWindow.send === 'function', 'RobotWindow transport', 15000);
     await waitFor(() => typeof workspace !== 'undefined' && workspace, 'Blockly workspace', 5000);

--- a/tools/ci/prepare_crazyflie_parametric_obstacle.py
+++ b/tools/ci/prepare_crazyflie_parametric_obstacle.py
@@ -33,7 +33,13 @@ def main() -> int:
   let reportSequence = 0;
   let reportChain = Promise.resolve();
   function report(event, detail) {
-    const payload = {seq: reportSequence++, event: event, detail: detail === undefined ? null : String(detail)};
+    const payload = {
+      seq: reportSequence++,
+      wall_ms: Date.now(),
+      performance_ms: typeof performance !== 'undefined' ? performance.now() : null,
+      event: event,
+      detail: detail === undefined ? null : String(detail),
+    };
     reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -60,6 +66,16 @@ def main() -> int:
 
     await waitFor(() => window.robotWindow && typeof window.robotWindow.send === 'function', 'RobotWindow transport', 15000);
     await waitFor(() => typeof workspace !== 'undefined' && workspace, 'Blockly workspace', 5000);
+
+    const realSend = window.robotWindow.send.bind(window.robotWindow);
+    window.robotWindow.send = function(message) {
+      if (message === 'WEBEEBLOCKS_MISSION_V1 DONE_ACK')
+        report('DONE_ACK_SEND_CALL', crazyflieRuntimeState);
+      const result = realSend(message);
+      if (message === 'WEBEEBLOCKS_MISSION_V1 DONE_ACK')
+        report('DONE_ACK_SEND_RETURN', crazyflieRuntimeState);
+      return result;
+    };
 
     workspace.clear();
     Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(__FIXTURE__), workspace);

--- a/tools/ci/prepare_crazyflie_parametric_obstacle.py
+++ b/tools/ci/prepare_crazyflie_parametric_obstacle.py
@@ -44,10 +44,15 @@ def main() -> int:
 
   try {
     const responses = [];
+    let stateWhenDone = null;
     window.addEventListener('webeeblocks-wwi', event => {
       const value = String(event.detail);
       responses.push(value);
       report('RX', value);
+      if (value === 'WEBEEBLOCKS_MISSION_V1 DONE') {
+        stateWhenDone = crazyflieRuntimeState;
+        report('STATE_AFTER_DONE', stateWhenDone);
+      }
     });
 
     await waitFor(() => window.robotWindow && typeof window.robotWindow.send === 'function', 'RobotWindow transport', 15000);
@@ -73,9 +78,8 @@ def main() -> int:
 
     if (__EXPECT_DONE__) {
       await waitFor(() => responses.indexOf('WEBEEBLOCKS_MISSION_V1 DONE') !== -1, 'DONE', 70000);
-      if (crazyflieRuntimeState !== 'WAITING')
-        throw new Error('DONE did not restore WAITING');
-      await report('COMPLETE', 'SUCCESS');
+      if (stateWhenDone !== 'WAITING')
+        throw new Error('DONE did not restore WAITING at its event boundary');
       await reportChain;
       return;
     }

--- a/tools/ci/prepare_crazyflie_parametric_obstacle.py
+++ b/tools/ci/prepare_crazyflie_parametric_obstacle.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fixture")
+    parser.add_argument("--expect-done", action="store_true")
+    args = parser.parse_args()
+
+    html_path = ROOT / "plugins/robot_windows/blockly/blockly.html"
+    fixture_path = ROOT / args.fixture
+    html = html_path.read_text(encoding="utf-8")
+    fixture = fixture_path.read_text(encoding="utf-8")
+
+    script = r'''
+<script>
+(async function() {
+  function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+  async function waitFor(predicate, label, timeoutMs) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (predicate()) return;
+      await sleep(25);
+    }
+    throw new Error('timeout waiting for ' + label);
+  }
+
+  let reportSequence = 0;
+  let reportChain = Promise.resolve();
+  function report(event, detail) {
+    const payload = {seq: reportSequence++, event: event, detail: detail === undefined ? null : String(detail)};
+    reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    }));
+    return reportChain;
+  }
+
+  try {
+    const responses = [];
+    window.addEventListener('webeeblocks-wwi', event => {
+      const value = String(event.detail);
+      responses.push(value);
+      report('RX', value);
+    });
+
+    await waitFor(() => window.robotWindow && typeof window.robotWindow.send === 'function', 'RobotWindow transport', 15000);
+    await waitFor(() => typeof workspace !== 'undefined' && workspace, 'Blockly workspace', 5000);
+
+    workspace.clear();
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(__FIXTURE__), workspace);
+    const blocks = workspace.getAllBlocks(false).map(block => block.type + ':' + (block.getFieldValue('DISTANCE') || block.getFieldValue('ANGLE') || '')).join('|');
+    const message = WebeeBlocksCrazyflie.workspaceToMissionMessage(workspace);
+    await report('BLOCKS', blocks);
+    await report('MISSION', message.replace(/\n/g, '|'));
+
+    const before = responses.length;
+    document.getElementById('submit').click();
+    if (crazyflieRuntimeState !== 'PENDING')
+      throw new Error('Submit did not enter PENDING');
+    await report('STATE_AFTER_SUBMIT', crazyflieRuntimeState);
+    await waitFor(() => responses.slice(before).indexOf('WEBEEBLOCKS_MISSION_V1 ACK') !== -1, 'ACK', 5000);
+    if (crazyflieRuntimeState !== 'RUNNING')
+      throw new Error('ACK did not enter RUNNING');
+    await report('STATE_AFTER_ACK', crazyflieRuntimeState);
+    await report('ARMED', 'Blockly mission accepted at runtime');
+
+    if (__EXPECT_DONE__) {
+      await waitFor(() => responses.indexOf('WEBEEBLOCKS_MISSION_V1 DONE') !== -1, 'DONE', 70000);
+      if (crazyflieRuntimeState !== 'WAITING')
+        throw new Error('DONE did not restore WAITING');
+      await report('COMPLETE', 'SUCCESS');
+      await reportChain;
+      return;
+    }
+
+    // Collision witness: the external Supervisor ends Webots when the physical
+    // contact happens. Keep the page alive after proving Blockly -> Submit -> ACK.
+    while (true)
+      await sleep(1000);
+  } catch (error) {
+    await report('ERROR', error && error.stack ? error.stack : String(error));
+    await reportChain;
+  }
+})();
+</script>
+'''.replace('__FIXTURE__', json.dumps(fixture)).replace('__EXPECT_DONE__', 'true' if args.expect_done else 'false')
+
+    html_path.write_text(html + "\n" + script, encoding="utf-8")
+    print(f"Prepared runtime obstacle harness for {fixture_path.name}; expect_done={args.expect_done}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/prepare_crazyflie_runtime_wwi.py
+++ b/tools/ci/prepare_crazyflie_runtime_wwi.py
@@ -24,7 +24,13 @@ script = r'''
   let reportSequence = 0;
   let reportChain = Promise.resolve();
   function report(event, detail) {
-    const payload = {seq: reportSequence++, event: event, detail: detail === undefined ? null : String(detail)};
+    const payload = {
+      seq: reportSequence++,
+      wall_ms: Date.now(),
+      performance_ms: typeof performance !== 'undefined' ? performance.now() : null,
+      event: event,
+      detail: detail === undefined ? null : String(detail),
+    };
     reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -80,8 +86,13 @@ script = r'''
     const realSend = window.robotWindow.send.bind(window.robotWindow);
     let uiTransportSends = 0;
     window.robotWindow.send = function(message) {
+      if (message === 'WEBEEBLOCKS_MISSION_V1 DONE_ACK')
+        report('DONE_ACK_SEND_CALL', crazyflieRuntimeState);
       uiTransportSends += 1;
-      return realSend(message);
+      const result = realSend(message);
+      if (message === 'WEBEEBLOCKS_MISSION_V1 DONE_ACK')
+        report('DONE_ACK_SEND_RETURN', crazyflieRuntimeState);
+      return result;
     };
 
     const ackBefore = responses.length;

--- a/tools/ci/prepare_crazyflie_runtime_wwi.py
+++ b/tools/ci/prepare_crazyflie_runtime_wwi.py
@@ -50,6 +50,9 @@ script = r'''
       }
       console.log('WEBEEBLOCKS_CI_WWI_RX=' + value);
     });
+    window.addEventListener('webeeblocks-runtime', event => {
+      report(String(event.detail), crazyflieRuntimeState);
+    });
 
     await waitFor(() => window.robotWindow && typeof window.robotWindow.send === 'function', 'RobotWindow transport', 15000);
     await waitFor(() => typeof workspace !== 'undefined' && workspace, 'Blockly workspace', 5000);

--- a/tools/ci/prepare_crazyflie_runtime_wwi.py
+++ b/tools/ci/prepare_crazyflie_runtime_wwi.py
@@ -35,10 +35,19 @@ script = r'''
 
   try {
     const responses = [];
+    let stateWhenBusy = null;
+    let stateWhenDone = null;
     window.addEventListener('webeeblocks-wwi', event => {
       const value = String(event.detail);
       responses.push(value);
       report('RX', value);
+      if (value === 'WEBEEBLOCKS_MISSION_V1 ERR BUSY') {
+        stateWhenBusy = crazyflieRuntimeState;
+        report('STATE_AFTER_BUSY', stateWhenBusy);
+      } else if (value === 'WEBEEBLOCKS_MISSION_V1 DONE') {
+        stateWhenDone = crazyflieRuntimeState;
+        report('STATE_AFTER_DONE', stateWhenDone);
+      }
       console.log('WEBEEBLOCKS_CI_WWI_RX=' + value);
     });
 
@@ -95,15 +104,12 @@ script = r'''
     await report('BUSY_PROBE_SEND', 'runtime transport direct');
     realSend(validMessage);
     await waitFor(() => responses.slice(busyBefore).indexOf('WEBEEBLOCKS_MISSION_V1 ERR BUSY') !== -1, 'BUSY rejection', 5000);
-    if (crazyflieRuntimeState !== 'RUNNING')
-      throw new Error('BUSY incorrectly unlocked the active mission');
-    await report('STATE_AFTER_BUSY', crazyflieRuntimeState);
+    if (stateWhenBusy !== 'RUNNING')
+      throw new Error('BUSY response did not preserve RUNNING at its event boundary');
 
     await waitFor(() => responses.indexOf('WEBEEBLOCKS_MISSION_V1 DONE') !== -1, 'mission DONE', 70000);
-    if (crazyflieRuntimeState !== 'WAITING')
-      throw new Error('DONE did not return UI to WAITING');
-    await report('STATE_AFTER_DONE', crazyflieRuntimeState);
-    await report('COMPLETE', 'runtime WWI handshake proved');
+    if (stateWhenDone !== 'WAITING')
+      throw new Error('DONE did not return UI to WAITING at its event boundary');
     await reportChain;
     console.log('WEBEEBLOCKS_CI_RUNTIME_WWI_DONE');
   } catch (error) {

--- a/tools/ci/prepare_crazyflie_runtime_wwi.py
+++ b/tools/ci/prepare_crazyflie_runtime_wwi.py
@@ -61,12 +61,10 @@ script = r'''
 
     await sendAndExpect('TX_NEGATIVE_VERSION', 'WEBEEBLOCKS_MISSION_V0\nTAKEOFF 1', 'WEBEEBLOCKS_MISSION_V1 ERR VERSION');
     await sendAndExpect('TX_NEGATIVE_COMMAND', 'WEBEEBLOCKS_MISSION_V1\nTAKEOFF 1\nSPIN 1\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR COMMAND');
-    await sendAndExpect('TX_NEGATIVE_PARAMETER', 'WEBEEBLOCKS_MISSION_V1\nTAKEOFF 1\nFORWARD 0.5\nTURN 1.5707963267948966\nFORWARD 1\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR PARAMETER');
-    await sendAndExpect('TX_NEGATIVE_SEQUENCE', 'WEBEEBLOCKS_MISSION_V1\nTAKEOFF 1\nTURN 1.5707963267948966\nFORWARD 1\nFORWARD 1\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR SEQUENCE');
-    await sendAndExpect('TX_NEGATIVE_TOO_LONG', 'WEBEEBLOCKS_MISSION_V1\nTAKEOFF 1\nFORWARD 1\nTURN 1.5707963267948966\nFORWARD 1\nTURN 1.5707963267948966\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR TOO_LONG');
+    await sendAndExpect('TX_NEGATIVE_PARAMETER', 'WEBEEBLOCKS_MISSION_V1\nTAKEOFF 1\nFORWARD 0.05\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR PARAMETER');
+    await sendAndExpect('TX_NEGATIVE_SEQUENCE', 'WEBEEBLOCKS_MISSION_V1\nFORWARD 1\nTURN 1.5707963267948966\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR SEQUENCE');
+    await sendAndExpect('TX_NEGATIVE_TOO_LONG', 'WEBEEBLOCKS_MISSION_V1\nTAKEOFF 1\nFORWARD 1\nTURN 1.5707963267948966\nFORWARD 1\nTURN 1.5707963267948966\nFORWARD 1\nLAND 0', 'WEBEEBLOCKS_MISSION_V1 ERR TOO_LONG');
 
-    // Count actual transport sends so the gate can prove that a second UI click
-    // is blocked locally while a mission is pending/running.
     const realSend = window.robotWindow.send.bind(window.robotWindow);
     let uiTransportSends = 0;
     window.robotWindow.send = function(message) {
@@ -93,8 +91,6 @@ script = r'''
       throw new Error('second UI Submit was not blocked locally');
     await report('SECOND_SUBMIT_BLOCKED_LOCAL', crazyflieRuntimeState);
 
-    // Separately prove the controller-side BUSY guard using a low-level browser
-    // transport probe that deliberately bypasses the UI lock.
     const busyBefore = responses.length;
     await report('BUSY_PROBE_SEND', 'runtime transport direct');
     realSend(validMessage);

--- a/worlds/.crazyflie_runtime_obstacle.wbproj
+++ b/worlds/.crazyflie_runtime_obstacle.wbproj
@@ -1,0 +1,2 @@
+Webots Project File version R2025a
+robotWindow: Crazyflie Runtime

--- a/worlds/crazyflie_runtime_obstacle.wbt
+++ b/worlds/crazyflie_runtime_obstacle.wbt
@@ -1,0 +1,58 @@
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
+
+WorldInfo {
+  basicTimeStep 32
+  randomSeed 1
+  optimalThreadCount 1
+  title "WebeeBlocks runtime Blockly obstacle challenge"
+}
+Viewpoint {
+  orientation -0.45 0.47 0.76 1.05
+  position -3 -3 3
+  follow "Crazyflie Runtime"
+}
+TexturedBackground {
+}
+TexturedBackgroundLight {
+}
+Floor {
+  size 6 6
+}
+DEF OBSTACLE Solid {
+  translation 1.25 0 0.70
+  children [
+    Shape {
+      appearance PBRAppearance {
+        baseColor 0.8 0.1 0.1
+        roughness 0.6
+        metalness 0
+      }
+      geometry Box {
+        size 0.05 0.30 1.40
+      }
+    }
+  ]
+  boundingObject Box {
+    size 0.05 0.30 1.40
+  }
+}
+DEF CRAZYFLIE Crazyflie {
+  name "Crazyflie Runtime"
+  synchronization TRUE
+  controller "crazyflie_l_course"
+  controllerArgs [
+    "runtime"
+  ]
+  window "blockly"
+  supervisor TRUE
+}
+Robot {
+  name "Collision observer"
+  controller "crazyflie_collision_observer"
+  supervisor TRUE
+}


### PR DESCRIPTION
## Goal
Close the last artificial seam after #36: let a student-composed Blockly mission vary within the already-characterized v0 domain, without adding a new navigation engine.

## Scope
- keep `WEBEEBLOCKS_MISSION_V1` and the existing Blockly -> Robot Window -> WWI runtime path;
- accept short sequential missions built only from `TAKEOFF`, `FORWARD(distance)`, `TURN(angle)`, `LAND`;
- keep v0 bounded to max 5 commands, `forward` 0.10–2.00 m, `turn` -90°..+135° (0 excluded), fixed 1 m takeoff and zero-valued land;
- validate the whole mission atomically before takeoff; retain ACK/DONE/ERR and BUSY semantics;
- execute every accepted mission through the same shared STOP runner/backend B/PID;
- no new block, loop, sensor, condition, scoring, obstacle geometry, PID/navigation tuning, or changes to `main`.

## Product proof
A new R2025a gate uses the real Blockly workspace and a real Submit/WWI path twice against the exact same collision obstacle:
1. `TAKEOFF -> FORWARD(2 m) -> LAND` must be accepted from Blockly and end in a physical `COLLISION` observed externally by Supervisor contact points.
2. `TAKEOFF -> FORWARD(1 m) -> TURN(+90°) -> FORWARD(1 m) -> LAND` must be accepted from Blockly, produce no obstacle contact, cross G1/G2 and land with the existing STOP reference.

The workflow records the actual Blockly block chain and serialized mission for each run, and hashes the controller before/after both Submit operations to prove there is no source patch or rebuild after Submit.

## Non-regression
The existing runtime WWI negative probes are updated to remain genuinely invalid under the broader v0 grammar. All current historical/Crazyflie gates must remain green before merge.

Base: `webots-ci`. `main` is untouched.