### PR TITLE
Clarify student-facing Crazyflie challenge

### DIFF
--- a/.github/workflows/crazyflie-challenge-ux-r2025a.yml
+++ b/.github/workflows/crazyflie-challenge-ux-r2025a.yml
@@ -22,11 +22,32 @@ jobs:
           python3 -m py_compile tools/ci/runtime_wwi_event_server.py
           python3 -m py_compile tools/ci/instrument_runtime_done_ack.py
           python3 - <<'PY'
+          import re
           from pathlib import Path
+
           detour = Path('controllers/Blockly_Programs/CrazyflieDetourOffset.xml').read_text()
           reference = Path('controllers/Blockly_Programs/CrazyflieL.xml').read_text()
           assert detour != reference, 'detour fixture must differ from reference L'
           assert '<field name="DISTANCE">1.1</field>' in detour, 'detour must contain representable 1.1 m second leg'
+
+          html = Path('plugins/robot_windows/blockly/blockly.html').read_text()
+          assert 'Assemble les blocs nécessaires de la rubrique <em>Crazyflie</em>.' in html
+          assert 'Assemble les 4 blocs' not in html
+
+          world = Path('worlds/crazyflie_runtime_obstacle.wbt').read_text()
+          controller = Path('controllers/crazyflie_l_course/crazyflie_l_course.c').read_text()
+          match = re.search(r'#define GATE_HALF_WIDTH_M\s+([0-9.]+)', controller)
+          assert match, 'GATE_HALF_WIDTH_M missing from controller'
+          gate_half_width = float(match.group(1))
+          post_thickness = 0.035
+          post_center = gate_half_width + post_thickness / 2.0
+          assert f'translation 0.9 -{post_center:.4f} 1.0' in world
+          assert f'translation 0.9 {post_center:.4f} 1.0' in world
+          assert f'translation {1.0 - post_center:.4f} 0.9 1.0' in world
+          assert f'translation {1.0 + post_center:.4f} 0.9 1.0' in world
+          assert 'geometry Box { size 0.025 0.67 0.035 }' in world
+          assert 'geometry Box { size 0.67 0.025 0.035 }' in world
+          assert 'LANDING_TARGET' not in world, 'visual landing target must not imply a success criterion that does not exist'
           PY
 
       - name: Prepare same-session challenge harness

--- a/plugins/robot_windows/blockly/blockly.html
+++ b/plugins/robot_windows/blockly/blockly.html
@@ -55,7 +55,7 @@
                 Quand ton parcours réussit, modifie tes blocs pour améliorer ton temps.
             </div>
             <div class="studentChallengeSteps">
-                <span><strong>1.</strong> Assemble les 4 blocs de <em>Vol Crazyflie</em>.</span>
+                <span><strong>1.</strong> Assemble les 4 blocs de la rubrique <em>Crazyflie</em>.</span>
                 <span><strong>2.</strong> Clique sur <em>Lancer le vol</em>.</span>
                 <span><strong>3.</strong> Observe le résultat et le temps, puis corrige ou optimise.</span>
             </div>
@@ -78,7 +78,7 @@
     <body>
 
 	<xml id="toolbox" style="display: none">
-    <category name="Vol Crazyflie" colour=20>
+    <category name="Crazyflie" colour=20>
       <block type="webeeblocks_takeoff"></block>
       <block type="webeeblocks_forward"></block>
       <block type="webeeblocks_turn"></block>

--- a/plugins/robot_windows/blockly/blockly.html
+++ b/plugins/robot_windows/blockly/blockly.html
@@ -55,7 +55,7 @@
                 Quand ton parcours réussit, modifie tes blocs pour améliorer ton temps.
             </div>
             <div class="studentChallengeSteps">
-                <span><strong>1.</strong> Assemble les 4 blocs de la rubrique <em>Crazyflie</em>.</span>
+                <span><strong>1.</strong> Assemble les blocs nécessaires de la rubrique <em>Crazyflie</em>.</span>
                 <span><strong>2.</strong> Clique sur <em>Lancer le vol</em>.</span>
                 <span><strong>3.</strong> Observe le résultat et le temps, puis corrige ou optimise.</span>
             </div>
@@ -219,3 +219,4 @@
     });
     updateStudentChallengeMode();
 </script>
+    

--- a/plugins/robot_windows/blockly/blockly.html
+++ b/plugins/robot_windows/blockly/blockly.html
@@ -2,7 +2,7 @@
 <html>
     <meta charset="utf-8">
 
-    <link rel = "stylesheet" href="main.css">
+    <link rel="stylesheet" href="main.css">
 
     <script src="google-blockly-31ee4ea/blockly_uncompressed.js"></script>
     <script src="google-blockly-31ee4ea/generators/python.js"></script>
@@ -17,12 +17,12 @@
     <script src="google-blockly-31ee4ea/blocks/variables.js"></script>
     <script src="google-blockly-31ee4ea/blocks/procedures.js"></script>
     <script src="google-blockly-31ee4ea/blocks/motors.js"></script>
-		<script src="google-blockly-31ee4ea/blocks/time.js"></script>
+    <script src="google-blockly-31ee4ea/blocks/time.js"></script>
     <script src="google-blockly-31ee4ea/blocks/sensors.js"></script>
     <script src="google-blockly-31ee4ea/blocks/other.js"></script>
-		<script src="google-blockly-31ee4ea/blocks/camera.js"></script>
+    <script src="google-blockly-31ee4ea/blocks/camera.js"></script>
     <script src="google-blockly-31ee4ea/blocks/crazyflie.js"></script>
-    
+
     <script src="google-blockly-31ee4ea/generators/python/logic.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/loops.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/math.js"></script>
@@ -35,55 +35,65 @@
     <script src="google-blockly-31ee4ea/generators/python/time.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/sensors.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/other.js"></script>
-		<script src="google-blockly-31ee4ea/generators/python/camera.js"></script>
-    
+    <script src="google-blockly-31ee4ea/generators/python/camera.js"></script>
+
     <head>
-        <div>
-            <h1 id = "projectTitle" contenteditable="true" style = "display: inline-block">Untitled</h1>
-           <!-- <button onclick = "document.getElementById('projectTitle').focus()">rename</button>-->
-            <div id = "editorButtons">
-                <button id = "submit">Submit</button>
-                <button id = "save">Save</button>
-                <button id = "restore">Restore</button>
+        <div id="editorHeader">
+            <h1 id="projectTitle" contenteditable="true">WebeeBlocks</h1>
+            <div id="editorButtons">
+                <button id="submit">Lancer le vol</button>
+                <button id="save">Enregistrer</button>
+                <button id="restore">Ouvrir</button>
             </div>
         </div>
 
-        <div id="myModal" class="modal">
+        <div id="studentChallengeBrief" aria-label="Consigne du défi Crazyflie">
+            <div class="studentChallengeTitle">Défi Crazyflie — contre-la-montre</div>
+            <div class="studentChallengeGoal">
+                Franchis les <strong>deux portes dans l’ordre</strong>, évite l’obstacle puis atterris.
+                Quand ton parcours réussit, modifie tes blocs pour améliorer ton temps.
+            </div>
+            <div class="studentChallengeSteps">
+                <span><strong>1.</strong> Utilise les 4 blocs de <em>Vol Crazyflie</em>.</span>
+                <span><strong>2.</strong> Clique sur <em>Lancer le vol</em>.</span>
+                <span><strong>3.</strong> Observe le résultat et le temps, puis corrige ou optimise.</span>
+            </div>
+            <div class="studentChallengeHint">Pour tourner : angle positif = gauche, angle négatif = droite.</div>
+        </div>
 
-            <!-- Modal content -->
+        <div id="myModal" class="modal">
             <div class="modal-content">
                 <span class="closeButton">&times;</span>
-                <div id = "saveList" style="margin-top: 50px;">
-               <a style = "display:block;">f</a>
-               <a style = "display:block;">f </a>
+                <div id="saveList" style="margin-top: 50px;">
+                    <a style="display:block;">f</a>
+                    <a style="display:block;">f</a>
                 </div>
             </div>
-
         </div>
     </head>
     <body>
 
-	<xml id="toolbox" style="display: none">
-    <category name="Crazyflie" colour=20>
+    <xml id="toolbox" style="display: none">
+    <category name="Vol Crazyflie" colour=20>
       <block type="webeeblocks_takeoff"></block>
       <block type="webeeblocks_forward"></block>
       <block type="webeeblocks_turn"></block>
       <block type="webeeblocks_land"></block>
     </category>
     <category name="Variables" colour="%{BKY_VARIABLES_HUE}" custom="VARIABLE"></category>
-	<category name="Functions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
-	<category name="Motors" colour=120>
+    <category name="Fonctions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
+    <category name="Moteurs" colour=120>
       <block type="motors_setupmotor"></block>
       <block type="motors_setspeed"></block>
       <block type="motors_resetencoders"></block>
       <block type="motors_getencoders"></block>
     </category>
-	<category name="Time" colour=80>
+    <category name="Temps" colour=80>
       <block type="time_delay"></block>
       <block type="time_gettime"></block>
       <block type="time_resettime"></block>
     </category>
-    <category name="Sensors" colour=60>
+    <category name="Capteurs" colour=60>
       <block type="sensors_initializegyro"></block>
       <block type="sensors_initializegps"></block>
       <block type="sensors_initializesensor"></block>
@@ -93,16 +103,16 @@
       <block type="sensors_getcolor"></block>
       <block type="sensors_getgray"></block>
     </category>
-	<category name="Control" colour=240>
-	  <block type="logic_boolean"></block>
-	  <block type="controls_if"></block>
-	  <block type="controls_repeat_ext"></block>
-	  <block type="logic_compare"></block>
-	  <block type="logic_operation"></block>
-	  <block type="controls_whileUntil"></block> 
-		<block type="controls_flow_statements"></block>
-	</category>
-	<category name="Lists" colour=210>
+    <category name="Contrôle" colour=240>
+      <block type="logic_boolean"></block>
+      <block type="controls_if"></block>
+      <block type="controls_repeat_ext"></block>
+      <block type="logic_compare"></block>
+      <block type="logic_operation"></block>
+      <block type="controls_whileUntil"></block>
+      <block type="controls_flow_statements"></block>
+    </category>
+    <category name="Listes" colour=210>
       <block type="lists_create_with">
         <mutation items="0"></mutation>
       </block>
@@ -122,7 +132,7 @@
           </block>
         </value>
       </block>
-	  <block type="lists_append">
+      <block type="lists_append">
         <value name="LIST">
           <block type="variables_get">
             <field name="VAR">{listVariable}</field>
@@ -130,46 +140,45 @@
         </value>
       </block>
     </category>
-	<category name="Math" colour=180>
-	  <block type="math_number"></block>
-	  <block type="math_arithmetic"></block>
-	  <block type="math_abs"></block>
-	  <block type="math_mod"></block>
-	  <block type="math_round2"></block>
-	</category>
-	<category name="Camera" colour="#AABBCC"> <!-- Change color -->
-		<block type="camera_initializecamera"></block>
-	  <block type="camera_getrecognitionobjects"></block>
-		<block type="camera_getnumobj"></block>
-		<block type="camera_getobjcolors"></block>
-		<block type="camera_getobjpos"></block>
-		<block type="camera_getobjang"></block>
-	</category>
-	<category name="Other" colour=0>
-		<block type="other_start"></block>
-		<block type="other_end"></block>
-		<block type="text"></block>
-		<block type="concattext"></block>
-		<block type="concattext2"></block>
-		<block type="text_print"></block>
-	</category>
-        </xml>
-        <div id = "blocklyContainer">
-        <div id="blocklyDiv" style="height:98%;"></div>
-        </div>
-        <div id ="textCodeArea">
-            <h3>Text Output</h3>
-            <div id = "codeBox"> 
-                <code id="textCode">
+    <category name="Maths" colour=180>
+      <block type="math_number"></block>
+      <block type="math_arithmetic"></block>
+      <block type="math_abs"></block>
+      <block type="math_mod"></block>
+      <block type="math_round2"></block>
+    </category>
+    <category name="Caméra" colour="#AABBCC">
+      <block type="camera_initializecamera"></block>
+      <block type="camera_getrecognitionobjects"></block>
+      <block type="camera_getnumobj"></block>
+      <block type="camera_getobjcolors"></block>
+      <block type="camera_getobjpos"></block>
+      <block type="camera_getobjang"></block>
+    </category>
+    <category name="Autres" colour=0>
+      <block type="other_start"></block>
+      <block type="other_end"></block>
+      <block type="text"></block>
+      <block type="concattext"></block>
+      <block type="concattext2"></block>
+      <block type="text_print"></block>
+    </category>
+    </xml>
 
-                </code>
+        <div id="blocklyContainer">
+            <div id="blocklyDiv" style="height:98%;"></div>
+        </div>
+        <div id="textCodeArea">
+            <h3>Code généré — anciens exercices</h3>
+            <div id="codeBox">
+                <code id="textCode"></code>
             </div>
         </div>
 
     </body>
 </html>
 <script src="main.js"></script>
-    <script>
+<script>
     var workspace = Blockly.inject(blocklyDiv,
         {toolbox: document.getElementById('toolbox')});
     workspace.addChangeListener(realTimeUpdate);

--- a/plugins/robot_windows/blockly/blockly.html
+++ b/plugins/robot_windows/blockly/blockly.html
@@ -39,11 +39,11 @@
 
     <head>
         <div id="editorHeader">
-            <h1 id="projectTitle" contenteditable="true">WebeeBlocks</h1>
+            <h1 id="projectTitle" contenteditable="true">Untitled</h1>
             <div id="editorButtons">
-                <button id="submit">Lancer le vol</button>
-                <button id="save">Enregistrer</button>
-                <button id="restore">Ouvrir</button>
+                <button id="submit">Submit</button>
+                <button id="save">Save</button>
+                <button id="restore">Restore</button>
             </div>
         </div>
 
@@ -54,7 +54,7 @@
                 Quand ton parcours réussit, modifie tes blocs pour améliorer ton temps.
             </div>
             <div class="studentChallengeSteps">
-                <span><strong>1.</strong> Utilise les 4 blocs de <em>Vol Crazyflie</em>.</span>
+                <span><strong>1.</strong> Assemble les 4 blocs de <em>Vol Crazyflie</em>.</span>
                 <span><strong>2.</strong> Clique sur <em>Lancer le vol</em>.</span>
                 <span><strong>3.</strong> Observe le résultat et le temps, puis corrige ou optimise.</span>
             </div>
@@ -81,19 +81,19 @@
       <block type="webeeblocks_land"></block>
     </category>
     <category name="Variables" colour="%{BKY_VARIABLES_HUE}" custom="VARIABLE"></category>
-    <category name="Fonctions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
-    <category name="Moteurs" colour=120>
+    <category name="Functions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
+    <category name="Motors" colour=120>
       <block type="motors_setupmotor"></block>
       <block type="motors_setspeed"></block>
       <block type="motors_resetencoders"></block>
       <block type="motors_getencoders"></block>
     </category>
-    <category name="Temps" colour=80>
+    <category name="Time" colour=80>
       <block type="time_delay"></block>
       <block type="time_gettime"></block>
       <block type="time_resettime"></block>
     </category>
-    <category name="Capteurs" colour=60>
+    <category name="Sensors" colour=60>
       <block type="sensors_initializegyro"></block>
       <block type="sensors_initializegps"></block>
       <block type="sensors_initializesensor"></block>
@@ -103,7 +103,7 @@
       <block type="sensors_getcolor"></block>
       <block type="sensors_getgray"></block>
     </category>
-    <category name="Contrôle" colour=240>
+    <category name="Control" colour=240>
       <block type="logic_boolean"></block>
       <block type="controls_if"></block>
       <block type="controls_repeat_ext"></block>
@@ -112,7 +112,7 @@
       <block type="controls_whileUntil"></block>
       <block type="controls_flow_statements"></block>
     </category>
-    <category name="Listes" colour=210>
+    <category name="Lists" colour=210>
       <block type="lists_create_with">
         <mutation items="0"></mutation>
       </block>
@@ -140,14 +140,14 @@
         </value>
       </block>
     </category>
-    <category name="Maths" colour=180>
+    <category name="Math" colour=180>
       <block type="math_number"></block>
       <block type="math_arithmetic"></block>
       <block type="math_abs"></block>
       <block type="math_mod"></block>
       <block type="math_round2"></block>
     </category>
-    <category name="Caméra" colour="#AABBCC">
+    <category name="Camera" colour="#AABBCC">
       <block type="camera_initializecamera"></block>
       <block type="camera_getrecognitionobjects"></block>
       <block type="camera_getnumobj"></block>
@@ -155,7 +155,7 @@
       <block type="camera_getobjpos"></block>
       <block type="camera_getobjang"></block>
     </category>
-    <category name="Autres" colour=0>
+    <category name="Other" colour=0>
       <block type="other_start"></block>
       <block type="other_end"></block>
       <block type="text"></block>
@@ -169,7 +169,7 @@
             <div id="blocklyDiv" style="height:98%;"></div>
         </div>
         <div id="textCodeArea">
-            <h3>Code généré — anciens exercices</h3>
+            <h3>Text Output</h3>
             <div id="codeBox">
                 <code id="textCode"></code>
             </div>
@@ -182,4 +182,27 @@
     var workspace = Blockly.inject(blocklyDiv,
         {toolbox: document.getElementById('toolbox')});
     workspace.addChangeListener(realTimeUpdate);
+
+    function updateStudentChallengeMode() {
+        var crazyflie = isCrazyflieWorkspace();
+        var brief = document.getElementById('studentChallengeBrief');
+        var submitButton = document.getElementById('submit');
+        var saveButton = document.getElementById('save');
+        var restoreButton = document.getElementById('restore');
+        if (brief)
+            brief.style.display = crazyflie ? 'block' : 'none';
+        if (submitButton)
+            submitButton.textContent = crazyflie ? 'Lancer le vol' : 'Submit';
+        if (saveButton)
+            saveButton.textContent = crazyflie ? 'Enregistrer' : 'Save';
+        if (restoreButton)
+            restoreButton.textContent = crazyflie ? 'Ouvrir' : 'Restore';
+        document.body.classList.toggle('crazyflieStudentMode', crazyflie);
+    }
+
+    workspace.addChangeListener(function(event) {
+        if (!event || event.type !== Blockly.Events.UI)
+            updateStudentChallengeMode();
+    });
+    updateStudentChallengeMode();
 </script>

--- a/plugins/robot_windows/blockly/blockly.html
+++ b/plugins/robot_windows/blockly/blockly.html
@@ -183,8 +183,16 @@
         {toolbox: document.getElementById('toolbox')});
     workspace.addChangeListener(realTimeUpdate);
 
+    function isCrazyflieRobotWindow() {
+        try {
+            return new URLSearchParams(window.location.search).get('name') === 'Crazyflie Runtime';
+        } catch (error) {
+            return false;
+        }
+    }
+
     function updateStudentChallengeMode() {
-        var crazyflie = isCrazyflieWorkspace();
+        var crazyflie = isCrazyflieRobotWindow() || isCrazyflieWorkspace();
         var brief = document.getElementById('studentChallengeBrief');
         var submitButton = document.getElementById('submit');
         var saveButton = document.getElementById('save');

--- a/plugins/robot_windows/blockly/blockly.html
+++ b/plugins/robot_windows/blockly/blockly.html
@@ -2,7 +2,7 @@
 <html>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="main.css">
+    <link rel = "stylesheet" href="main.css">
 
     <script src="google-blockly-31ee4ea/blockly_uncompressed.js"></script>
     <script src="google-blockly-31ee4ea/generators/python.js"></script>
@@ -17,12 +17,12 @@
     <script src="google-blockly-31ee4ea/blocks/variables.js"></script>
     <script src="google-blockly-31ee4ea/blocks/procedures.js"></script>
     <script src="google-blockly-31ee4ea/blocks/motors.js"></script>
-    <script src="google-blockly-31ee4ea/blocks/time.js"></script>
+		<script src="google-blockly-31ee4ea/blocks/time.js"></script>
     <script src="google-blockly-31ee4ea/blocks/sensors.js"></script>
     <script src="google-blockly-31ee4ea/blocks/other.js"></script>
-    <script src="google-blockly-31ee4ea/blocks/camera.js"></script>
+		<script src="google-blockly-31ee4ea/blocks/camera.js"></script>
     <script src="google-blockly-31ee4ea/blocks/crazyflie.js"></script>
-
+    
     <script src="google-blockly-31ee4ea/generators/python/logic.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/loops.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/math.js"></script>
@@ -35,15 +35,16 @@
     <script src="google-blockly-31ee4ea/generators/python/time.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/sensors.js"></script>
     <script src="google-blockly-31ee4ea/generators/python/other.js"></script>
-    <script src="google-blockly-31ee4ea/generators/python/camera.js"></script>
-
+		<script src="google-blockly-31ee4ea/generators/python/camera.js"></script>
+    
     <head>
-        <div id="editorHeader">
-            <h1 id="projectTitle" contenteditable="true">Untitled</h1>
-            <div id="editorButtons">
-                <button id="submit">Submit</button>
-                <button id="save">Save</button>
-                <button id="restore">Restore</button>
+        <div>
+            <h1 id = "projectTitle" contenteditable="true" style = "display: inline-block">Untitled</h1>
+           <!-- <button onclick = "document.getElementById('projectTitle').focus()">rename</button>-->
+            <div id = "editorButtons">
+                <button id = "submit">Submit</button>
+                <button id = "save">Save</button>
+                <button id = "restore">Restore</button>
             </div>
         </div>
 
@@ -62,18 +63,21 @@
         </div>
 
         <div id="myModal" class="modal">
+
+            <!-- Modal content -->
             <div class="modal-content">
                 <span class="closeButton">&times;</span>
-                <div id="saveList" style="margin-top: 50px;">
-                    <a style="display:block;">f</a>
-                    <a style="display:block;">f</a>
+                <div id = "saveList" style="margin-top: 50px;">
+               <a style = "display:block;">f</a>
+               <a style = "display:block;">f </a>
                 </div>
             </div>
+
         </div>
     </head>
     <body>
 
-    <xml id="toolbox" style="display: none">
+	<xml id="toolbox" style="display: none">
     <category name="Vol Crazyflie" colour=20>
       <block type="webeeblocks_takeoff"></block>
       <block type="webeeblocks_forward"></block>
@@ -81,14 +85,14 @@
       <block type="webeeblocks_land"></block>
     </category>
     <category name="Variables" colour="%{BKY_VARIABLES_HUE}" custom="VARIABLE"></category>
-    <category name="Functions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
-    <category name="Motors" colour=120>
+	<category name="Functions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
+	<category name="Motors" colour=120>
       <block type="motors_setupmotor"></block>
       <block type="motors_setspeed"></block>
       <block type="motors_resetencoders"></block>
       <block type="motors_getencoders"></block>
     </category>
-    <category name="Time" colour=80>
+	<category name="Time" colour=80>
       <block type="time_delay"></block>
       <block type="time_gettime"></block>
       <block type="time_resettime"></block>
@@ -103,16 +107,16 @@
       <block type="sensors_getcolor"></block>
       <block type="sensors_getgray"></block>
     </category>
-    <category name="Control" colour=240>
-      <block type="logic_boolean"></block>
-      <block type="controls_if"></block>
-      <block type="controls_repeat_ext"></block>
-      <block type="logic_compare"></block>
-      <block type="logic_operation"></block>
-      <block type="controls_whileUntil"></block>
-      <block type="controls_flow_statements"></block>
-    </category>
-    <category name="Lists" colour=210>
+	<category name="Control" colour=240>
+	  <block type="logic_boolean"></block>
+	  <block type="controls_if"></block>
+	  <block type="controls_repeat_ext"></block>
+	  <block type="logic_compare"></block>
+	  <block type="logic_operation"></block>
+	  <block type="controls_whileUntil"></block> 
+		<block type="controls_flow_statements"></block>
+	</category>
+	<category name="Lists" colour=210>
       <block type="lists_create_with">
         <mutation items="0"></mutation>
       </block>
@@ -132,7 +136,7 @@
           </block>
         </value>
       </block>
-      <block type="lists_append">
+	  <block type="lists_append">
         <value name="LIST">
           <block type="variables_get">
             <field name="VAR">{listVariable}</field>
@@ -140,45 +144,46 @@
         </value>
       </block>
     </category>
-    <category name="Math" colour=180>
-      <block type="math_number"></block>
-      <block type="math_arithmetic"></block>
-      <block type="math_abs"></block>
-      <block type="math_mod"></block>
-      <block type="math_round2"></block>
-    </category>
-    <category name="Camera" colour="#AABBCC">
-      <block type="camera_initializecamera"></block>
-      <block type="camera_getrecognitionobjects"></block>
-      <block type="camera_getnumobj"></block>
-      <block type="camera_getobjcolors"></block>
-      <block type="camera_getobjpos"></block>
-      <block type="camera_getobjang"></block>
-    </category>
-    <category name="Other" colour=0>
-      <block type="other_start"></block>
-      <block type="other_end"></block>
-      <block type="text"></block>
-      <block type="concattext"></block>
-      <block type="concattext2"></block>
-      <block type="text_print"></block>
-    </category>
-    </xml>
-
-        <div id="blocklyContainer">
-            <div id="blocklyDiv" style="height:98%;"></div>
+	<category name="Math" colour=180>
+	  <block type="math_number"></block>
+	  <block type="math_arithmetic"></block>
+	  <block type="math_abs"></block>
+	  <block type="math_mod"></block>
+	  <block type="math_round2"></block>
+	</category>
+	<category name="Camera" colour="#AABBCC"> <!-- Change color -->
+		<block type="camera_initializecamera"></block>
+	  <block type="camera_getrecognitionobjects"></block>
+		<block type="camera_getnumobj"></block>
+		<block type="camera_getobjcolors"></block>
+		<block type="camera_getobjpos"></block>
+		<block type="camera_getobjang"></block>
+	</category>
+	<category name="Other" colour=0>
+		<block type="other_start"></block>
+		<block type="other_end"></block>
+		<block type="text"></block>
+		<block type="concattext"></block>
+		<block type="concattext2"></block>
+		<block type="text_print"></block>
+	</category>
+        </xml>
+        <div id = "blocklyContainer">
+        <div id="blocklyDiv" style="height:98%;"></div>
         </div>
-        <div id="textCodeArea">
+        <div id ="textCodeArea">
             <h3>Text Output</h3>
-            <div id="codeBox">
-                <code id="textCode"></code>
+            <div id = "codeBox"> 
+                <code id="textCode">
+
+                </code>
             </div>
         </div>
 
     </body>
 </html>
 <script src="main.js"></script>
-<script>
+    <script>
     var workspace = Blockly.inject(blocklyDiv,
         {toolbox: document.getElementById('toolbox')});
     workspace.addChangeListener(realTimeUpdate);

--- a/plugins/robot_windows/blockly/main.css
+++ b/plugins/robot_windows/blockly/main.css
@@ -42,6 +42,7 @@ body {
 }
 
 #studentChallengeBrief {
+    display: none;
     margin: 0 0 10px 0;
     padding: 12px 14px;
     border: 1px solid #aeb4bc;
@@ -91,6 +92,10 @@ body {
 #textCodeArea {
     margin-top: 12px;
     color: #5f6368;
+}
+
+.crazyflieStudentMode #textCodeArea {
+    display: none;
 }
 
 #textCodeArea h3 {

--- a/plugins/robot_windows/blockly/main.css
+++ b/plugins/robot_windows/blockly/main.css
@@ -1,27 +1,63 @@
 body {
+    margin-left: 20px;
+}
+
+#editorButtons {
+    margin-right: 50px;
+    margin-top: 35px;
+    float: right;
+}
+
+#blocklyContainer {
+    height:500px;
+    overflow:auto;
+    margin-right:50px;
+}
+
+#textCodeArea {
+}
+
+#codeBox {
+    height:700px;
+    margin-right:50px;
+    overflow-y:auto;
+    background-color: white;
+}
+
+#textCode {
+    white-space: pre-wrap;
+}
+
+/* Student challenge presentation is deliberately scoped to the Crazyflie
+ * Robot Window so historical Pioneer exercises keep their legacy appearance. */
+#studentChallengeBrief {
+    display: none;
+}
+
+body.crazyflieStudentMode {
     margin: 0 28px 24px 20px;
     font-family: Arial, Helvetica, sans-serif;
     color: #202124;
     background: #f7f8fa;
 }
 
-#editorHeader {
+.crazyflieStudentMode #editorHeader {
     min-height: 76px;
 }
 
-#projectTitle {
+.crazyflieStudentMode #projectTitle {
     display: inline-block;
     margin: 18px 0 8px 0;
 }
 
-#editorButtons {
+.crazyflieStudentMode #editorButtons {
+    margin-right: 0;
     margin-top: 22px;
-    float: right;
     display: flex;
     gap: 8px;
 }
 
-#editorButtons button {
+.crazyflieStudentMode #editorButtons button {
     min-height: 38px;
     padding: 0 14px;
     border: 1px solid #7a7f87;
@@ -31,18 +67,18 @@ body {
     cursor: pointer;
 }
 
-#editorButtons #submit {
+.crazyflieStudentMode #editorButtons #submit {
     font-weight: bold;
     border-width: 2px;
 }
 
-#editorButtons button:disabled {
+.crazyflieStudentMode #editorButtons button:disabled {
     cursor: not-allowed;
     opacity: 0.55;
 }
 
-#studentChallengeBrief {
-    display: none;
+.crazyflieStudentMode #studentChallengeBrief {
+    display: block;
     margin: 0 0 10px 0;
     padding: 12px 14px;
     border: 1px solid #aeb4bc;
@@ -51,73 +87,48 @@ body {
     line-height: 1.35;
 }
 
-.studentChallengeTitle {
+.crazyflieStudentMode .studentChallengeTitle {
     font-size: 18px;
     font-weight: bold;
     margin-bottom: 5px;
 }
 
-.studentChallengeGoal {
+.crazyflieStudentMode .studentChallengeGoal {
     font-size: 15px;
     margin-bottom: 8px;
 }
 
-.studentChallengeSteps {
+.crazyflieStudentMode .studentChallengeSteps {
     display: flex;
     flex-wrap: wrap;
     gap: 8px 18px;
     font-size: 14px;
 }
 
-.studentChallengeHint {
+.crazyflieStudentMode .studentChallengeHint {
     margin-top: 7px;
     font-size: 13px;
     color: #555b63;
 }
 
-#webeeblocksChallenge {
+.crazyflieStudentMode #webeeblocksChallenge {
     background: white;
     font-size: 15px;
 }
 
-#blocklyContainer {
+.crazyflieStudentMode #blocklyContainer {
     height: 500px;
-    overflow: auto;
     margin-right: 0;
     border: 1px solid #c5c9cf;
     border-radius: 6px;
     background: white;
 }
 
-#textCodeArea {
-    margin-top: 12px;
-    color: #5f6368;
-}
-
 .crazyflieStudentMode #textCodeArea {
     display: none;
 }
 
-#textCodeArea h3 {
-    margin-bottom: 6px;
-    font-size: 14px;
-    font-weight: normal;
-}
-
-#codeBox {
-    min-height: 120px;
-    max-height: 260px;
-    overflow-y: auto;
-    padding: 8px;
-    background-color: white;
-    border: 1px solid #d5d8dc;
-}
-
-#textCode {
-    white-space: pre-wrap;
-}
-
-/* modal css */
+/*modal css */
 .modal {
   display: none;
   position: fixed;
@@ -152,7 +163,6 @@ body {
   text-decoration: none;
   cursor: pointer;
 }
-
 #projectTitle:focus,
 #projectTitle:hover {
     color: #4f4f4f;

--- a/plugins/robot_windows/blockly/main.css
+++ b/plugins/robot_windows/blockly/main.css
@@ -1,59 +1,139 @@
 body {
-    margin-left: 20px;
+    margin: 0 28px 24px 20px;
+    font-family: Arial, Helvetica, sans-serif;
+    color: #202124;
+    background: #f7f8fa;
+}
+
+#editorHeader {
+    min-height: 76px;
+}
+
+#projectTitle {
+    display: inline-block;
+    margin: 18px 0 8px 0;
 }
 
 #editorButtons {
-
-    margin-right: 50px;
-    margin-top: 35px;
+    margin-top: 22px;
     float: right;
+    display: flex;
+    gap: 8px;
 }
-#blocklyContainer {
 
-    height:500px;
-   /* resize: vertical; */
-    overflow:auto;
-    margin-right:50px;
+#editorButtons button {
+    min-height: 38px;
+    padding: 0 14px;
+    border: 1px solid #7a7f87;
+    border-radius: 6px;
+    background: white;
+    font-size: 14px;
+    cursor: pointer;
 }
+
+#editorButtons #submit {
+    font-weight: bold;
+    border-width: 2px;
+}
+
+#editorButtons button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+#studentChallengeBrief {
+    margin: 0 0 10px 0;
+    padding: 12px 14px;
+    border: 1px solid #aeb4bc;
+    border-radius: 8px;
+    background: white;
+    line-height: 1.35;
+}
+
+.studentChallengeTitle {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.studentChallengeGoal {
+    font-size: 15px;
+    margin-bottom: 8px;
+}
+
+.studentChallengeSteps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 18px;
+    font-size: 14px;
+}
+
+.studentChallengeHint {
+    margin-top: 7px;
+    font-size: 13px;
+    color: #555b63;
+}
+
+#webeeblocksChallenge {
+    background: white;
+    font-size: 15px;
+}
+
+#blocklyContainer {
+    height: 500px;
+    overflow: auto;
+    margin-right: 0;
+    border: 1px solid #c5c9cf;
+    border-radius: 6px;
+    background: white;
+}
+
 #textCodeArea {
+    margin-top: 12px;
+    color: #5f6368;
+}
+
+#textCodeArea h3 {
+    margin-bottom: 6px;
+    font-size: 14px;
+    font-weight: normal;
 }
 
 #codeBox {
-
-    height:700px;
-    margin-right:50px;    
-    overflow-y:auto;
+    min-height: 120px;
+    max-height: 260px;
+    overflow-y: auto;
+    padding: 8px;
     background-color: white;
+    border: 1px solid #d5d8dc;
 }
 
 #textCode {
     white-space: pre-wrap;
 }
 
-/*modal css */
+/* modal css */
 .modal {
-  display: none; /* Hidden by default */
-  position: fixed; /* Stay in place */
-  z-index: 71; /* Sit on top */
+  display: none;
+  position: fixed;
+  z-index: 71;
   left: 0;
   top: 0;
-  width: 100%; /* Full width */
-  height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
-  background-color: rgb(0,0,0); /* Fallback color */
-  background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
 }
 
-/* Modal Content/Box */
 .modal-content {
   background-color: #fefefe;
-  margin: 15% auto; /* 15% from the top and centered */
+  margin: 15% auto;
   padding: 20px;
   border: 1px solid #888;
-  width: 80%; /* Could be more or less, depending on screen size */
+  width: 80%;
 }
 
-/* The Close Button */
 .closeButton {
   color: #aaa;
   float: right;
@@ -67,8 +147,8 @@ body {
   text-decoration: none;
   cursor: pointer;
 }
+
 #projectTitle:focus,
 #projectTitle:hover {
-
     color: #4f4f4f;
 }

--- a/worlds/crazyflie_runtime_obstacle.wbt
+++ b/worlds/crazyflie_runtime_obstacle.wbt
@@ -23,6 +23,112 @@ TexturedBackgroundLight {
 Floor {
   size 6 6
 }
+
+# Visual-only course markers. They deliberately have no boundingObject and do not
+# participate in the physical oracle: the controller still evaluates the same
+# mathematical G1/G2 planes and the same collision observer as before.
+DEF GATE_1 Group {
+  children [
+    Pose {
+      translation 0.9 -0.3 1.0
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.1 0.75 0.25
+            emissiveColor 0.02 0.12 0.04
+            roughness 0.5
+          }
+          geometry Box { size 0.025 0.035 0.8 }
+        }
+      ]
+    }
+    Pose {
+      translation 0.9 0.3 1.0
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.1 0.75 0.25
+            emissiveColor 0.02 0.12 0.04
+            roughness 0.5
+          }
+          geometry Box { size 0.025 0.035 0.8 }
+        }
+      ]
+    }
+    Pose {
+      translation 0.9 0 1.4
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.1 0.75 0.25
+            emissiveColor 0.02 0.12 0.04
+            roughness 0.5
+          }
+          geometry Box { size 0.025 0.635 0.035 }
+        }
+      ]
+    }
+  ]
+}
+
+DEF GATE_2 Group {
+  children [
+    Pose {
+      translation 0.7 0.9 1.0
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.1 0.75 0.25
+            emissiveColor 0.02 0.12 0.04
+            roughness 0.5
+          }
+          geometry Box { size 0.035 0.025 0.8 }
+        }
+      ]
+    }
+    Pose {
+      translation 1.3 0.9 1.0
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.1 0.75 0.25
+            emissiveColor 0.02 0.12 0.04
+            roughness 0.5
+          }
+          geometry Box { size 0.035 0.025 0.8 }
+        }
+      ]
+    }
+    Pose {
+      translation 1.0 0.9 1.4
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.1 0.75 0.25
+            emissiveColor 0.02 0.12 0.04
+            roughness 0.5
+          }
+          geometry Box { size 0.635 0.025 0.035 }
+        }
+      ]
+    }
+  ]
+}
+
+DEF LANDING_TARGET Pose {
+  translation 1 1 0.004
+  children [
+    Shape {
+      appearance PBRAppearance {
+        baseColor 0.1 0.35 0.85
+        emissiveColor 0.01 0.04 0.12
+        roughness 0.7
+      }
+      geometry Box { size 0.4 0.4 0.008 }
+    }
+  ]
+}
+
 DEF OBSTACLE Solid {
   translation 1.25 0 0.70
   children [

--- a/worlds/crazyflie_runtime_obstacle.wbt
+++ b/worlds/crazyflie_runtime_obstacle.wbt
@@ -30,7 +30,7 @@ Floor {
 DEF GATE_1 Group {
   children [
     Pose {
-      translation 0.9 -0.3 1.0
+      translation 0.9 -0.3175 1.0
       children [
         Shape {
           appearance PBRAppearance {
@@ -43,7 +43,7 @@ DEF GATE_1 Group {
       ]
     }
     Pose {
-      translation 0.9 0.3 1.0
+      translation 0.9 0.3175 1.0
       children [
         Shape {
           appearance PBRAppearance {
@@ -64,7 +64,7 @@ DEF GATE_1 Group {
             emissiveColor 0.02 0.12 0.04
             roughness 0.5
           }
-          geometry Box { size 0.025 0.635 0.035 }
+          geometry Box { size 0.025 0.67 0.035 }
         }
       ]
     }
@@ -74,7 +74,7 @@ DEF GATE_1 Group {
 DEF GATE_2 Group {
   children [
     Pose {
-      translation 0.7 0.9 1.0
+      translation 0.6825 0.9 1.0
       children [
         Shape {
           appearance PBRAppearance {
@@ -87,7 +87,7 @@ DEF GATE_2 Group {
       ]
     }
     Pose {
-      translation 1.3 0.9 1.0
+      translation 1.3175 0.9 1.0
       children [
         Shape {
           appearance PBRAppearance {
@@ -108,23 +108,9 @@ DEF GATE_2 Group {
             emissiveColor 0.02 0.12 0.04
             roughness 0.5
           }
-          geometry Box { size 0.635 0.025 0.035 }
+          geometry Box { size 0.67 0.025 0.035 }
         }
       ]
-    }
-  ]
-}
-
-DEF LANDING_TARGET Pose {
-  translation 1 1 0.004
-  children [
-    Shape {
-      appearance PBRAppearance {
-        baseColor 0.1 0.35 0.85
-        emissiveColor 0.01 0.04 0.12
-        roughness 0.7
-      }
-      geometry Box { size 0.4 0.4 0.008 }
     }
   ]
 }


### PR DESCRIPTION
## Goal
Reduce the gap between the validated Crazyflie prototype and an activity a collège student can understand without technical explanation.

## Scope
Presentation only; no flight behavior changes.

- make the challenge objective and optimization loop explicit in French;
- activate the student presentation only for the `Crazyflie Runtime` Robot Window (R2025a supplies the robot name in the Robot Window URL), with workspace detection as a fallback;
- rename visible actions in Crazyflie mode (`Lancer le vol`, `Enregistrer`, `Ouvrir`) while historical Pioneer workspaces retain `Submit / Save / Restore`;
- keep the existing `Crazyflie` toolbox category unchanged and refer to it directly in the student instruction;
- hide the irrelevant historical text-code area only in Crazyflie mode;
- add visual-only G1/G2 gate frames to the existing obstacle world, with their inner openings aligned to the existing `GATE_HALF_WIDTH_M = 0.30 m` physical oracle. These Shapes have no `boundingObject` and do not alter collision/timing semantics;
- deliberately do **not** show a landing target, because landing position is not currently part of the success oracle.

## Non-goals
No new block, score/ranking, backend, PID/gain, STOP semantics, mission grammar, obstacle physics, timing source, landing-position criterion, or `main` change.

## Validation expected
All existing R2025a historical/Crazyflie gates must remain green. In particular the timed challenge UX gate must still prove that displayed state/result/time are caused by the existing runtime/physical events, not by DOM-only fixtures; strategy timing must preserve the two physical successes from #40. The UX gate also asserts that the student instruction does not imply four block occurrences, that no landing target is presented, and that the visible G1/G2 openings numerically match the controller's `GATE_HALF_WIDTH_M`. Verification is asked to reject any green that only proves text presence.