### PR TITLE
Experiment: declarative generic activity profiles

### DIFF
--- a/.github/workflows/experimental-generic-activities.yml
+++ b/.github/workflows/experimental-generic-activities.yml
@@ -1,0 +1,40 @@
+name: Experimental generic activities
+
+on:
+  pull_request:
+    paths:
+      - 'experiments/generic-activities/**'
+      - 'plugins/robot_windows/blockly/google-blockly-31ee4ea/**'
+      - '.github/workflows/experimental-generic-activities.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generic-activity-profile:
+    if: github.head_ref == 'experiment/generic-activities' || github.ref_name == 'experiment/generic-activities'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate declarative resolver
+        run: node experiments/generic-activities/test_activity_profile.js
+
+      - name: Locate browser
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              echo "CHROME_BIN=$(command -v "$candidate")" >> "$GITHUB_ENV"
+              "$candidate" --version
+              exit 0
+            fi
+          done
+          echo 'No Chrome/Chromium binary available on runner' >&2
+          exit 1
+
+      - name: Exercise real Blockly profile switching
+        run: python3 experiments/generic-activities/run_ui_harness.py

--- a/experiments/generic-activities/README.md
+++ b/experiments/generic-activities/README.md
@@ -1,0 +1,30 @@
+# Generic activity profiles — experiment
+
+## Question
+
+Can WebeeBlocks separate an activity definition from the hard-coded Crazyflie challenge UI, so that the same Webots world can be reused with different briefs, toolboxes and evaluation contracts?
+
+## Prototype
+
+`activities.json` declares activity profiles. `activity_profile.js` validates and resolves one profile against an explicit block catalog. The resolver is deliberately independent of Webots and of the Blockly DOM: this first experiment tests the configuration boundary before changing the release-candidate interface.
+
+The two sample activities reuse `worlds/crazyflie_runtime_obstacle.wbt` but differ in brief visibility, toolbox contents, hardware declaration, timer and evaluation contract.
+
+## Proven by the executable test
+
+`node experiments/generic-activities/test_activity_profile.js`
+
+The test proves that:
+
+- two profiles can reuse the same world;
+- the current four-block Crazyflie palette can be retained unchanged for one profile;
+- another profile on that same world can expose a different palette;
+- the in-interface brief can be visible or completely hidden;
+- parameter bounds are carried by the resolved block configuration;
+- unknown blocks and bounds targeting hidden blocks fail closed.
+
+## Explicit limits
+
+This experiment does **not** change `blockly.html`, Webots worlds, mission runtime or the frozen `webots-ci` release candidate. It does not claim that conditional Crazyflie missions are executable: the second sample profile labels that capability as an experimental requirement.
+
+A later experiment may connect this resolver to a disposable UI harness and prove dynamic toolbox/brief rendering. That should happen only on an experimental branch and must not be merged into `webots-ci` before the human-trial feedback and Lead arbitration.

--- a/experiments/generic-activities/README.md
+++ b/experiments/generic-activities/README.md
@@ -6,25 +6,58 @@ Can WebeeBlocks separate an activity definition from the hard-coded Crazyflie ch
 
 ## Prototype
 
-`activities.json` declares activity profiles. `activity_profile.js` validates and resolves one profile against an explicit block catalog. The resolver is deliberately independent of Webots and of the Blockly DOM: this first experiment tests the configuration boundary before changing the release-candidate interface.
+`activities.json` declares activity profiles. `activity_profile.js` validates and resolves one profile against an explicit block catalog. The resolver is deliberately independent of Webots and of the release-candidate Blockly DOM.
 
-The two sample activities reuse `worlds/crazyflie_runtime_obstacle.wbt` but differ in brief visibility, toolbox contents, hardware declaration, timer and evaluation contract.
+The two sample activities reuse `worlds/crazyflie_runtime_obstacle.wbt` but differ in brief visibility, toolbox contents, hardware declaration, timer and evaluation contract. The preview profile also deliberately narrows the real numeric ranges (`forward` max 1.5 m, `turn` max +90°) so the UI experiment can prove that profile bounds are actually applied rather than merely carried as metadata.
 
-## Proven by the executable test
+## Executable proof 1 — pure resolver
 
-`node experiments/generic-activities/test_activity_profile.js`
+```bash
+node experiments/generic-activities/test_activity_profile.js
+```
 
-The test proves that:
+This proves that:
 
 - two profiles can reuse the same world;
 - the current four-block Crazyflie palette can be retained unchanged for one profile;
 - another profile on that same world can expose a different palette;
 - the in-interface brief can be visible or completely hidden;
 - parameter bounds are carried by the resolved block configuration;
+- the same registered block can receive different bounds in different profiles;
 - unknown blocks and bounds targeting hidden blocks fail closed.
+
+## Executable proof 2 — disposable real-Blockly harness
+
+`ui_harness.html` loads the **actual Blockly 2020 build and actual Crazyflie block definitions from this repository**. It does not import or modify the frozen `blockly.html` product page.
+
+Serve the repository root and open:
+
+```text
+experiments/generic-activities/ui_harness.html
+```
+
+or, on a machine with Chrome/Chromium available:
+
+```bash
+python3 experiments/generic-activities/run_ui_harness.py
+```
+
+The harness switches profiles at runtime and fails closed unless it can prove all of the following against real Blockly objects:
+
+- every profile-exposed block type is actually registered by the loaded Blockly build;
+- the real flyout contents equal the selected profile toolbox;
+- the visible challenge brief appears for the time-trial profile and is fully hidden for the preview profile;
+- both profiles still point to the exact same Webots world;
+- profile-specific bounds are applied through the real `Blockly.FieldNumber.setConstraints()` API;
+- the preview profile really clamps a `turn` value of +135° to its declared +90° maximum;
+- unsupported evaluation/timer contracts are rejected by the harness rather than silently treated as executable.
+
+The harness then switches back to the time-trial profile and verifies that its brief and toolbox are restored.
 
 ## Explicit limits
 
 This experiment does **not** change `blockly.html`, Webots worlds, mission runtime or the frozen `webots-ci` release candidate. It does not claim that conditional Crazyflie missions are executable: the second sample profile labels that capability as an experimental requirement.
 
-A later experiment may connect this resolver to a disposable UI harness and prove dynamic toolbox/brief rendering. That should happen only on an experimental branch and must not be merged into `webots-ci` before the human-trial feedback and Lead arbitration.
+`hardware`, `timer` and `evaluation` are still declarative contracts, not a generic runtime implementation. The browser harness validates only the two contract forms it explicitly knows how to represent and deliberately rejects unknown ones.
+
+This draft must not be merged into `webots-ci` before human-trial feedback and Lead arbitration.

--- a/experiments/generic-activities/activities.json
+++ b/experiments/generic-activities/activities.json
@@ -48,10 +48,10 @@
       ],
       "parameterBounds": {
         "webeeblocks_forward": {
-          "DISTANCE": {"min": 0.1, "max": 2.0, "step": 0.1}
+          "DISTANCE": {"min": 0.1, "max": 1.5, "step": 0.1}
         },
         "webeeblocks_turn": {
-          "ANGLE": {"min": -90, "max": 135, "step": 1}
+          "ANGLE": {"min": -90, "max": 90, "step": 1}
         }
       },
       "hardware": ["crazyflie-2.1", "flow-deck-v2", "multi-ranger-deck"],

--- a/experiments/generic-activities/activities.json
+++ b/experiments/generic-activities/activities.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "activities": [
+    {
+      "id": "obstacle-time-trial-v0",
+      "world": "worlds/crazyflie_runtime_obstacle.wbt",
+      "brief": {
+        "visible": true,
+        "title": "Défi Crazyflie — contre-la-montre",
+        "goal": "Franchis les deux portes dans l’ordre, évite l’obstacle puis atterris. Quand ton parcours réussit, améliore ton temps.",
+        "hint": "Angle positif = gauche ; angle négatif = droite."
+      },
+      "toolbox": [
+        "webeeblocks_takeoff",
+        "webeeblocks_forward",
+        "webeeblocks_turn",
+        "webeeblocks_land"
+      ],
+      "parameterBounds": {
+        "webeeblocks_forward": {
+          "DISTANCE": {"min": 0.1, "max": 2.0, "step": 0.1}
+        },
+        "webeeblocks_turn": {
+          "ANGLE": {"min": -90, "max": 135, "step": 1}
+        }
+      },
+      "hardware": ["crazyflie-2.1", "flow-deck-v2"],
+      "timer": {"enabled": true, "start": "takeoff", "stop": "land"},
+      "evaluation": {
+        "type": "ordered-gates-no-collision",
+        "gates": ["G1", "G2"],
+        "requireLanding": true
+      }
+    },
+    {
+      "id": "obstacle-algorithm-preview",
+      "world": "worlds/crazyflie_runtime_obstacle.wbt",
+      "brief": {
+        "visible": false
+      },
+      "toolbox": [
+        "webeeblocks_takeoff",
+        "webeeblocks_forward",
+        "webeeblocks_turn",
+        "webeeblocks_land",
+        "controls_if",
+        "logic_compare"
+      ],
+      "parameterBounds": {
+        "webeeblocks_forward": {
+          "DISTANCE": {"min": 0.1, "max": 2.0, "step": 0.1}
+        },
+        "webeeblocks_turn": {
+          "ANGLE": {"min": -90, "max": 135, "step": 1}
+        }
+      },
+      "hardware": ["crazyflie-2.1", "flow-deck-v2", "multi-ranger-deck"],
+      "timer": {"enabled": false},
+      "evaluation": {
+        "type": "teacher-defined"
+      },
+      "experimentalRequirements": [
+        "conditional mission semantics are not implemented in runtime v1"
+      ]
+    }
+  ]
+}

--- a/experiments/generic-activities/activity_profile.js
+++ b/experiments/generic-activities/activity_profile.js
@@ -1,0 +1,137 @@
+/*
+ * Experimental WebeeBlocks activity-profile resolver.
+ *
+ * This module is intentionally independent of Webots, Blockly DOM and the
+ * current release-candidate UI. It proves that an activity can declare its
+ * world, brief, toolbox subset, parameter bounds, hardware and evaluation
+ * contract without hard-coding those choices in blockly.html.
+ */
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksActivityProfiles = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  function isObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function requireString(value, path) {
+    if (typeof value !== 'string' || value.trim() === '')
+      throw new Error(path + ' must be a non-empty string');
+    return value;
+  }
+
+  function requireBoolean(value, path) {
+    if (typeof value !== 'boolean')
+      throw new Error(path + ' must be a boolean');
+    return value;
+  }
+
+  function validateBounds(bounds, path) {
+    if (!isObject(bounds))
+      throw new Error(path + ' must be an object');
+    ['min', 'max', 'step'].forEach(function(key) {
+      if (!Number.isFinite(bounds[key]))
+        throw new Error(path + '.' + key + ' must be finite');
+    });
+    if (bounds.min > bounds.max)
+      throw new Error(path + '.min must be <= max');
+    if (bounds.step <= 0)
+      throw new Error(path + '.step must be > 0');
+  }
+
+  function validateProfile(profile, blockCatalog) {
+    if (!isObject(profile))
+      throw new Error('profile must be an object');
+
+    requireString(profile.id, 'id');
+    requireString(profile.world, 'world');
+
+    if (!isObject(profile.brief))
+      throw new Error('brief must be an object');
+    requireBoolean(profile.brief.visible, 'brief.visible');
+    if (profile.brief.visible) {
+      requireString(profile.brief.title, 'brief.title');
+      requireString(profile.brief.goal, 'brief.goal');
+    }
+
+    if (!Array.isArray(profile.toolbox) || profile.toolbox.length === 0)
+      throw new Error('toolbox must be a non-empty array');
+
+    var seen = Object.create(null);
+    profile.toolbox.forEach(function(type, index) {
+      requireString(type, 'toolbox[' + index + ']');
+      if (!Object.prototype.hasOwnProperty.call(blockCatalog, type))
+        throw new Error('unknown block type: ' + type);
+      if (seen[type])
+        throw new Error('duplicate block type: ' + type);
+      seen[type] = true;
+    });
+
+    if (profile.parameterBounds !== undefined) {
+      if (!isObject(profile.parameterBounds))
+        throw new Error('parameterBounds must be an object');
+      Object.keys(profile.parameterBounds).forEach(function(blockType) {
+        if (!seen[blockType])
+          throw new Error('parameter bounds declared for hidden block: ' + blockType);
+        var fields = profile.parameterBounds[blockType];
+        if (!isObject(fields))
+          throw new Error('parameterBounds.' + blockType + ' must be an object');
+        Object.keys(fields).forEach(function(field) {
+          validateBounds(fields[field], 'parameterBounds.' + blockType + '.' + field);
+        });
+      });
+    }
+
+    if (!Array.isArray(profile.hardware))
+      throw new Error('hardware must be an array');
+
+    if (!isObject(profile.timer) || typeof profile.timer.enabled !== 'boolean')
+      throw new Error('timer.enabled must be a boolean');
+
+    if (!isObject(profile.evaluation))
+      throw new Error('evaluation must be an object');
+    requireString(profile.evaluation.type, 'evaluation.type');
+
+    return true;
+  }
+
+  function resolveProfile(profile, blockCatalog) {
+    validateProfile(profile, blockCatalog);
+    var resolved = clone(profile);
+    resolved.toolbox = resolved.toolbox.map(function(type) {
+      var definition = clone(blockCatalog[type]);
+      definition.type = type;
+      if (resolved.parameterBounds && resolved.parameterBounds[type])
+        definition.parameterBounds = clone(resolved.parameterBounds[type]);
+      return definition;
+    });
+    if (!resolved.brief.visible)
+      resolved.brief = {visible: false};
+    return resolved;
+  }
+
+  function resolveById(document, profileId, blockCatalog) {
+    if (!isObject(document) || !Array.isArray(document.activities))
+      throw new Error('activity document must contain an activities array');
+    var matches = document.activities.filter(function(profile) {
+      return profile.id === profileId;
+    });
+    if (matches.length !== 1)
+      throw new Error('activity id must resolve exactly once: ' + profileId);
+    return resolveProfile(matches[0], blockCatalog);
+  }
+
+  return {
+    validateProfile: validateProfile,
+    resolveProfile: resolveProfile,
+    resolveById: resolveById
+  };
+});

--- a/experiments/generic-activities/run_ui_harness.py
+++ b/experiments/generic-activities/run_ui_harness.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run the disposable generic-activity UI harness in a real headless browser.
+
+The script serves the repository root over localhost, opens the harness with an
+installed Chrome/Chromium binary and inspects the final DOM. It does not modify
+WebeeBlocks product files or require Webots.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import pathlib
+import shutil
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+HARNESS_RELATIVE = pathlib.Path("experiments/generic-activities/ui_harness.html")
+
+
+def browser_binary() -> str:
+    for candidate in (
+        os.environ.get("CHROME_BIN"),
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
+        if candidate and shutil.which(candidate):
+            return shutil.which(candidate) or candidate
+    raise RuntimeError("no Chrome/Chromium binary found; set CHROME_BIN")
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass
+
+
+def main() -> int:
+    browser = browser_binary()
+    os.chdir(REPO_ROOT)
+
+    with socketserver.TCPServer(("127.0.0.1", 0), QuietHandler) as server:
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        time.sleep(0.05)
+
+        url = f"http://127.0.0.1:{port}/{HARNESS_RELATIVE.as_posix()}"
+        command = [
+            browser,
+            "--headless",
+            "--disable-gpu",
+            "--no-sandbox",
+            "--disable-dev-shm-usage",
+            "--virtual-time-budget=5000",
+            "--dump-dom",
+            url,
+        ]
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        server.shutdown()
+
+    dom = completed.stdout
+    stderr = completed.stderr
+    marker = "PASS real Blockly activity profile harness"
+    if marker not in dom:
+        print("FAIL real Blockly activity profile harness", file=sys.stderr)
+        print("browser exit:", completed.returncode, file=sys.stderr)
+        if stderr:
+            print(stderr[-4000:], file=sys.stderr)
+        if dom:
+            print(dom[-8000:], file=sys.stderr)
+        return 1
+
+    print(marker)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/generic-activities/test_activity_profile.js
+++ b/experiments/generic-activities/test_activity_profile.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const profiles = require('./activity_profile.js');
+
+const document = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'activities.json'), 'utf8')
+);
+
+const catalog = {
+  webeeblocks_takeoff: {category: 'Crazyflie'},
+  webeeblocks_forward: {category: 'Crazyflie'},
+  webeeblocks_turn: {category: 'Crazyflie'},
+  webeeblocks_land: {category: 'Crazyflie'},
+  controls_if: {category: 'Control'},
+  logic_compare: {category: 'Control'}
+};
+
+function run() {
+  const timeTrial = profiles.resolveById(document, 'obstacle-time-trial-v0', catalog);
+  const algorithm = profiles.resolveById(document, 'obstacle-algorithm-preview', catalog);
+
+  assert.strictEqual(timeTrial.world, algorithm.world,
+    'two profiles should be able to reuse the same world');
+
+  assert.deepStrictEqual(
+    timeTrial.toolbox.map(block => block.type),
+    [
+      'webeeblocks_takeoff',
+      'webeeblocks_forward',
+      'webeeblocks_turn',
+      'webeeblocks_land'
+    ],
+    'time-trial profile must preserve the current four-block palette'
+  );
+
+  assert.deepStrictEqual(
+    algorithm.toolbox.map(block => block.type),
+    [
+      'webeeblocks_takeoff',
+      'webeeblocks_forward',
+      'webeeblocks_turn',
+      'webeeblocks_land',
+      'controls_if',
+      'logic_compare'
+    ],
+    'another profile on the same world must be able to expose a different palette'
+  );
+
+  assert.strictEqual(timeTrial.brief.visible, true,
+    'activity may expose an in-UI brief');
+  assert.deepStrictEqual(algorithm.brief, {visible: false},
+    'activity may hide the in-UI brief completely');
+
+  assert.deepStrictEqual(
+    timeTrial.toolbox.find(block => block.type === 'webeeblocks_forward')
+      .parameterBounds.DISTANCE,
+    {min: 0.1, max: 2.0, step: 0.1},
+    'parameter bounds must travel with the resolved block definition'
+  );
+
+  assert.strictEqual(timeTrial.timer.enabled, true);
+  assert.strictEqual(algorithm.timer.enabled, false);
+  assert.strictEqual(timeTrial.evaluation.type, 'ordered-gates-no-collision');
+  assert.strictEqual(algorithm.evaluation.type, 'teacher-defined');
+
+  const bad = JSON.parse(JSON.stringify(document.activities[0]));
+  bad.id = 'bad-unknown-block';
+  bad.toolbox.push('future_block_not_in_catalog');
+  assert.throws(
+    () => profiles.resolveProfile(bad, catalog),
+    /unknown block type/,
+    'a profile must fail closed when it asks for an unknown block'
+  );
+
+  const badBounds = JSON.parse(JSON.stringify(document.activities[0]));
+  badBounds.id = 'bad-hidden-bounds';
+  badBounds.toolbox = badBounds.toolbox.filter(type => type !== 'webeeblocks_turn');
+  assert.throws(
+    () => profiles.resolveProfile(badBounds, catalog),
+    /parameter bounds declared for hidden block/,
+    'bounds must not silently target a block hidden by the activity'
+  );
+
+  console.log('PASS generic activity profile prototype');
+  console.log('same world:', timeTrial.world);
+  console.log('time-trial blocks:', timeTrial.toolbox.length);
+  console.log('algorithm-preview blocks:', algorithm.toolbox.length);
+}
+
+run();

--- a/experiments/generic-activities/test_activity_profile.js
+++ b/experiments/generic-activities/test_activity_profile.js
@@ -59,6 +59,20 @@ function run() {
     'parameter bounds must travel with the resolved block definition'
   );
 
+  assert.deepStrictEqual(
+    algorithm.toolbox.find(block => block.type === 'webeeblocks_forward')
+      .parameterBounds.DISTANCE,
+    {min: 0.1, max: 1.5, step: 0.1},
+    'same block may have profile-specific bounds on the same world'
+  );
+
+  assert.deepStrictEqual(
+    algorithm.toolbox.find(block => block.type === 'webeeblocks_turn')
+      .parameterBounds.ANGLE,
+    {min: -90, max: 90, step: 1},
+    'preview profile should visibly differ from the current turn range'
+  );
+
   assert.strictEqual(timeTrial.timer.enabled, true);
   assert.strictEqual(algorithm.timer.enabled, false);
   assert.strictEqual(timeTrial.evaluation.type, 'ordered-gates-no-collision');

--- a/experiments/generic-activities/ui_harness.html
+++ b/experiments/generic-activities/ui_harness.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>WebeeBlocks generic activity UI harness</title>
+  <style>
+    body { font-family: sans-serif; margin: 16px; }
+    #brief[hidden] { display: none; }
+    #brief { border: 1px solid #bbb; padding: 10px; margin: 10px 0; }
+    #blocklyDiv { height: 360px; width: 100%; border: 1px solid #ddd; }
+    #result { white-space: pre-wrap; background: #f5f5f5; padding: 10px; }
+  </style>
+
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blockly_uncompressed.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/msg/js/en.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/logic.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/loops.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/crazyflie.js"></script>
+  <script src="activity_profile.js"></script>
+</head>
+<body>
+  <h1>Generic activity profile — disposable harness</h1>
+  <label>Activity:
+    <select id="activitySelect"></select>
+  </label>
+  <div>World: <code id="worldPath"></code></div>
+  <div id="brief">
+    <strong id="briefTitle"></strong>
+    <div id="briefGoal"></div>
+    <div id="briefHint"></div>
+  </div>
+  <div id="blocklyDiv"></div>
+  <pre id="result">RUNNING</pre>
+
+<script>
+(function() {
+  'use strict';
+
+  var workspace = null;
+  var documentProfiles = null;
+  var currentResolved = null;
+  var result = document.getElementById('result');
+
+  var SUPPORTED_EVALUATIONS = {
+    'ordered-gates-no-collision': true,
+    'teacher-defined': true
+  };
+
+  function fail(message) {
+    result.textContent = 'FAIL: ' + message;
+    result.setAttribute('data-status', 'FAIL');
+    throw new Error(message);
+  }
+
+  function assert(condition, message) {
+    if (!condition)
+      fail(message);
+  }
+
+  function allDeclaredBlockTypes(doc) {
+    var seen = Object.create(null);
+    doc.activities.forEach(function(activity) {
+      activity.toolbox.forEach(function(type) { seen[type] = true; });
+    });
+    return Object.keys(seen);
+  }
+
+  function realBlocklyCatalog(doc) {
+    var catalog = {};
+    allDeclaredBlockTypes(doc).forEach(function(type) {
+      assert(Blockly.Blocks[type], 'profile exposes unregistered Blockly block: ' + type);
+      catalog[type] = {registeredByBlockly: true};
+    });
+    return catalog;
+  }
+
+  function validateExecutableContract(profile) {
+    assert(SUPPORTED_EVALUATIONS[profile.evaluation.type],
+      'unsupported evaluation contract in harness: ' + profile.evaluation.type);
+    assert(typeof profile.timer.enabled === 'boolean', 'timer.enabled must be boolean');
+    if (profile.timer.enabled) {
+      assert(profile.timer.start === 'takeoff' && profile.timer.stop === 'land',
+        'unsupported timer contract in harness');
+    }
+  }
+
+  function toolboxXml(resolved) {
+    var xml = document.createElement('xml');
+    resolved.toolbox.forEach(function(definition) {
+      var block = document.createElement('block');
+      block.setAttribute('type', definition.type);
+      xml.appendChild(block);
+    });
+    return xml;
+  }
+
+  function applyBounds(block, resolved) {
+    var definition = resolved.toolbox.filter(function(item) {
+      return item.type === block.type;
+    })[0];
+    if (!definition || !definition.parameterBounds)
+      return;
+    Object.keys(definition.parameterBounds).forEach(function(fieldName) {
+      var field = block.getField(fieldName);
+      assert(field && typeof field.setConstraints === 'function',
+        block.type + '.' + fieldName + ' is not a real numeric Blockly field');
+      var bounds = definition.parameterBounds[fieldName];
+      field.setConstraints(bounds.min, bounds.max, bounds.step);
+    });
+  }
+
+  function flyoutTypes() {
+    var flyout = (workspace.getFlyout && workspace.getFlyout()) || workspace.flyout_;
+    assert(flyout && flyout.workspace_, 'real Blockly flyout unavailable');
+    return flyout.workspace_.getAllBlocks(false).map(function(block) {
+      return block.type;
+    });
+  }
+
+  function renderProfile(profileId) {
+    var catalog = realBlocklyCatalog(documentProfiles);
+    var resolved = WebeeBlocksActivityProfiles.resolveById(documentProfiles, profileId, catalog);
+    validateExecutableContract(resolved);
+    currentResolved = resolved;
+
+    document.getElementById('worldPath').textContent = resolved.world;
+    var brief = document.getElementById('brief');
+    brief.hidden = !resolved.brief.visible;
+    document.getElementById('briefTitle').textContent = resolved.brief.visible ? resolved.brief.title : '';
+    document.getElementById('briefGoal').textContent = resolved.brief.visible ? resolved.brief.goal : '';
+    document.getElementById('briefHint').textContent = resolved.brief.visible ? (resolved.brief.hint || '') : '';
+
+    var xml = toolboxXml(resolved);
+    if (!workspace) {
+      workspace = Blockly.inject('blocklyDiv', {toolbox: xml});
+    } else {
+      workspace.clear();
+      workspace.updateToolbox(xml);
+    }
+
+    return resolved;
+  }
+
+  function inspectRealField(type, fieldName, resolved) {
+    var block = workspace.newBlock(type);
+    applyBounds(block, resolved);
+    var field = block.getField(fieldName);
+    var data = {
+      min: field.getMin(),
+      max: field.getMax(),
+      step: field.getPrecision()
+    };
+    block.dispose(false);
+    return data;
+  }
+
+  function sameBounds(actual, expected) {
+    return actual.min === expected.min && actual.max === expected.max && actual.step === expected.step;
+  }
+
+  function afterRender(callback) {
+    window.setTimeout(callback, 50);
+  }
+
+  function runAssertions() {
+    var first = renderProfile('obstacle-time-trial-v0');
+    afterRender(function() {
+      try {
+        assert(first.world === 'worlds/crazyflie_runtime_obstacle.wbt', 'unexpected first world');
+        assert(document.getElementById('brief').hidden === false, 'time-trial brief should be visible');
+        assert(document.getElementById('briefTitle').textContent.indexOf('contre-la-montre') !== -1,
+          'visible brief title not rendered');
+        assert(JSON.stringify(flyoutTypes()) === JSON.stringify(first.toolbox.map(function(b) { return b.type; })),
+          'real Blockly flyout does not match time-trial profile');
+
+        var firstForward = inspectRealField('webeeblocks_forward', 'DISTANCE', first);
+        assert(sameBounds(firstForward, {min: 0.1, max: 2.0, step: 0.1}),
+          'time-trial bounds were not applied to real forward FieldNumber');
+
+        var second = renderProfile('obstacle-algorithm-preview');
+        afterRender(function() {
+          try {
+            assert(second.world === first.world, 'profile switch changed the world');
+            assert(document.getElementById('brief').hidden === true, 'algorithm brief should be hidden');
+            assert(JSON.stringify(flyoutTypes()) === JSON.stringify(second.toolbox.map(function(b) { return b.type; })),
+              'real Blockly flyout does not match algorithm profile');
+
+            var turn = inspectRealField('webeeblocks_turn', 'ANGLE', second);
+            assert(sameBounds(turn, {min: -90, max: 90, step: 1}),
+              'profile-specific bounds were not applied to real turn FieldNumber');
+
+            var testTurn = workspace.newBlock('webeeblocks_turn');
+            applyBounds(testTurn, second);
+            testTurn.setFieldValue('135', 'ANGLE');
+            assert(Number(testTurn.getFieldValue('ANGLE')) === 90,
+              'real FieldNumber did not clamp 135° to profile max 90°');
+            testTurn.dispose(false);
+
+            renderProfile('obstacle-time-trial-v0');
+            afterRender(function() {
+              try {
+                assert(document.getElementById('brief').hidden === false,
+                  'brief did not return when switching back');
+                assert(JSON.stringify(flyoutTypes()) === JSON.stringify(first.toolbox.map(function(b) { return b.type; })),
+                  'toolbox did not return when switching back');
+                result.textContent = 'PASS real Blockly activity profile harness';
+                result.setAttribute('data-status', 'PASS');
+              } catch (error) {
+                if (result.getAttribute('data-status') !== 'FAIL')
+                  fail(error.message || String(error));
+              }
+            });
+          } catch (error) {
+            if (result.getAttribute('data-status') !== 'FAIL')
+              fail(error.message || String(error));
+          }
+        });
+      } catch (error) {
+        if (result.getAttribute('data-status') !== 'FAIL')
+          fail(error.message || String(error));
+      }
+    });
+  }
+
+  fetch('activities.json')
+    .then(function(response) {
+      if (!response.ok)
+        throw new Error('activities.json HTTP ' + response.status);
+      return response.json();
+    })
+    .then(function(doc) {
+      documentProfiles = doc;
+      var select = document.getElementById('activitySelect');
+      doc.activities.forEach(function(activity) {
+        var option = document.createElement('option');
+        option.value = activity.id;
+        option.textContent = activity.id;
+        select.appendChild(option);
+      });
+      select.addEventListener('change', function() { renderProfile(select.value); });
+      runAssertions();
+    })
+    .catch(function(error) { fail(error.message || String(error)); });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Experimental scope

This draft PR is intentionally isolated from the frozen release candidate. It does not modify `webots-ci` product files, worlds, runtime, PID, Blockly product UI or `main`. The only non-`experiments/` addition is a CI workflow dedicated to this experimental branch.

## Question

Can WebeeBlocks represent an activity independently from the current hard-coded time-trial interface, so one world can be reused with different briefs, palettes, parameter limits, hardware declarations and evaluation contracts?

## Prototype

Adds a pure-JS activity profile resolver plus two declarative profiles that both reference `worlds/crazyflie_runtime_obstacle.wbt`:

- `obstacle-time-trial-v0`: current four Crazyflie blocks, visible brief, timer and ordered-gate/no-collision evaluation;
- `obstacle-algorithm-preview`: same world, hidden brief, different palette including Blockly condition blocks, Flow + Multi-ranger declaration, teacher-defined evaluation. It deliberately narrows real field ranges (`forward` max 1.5 m, `turn` max +90°) so the UI experiment can detect whether profile bounds are truly applied.

The resolver validates profiles fail-closed and carries parameter bounds into the resolved block configuration.

## Proof 1 — resolver

`node experiments/generic-activities/test_activity_profile.js`

Proves same-world reuse, different toolboxes, optional brief, profile-specific parameter bounds, and rejection of unknown/hidden-block configuration.

## Proof 2 — real Blockly 2020 browser harness

`ui_harness.html` loads the actual Blockly 2020 build and actual Crazyflie block definitions from this repository, but never imports or modifies the frozen product `blockly.html`.

`python3 experiments/generic-activities/run_ui_harness.py` executes it in a real headless Chrome/Chromium browser. The dedicated `Experimental generic activities` GitHub Actions run #1 is **green** on head `953e1697…`.

The browser harness fails closed unless it proves:

- every exposed block is actually registered by real Blockly;
- the real Blockly flyout matches the selected profile toolbox;
- profile switching on the same world shows/hides the brief;
- bounds are applied to real `Blockly.FieldNumber` objects through `setConstraints()`;
- the preview profile really clamps +135° to its declared +90° maximum;
- switching back restores the first profile;
- unsupported timer/evaluation contracts are rejected rather than silently treated as executable.

## Limits / non-claims

- No product UI rendering change is proposed.
- No conditional Crazyflie runtime support is claimed.
- `hardware`, `timer` and `evaluation` remain declarative contracts, not a generic runtime implementation.
- No merge into `webots-ci` should occur before human-trial feedback and Lead arbitration.

## Engineering conclusion

The configuration/UI boundary is now experimentally demonstrated strongly enough to stop expanding this branch. The next generic-activity experiment should be a separate branch testing one executable activity contract at a time, rather than turning this draft into a product refactor.