### PR TITLE
Experiment: extended Crazyflie semantic blocks

### DIFF
--- a/.github/workflows/experimental-extended-blocks.yml
+++ b/.github/workflows/experimental-extended-blocks.yml
@@ -1,0 +1,21 @@
+name: Experimental extended blocks
+
+on:
+  pull_request:
+    paths:
+      - 'experiments/extended-blocks/**'
+      - '.github/workflows/experimental-extended-blocks.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  extended-block-semantics:
+    if: github.head_ref == 'experiment/extended-blocks' || github.ref_name == 'experiment/extended-blocks'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate extended semantic AST
+        run: node experiments/extended-blocks/test_extended_blocks.js

--- a/.github/workflows/experimental-extended-blocks.yml
+++ b/.github/workflows/experimental-extended-blocks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'experiments/extended-blocks/**'
+      - 'plugins/robot_windows/blockly/google-blockly-31ee4ea/**'
       - '.github/workflows/experimental-extended-blocks.yml'
   workflow_dispatch:
 
@@ -14,8 +15,26 @@ jobs:
   extended-block-semantics:
     if: github.head_ref == 'experiment/extended-blocks' || github.ref_name == 'experiment/extended-blocks'
     runs-on: ubuntu-22.04
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Validate extended semantic AST
+
+      - name: Validate semantic compiler
         run: node experiments/extended-blocks/test_extended_blocks.js
+
+      - name: Locate browser
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              echo "CHROME_BIN=$(command -v "$candidate")" >> "$GITHUB_ENV"
+              "$candidate" --version
+              exit 0
+            fi
+          done
+          echo 'No Chrome/Chromium binary available on runner' >&2
+          exit 1
+
+      - name: Exercise real bundled Blockly 2020
+        run: python3 experiments/extended-blocks/run_ui_harness.py

--- a/experiments/extended-blocks/README.md
+++ b/experiments/extended-blocks/README.md
@@ -8,7 +8,7 @@ Can WebeeBlocks represent a richer student program — including movement, speed
 
 ## Experimental semantic catalogue
 
-The prototype currently covers:
+The prototype covers:
 
 - take off to a relative height;
 - land;
@@ -25,7 +25,9 @@ There is deliberately **no** `avoid obstacle` block. The semantic tree keeps the
 
 ## Output
 
-`extended_blocks.js` compiles Blockly-like objects to an experimental, backend-neutral AST, for example:
+`extended_blocks.js` compiles the workspace into an experimental backend-neutral AST. No Python generator is involved.
+
+Example semantic fragment:
 
 ```json
 {
@@ -43,24 +45,40 @@ There is deliberately **no** `avoid obstacle` block. The semantic tree keeps the
 
 The compiler fails closed on unsupported blocks, invalid directions and out-of-range parameters.
 
-## Proof
-
-Run:
+## Proof 1 — semantic unit tests
 
 ```bash
 node experiments/extended-blocks/test_extended_blocks.js
 ```
 
-The tests cover a richer sequential mission and a reactive structure equivalent to:
+These tests cover a richer sequential mission, a reactive structure and invalid inputs.
 
-`repeat 3 times: if front range < 0.5 m then move left 0.3 m else move forward 0.3 m`.
+## Proof 2 — real bundled Blockly 2020
+
+`ui_harness.html` loads the actual Blockly 2020 build from this repository, the standard Blockly `logic`, `loops` and `math` blocks, and disposable experimental Crazyflie block definitions.
+
+```bash
+python3 experiments/extended-blocks/run_ui_harness.py
+```
+
+The browser proof constructs the real visual program:
+
+`takeoff → repeat 3 times { if front range < 0.5 m then left 0.3 m else forward 0.3 m } → land`
+
+and requires the exact backend-neutral AST. It also serializes the workspace to Blockly XML, reloads it into a fresh workspace and requires the same AST after round-trip.
+
+This proof exposed and fixed a real integration mismatch: Blockly 2020 `controls_repeat_ext` stores `TIMES` as a **value input**, not a field. The compiler now handles the real Blockly structure while retaining a field fallback only for lightweight test doubles.
 
 ## Explicit limits
 
-- This does **not** define the final student block wording or visual design.
-- This does **not** claim that conditions or Multi-ranger sensing are executable by runtime v1.
-- It does not yet instantiate these experimental blocks in the real Blockly 2020 browser.
-- It does not choose between a future Webots backend and a real-drone backend for these richer semantics.
-- Numeric limits are experimental guardrails, not final pedagogical constraints.
+- This does **not** define final student wording or visual design.
+- Conditions and Multi-ranger sensing are **not** claimed executable by runtime v1.
+- The disposable block definitions are not loaded by the frozen product UI.
+- It does not choose a future runtime implementation for condition/repeat execution.
+- It does not claim real Crazyflie behavior.
+- Numeric limits remain experimental guardrails.
+- No merge into `webots-ci` should occur before human-trial feedback and Lead arbitration.
 
-The next valuable proof on this branch is a disposable real-Blockly harness that instantiates the proposed blocks plus standard `if/repeat/logic` blocks and verifies that the exact semantic AST is produced without Python generation.
+## Engineering conclusion
+
+The semantic/UI boundary is now testable against the real bundled Blockly 2020. The next useful experiment should not add more block types here; it should test execution of one small reactive AST against a disposable backend/mock, or move to the independent real-Crazyflie transport axis.

--- a/experiments/extended-blocks/README.md
+++ b/experiments/extended-blocks/README.md
@@ -1,0 +1,66 @@
+# Extended Crazyflie blocks — experiment
+
+This branch is intentionally isolated from the frozen `webots-ci` release candidate. It does not modify the product Blockly page, Webots worlds, Crazyflie runtime, PID, STOP semantics or `main`.
+
+## Question
+
+Can WebeeBlocks represent a richer student program — including movement, speed, timing, Multi-ranger sensing, conditions and repetition — as a semantic structure without exposing or generating Python?
+
+## Experimental semantic catalogue
+
+The prototype currently covers:
+
+- take off to a relative height;
+- land;
+- move forward/back/left/right by a distance;
+- move up/down by a distance;
+- turn left/right by an angle;
+- wait;
+- set translational speed;
+- Multi-ranger value expressions: front/back/left/right/up;
+- standard Blockly comparisons and AND/OR expressions;
+- standard Blockly `if/else` and `repeat N times` control blocks.
+
+There is deliberately **no** `avoid obstacle` block. The semantic tree keeps the pedagogical sequence visible: measure → compare → decide → act.
+
+## Output
+
+`extended_blocks.js` compiles Blockly-like objects to an experimental, backend-neutral AST, for example:
+
+```json
+{
+  "kind": "if",
+  "condition": {
+    "kind": "compare",
+    "op": "LT",
+    "left": {"kind": "range", "direction": "front", "unit": "m"},
+    "right": {"kind": "number", "value": 0.5}
+  },
+  "then": [{"kind": "move", "direction": "left", "distance_m": 0.3}],
+  "else": [{"kind": "move", "direction": "forward", "distance_m": 0.3}]
+}
+```
+
+The compiler fails closed on unsupported blocks, invalid directions and out-of-range parameters.
+
+## Proof
+
+Run:
+
+```bash
+node experiments/extended-blocks/test_extended_blocks.js
+```
+
+The tests cover a richer sequential mission and a reactive structure equivalent to:
+
+`repeat 3 times: if front range < 0.5 m then move left 0.3 m else move forward 0.3 m`.
+
+## Explicit limits
+
+- This does **not** define the final student block wording or visual design.
+- This does **not** claim that conditions or Multi-ranger sensing are executable by runtime v1.
+- It does not yet instantiate these experimental blocks in the real Blockly 2020 browser.
+- It does not choose between a future Webots backend and a real-drone backend for these richer semantics.
+- Numeric limits are experimental guardrails, not final pedagogical constraints.
+
+The next valuable proof on this branch is a disposable real-Blockly harness that instantiates the proposed blocks plus standard `if/repeat/logic` blocks and verifies that the exact semantic AST is produced without Python generation.

--- a/experiments/extended-blocks/experimental_blocks.js
+++ b/experiments/extended-blocks/experimental_blocks.js
@@ -1,0 +1,78 @@
+/* Experimental Blockly 2020 block definitions. Never loaded by the frozen product UI. */
+(function() {
+  'use strict';
+
+  Blockly.defineBlocksWithJsonArray([
+    {
+      type: 'webeeblocks_exp_takeoff',
+      message0: 'décoller à %1 m',
+      args0: [{type: 'field_number', name: 'HEIGHT', value: 0.5, min: 0.2, max: 1.5, precision: 0.1}],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_exp_land',
+      message0: 'atterrir',
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_exp_move',
+      message0: '%1 de %2 m',
+      args0: [
+        {type: 'field_dropdown', name: 'DIRECTION', options: [['avancer','forward'],['reculer','back'],['aller à gauche','left'],['aller à droite','right']]},
+        {type: 'field_number', name: 'DISTANCE', value: 0.3, min: 0.1, max: 2.0, precision: 0.1}
+      ],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_exp_vertical',
+      message0: '%1 de %2 m',
+      args0: [
+        {type: 'field_dropdown', name: 'DIRECTION', options: [['monter','up'],['descendre','down']]},
+        {type: 'field_number', name: 'DISTANCE', value: 0.2, min: 0.1, max: 0.8, precision: 0.1}
+      ],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_exp_turn',
+      message0: 'tourner à %1 de %2 °',
+      args0: [
+        {type: 'field_dropdown', name: 'DIRECTION', options: [['gauche','left'],['droite','right']]},
+        {type: 'field_number', name: 'ANGLE', value: 90, min: 1, max: 179, precision: 1}
+      ],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_exp_wait',
+      message0: 'attendre %1 s',
+      args0: [{type: 'field_number', name: 'SECONDS', value: 0.5, min: 0.1, max: 5.0, precision: 0.1}],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 80
+    },
+    {
+      type: 'webeeblocks_exp_speed',
+      message0: 'régler la vitesse à %1 m/s',
+      args0: [{type: 'field_number', name: 'SPEED', value: 0.2, min: 0.1, max: 0.6, precision: 0.1}],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 80
+    },
+    {
+      type: 'webeeblocks_exp_range',
+      message0: 'distance %1',
+      args0: [{type: 'field_dropdown', name: 'DIRECTION', options: [['devant','front'],['derrière','back'],['à gauche','left'],['à droite','right'],['au-dessus','up']]}],
+      output: 'Number',
+      colour: 60
+    }
+  ]);
+})();

--- a/experiments/extended-blocks/extended_blocks.js
+++ b/experiments/extended-blocks/extended_blocks.js
@@ -1,0 +1,159 @@
+/* Experimental only: richer Crazyflie block semantics without touching the frozen product. */
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksExtended = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  const LIMITS = Object.freeze({
+    height_m: {min: 0.2, max: 1.5},
+    distance_m: {min: 0.1, max: 2.0},
+    vertical_m: {min: 0.1, max: 0.8},
+    wait_s: {min: 0.1, max: 5.0},
+    speed_m_s: {min: 0.1, max: 0.6},
+    range_m: {min: 0.05, max: 4.0},
+    repeat: {min: 1, max: 20}
+  });
+
+  const SENSOR_DIRECTIONS = Object.freeze(['front', 'back', 'left', 'right', 'up']);
+
+  function finite(value, name) {
+    const n = Number(value);
+    if (!Number.isFinite(n))
+      throw new Error(name + ' must be finite');
+    return n;
+  }
+
+  function bounded(value, name, limits) {
+    const n = finite(value, name);
+    if (n < limits.min || n > limits.max)
+      throw new Error(name + ' out of experimental range: ' + n);
+    return n;
+  }
+
+  function field(block, name) {
+    if (!block || typeof block.getFieldValue !== 'function')
+      throw new Error('invalid Blockly block');
+    return block.getFieldValue(name);
+  }
+
+  function statementChildren(block, inputName) {
+    if (!block || typeof block.getInputTargetBlock !== 'function')
+      throw new Error('block does not expose statement input ' + inputName);
+    const first = block.getInputTargetBlock(inputName);
+    return compileSequence(first);
+  }
+
+  function valueChild(block, inputName) {
+    if (!block || typeof block.getInputTargetBlock !== 'function')
+      throw new Error('block does not expose value input ' + inputName);
+    const child = block.getInputTargetBlock(inputName);
+    if (!child)
+      throw new Error('missing value input ' + inputName);
+    return compileExpression(child);
+  }
+
+  function compileExpression(block) {
+    switch (block.type) {
+      case 'webeeblocks_exp_range': {
+        const direction = String(field(block, 'DIRECTION'));
+        if (SENSOR_DIRECTIONS.indexOf(direction) < 0)
+          throw new Error('unsupported range direction: ' + direction);
+        return {kind: 'range', direction: direction, unit: 'm'};
+      }
+      case 'math_number':
+        return {kind: 'number', value: finite(field(block, 'NUM'), 'number')};
+      case 'logic_compare': {
+        const op = String(field(block, 'OP'));
+        if (['LT', 'LTE', 'GT', 'GTE', 'EQ', 'NEQ'].indexOf(op) < 0)
+          throw new Error('unsupported comparison: ' + op);
+        return {kind: 'compare', op: op, left: valueChild(block, 'A'), right: valueChild(block, 'B')};
+      }
+      case 'logic_operation': {
+        const op = String(field(block, 'OP'));
+        if (op !== 'AND' && op !== 'OR')
+          throw new Error('unsupported logic operation: ' + op);
+        return {kind: 'logic', op: op, left: valueChild(block, 'A'), right: valueChild(block, 'B')};
+      }
+      default:
+        throw new Error('unsupported experimental expression block: ' + block.type);
+    }
+  }
+
+  function compileStatement(block) {
+    switch (block.type) {
+      case 'webeeblocks_exp_takeoff':
+        return {kind: 'takeoff', height_m: bounded(field(block, 'HEIGHT'), 'height_m', LIMITS.height_m)};
+      case 'webeeblocks_exp_land':
+        return {kind: 'land'};
+      case 'webeeblocks_exp_move': {
+        const direction = String(field(block, 'DIRECTION'));
+        if (['forward', 'back', 'left', 'right'].indexOf(direction) < 0)
+          throw new Error('unsupported move direction: ' + direction);
+        return {kind: 'move', direction: direction, distance_m: bounded(field(block, 'DISTANCE'), 'distance_m', LIMITS.distance_m)};
+      }
+      case 'webeeblocks_exp_vertical': {
+        const direction = String(field(block, 'DIRECTION'));
+        if (direction !== 'up' && direction !== 'down')
+          throw new Error('unsupported vertical direction: ' + direction);
+        return {kind: 'vertical', direction: direction, distance_m: bounded(field(block, 'DISTANCE'), 'vertical_m', LIMITS.vertical_m)};
+      }
+      case 'webeeblocks_exp_turn': {
+        const direction = String(field(block, 'DIRECTION'));
+        const degrees = bounded(field(block, 'ANGLE'), 'angle_deg', {min: 1, max: 179});
+        if (direction !== 'left' && direction !== 'right')
+          throw new Error('unsupported turn direction: ' + direction);
+        return {kind: 'turn', angle_deg: direction === 'left' ? degrees : -degrees};
+      }
+      case 'webeeblocks_exp_wait':
+        return {kind: 'wait', seconds: bounded(field(block, 'SECONDS'), 'wait_s', LIMITS.wait_s)};
+      case 'webeeblocks_exp_speed':
+        return {kind: 'set_speed', speed_m_s: bounded(field(block, 'SPEED'), 'speed_m_s', LIMITS.speed_m_s)};
+      case 'controls_repeat_ext':
+        return {kind: 'repeat', count: bounded(field(block, 'TIMES'), 'repeat', LIMITS.repeat), body: statementChildren(block, 'DO')};
+      case 'controls_if': {
+        const result = {kind: 'if', condition: valueChild(block, 'IF0'), then: statementChildren(block, 'DO0')};
+        const otherwise = block.getInputTargetBlock('ELSE');
+        if (otherwise)
+          result.else = compileSequence(otherwise);
+        return result;
+      }
+      default:
+        throw new Error('unsupported experimental statement block: ' + block.type);
+    }
+  }
+
+  function compileSequence(first) {
+    const result = [];
+    let block = first;
+    let guard = 0;
+    while (block) {
+      if (++guard > 200)
+        throw new Error('experimental program too large');
+      result.push(compileStatement(block));
+      block = typeof block.getNextBlock === 'function' ? block.getNextBlock() : null;
+    }
+    return result;
+  }
+
+  function compileWorkspace(workspace) {
+    const tops = workspace.getTopBlocks(true);
+    if (tops.length !== 1)
+      throw new Error('experimental Crazyflie program must have exactly one top-level sequence');
+    const program = compileSequence(tops[0]);
+    if (program.length < 2 || program[0].kind !== 'takeoff' || program[program.length - 1].kind !== 'land')
+      throw new Error('experimental program must start with takeoff and end with land');
+    return {version: 1, semantics: 'webeeblocks-experimental-ast', program: program};
+  }
+
+  return {
+    LIMITS: LIMITS,
+    SENSOR_DIRECTIONS: SENSOR_DIRECTIONS,
+    compileExpression: compileExpression,
+    compileStatement: compileStatement,
+    compileSequence: compileSequence,
+    compileWorkspace: compileWorkspace
+  };
+});

--- a/experiments/extended-blocks/extended_blocks.js
+++ b/experiments/extended-blocks/extended_blocks.js
@@ -42,8 +42,7 @@
   function statementChildren(block, inputName) {
     if (!block || typeof block.getInputTargetBlock !== 'function')
       throw new Error('block does not expose statement input ' + inputName);
-    const first = block.getInputTargetBlock(inputName);
-    return compileSequence(first);
+    return compileSequence(block.getInputTargetBlock(inputName));
   }
 
   function valueChild(block, inputName) {
@@ -82,6 +81,18 @@
     }
   }
 
+  function repeatCount(block) {
+    /* Real Blockly 2020 controls_repeat_ext stores TIMES as a value input.
+       Keep the legacy field fallback only for lightweight unit-test doubles. */
+    if (typeof block.getInputTargetBlock === 'function' && block.getInputTargetBlock('TIMES')) {
+      const expression = valueChild(block, 'TIMES');
+      if (expression.kind !== 'number' || Math.floor(expression.value) !== expression.value)
+        throw new Error('repeat count must be an integer literal');
+      return bounded(expression.value, 'repeat', LIMITS.repeat);
+    }
+    return bounded(field(block, 'TIMES'), 'repeat', LIMITS.repeat);
+  }
+
   function compileStatement(block) {
     switch (block.type) {
       case 'webeeblocks_exp_takeoff':
@@ -112,7 +123,7 @@
       case 'webeeblocks_exp_speed':
         return {kind: 'set_speed', speed_m_s: bounded(field(block, 'SPEED'), 'speed_m_s', LIMITS.speed_m_s)};
       case 'controls_repeat_ext':
-        return {kind: 'repeat', count: bounded(field(block, 'TIMES'), 'repeat', LIMITS.repeat), body: statementChildren(block, 'DO')};
+        return {kind: 'repeat', count: repeatCount(block), body: statementChildren(block, 'DO')};
       case 'controls_if': {
         const result = {kind: 'if', condition: valueChild(block, 'IF0'), then: statementChildren(block, 'DO0')};
         const otherwise = block.getInputTargetBlock('ELSE');

--- a/experiments/extended-blocks/run_ui_harness.py
+++ b/experiments/extended-blocks/run_ui_harness.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Execute the disposable extended-block harness in the real bundled Blockly 2020."""
+
+from __future__ import annotations
+
+import http.server
+import os
+import pathlib
+import shutil
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+HARNESS = pathlib.Path("experiments/extended-blocks/ui_harness.html")
+
+
+def browser_binary() -> str:
+    for candidate in (
+        os.environ.get("CHROME_BIN"),
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+    ):
+        if candidate and shutil.which(candidate):
+            return shutil.which(candidate) or candidate
+    raise RuntimeError("no Chrome/Chromium binary found; set CHROME_BIN")
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass
+
+
+def main() -> int:
+    browser = browser_binary()
+    os.chdir(REPO_ROOT)
+    with socketserver.TCPServer(("127.0.0.1", 0), QuietHandler) as server:
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        time.sleep(0.05)
+        url = f"http://127.0.0.1:{port}/{HARNESS.as_posix()}"
+        completed = subprocess.run(
+            [browser, "--headless", "--disable-gpu", "--no-sandbox", "--disable-dev-shm-usage",
+             "--virtual-time-budget=4000", "--dump-dom", url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        server.shutdown()
+
+    marker = "PASS real Blockly 2020 extended semantic AST"
+    if marker not in completed.stdout:
+        print("FAIL real Blockly 2020 extended semantic AST", file=sys.stderr)
+        print("browser exit:", completed.returncode, file=sys.stderr)
+        if completed.stderr:
+            print(completed.stderr[-4000:], file=sys.stderr)
+        if completed.stdout:
+            print(completed.stdout[-8000:], file=sys.stderr)
+        return 1
+    print(marker)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/extended-blocks/test_extended_blocks.js
+++ b/experiments/extended-blocks/test_extended_blocks.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const Extended = require('./extended_blocks.js');
+
+function block(type, fields, inputs) {
+  return {
+    type,
+    _fields: fields || {},
+    _inputs: inputs || {},
+    _next: null,
+    getFieldValue(name) { return this._fields[name]; },
+    getInputTargetBlock(name) { return this._inputs[name] || null; },
+    getNextBlock() { return this._next; },
+    next(other) { this._next = other; return other; }
+  };
+}
+
+function workspace(top) {
+  return { getTopBlocks() { return [top]; } };
+}
+
+function number(n) { return block('math_number', {NUM: n}); }
+function range(direction) { return block('webeeblocks_exp_range', {DIRECTION: direction}); }
+function compare(op, a, b) { return block('logic_compare', {OP: op}, {A: a, B: b}); }
+
+(function simpleMotionProgram() {
+  const takeoff = block('webeeblocks_exp_takeoff', {HEIGHT: 0.5});
+  const speed = takeoff.next(block('webeeblocks_exp_speed', {SPEED: 0.3}));
+  const forward = speed.next(block('webeeblocks_exp_move', {DIRECTION: 'forward', DISTANCE: 0.5}));
+  const left = forward.next(block('webeeblocks_exp_move', {DIRECTION: 'left', DISTANCE: 0.3}));
+  const up = left.next(block('webeeblocks_exp_vertical', {DIRECTION: 'up', DISTANCE: 0.2}));
+  const turn = up.next(block('webeeblocks_exp_turn', {DIRECTION: 'right', ANGLE: 90}));
+  const wait = turn.next(block('webeeblocks_exp_wait', {SECONDS: 0.5}));
+  wait.next(block('webeeblocks_exp_land'));
+
+  const ast = Extended.compileWorkspace(workspace(takeoff));
+  assert.deepStrictEqual(ast.program.map(x => x.kind), ['takeoff','set_speed','move','move','vertical','turn','wait','land']);
+  assert.strictEqual(ast.program[0].height_m, 0.5);
+  assert.strictEqual(ast.program[2].direction, 'forward');
+  assert.strictEqual(ast.program[3].direction, 'left');
+  assert.strictEqual(ast.program[5].angle_deg, -90);
+})();
+
+(function reactiveAvoidanceStructure() {
+  const takeoff = block('webeeblocks_exp_takeoff', {HEIGHT: 0.5});
+  const repeat = takeoff.next(block('controls_repeat_ext', {TIMES: 3}));
+  const condition = compare('LT', range('front'), number(0.5));
+  const ifBlock = block('controls_if', {}, {IF0: condition});
+  const sidestep = block('webeeblocks_exp_move', {DIRECTION: 'left', DISTANCE: 0.3});
+  const forward = block('webeeblocks_exp_move', {DIRECTION: 'forward', DISTANCE: 0.3});
+  ifBlock._inputs.DO0 = sidestep;
+  ifBlock._inputs.ELSE = forward;
+  repeat._inputs.DO = ifBlock;
+  repeat.next(block('webeeblocks_exp_land'));
+
+  const ast = Extended.compileWorkspace(workspace(takeoff));
+  assert.strictEqual(ast.program[1].kind, 'repeat');
+  assert.strictEqual(ast.program[1].count, 3);
+  const decision = ast.program[1].body[0];
+  assert.strictEqual(decision.kind, 'if');
+  assert.deepStrictEqual(decision.condition, {
+    kind: 'compare', op: 'LT',
+    left: {kind: 'range', direction: 'front', unit: 'm'},
+    right: {kind: 'number', value: 0.5}
+  });
+  assert.strictEqual(decision.then[0].direction, 'left');
+  assert.strictEqual(decision.else[0].direction, 'forward');
+})();
+
+(function failClosed() {
+  assert.throws(() => Extended.compileExpression(range('down')), /unsupported range direction/);
+  assert.throws(() => Extended.compileStatement(block('webeeblocks_exp_move', {DIRECTION: 'forward', DISTANCE: 2.1})), /out of experimental range/);
+  assert.throws(() => Extended.compileStatement(block('webeeblocks_exp_speed', {SPEED: 0.9})), /out of experimental range/);
+  assert.throws(() => Extended.compileStatement(block('controls_repeat_ext', {TIMES: 0}, {DO: block('webeeblocks_exp_land')})), /out of experimental range/);
+  assert.throws(() => Extended.compileWorkspace({getTopBlocks() { return []; }}), /exactly one top-level sequence/);
+  assert.throws(() => Extended.compileWorkspace(workspace(block('webeeblocks_exp_move', {DIRECTION: 'forward', DISTANCE: 0.5}))), /start with takeoff/);
+})();
+
+console.log('PASS extended block semantic AST');

--- a/experiments/extended-blocks/ui_harness.html
+++ b/experiments/extended-blocks/ui_harness.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>WebeeBlocks extended blocks harness</title>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blockly_uncompressed.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/msg/js/en.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/logic.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/loops.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/math.js"></script>
+  <script src="experimental_blocks.js"></script>
+  <script src="extended_blocks.js"></script>
+</head>
+<body>
+  <xml id="toolbox" style="display:none">
+    <category name="Vol">
+      <block type="webeeblocks_exp_takeoff"></block>
+      <block type="webeeblocks_exp_move"></block>
+      <block type="webeeblocks_exp_vertical"></block>
+      <block type="webeeblocks_exp_turn"></block>
+      <block type="webeeblocks_exp_wait"></block>
+      <block type="webeeblocks_exp_speed"></block>
+      <block type="webeeblocks_exp_land"></block>
+    </category>
+    <category name="Capteurs"><block type="webeeblocks_exp_range"></block></category>
+    <category name="Contrôle">
+      <block type="controls_if"></block>
+      <block type="controls_repeat_ext"><value name="TIMES"><shadow type="math_number"><field name="NUM">3</field></shadow></value></block>
+      <block type="logic_compare"></block>
+      <block type="logic_operation"></block>
+      <block type="math_number"></block>
+    </category>
+  </xml>
+  <div id="blocklyDiv" style="height:320px;width:100%"></div>
+  <pre id="result">RUNNING</pre>
+
+  <xml id="reactiveProgram" style="display:none">
+    <block type="webeeblocks_exp_takeoff" x="20" y="20">
+      <field name="HEIGHT">0.5</field>
+      <next>
+        <block type="controls_repeat_ext">
+          <value name="TIMES"><block type="math_number"><field name="NUM">3</field></block></value>
+          <statement name="DO">
+            <block type="controls_if">
+              <mutation else="1"></mutation>
+              <value name="IF0">
+                <block type="logic_compare">
+                  <field name="OP">LT</field>
+                  <value name="A"><block type="webeeblocks_exp_range"><field name="DIRECTION">front</field></block></value>
+                  <value name="B"><block type="math_number"><field name="NUM">0.5</field></block></value>
+                </block>
+              </value>
+              <statement name="DO0">
+                <block type="webeeblocks_exp_move"><field name="DIRECTION">left</field><field name="DISTANCE">0.3</field></block>
+              </statement>
+              <statement name="ELSE">
+                <block type="webeeblocks_exp_move"><field name="DIRECTION">forward</field><field name="DISTANCE">0.3</field></block>
+              </statement>
+            </block>
+          </statement>
+          <next><block type="webeeblocks_exp_land"></block></next>
+        </block>
+      </next>
+    </block>
+  </xml>
+
+<script>
+(function() {
+  'use strict';
+  var result = document.getElementById('result');
+
+  function fail(message) {
+    result.textContent = 'FAIL: ' + message;
+    result.setAttribute('data-status', 'FAIL');
+    throw new Error(message);
+  }
+  function assert(condition, message) { if (!condition) fail(message); }
+
+  try {
+    var required = [
+      'webeeblocks_exp_takeoff','webeeblocks_exp_land','webeeblocks_exp_move',
+      'webeeblocks_exp_vertical','webeeblocks_exp_turn','webeeblocks_exp_wait',
+      'webeeblocks_exp_speed','webeeblocks_exp_range','controls_repeat_ext',
+      'controls_if','logic_compare','logic_operation','math_number'
+    ];
+    required.forEach(function(type) { assert(Blockly.Blocks[type], 'missing real Blockly block ' + type); });
+
+    var workspace = Blockly.inject('blocklyDiv', {toolbox: document.getElementById('toolbox')});
+    Blockly.Xml.domToWorkspace(document.getElementById('reactiveProgram'), workspace);
+
+    var repeat = workspace.getAllBlocks(false).filter(function(block) { return block.type === 'controls_repeat_ext'; })[0];
+    assert(repeat && repeat.getInputTargetBlock('TIMES'), 'real controls_repeat_ext TIMES value input missing');
+    assert(repeat.getField('TIMES') === null, 'real controls_repeat_ext unexpectedly exposes TIMES as field');
+
+    var ast = WebeeBlocksExtended.compileWorkspace(workspace);
+    var expected = {
+      version: 1,
+      semantics: 'webeeblocks-experimental-ast',
+      program: [
+        {kind:'takeoff', height_m:0.5},
+        {kind:'repeat', count:3, body:[
+          {kind:'if', condition:{kind:'compare', op:'LT', left:{kind:'range', direction:'front', unit:'m'}, right:{kind:'number', value:0.5}}, then:[{kind:'move', direction:'left', distance_m:0.3}], else:[{kind:'move', direction:'forward', distance_m:0.3}]}
+        ]},
+        {kind:'land'}
+      ]
+    };
+    assert(JSON.stringify(ast) === JSON.stringify(expected), 'real Blockly AST differs: ' + JSON.stringify(ast));
+
+    var xmlText = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
+    var roundTrip = new Blockly.Workspace();
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xmlText), roundTrip);
+    assert(JSON.stringify(WebeeBlocksExtended.compileWorkspace(roundTrip)) === JSON.stringify(expected),
+      'Blockly XML round-trip changed semantic AST');
+    roundTrip.dispose();
+
+    result.textContent = 'PASS real Blockly 2020 extended semantic AST';
+    result.setAttribute('data-status', 'PASS');
+  } catch (error) {
+    if (result.getAttribute('data-status') !== 'FAIL')
+      fail(error.message || String(error));
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Experimental scope

This draft PR is isolated from the frozen release candidate. It does not modify `webots-ci` product files, worlds, runtime, PID, STOP semantics, Blockly product UI or `main`.

## Question

Can WebeeBlocks express richer Crazyflie student programs — movement, speed, waiting, Multi-ranger sensing, comparisons, conditions and repetition — as a backend-neutral semantic structure without exposing or generating Python?

## Prototype

Adds an experimental semantic compiler covering:

- takeoff to relative height, land;
- forward/back/left/right;
- up/down;
- left/right turn;
- wait and translational speed;
- Multi-ranger value expressions for front/back/left/right/up;
- standard Blockly comparisons and AND/OR;
- standard Blockly `if/else` and `repeat N times`.

There is deliberately no `avoid obstacle` primitive: the AST preserves measure → compare → decide → act.

## Proof 1 — semantic tests

`node experiments/extended-blocks/test_extended_blocks.js`

Covers a richer sequential mission, a reactive structure and fail-closed behavior for unsupported sensor directions, out-of-range distances/speeds/repeat counts, invalid workspace shape and missing takeoff/land boundaries.

## Proof 2 — real bundled Blockly 2020

This head now adds a disposable browser harness which loads the **actual Blockly 2020 build bundled in this repository**, the real standard `logic`, `loops` and `math` blocks, plus experimental Crazyflie block definitions that are never imported by the frozen product UI.

The visual fixture is:

`takeoff → repeat 3 times { if front range < 0.5 m then left 0.3 m else forward 0.3 m } → land`

The harness requires the exact backend-neutral AST, then serializes the workspace to Blockly XML, reloads it into a fresh workspace and requires the same AST after round-trip.

This integration already exposed one real mismatch in the original prototype: Blockly 2020 `controls_repeat_ext` stores `TIMES` as a **value input**, not as a field. The compiler has been corrected to use the real structure while retaining a field fallback only for lightweight test doubles.

Dedicated Actions now runs both semantic tests and the real-browser harness. **The final head CI is pending; do not treat the browser proof as green until that run completes.**

## Explicit limits / non-claims

- No final wording or visual design of student blocks is proposed.
- Conditions and Multi-ranger sensing are not claimed executable by runtime v1.
- The experimental block definitions are not loaded by the frozen product UI.
- Numeric limits are experimental guardrails only.
- No real Crazyflie behavior is claimed.
- No merge into `webots-ci` should occur before human-trial feedback and Lead arbitration.

## Engineering conclusion

If the real-browser gate is green, this branch has answered its current question strongly enough and should stop expanding. The next high-value experiment should either execute one small reactive AST against a disposable backend/mock, or advance the independent `experiment/real-crazyflie` transport axis.