### PR TITLE
Experiment: compose real Blockly compiler with reactive interpreter

### DIFF
--- a/.github/workflows/experimental-reactive-blockly-pipeline.yml
+++ b/.github/workflows/experimental-reactive-blockly-pipeline.yml
@@ -1,0 +1,35 @@
+name: Experimental reactive Blockly pipeline
+
+on:
+  pull_request:
+    paths:
+      - 'experiments/reactive-blockly-pipeline/**'
+      - 'experiments/reactive-ast-interpreter/**'
+      - 'plugins/robot_windows/blockly/google-blockly-31ee4ea/**'
+      - '.github/workflows/experimental-reactive-blockly-pipeline.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reactive-blockly-pipeline:
+    if: github.head_ref == 'experiment/reactive-blockly-pipeline' || github.ref_name == 'experiment/reactive-blockly-pipeline'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Locate browser
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              echo "CHROME_BIN=$(command -v "$candidate")" >> "$GITHUB_ENV"
+              "$candidate" --version
+              exit 0
+            fi
+          done
+          exit 1
+      - name: Execute real Blockly compiler-to-interpreter pipeline
+        run: python3 experiments/reactive-blockly-pipeline/run_pipeline_harness.py

--- a/experiments/reactive-blockly-pipeline/README.md
+++ b/experiments/reactive-blockly-pipeline/README.md
@@ -1,0 +1,38 @@
+# Reactive Blockly pipeline — stacked experiment
+
+This experiment is isolated from the frozen `webots-ci` release candidate. It is stacked on draft PR #45 and copies the exact experimental compiler/block definitions from draft PR #44 so neither prior draft needs to move.
+
+## Question
+
+Can the already-demonstrated layers compose without a hand-written AST?
+
+`real bundled Blockly 2020 → #44 compiler → AST → #45 interpreter → scripted backend`
+
+## Proof
+
+The browser harness constructs the same reactive visual program used by #44:
+
+`takeoff → repeat 3 { if range(front) < 0.5 then left 0.3 else forward 0.3 } → land`
+
+with scripted ranges `0.40, 0.80, 0.30 m`.
+
+It requires the exact execution trace:
+
+`takeoff → range 0.40 → left → range 0.80 → forward → range 0.30 → left → land`.
+
+It then serializes the real Blockly workspace to XML, reloads it, recompiles it and requires both the identical AST and identical execution trace.
+
+A negative workspace containing a standard historical `text_print` block must fail in the compiler before any backend action occurs.
+
+## Limits
+
+- No Webots execution.
+- No cflib/Crazyradio/physical Crazyflie behavior.
+- No real Multi-ranger telemetry.
+- No variables, procedures, lights or additional primitives.
+- Interpreter/backend calls remain synchronous in this proof.
+- No merge into `webots-ci` before human-trial feedback and explicit Lead arbitration.
+
+## Stop criterion
+
+Freeze this branch as soon as the dedicated CI proves the composed pipeline and Verification finds no semantic false positive.

--- a/experiments/reactive-blockly-pipeline/experimental_blocks.js
+++ b/experiments/reactive-blockly-pipeline/experimental_blocks.js
@@ -1,0 +1,14 @@
+/* Exact disposable block definitions from draft PR #44 head c43130c. */
+(function() {
+  'use strict';
+  Blockly.defineBlocksWithJsonArray([
+    {type:'webeeblocks_exp_takeoff',message0:'décoller à %1 m',args0:[{type:'field_number',name:'HEIGHT',value:0.5,min:0.2,max:1.5,precision:0.1}],previousStatement:null,nextStatement:null,colour:20},
+    {type:'webeeblocks_exp_land',message0:'atterrir',previousStatement:null,nextStatement:null,colour:20},
+    {type:'webeeblocks_exp_move',message0:'%1 de %2 m',args0:[{type:'field_dropdown',name:'DIRECTION',options:[['avancer','forward'],['reculer','back'],['aller à gauche','left'],['aller à droite','right']]},{type:'field_number',name:'DISTANCE',value:0.3,min:0.1,max:2.0,precision:0.1}],previousStatement:null,nextStatement:null,colour:20},
+    {type:'webeeblocks_exp_vertical',message0:'%1 de %2 m',args0:[{type:'field_dropdown',name:'DIRECTION',options:[['monter','up'],['descendre','down']]},{type:'field_number',name:'DISTANCE',value:0.2,min:0.1,max:0.8,precision:0.1}],previousStatement:null,nextStatement:null,colour:20},
+    {type:'webeeblocks_exp_turn',message0:'tourner à %1 de %2 °',args0:[{type:'field_dropdown',name:'DIRECTION',options:[['gauche','left'],['droite','right']]},{type:'field_number',name:'ANGLE',value:90,min:1,max:179,precision:1}],previousStatement:null,nextStatement:null,colour:20},
+    {type:'webeeblocks_exp_wait',message0:'attendre %1 s',args0:[{type:'field_number',name:'SECONDS',value:0.5,min:0.1,max:5.0,precision:0.1}],previousStatement:null,nextStatement:null,colour:80},
+    {type:'webeeblocks_exp_speed',message0:'régler la vitesse à %1 m/s',args0:[{type:'field_number',name:'SPEED',value:0.2,min:0.1,max:0.6,precision:0.1}],previousStatement:null,nextStatement:null,colour:80},
+    {type:'webeeblocks_exp_range',message0:'distance %1',args0:[{type:'field_dropdown',name:'DIRECTION',options:[['devant','front'],['derrière','back'],['à gauche','left'],['à droite','right'],['au-dessus','up']]}],output:'Number',colour:60}
+  ]);
+})();

--- a/experiments/reactive-blockly-pipeline/extended_blocks.js
+++ b/experiments/reactive-blockly-pipeline/extended_blocks.js
@@ -1,0 +1,170 @@
+/* Experimental composition copy from draft PR #44 head c43130c.
+ * Kept local to this disposable stacked experiment so #44/#45 remain frozen.
+ */
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksExtended = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  const LIMITS = Object.freeze({
+    height_m: {min: 0.2, max: 1.5},
+    distance_m: {min: 0.1, max: 2.0},
+    vertical_m: {min: 0.1, max: 0.8},
+    wait_s: {min: 0.1, max: 5.0},
+    speed_m_s: {min: 0.1, max: 0.6},
+    range_m: {min: 0.05, max: 4.0},
+    repeat: {min: 1, max: 20}
+  });
+
+  const SENSOR_DIRECTIONS = Object.freeze(['front', 'back', 'left', 'right', 'up']);
+
+  function finite(value, name) {
+    const n = Number(value);
+    if (!Number.isFinite(n))
+      throw new Error(name + ' must be finite');
+    return n;
+  }
+
+  function bounded(value, name, limits) {
+    const n = finite(value, name);
+    if (n < limits.min || n > limits.max)
+      throw new Error(name + ' out of experimental range: ' + n);
+    return n;
+  }
+
+  function field(block, name) {
+    if (!block || typeof block.getFieldValue !== 'function')
+      throw new Error('invalid Blockly block');
+    return block.getFieldValue(name);
+  }
+
+  function statementChildren(block, inputName) {
+    if (!block || typeof block.getInputTargetBlock !== 'function')
+      throw new Error('block does not expose statement input ' + inputName);
+    return compileSequence(block.getInputTargetBlock(inputName));
+  }
+
+  function valueChild(block, inputName) {
+    if (!block || typeof block.getInputTargetBlock !== 'function')
+      throw new Error('block does not expose value input ' + inputName);
+    const child = block.getInputTargetBlock(inputName);
+    if (!child)
+      throw new Error('missing value input ' + inputName);
+    return compileExpression(child);
+  }
+
+  function compileExpression(block) {
+    switch (block.type) {
+      case 'webeeblocks_exp_range': {
+        const direction = String(field(block, 'DIRECTION'));
+        if (SENSOR_DIRECTIONS.indexOf(direction) < 0)
+          throw new Error('unsupported range direction: ' + direction);
+        return {kind: 'range', direction: direction, unit: 'm'};
+      }
+      case 'math_number':
+        return {kind: 'number', value: finite(field(block, 'NUM'), 'number')};
+      case 'logic_compare': {
+        const op = String(field(block, 'OP'));
+        if (['LT', 'LTE', 'GT', 'GTE', 'EQ', 'NEQ'].indexOf(op) < 0)
+          throw new Error('unsupported comparison: ' + op);
+        return {kind: 'compare', op: op, left: valueChild(block, 'A'), right: valueChild(block, 'B')};
+      }
+      case 'logic_operation': {
+        const op = String(field(block, 'OP'));
+        if (op !== 'AND' && op !== 'OR')
+          throw new Error('unsupported logic operation: ' + op);
+        return {kind: 'logic', op: op, left: valueChild(block, 'A'), right: valueChild(block, 'B')};
+      }
+      default:
+        throw new Error('unsupported experimental expression block: ' + block.type);
+    }
+  }
+
+  function repeatCount(block) {
+    if (typeof block.getInputTargetBlock === 'function' && block.getInputTargetBlock('TIMES')) {
+      const expression = valueChild(block, 'TIMES');
+      if (expression.kind !== 'number' || Math.floor(expression.value) !== expression.value)
+        throw new Error('repeat count must be an integer literal');
+      return bounded(expression.value, 'repeat', LIMITS.repeat);
+    }
+    return bounded(field(block, 'TIMES'), 'repeat', LIMITS.repeat);
+  }
+
+  function compileStatement(block) {
+    switch (block.type) {
+      case 'webeeblocks_exp_takeoff':
+        return {kind: 'takeoff', height_m: bounded(field(block, 'HEIGHT'), 'height_m', LIMITS.height_m)};
+      case 'webeeblocks_exp_land':
+        return {kind: 'land'};
+      case 'webeeblocks_exp_move': {
+        const direction = String(field(block, 'DIRECTION'));
+        if (['forward', 'back', 'left', 'right'].indexOf(direction) < 0)
+          throw new Error('unsupported move direction: ' + direction);
+        return {kind: 'move', direction: direction, distance_m: bounded(field(block, 'DISTANCE'), 'distance_m', LIMITS.distance_m)};
+      }
+      case 'webeeblocks_exp_vertical': {
+        const direction = String(field(block, 'DIRECTION'));
+        if (direction !== 'up' && direction !== 'down')
+          throw new Error('unsupported vertical direction: ' + direction);
+        return {kind: 'vertical', direction: direction, distance_m: bounded(field(block, 'DISTANCE'), 'vertical_m', LIMITS.vertical_m)};
+      }
+      case 'webeeblocks_exp_turn': {
+        const direction = String(field(block, 'DIRECTION'));
+        const degrees = bounded(field(block, 'ANGLE'), 'angle_deg', {min: 1, max: 179});
+        if (direction !== 'left' && direction !== 'right')
+          throw new Error('unsupported turn direction: ' + direction);
+        return {kind: 'turn', angle_deg: direction === 'left' ? degrees : -degrees};
+      }
+      case 'webeeblocks_exp_wait':
+        return {kind: 'wait', seconds: bounded(field(block, 'SECONDS'), 'wait_s', LIMITS.wait_s)};
+      case 'webeeblocks_exp_speed':
+        return {kind: 'set_speed', speed_m_s: bounded(field(block, 'SPEED'), 'speed_m_s', LIMITS.speed_m_s)};
+      case 'controls_repeat_ext':
+        return {kind: 'repeat', count: repeatCount(block), body: statementChildren(block, 'DO')};
+      case 'controls_if': {
+        const result = {kind: 'if', condition: valueChild(block, 'IF0'), then: statementChildren(block, 'DO0')};
+        const otherwise = block.getInputTargetBlock('ELSE');
+        if (otherwise)
+          result.else = compileSequence(otherwise);
+        return result;
+      }
+      default:
+        throw new Error('unsupported experimental statement block: ' + block.type);
+    }
+  }
+
+  function compileSequence(first) {
+    const result = [];
+    let block = first;
+    let guard = 0;
+    while (block) {
+      if (++guard > 200)
+        throw new Error('experimental program too large');
+      result.push(compileStatement(block));
+      block = typeof block.getNextBlock === 'function' ? block.getNextBlock() : null;
+    }
+    return result;
+  }
+
+  function compileWorkspace(workspace) {
+    const tops = workspace.getTopBlocks(true);
+    if (tops.length !== 1)
+      throw new Error('experimental Crazyflie program must have exactly one top-level sequence');
+    const program = compileSequence(tops[0]);
+    if (program.length < 2 || program[0].kind !== 'takeoff' || program[program.length - 1].kind !== 'land')
+      throw new Error('experimental program must start with takeoff and end with land');
+    return {version: 1, semantics: 'webeeblocks-experimental-ast', program: program};
+  }
+
+  return {
+    LIMITS: LIMITS,
+    SENSOR_DIRECTIONS: SENSOR_DIRECTIONS,
+    compileExpression: compileExpression,
+    compileStatement: compileStatement,
+    compileSequence: compileSequence,
+    compileWorkspace: compileWorkspace
+  };
+});

--- a/experiments/reactive-blockly-pipeline/run_pipeline_harness.py
+++ b/experiments/reactive-blockly-pipeline/run_pipeline_harness.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import http.server, os, pathlib, shutil, socketserver, subprocess, sys, threading, time
+HERE=pathlib.Path(__file__).resolve().parent
+ROOT=HERE.parents[1]
+HARNESS=pathlib.Path('experiments/reactive-blockly-pipeline/ui_pipeline_harness.html')
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args): pass
+
+def browser():
+    for c in (os.environ.get('CHROME_BIN'),'google-chrome','google-chrome-stable','chromium','chromium-browser'):
+        if c and shutil.which(c): return shutil.which(c)
+    raise RuntimeError('no Chrome/Chromium binary found')
+
+def main():
+    os.chdir(ROOT)
+    with socketserver.TCPServer(('127.0.0.1',0),Quiet) as server:
+        port=server.server_address[1]
+        threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(0.05)
+        cp=subprocess.run([browser(),'--headless','--disable-gpu','--no-sandbox','--disable-dev-shm-usage','--virtual-time-budget=5000','--dump-dom',f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'],stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True,timeout=30,check=False)
+        server.shutdown()
+    marker='PASS real Blockly 2020 -> compiler #44 -> interpreter #45 -> scripted backend'
+    if marker not in cp.stdout:
+        print('FAIL composed reactive pipeline',file=sys.stderr); print(cp.stderr[-4000:],file=sys.stderr); print(cp.stdout[-8000:],file=sys.stderr); return 1
+    print(marker); return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/experiments/reactive-blockly-pipeline/ui_pipeline_harness.html
+++ b/experiments/reactive-blockly-pipeline/ui_pipeline_harness.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>WebeeBlocks reactive Blockly pipeline</title>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blockly_uncompressed.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/msg/js/en.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/logic.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/loops.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/math.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/text.js"></script>
+  <script src="experimental_blocks.js"></script>
+  <script src="extended_blocks.js"></script>
+  <script src="../reactive-ast-interpreter/interpreter.js"></script>
+</head>
+<body>
+<div id="blocklyDiv" style="height:320px;width:100%"></div>
+<pre id="result">RUNNING</pre>
+<xml id="reactiveProgram" style="display:none">
+  <block type="webeeblocks_exp_takeoff">
+    <field name="HEIGHT">0.5</field>
+    <next><block type="controls_repeat_ext">
+      <value name="TIMES"><block type="math_number"><field name="NUM">3</field></block></value>
+      <statement name="DO"><block type="controls_if">
+        <mutation else="1"></mutation>
+        <value name="IF0"><block type="logic_compare"><field name="OP">LT</field>
+          <value name="A"><block type="webeeblocks_exp_range"><field name="DIRECTION">front</field></block></value>
+          <value name="B"><block type="math_number"><field name="NUM">0.5</field></block></value>
+        </block></value>
+        <statement name="DO0"><block type="webeeblocks_exp_move"><field name="DIRECTION">left</field><field name="DISTANCE">0.3</field></block></statement>
+        <statement name="ELSE"><block type="webeeblocks_exp_move"><field name="DIRECTION">forward</field><field name="DISTANCE">0.3</field></block></statement>
+      </block></statement>
+      <next><block type="webeeblocks_exp_land"></block></next>
+    </block></next>
+  </block>
+</xml>
+<xml id="invalidProgram" style="display:none">
+  <block type="webeeblocks_exp_takeoff"><field name="HEIGHT">0.5</field>
+    <next><block type="text_print"><value name="TEXT"><block type="text"><field name="TEXT">python-era block</field></block></value>
+      <next><block type="webeeblocks_exp_land"></block></next>
+    </block></next>
+  </block>
+</xml>
+<script>
+(function() {
+  'use strict';
+  var result = document.getElementById('result');
+  function fail(message) { result.textContent='FAIL: '+message; result.setAttribute('data-status','FAIL'); throw new Error(message); }
+  function assert(condition,message) { if (!condition) fail(message); }
+  function traceFor(workspace) {
+    var ast = WebeeBlocksExtended.compileWorkspace(workspace);
+    var backend = new WebeeBlocksReactiveInterpreter.ScriptedBackend({front:[0.40,0.80,0.30]});
+    WebeeBlocksReactiveInterpreter.run(ast, backend);
+    return {ast:ast, trace:backend.trace};
+  }
+  var expectedTrace = [
+    {op:'takeoff',height_m:0.5},
+    {op:'range',direction:'front',value_m:0.4,read:1},
+    {op:'move',direction:'left',distance_m:0.3},
+    {op:'range',direction:'front',value_m:0.8,read:2},
+    {op:'move',direction:'forward',distance_m:0.3},
+    {op:'range',direction:'front',value_m:0.3,read:3},
+    {op:'move',direction:'left',distance_m:0.3},
+    {op:'land'}
+  ];
+  try {
+    var workspace = Blockly.inject('blocklyDiv', {toolbox:'<xml></xml>'});
+    Blockly.Xml.domToWorkspace(document.getElementById('reactiveProgram'), workspace);
+    var first = traceFor(workspace);
+    assert(JSON.stringify(first.trace)===JSON.stringify(expectedTrace), 'live Blockly pipeline trace differs: '+JSON.stringify(first.trace));
+
+    var xmlText = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
+    var roundTrip = new Blockly.Workspace();
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xmlText), roundTrip);
+    var second = traceFor(roundTrip);
+    assert(JSON.stringify(second.ast)===JSON.stringify(first.ast), 'XML round-trip changed compiler AST');
+    assert(JSON.stringify(second.trace)===JSON.stringify(expectedTrace), 'XML round-trip changed execution trace');
+    roundTrip.dispose();
+
+    var invalid = new Blockly.Workspace();
+    Blockly.Xml.domToWorkspace(document.getElementById('invalidProgram'), invalid);
+    var negativeBackend = new WebeeBlocksReactiveInterpreter.ScriptedBackend({front:[0.4]});
+    var rejected = false;
+    try {
+      var invalidAst = WebeeBlocksExtended.compileWorkspace(invalid);
+      WebeeBlocksReactiveInterpreter.run(invalidAst, negativeBackend);
+    } catch (error) {
+      rejected = /unsupported experimental statement block/.test(String(error));
+    }
+    assert(rejected, 'unsupported real Blockly block was not rejected by compiler');
+    assert(negativeBackend.trace.length===0, 'backend acted before compile-time fail-closed rejection');
+    invalid.dispose();
+
+    result.textContent='PASS real Blockly 2020 -> compiler #44 -> interpreter #45 -> scripted backend';
+    result.setAttribute('data-status','PASS');
+  } catch (error) {
+    if (result.getAttribute('data-status')!=='FAIL') fail(error.message||String(error));
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Experimental scope

Stacked draft on top of #45. The frozen `webots-ci` release candidate and `main` remain untouched.

## Question

Can the two already-demonstrated layers compose without reconstructing an AST by hand?

`real Blockly 2020 → exact #44 compiler → AST → exact #45 interpreter → scripted backend`

## Proof

The real bundled Blockly 2020 constructs the same reactive fixture as #44:

`takeoff → repeat 3 { if range(front)<0.5 then left 0.3 else forward 0.3 } → land`

with scripted front ranges `0.40, 0.80, 0.30 m`.

The dedicated browser gate requires the exact trace:

`takeoff → range(0.40) → left → range(0.80) → forward → range(0.30) → left → land`.

It then round-trips the workspace through Blockly XML and requires both an identical compiler AST and identical execution trace.

A negative real-Blockly workspace containing unsupported `text_print` must be rejected by the compiler before any backend action.

## Dependency handling

This branch is intentionally stacked from #45. It copies only the exact experimental compiler/block definitions from #44 head `c43130c` into this disposable pipeline directory so #44 and #45 can remain frozen at their stop criteria. No product code is imported or changed.

## Explicit limits

- No Webots runtime execution.
- No cflib/Crazyradio/physical Crazyflie behavior.
- No real Multi-ranger telemetry.
- No variables, procedures, lights or new primitives.
- No merge toward `webots-ci` before human-trial feedback and explicit Lead arbitration.

## Stop criterion

If the dedicated CI is green and Verification finds no semantic false positive, freeze this branch. The next axis should be selected separately.