### PR TITLE
Experiment: drive reactive AST from real Webots range sensor

### DIFF
--- a/.github/workflows/experimental-reactive-webots-adapter.yml
+++ b/.github/workflows/experimental-reactive-webots-adapter.yml
@@ -1,0 +1,106 @@
+name: Experimental reactive Webots adapter
+
+on:
+  pull_request:
+    paths:
+      - 'experiments/reactive-webots-adapter/**'
+      - 'experiments/reactive-blockly-pipeline/**'
+      - 'experiments/reactive-ast-interpreter/**'
+      - 'controllers/experimental_reactive_webots_adapter/**'
+      - 'worlds/experimental_reactive_webots_adapter.wbt'
+      - 'plugins/robot_windows/blockly/google-blockly-31ee4ea/**'
+      - '.github/workflows/experimental-reactive-webots-adapter.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reactive-webots-adapter:
+    if: github.head_ref == 'experiment/reactive-webots-adapter' || github.ref_name == 'experiment/reactive-webots-adapter'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Locate browser
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              echo "CHROME_BIN=$(command -v "$candidate")" >> "$GITHUB_ENV"
+              "$candidate" --version
+              exit 0
+            fi
+          done
+          exit 1
+
+      - name: Re-prove frozen Blockly to AST to interpreter chain
+        run: python3 experiments/reactive-blockly-pipeline/run_pipeline_harness.py
+
+      - name: Start Webots R2025a reactive adapter world
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ci-artifacts
+          docker pull cyberbotics/webots:R2025a-ubuntu22.04
+          docker run -d --rm \
+            --name webeeblocks-reactive-webots \
+            -p 8765:8765 \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/experimental_reactive_webots_adapter.wbt' \
+            > ci-artifacts/container-id.txt
+
+      - name: Execute real Blockly reactive program against Webots
+        shell: bash
+        run: |
+          set -euo pipefail
+          cleanup() {
+            docker logs webeeblocks-reactive-webots > ci-artifacts/webots.log 2>&1 || true
+            python3 - <<'PY' > ci-artifacts/controller-trace.json || true
+          import json, urllib.request
+          with urllib.request.urlopen('http://127.0.0.1:8765/trace', timeout=2) as r:
+              print(json.dumps(json.load(r), indent=2))
+          PY
+            docker stop webeeblocks-reactive-webots >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          python3 experiments/reactive-webots-adapter/run_webots_harness.py | tee ci-artifacts/browser-harness.log
+
+          python3 - <<'PY'
+          import json, urllib.request
+          with urllib.request.urlopen('http://127.0.0.1:8765/trace', timeout=2) as r:
+              trace=json.load(r)['trace']
+          ops=[x['op'] + (':' + x['direction'] if 'direction' in x else '') for x in trace if x['op'] != 'error']
+          expected=['takeoff','range:front','move:left','range:front','move:forward','range:front','move:left','land']
+          assert ops == expected, (ops, expected)
+          ranges=[x['value_m'] for x in trace if x['op']=='range']
+          assert len(ranges)==3 and ranges[0] < 0.5 and ranges[1] >= 0.5 and ranges[2] < 0.5, ranges
+          print('WEBEEBLOCKS_REACTIVE_WEBOTS_CAUSAL_TRACE', json.dumps({'ops':ops,'ranges_m':ranges}))
+          PY
+
+      - name: Assert Webots controller stayed healthy
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker logs webeeblocks-reactive-webots > ci-artifacts/webots-final.log 2>&1 || true
+          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots-final.log; then
+            cat ci-artifacts/webots-final.log
+            exit 1
+          fi
+          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots-final.log
+
+      - name: Upload experimental evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reactive-webots-adapter-evidence
+          path: ci-artifacts/
+          if-no-files-found: warn

--- a/.github/workflows/experimental-reactive-webots-adapter.yml
+++ b/.github/workflows/experimental-reactive-webots-adapter.yml
@@ -44,9 +44,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ci-artifacts
-          rm -f ci-artifacts/reactive-controller-*.txt
+          rm -f ci-artifacts/reactive-controller-*.txt ci-artifacts/webots.log
           docker pull cyberbotics/webots:R2025a-ubuntu22.04
-          docker run -d \
+
+          # Keep Webots in the container foreground, exactly like the already
+          # proven R2025a gates. Only the host docker client is backgrounded so
+          # the browser harness can run concurrently.
+          set +e
+          docker run --rm \
             --name webeeblocks-reactive-webots \
             -p 8765:8765 \
             -e PYTHONUNBUFFERED=1 \
@@ -55,21 +60,26 @@ jobs:
             -v "$GITHUB_WORKSPACE:/workspace" \
             -w /workspace \
             cyberbotics/webots:R2025a-ubuntu22.04 \
-            bash -lc 'xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/experimental_reactive_webots_adapter.wbt' \
-            > ci-artifacts/container-id.txt
+            bash -lc 'timeout -k 5s 180s xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/experimental_reactive_webots_adapter.wbt' \
+            > ci-artifacts/webots.log 2>&1 &
+          WEBOTS_DOCKER_PID=$!
+          set -e
+          echo "$WEBOTS_DOCKER_PID" > ci-artifacts/docker-client-pid.txt
+          echo "WEBOTS_DOCKER_PID=$WEBOTS_DOCKER_PID" >> "$GITHUB_ENV"
 
-          for i in $(seq 1 40); do
+          for i in $(seq 1 80); do
             if [ -s ci-artifacts/reactive-controller-ready.txt ]; then
               cat ci-artifacts/reactive-controller-ready.txt
               exit 0
             fi
             if [ -s ci-artifacts/reactive-controller-fatal.txt ]; then
               cat ci-artifacts/reactive-controller-fatal.txt
-              docker logs webeeblocks-reactive-webots || true
+              cat ci-artifacts/webots.log || true
               exit 1
             fi
-            if ! docker inspect -f '{{.State.Running}}' webeeblocks-reactive-webots 2>/dev/null | grep -q true; then
-              docker logs webeeblocks-reactive-webots || true
+            if ! kill -0 "$WEBOTS_DOCKER_PID" 2>/dev/null; then
+              echo '::error::Webots docker client exited before controller READY.'
+              cat ci-artifacts/webots.log || true
               exit 1
             fi
             sleep 0.5
@@ -77,7 +87,7 @@ jobs:
           echo '::error::Webots controller did not cross the READY boundary.'
           ls -l ci-artifacts || true
           docker exec webeeblocks-reactive-webots sh -lc 'ps aux; ls -la /workspace/controllers/experimental_reactive_webots_adapter' || true
-          docker logs webeeblocks-reactive-webots || true
+          cat ci-artifacts/webots.log || true
           exit 1
 
       - name: Execute real Blockly reactive program against Webots
@@ -85,12 +95,12 @@ jobs:
         run: |
           set -euo pipefail
           cleanup() {
-            docker logs webeeblocks-reactive-webots > ci-artifacts/webots.log 2>&1 || true
-            docker inspect webeeblocks-reactive-webots > ci-artifacts/container-inspect.json 2>&1 || true
             python3 -c 'import json,urllib.request; r=urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2); print(json.dumps(json.load(r),indent=2))' \
               > ci-artifacts/controller-trace.json 2>/dev/null || true
             docker stop webeeblocks-reactive-webots >/dev/null 2>&1 || true
-            docker rm webeeblocks-reactive-webots >/dev/null 2>&1 || true
+            if [ -n "${WEBOTS_DOCKER_PID:-}" ]; then
+              wait "$WEBOTS_DOCKER_PID" 2>/dev/null || true
+            fi
           }
           trap cleanup EXIT
 
@@ -98,12 +108,11 @@ jobs:
 
           python3 -c 'import json,urllib.request; trace=json.load(urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2))["trace"]; ops=[x["op"] + ((":"+x["direction"]) if "direction" in x else "") for x in trace if x["op"] != "error"]; expected=["takeoff","range:front","move:left","range:front","move:forward","range:front","move:left","land"]; assert ops==expected,(ops,expected); ranges=[x["value_m"] for x in trace if x["op"]=="range"]; assert len(ranges)==3 and ranges[0]<0.5 and ranges[1]>=0.5 and ranges[2]<0.5,ranges; print("WEBEEBLOCKS_REACTIVE_WEBOTS_CAUSAL_TRACE",json.dumps({"ops":ops,"ranges_m":ranges}))'
 
-          docker logs webeeblocks-reactive-webots > ci-artifacts/webots-live.log 2>&1
-          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots-live.log; then
-            cat ci-artifacts/webots-live.log
+          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots.log; then
+            cat ci-artifacts/webots.log
             exit 1
           fi
-          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots-live.log
+          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots.log
 
       - name: Upload experimental evidence
         if: always()

--- a/.github/workflows/experimental-reactive-webots-adapter.yml
+++ b/.github/workflows/experimental-reactive-webots-adapter.yml
@@ -60,42 +60,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cleanup() {
-            docker logs webeeblocks-reactive-webots > ci-artifacts/webots.log 2>&1 || true
-            python3 - <<'PY' > ci-artifacts/controller-trace.json || true
-          import json, urllib.request
-          with urllib.request.urlopen('http://127.0.0.1:8765/trace', timeout=2) as r:
-              print(json.dumps(json.load(r), indent=2))
-          PY
-            docker stop webeeblocks-reactive-webots >/dev/null 2>&1 || true
-          }
+          cleanup() { docker stop webeeblocks-reactive-webots >/dev/null 2>&1 || true; }
           trap cleanup EXIT
 
           python3 experiments/reactive-webots-adapter/run_webots_harness.py | tee ci-artifacts/browser-harness.log
 
-          python3 - <<'PY'
-          import json, urllib.request
-          with urllib.request.urlopen('http://127.0.0.1:8765/trace', timeout=2) as r:
-              trace=json.load(r)['trace']
-          ops=[x['op'] + (':' + x['direction'] if 'direction' in x else '') for x in trace if x['op'] != 'error']
-          expected=['takeoff','range:front','move:left','range:front','move:forward','range:front','move:left','land']
-          assert ops == expected, (ops, expected)
-          ranges=[x['value_m'] for x in trace if x['op']=='range']
-          assert len(ranges)==3 and ranges[0] < 0.5 and ranges[1] >= 0.5 and ranges[2] < 0.5, ranges
-          print('WEBEEBLOCKS_REACTIVE_WEBOTS_CAUSAL_TRACE', json.dumps({'ops':ops,'ranges_m':ranges}))
-          PY
+          python3 -c 'import json,urllib.request; r=urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2); print(json.dumps(json.load(r),indent=2))' \
+            > ci-artifacts/controller-trace.json
 
-      - name: Assert Webots controller stayed healthy
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker logs webeeblocks-reactive-webots > ci-artifacts/webots-final.log 2>&1 || true
-          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots-final.log; then
-            cat ci-artifacts/webots-final.log
+          python3 -c 'import json,urllib.request; trace=json.load(urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2))["trace"]; ops=[x["op"] + ((":"+x["direction"]) if "direction" in x else "") for x in trace if x["op"] != "error"]; expected=["takeoff","range:front","move:left","range:front","move:forward","range:front","move:left","land"]; assert ops==expected,(ops,expected); ranges=[x["value_m"] for x in trace if x["op"]=="range"]; assert len(ranges)==3 and ranges[0]<0.5 and ranges[1]>=0.5 and ranges[2]<0.5,ranges; print("WEBEEBLOCKS_REACTIVE_WEBOTS_CAUSAL_TRACE",json.dumps({"ops":ops,"ranges_m":ranges}))'
+
+          docker logs webeeblocks-reactive-webots > ci-artifacts/webots.log 2>&1
+          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots.log; then
+            cat ci-artifacts/webots.log
             exit 1
           fi
-          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots-final.log
+          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots.log
 
       - name: Upload experimental evidence
         if: always()

--- a/.github/workflows/experimental-reactive-webots-adapter.yml
+++ b/.github/workflows/experimental-reactive-webots-adapter.yml
@@ -44,10 +44,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ci-artifacts
+          rm -f ci-artifacts/reactive-controller-*.txt
           docker pull cyberbotics/webots:R2025a-ubuntu22.04
           docker run -d \
             --name webeeblocks-reactive-webots \
             -p 8765:8765 \
+            -e PYTHONUNBUFFERED=1 \
             -e LIBGL_ALWAYS_SOFTWARE=true \
             -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
             -v "$GITHUB_WORKSPACE:/workspace" \
@@ -55,6 +57,28 @@ jobs:
             cyberbotics/webots:R2025a-ubuntu22.04 \
             bash -lc 'xvfb-run -a webots --stdout --stderr --batch --mode=fast /workspace/worlds/experimental_reactive_webots_adapter.wbt' \
             > ci-artifacts/container-id.txt
+
+          for i in $(seq 1 40); do
+            if [ -s ci-artifacts/reactive-controller-ready.txt ]; then
+              cat ci-artifacts/reactive-controller-ready.txt
+              exit 0
+            fi
+            if [ -s ci-artifacts/reactive-controller-fatal.txt ]; then
+              cat ci-artifacts/reactive-controller-fatal.txt
+              docker logs webeeblocks-reactive-webots || true
+              exit 1
+            fi
+            if ! docker inspect -f '{{.State.Running}}' webeeblocks-reactive-webots 2>/dev/null | grep -q true; then
+              docker logs webeeblocks-reactive-webots || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+          echo '::error::Webots controller did not cross the READY boundary.'
+          ls -l ci-artifacts || true
+          docker exec webeeblocks-reactive-webots sh -lc 'ps aux; ls -la /workspace/controllers/experimental_reactive_webots_adapter' || true
+          docker logs webeeblocks-reactive-webots || true
+          exit 1
 
       - name: Execute real Blockly reactive program against Webots
         shell: bash

--- a/.github/workflows/experimental-reactive-webots-adapter.yml
+++ b/.github/workflows/experimental-reactive-webots-adapter.yml
@@ -45,7 +45,7 @@ jobs:
           set -euo pipefail
           mkdir -p ci-artifacts
           docker pull cyberbotics/webots:R2025a-ubuntu22.04
-          docker run -d --rm \
+          docker run -d \
             --name webeeblocks-reactive-webots \
             -p 8765:8765 \
             -e LIBGL_ALWAYS_SOFTWARE=true \
@@ -60,22 +60,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cleanup() { docker stop webeeblocks-reactive-webots >/dev/null 2>&1 || true; }
+          cleanup() {
+            docker logs webeeblocks-reactive-webots > ci-artifacts/webots.log 2>&1 || true
+            docker inspect webeeblocks-reactive-webots > ci-artifacts/container-inspect.json 2>&1 || true
+            python3 -c 'import json,urllib.request; r=urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2); print(json.dumps(json.load(r),indent=2))' \
+              > ci-artifacts/controller-trace.json 2>/dev/null || true
+            docker stop webeeblocks-reactive-webots >/dev/null 2>&1 || true
+            docker rm webeeblocks-reactive-webots >/dev/null 2>&1 || true
+          }
           trap cleanup EXIT
 
           python3 experiments/reactive-webots-adapter/run_webots_harness.py | tee ci-artifacts/browser-harness.log
 
-          python3 -c 'import json,urllib.request; r=urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2); print(json.dumps(json.load(r),indent=2))' \
-            > ci-artifacts/controller-trace.json
-
           python3 -c 'import json,urllib.request; trace=json.load(urllib.request.urlopen("http://127.0.0.1:8765/trace",timeout=2))["trace"]; ops=[x["op"] + ((":"+x["direction"]) if "direction" in x else "") for x in trace if x["op"] != "error"]; expected=["takeoff","range:front","move:left","range:front","move:forward","range:front","move:left","land"]; assert ops==expected,(ops,expected); ranges=[x["value_m"] for x in trace if x["op"]=="range"]; assert len(ranges)==3 and ranges[0]<0.5 and ranges[1]>=0.5 and ranges[2]<0.5,ranges; print("WEBEEBLOCKS_REACTIVE_WEBOTS_CAUSAL_TRACE",json.dumps({"ops":ops,"ranges_m":ranges}))'
 
-          docker logs webeeblocks-reactive-webots > ci-artifacts/webots.log 2>&1
-          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots.log; then
-            cat ci-artifacts/webots.log
+          docker logs webeeblocks-reactive-webots > ci-artifacts/webots-live.log 2>&1
+          if grep -Fq 'WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL' ci-artifacts/webots-live.log; then
+            cat ci-artifacts/webots-live.log
             exit 1
           fi
-          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots.log
+          grep -F 'WEBEEBLOCKS_REACTIVE_WEBOTS_READY' ci-artifacts/webots-live.log
 
       - name: Upload experimental evidence
         if: always()

--- a/controllers/experimental_reactive_webots_adapter/experimental_reactive_webots_adapter.py
+++ b/controllers/experimental_reactive_webots_adapter/experimental_reactive_webots_adapter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import math
+import pathlib
 import queue
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -10,6 +11,9 @@ PORT = 8765
 MAX_MOVE_STEP_M = 0.02
 
 robot = Supervisor()
+artifact_dir = pathlib.Path(robot.getProjectPath()) / 'ci-artifacts'
+artifact_dir.mkdir(parents=True, exist_ok=True)
+(artifact_dir / 'reactive-controller-started.txt').write_text('controller constructed\n', encoding='utf-8')
 timestep = int(robot.getBasicTimeStep())
 self_node = robot.getSelf()
 translation = self_node.getField('translation')
@@ -156,6 +160,7 @@ try:
     anchor = list(origin)
     hold(anchor, 5)
     ready = True
+    (artifact_dir / 'reactive-controller-ready.txt').write_text(json.dumps({'port': PORT, 'origin': origin}) + '\n', encoding='utf-8')
     print('WEBEEBLOCKS_REACTIVE_WEBOTS_READY port=%d origin=%s' % (PORT, origin), flush=True)
 
     while robot.step(timestep) != -1:
@@ -174,6 +179,7 @@ try:
         request.event.set()
 except Exception as exc:
     fatal = str(exc)
+    (artifact_dir / 'reactive-controller-fatal.txt').write_text(fatal + '\n', encoding='utf-8')
     print('WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL ' + fatal, flush=True)
     while robot.step(timestep) != -1:
         pass

--- a/controllers/experimental_reactive_webots_adapter/experimental_reactive_webots_adapter.py
+++ b/controllers/experimental_reactive_webots_adapter/experimental_reactive_webots_adapter.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+import json
+import math
+import queue
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from controller import Supervisor
+
+PORT = 8765
+MAX_MOVE_STEP_M = 0.02
+
+robot = Supervisor()
+timestep = int(robot.getBasicTimeStep())
+self_node = robot.getSelf()
+translation = self_node.getField('translation')
+range_front = robot.getDevice('range_front')
+requests = queue.Queue()
+trace = []
+ready = False
+fatal = None
+origin = None
+anchor = None
+
+class RpcRequest:
+    def __init__(self, payload):
+        self.payload = payload
+        self.event = threading.Event()
+        self.response = None
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def cors(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+
+    def send_json(self, status, payload):
+        body = json.dumps(payload, separators=(',', ':')).encode('utf-8')
+        self.send_response(status)
+        self.cors()
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.cors()
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path == '/health':
+            self.send_json(200, {'ready': ready, 'fatal': fatal})
+        elif self.path == '/trace':
+            self.send_json(200, {'trace': trace})
+        else:
+            self.send_json(404, {'ok': False, 'error': 'not found'})
+
+    def do_POST(self):
+        if self.path != '/rpc':
+            self.send_json(404, {'ok': False, 'error': 'not found'})
+            return
+        try:
+            length = int(self.headers.get('Content-Length', '0'))
+            payload = json.loads(self.rfile.read(length).decode('utf-8'))
+        except Exception as exc:
+            self.send_json(400, {'ok': False, 'error': 'invalid JSON: ' + str(exc)})
+            return
+        if not ready or fatal:
+            self.send_json(503, {'ok': False, 'error': fatal or 'Webots adapter not ready'})
+            return
+        request = RpcRequest(payload)
+        requests.put(request)
+        if not request.event.wait(20):
+            self.send_json(504, {'ok': False, 'error': 'Webots adapter command timeout'})
+            return
+        self.send_json(200, request.response)
+
+def pose():
+    return [float(v) for v in translation.getSFVec3f()]
+
+def hold(position, steps=1):
+    global anchor
+    anchor = list(position)
+    for _ in range(steps):
+        translation.setSFVec3f(anchor)
+        self_node.resetPhysics()
+        if robot.step(timestep) == -1:
+            raise RuntimeError('simulation stopped during action')
+
+def move_to(target):
+    start = pose()
+    dx, dy, dz = [target[i] - start[i] for i in range(3)]
+    distance = math.sqrt(dx * dx + dy * dy + dz * dz)
+    count = max(1, int(math.ceil(distance / MAX_MOVE_STEP_M)))
+    for i in range(1, count + 1):
+        alpha = i / count
+        hold([start[0] + dx * alpha, start[1] + dy * alpha, start[2] + dz * alpha])
+    hold(target, 2)
+    return start, pose()
+
+def handle(payload):
+    if not isinstance(payload, dict):
+        raise ValueError('payload must be an object')
+    op = payload.get('op')
+    if op == 'range':
+        if payload.get('direction') != 'front':
+            raise ValueError('CAPABILITY_UNAVAILABLE range direction')
+        hold(anchor, 1)
+        raw = float(range_front.getValue())
+        value_m = raw / 1000.0
+        if not math.isfinite(value_m) or value_m < 0 or value_m > 2.001:
+            raise ValueError('INVALID_RANGE_SAMPLE')
+        entry = {'op': 'range', 'direction': 'front', 'raw': raw, 'value_m': value_m, 'pose': pose()}
+        trace.append(entry)
+        return {'ok': True, 'value_m': value_m, 'source': 'Webots range_front'}
+    if op == 'takeoff':
+        height = float(payload.get('height_m'))
+        if not math.isfinite(height) or height < 0.2 or height > 1.5:
+            raise ValueError('INVALID_TAKEOFF_HEIGHT')
+        before, after = move_to([anchor[0], anchor[1], origin[2] + height])
+        trace.append({'op': 'takeoff', 'height_m': height, 'before': before, 'after': after})
+        return {'ok': True, 'before': before, 'after': after}
+    if op == 'move':
+        direction = payload.get('direction')
+        distance = float(payload.get('distance_m'))
+        if direction not in ('forward', 'left'):
+            raise ValueError('CAPABILITY_UNAVAILABLE move direction')
+        if not math.isfinite(distance) or distance < 0.1 or distance > 2.0:
+            raise ValueError('INVALID_MOVE_DISTANCE')
+        target = list(anchor)
+        target[0 if direction == 'forward' else 1] += distance
+        before, after = move_to(target)
+        trace.append({'op': 'move', 'direction': direction, 'distance_m': distance, 'before': before, 'after': after})
+        return {'ok': True, 'before': before, 'after': after}
+    if op == 'land':
+        before, after = move_to([anchor[0], anchor[1], origin[2]])
+        trace.append({'op': 'land', 'before': before, 'after': after})
+        return {'ok': True, 'before': before, 'after': after}
+    raise ValueError('CAPABILITY_UNAVAILABLE operation')
+
+def server_main():
+    server = ThreadingHTTPServer(('0.0.0.0', PORT), Handler)
+    server.daemon_threads = True
+    server.serve_forever()
+
+threading.Thread(target=server_main, daemon=True).start()
+
+try:
+    if range_front is None or self_node is None or translation is None:
+        raise RuntimeError('required Webots capability missing')
+    range_front.enable(timestep)
+    origin = pose()
+    anchor = list(origin)
+    hold(anchor, 5)
+    ready = True
+    print('WEBEEBLOCKS_REACTIVE_WEBOTS_READY port=%d origin=%s' % (PORT, origin), flush=True)
+
+    while robot.step(timestep) != -1:
+        translation.setSFVec3f(anchor)
+        self_node.resetPhysics()
+        try:
+            request = requests.get_nowait()
+        except queue.Empty:
+            continue
+        try:
+            response = handle(request.payload)
+        except Exception as exc:
+            response = {'ok': False, 'error': str(exc)}
+            trace.append({'op': 'error', 'request': request.payload, 'error': str(exc)})
+        request.response = response
+        request.event.set()
+except Exception as exc:
+    fatal = str(exc)
+    print('WEBEEBLOCKS_REACTIVE_WEBOTS_FATAL ' + fatal, flush=True)
+    while robot.step(timestep) != -1:
+        pass

--- a/experiments/reactive-webots-adapter/README.md
+++ b/experiments/reactive-webots-adapter/README.md
@@ -1,0 +1,59 @@
+# Experiment B3 — reactive Webots adapter
+
+This disposable experiment answers one question only:
+
+> Can the already-proved `real Blockly 2020 -> semantic AST -> shared reactive interpreter` chain consume a real Webots `range_front` measurement and make different Webots movement effects from it?
+
+## What is deliberately unchanged
+
+The branch is stacked on draft #46. It reuses without modification:
+
+- the real bundled Blockly 2020;
+- the experimental block definitions/compiler frozen by #44;
+- the reactive interpreter frozen by #45;
+- the exact reactive fixture proved by #46:
+  `takeoff -> repeat 3 { if range(front) < 0.5 then left 0.3 else forward 0.3 } -> land`.
+
+No `if`, `repeat` or comparison logic exists in the Webots adapter.
+
+## Webots adapter boundary
+
+`webots_backend.js` is intentionally tiny. It exposes only:
+
+- `takeoff(height)`;
+- `move(forward|left, distance)`;
+- `readRange(front)`;
+- `land()`.
+
+All other semantic capabilities fail closed. `readRange(front)` is sourced from the native Crazyflie R2025a `range_front` DistanceSensor and converted from the PROTO's millimetre lookup-table output to metres.
+
+The Webots-side controller is **kinematic on purpose**: it moves the native Crazyflie node through Supervisor pose updates instead of motors/PID. This proves the sensor/interpreter/action seam and real Webots geometry only. It does **not** claim Crazyflie flight dynamics, backend-B parity, physical Multi-ranger behavior or cflib behavior.
+
+## Discriminating world
+
+Two narrow physical obstacles are arranged so the same real `range_front` sensor should produce this branch sequence as the vehicle moves:
+
+1. near obstacle -> `left(0.3)`;
+2. clear ahead after moving left -> `forward(0.3)`;
+3. second obstacle now near -> `left(0.3)`.
+
+The browser and Webots controller keep independent causal traces. CI requires:
+
+`takeoff -> range -> left -> range -> forward -> range -> left -> land`
+
+and checks that each movement changes the actual Webots node pose in the commanded axis.
+
+## Fail-closed proof
+
+A second real Blockly workspace changes only the sensor direction to `left`. The compiler still produces a valid semantic AST, but this minimal adapter does not advertise that capability. Execution must fail before any Webots RPC or action is recorded.
+
+## Explicit limits / stop criterion
+
+- No product or `webots-ci` modification.
+- No new language feature.
+- No variables, procedures or lights.
+- No motor/PID flight semantics.
+- No physical Crazyflie/Crazyradio/deck claim.
+- No merge toward `webots-ci` before the human trial and explicit Lead arbitration.
+
+If CI proves real Webots sensor re-read -> interpreter branch -> movement effect, freeze this draft. Do not expand the language here.

--- a/experiments/reactive-webots-adapter/run_webots_harness.py
+++ b/experiments/reactive-webots-adapter/run_webots_harness.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import http.server
+import json
+import os
+import pathlib
+import shutil
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+HARNESS = pathlib.Path('experiments/reactive-webots-adapter/ui_webots_harness.html')
+
+class Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+def browser():
+    for candidate in (os.environ.get('CHROME_BIN'), 'google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser'):
+        if candidate and shutil.which(candidate):
+            return shutil.which(candidate)
+    raise RuntimeError('no Chrome/Chromium binary found')
+
+def wait_webots(timeout=60.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen('http://127.0.0.1:8765/health', timeout=1) as response:
+                payload = json.load(response)
+            if payload.get('fatal'):
+                raise RuntimeError('Webots adapter fatal: ' + str(payload['fatal']))
+            if payload.get('ready') is True:
+                return
+            last = payload
+        except Exception as exc:
+            last = str(exc)
+        time.sleep(0.25)
+    raise RuntimeError('Webots adapter did not become ready: ' + repr(last))
+
+def main():
+    wait_webots()
+    os.chdir(ROOT)
+    with socketserver.TCPServer(('127.0.0.1', 0), Quiet) as server:
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        time.sleep(0.05)
+        command = [
+            browser(), '--headless', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage',
+            '--disable-background-networking', '--dump-dom',
+            f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'
+        ]
+        try:
+            completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=75, check=False)
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ''
+            stderr = exc.stderr or ''
+            marker = 'PASS real Blockly 2020 -> #44 compiler -> #45 interpreter -> real Webots range/action adapter'
+            if marker in stdout:
+                print(marker)
+                return 0
+            print('FAIL browser timeout', file=sys.stderr)
+            print(stderr[-4000:], file=sys.stderr)
+            print(stdout[-10000:], file=sys.stderr)
+            return 1
+        finally:
+            server.shutdown()
+    marker = 'PASS real Blockly 2020 -> #44 compiler -> #45 interpreter -> real Webots range/action adapter'
+    if completed.returncode != 0 or marker not in completed.stdout:
+        print('FAIL reactive Webots adapter harness', file=sys.stderr)
+        print(completed.stderr[-4000:], file=sys.stderr)
+        print(completed.stdout[-12000:], file=sys.stderr)
+        return 1
+    print(marker)
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/experiments/reactive-webots-adapter/ui_webots_harness.html
+++ b/experiments/reactive-webots-adapter/ui_webots_harness.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>WebeeBlocks reactive Webots adapter</title>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blockly_uncompressed.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/msg/js/en.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/logic.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/loops.js"></script>
+  <script src="../../plugins/robot_windows/blockly/google-blockly-31ee4ea/blocks/math.js"></script>
+  <script src="../reactive-blockly-pipeline/experimental_blocks.js"></script>
+  <script src="../reactive-blockly-pipeline/extended_blocks.js"></script>
+  <script src="../reactive-ast-interpreter/interpreter.js"></script>
+  <script src="webots_backend.js"></script>
+</head>
+<body>
+<div id="blocklyDiv" style="height:320px;width:100%"></div>
+<pre id="result">RUNNING</pre>
+<xml id="reactiveProgram" style="display:none">
+  <block type="webeeblocks_exp_takeoff">
+    <field name="HEIGHT">0.5</field>
+    <next><block type="controls_repeat_ext">
+      <value name="TIMES"><block type="math_number"><field name="NUM">3</field></block></value>
+      <statement name="DO"><block type="controls_if">
+        <mutation else="1"></mutation>
+        <value name="IF0"><block type="logic_compare"><field name="OP">LT</field>
+          <value name="A"><block type="webeeblocks_exp_range"><field name="DIRECTION">front</field></block></value>
+          <value name="B"><block type="math_number"><field name="NUM">0.5</field></block></value>
+        </block></value>
+        <statement name="DO0"><block type="webeeblocks_exp_move"><field name="DIRECTION">left</field><field name="DISTANCE">0.3</field></block></statement>
+        <statement name="ELSE"><block type="webeeblocks_exp_move"><field name="DIRECTION">forward</field><field name="DISTANCE">0.3</field></block></statement>
+      </block></statement>
+      <next><block type="webeeblocks_exp_land"></block></next>
+    </block></next>
+  </block>
+</xml>
+<script>
+(function() {
+  'use strict';
+  var result = document.getElementById('result');
+  function fail(message) { result.textContent='FAIL: '+message; result.setAttribute('data-status','FAIL'); throw new Error(message); }
+  function assert(condition,message) { if (!condition) fail(message); }
+  function close(a,b,tol) { return Math.abs(a-b) <= tol; }
+  try {
+    var workspace = Blockly.inject('blocklyDiv', {toolbox:'<xml></xml>'});
+    Blockly.Xml.domToWorkspace(document.getElementById('reactiveProgram'), workspace);
+    var ast = WebeeBlocksExtended.compileWorkspace(workspace);
+    var backend = new WebeeBlocksWebotsBackend.WebotsBackend('http://127.0.0.1:8765');
+    WebeeBlocksReactiveInterpreter.run(ast, backend);
+
+    var ops = backend.trace.map(function(x) { return x.op + (x.direction ? ':'+x.direction : ''); });
+    var expected = ['takeoff','range:front','move:left','range:front','move:forward','range:front','move:left','land'];
+    assert(JSON.stringify(ops) === JSON.stringify(expected), 'unexpected causal trace '+JSON.stringify(ops));
+
+    var ranges = backend.trace.filter(function(x) { return x.op === 'range'; });
+    assert(ranges.length === 3, 'front range was not re-read three times');
+    assert(ranges[0].source === 'Webots range_front' && ranges[1].source === 'Webots range_front' && ranges[2].source === 'Webots range_front', 'range source is not Webots range_front');
+    assert(ranges[0].value_m < 0.5, 'first Webots range should select LEFT: '+ranges[0].value_m);
+    assert(ranges[1].value_m >= 0.5, 'second Webots range should select FORWARD: '+ranges[1].value_m);
+    assert(ranges[2].value_m < 0.5, 'third Webots range should select LEFT: '+ranges[2].value_m);
+
+    var moves = backend.trace.filter(function(x) { return x.op === 'move'; });
+    assert(moves.length === 3, 'expected three movement effects');
+    assert(moves[0].after[1] - moves[0].before[1] > 0.25, 'first LEFT did not move the Webots node');
+    assert(moves[1].after[0] - moves[1].before[0] > 0.25, 'FORWARD did not move the Webots node');
+    assert(moves[2].after[1] - moves[2].before[1] > 0.25, 'second LEFT did not move the Webots node');
+
+    var controller = backend.getControllerTrace().trace;
+    var controllerOps = controller.filter(function(x) { return x.op !== 'error'; }).map(function(x) { return x.op + (x.direction ? ':'+x.direction : ''); });
+    assert(JSON.stringify(controllerOps) === JSON.stringify(expected), 'controller causal trace differs '+JSON.stringify(controllerOps));
+    var controllerRanges = controller.filter(function(x) { return x.op === 'range'; });
+    for (var i=0; i<3; ++i)
+      assert(close(controllerRanges[i].value_m, ranges[i].value_m, 1e-9), 'browser/controller sensor trace mismatch at read '+i);
+
+    // Fail-closed capability proof with a real Blockly workspace: change only
+    // the sensor direction to LEFT. The compiler still accepts the AST, but the
+    // minimal Webots adapter must reject that unavailable capability before any
+    // Webots RPC/action occurs.
+    var negative = new Blockly.Workspace();
+    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(Blockly.Xml.domToText(document.getElementById('reactiveProgram'))), negative);
+    var rangeBlock = negative.getAllBlocks(false).filter(function(b) { return b.type === 'webeeblocks_exp_range'; })[0];
+    rangeBlock.setFieldValue('left', 'DIRECTION');
+    var negativeAst = WebeeBlocksExtended.compileWorkspace(negative);
+    var beforeCount = backend.getControllerTrace().trace.length;
+    var rejected = false;
+    try { WebeeBlocksReactiveInterpreter.run(negativeAst, backend); }
+    catch (error) { rejected = /capability unavailable: range\(left\)/.test(String(error)); }
+    assert(rejected, 'unavailable Webots range capability did not fail closed');
+    assert(backend.getControllerTrace().trace.length === beforeCount, 'backend acted before capability rejection');
+    negative.dispose();
+
+    result.textContent='PASS real Blockly 2020 -> #44 compiler -> #45 interpreter -> real Webots range/action adapter\n'+JSON.stringify({ranges:ranges, moves:moves});
+    result.setAttribute('data-status','PASS');
+  } catch (error) {
+    if (result.getAttribute('data-status') !== 'FAIL') fail(error.message || String(error));
+  }
+})();
+</script>
+</body>
+</html>

--- a/experiments/reactive-webots-adapter/ui_webots_harness.html
+++ b/experiments/reactive-webots-adapter/ui_webots_harness.html
@@ -46,6 +46,7 @@
     Blockly.Xml.domToWorkspace(document.getElementById('reactiveProgram'), workspace);
     var ast = WebeeBlocksExtended.compileWorkspace(workspace);
     var backend = new WebeeBlocksWebotsBackend.WebotsBackend('http://127.0.0.1:8765');
+    backend.assertCapabilities(ast);
     WebeeBlocksReactiveInterpreter.run(ast, backend);
 
     var ops = backend.trace.map(function(x) { return x.op + (x.direction ? ':'+x.direction : ''); });
@@ -74,8 +75,8 @@
 
     // Fail-closed capability proof with a real Blockly workspace: change only
     // the sensor direction to LEFT. The compiler still accepts the AST, but the
-    // minimal Webots adapter must reject that unavailable capability before any
-    // Webots RPC/action occurs.
+    // Webots capability preflight must reject the complete mission before the
+    // interpreter can execute TAKEOFF or any other backend action.
     var negative = new Blockly.Workspace();
     Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(Blockly.Xml.domToText(document.getElementById('reactiveProgram'))), negative);
     var rangeBlock = negative.getAllBlocks(false).filter(function(b) { return b.type === 'webeeblocks_exp_range'; })[0];
@@ -83,10 +84,10 @@
     var negativeAst = WebeeBlocksExtended.compileWorkspace(negative);
     var beforeCount = backend.getControllerTrace().trace.length;
     var rejected = false;
-    try { WebeeBlocksReactiveInterpreter.run(negativeAst, backend); }
+    try { backend.assertCapabilities(negativeAst); }
     catch (error) { rejected = /capability unavailable: range\(left\)/.test(String(error)); }
-    assert(rejected, 'unavailable Webots range capability did not fail closed');
-    assert(backend.getControllerTrace().trace.length === beforeCount, 'backend acted before capability rejection');
+    assert(rejected, 'unavailable Webots range capability did not fail closed in preflight');
+    assert(backend.getControllerTrace().trace.length === beforeCount, 'Webots acted before capability preflight rejection');
     negative.dispose();
 
     result.textContent='PASS real Blockly 2020 -> #44 compiler -> #45 interpreter -> real Webots range/action adapter\n'+JSON.stringify({ranges:ranges, moves:moves});

--- a/experiments/reactive-webots-adapter/webots_backend.js
+++ b/experiments/reactive-webots-adapter/webots_backend.js
@@ -1,0 +1,88 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksWebotsBackend = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  function fail(message) {
+    throw new Error('webots adapter: ' + message);
+  }
+
+  function finite(value, name) {
+    var n = Number(value);
+    if (!Number.isFinite(n))
+      fail(name + ' must be finite');
+    return n;
+  }
+
+  function WebotsBackend(endpoint) {
+    this.endpoint = endpoint || 'http://127.0.0.1:8765';
+    this.trace = [];
+  }
+
+  WebotsBackend.prototype.rpc = function(payload) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', this.endpoint + '/rpc', false);
+    xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+    xhr.send(JSON.stringify(payload));
+    if (xhr.status !== 200)
+      fail('RPC HTTP ' + xhr.status + ': ' + xhr.responseText);
+    var response;
+    try {
+      response = JSON.parse(xhr.responseText);
+    } catch (error) {
+      fail('invalid RPC JSON');
+    }
+    if (!response || response.ok !== true)
+      fail(response && response.error ? response.error : 'RPC failed');
+    return response;
+  };
+
+  WebotsBackend.prototype.readRange = function(direction) {
+    if (direction !== 'front')
+      fail('capability unavailable: range(' + direction + ')');
+    var response = this.rpc({op: 'range', direction: direction});
+    var value = finite(response.value_m, 'range(front)');
+    if (value < 0 || value > 2.001)
+      fail('range(front) outside Webots sensor domain: ' + value);
+    this.trace.push({op: 'range', direction: 'front', value_m: value, source: response.source});
+    return value;
+  };
+
+  WebotsBackend.prototype.takeoff = function(height_m) {
+    var height = finite(height_m, 'height_m');
+    var response = this.rpc({op: 'takeoff', height_m: height});
+    this.trace.push({op: 'takeoff', height_m: height, before: response.before, after: response.after});
+  };
+
+  WebotsBackend.prototype.land = function() {
+    var response = this.rpc({op: 'land'});
+    this.trace.push({op: 'land', before: response.before, after: response.after});
+  };
+
+  WebotsBackend.prototype.move = function(direction, distance_m) {
+    if (direction !== 'forward' && direction !== 'left')
+      fail('capability unavailable: move(' + direction + ')');
+    var distance = finite(distance_m, 'distance_m');
+    var response = this.rpc({op: 'move', direction: direction, distance_m: distance});
+    this.trace.push({op: 'move', direction: direction, distance_m: distance, before: response.before, after: response.after});
+  };
+
+  WebotsBackend.prototype.vertical = function(direction) { fail('capability unavailable: vertical(' + direction + ')'); };
+  WebotsBackend.prototype.turn = function() { fail('capability unavailable: turn'); };
+  WebotsBackend.prototype.wait = function() { fail('capability unavailable: wait'); };
+  WebotsBackend.prototype.setSpeed = function() { fail('capability unavailable: setSpeed'); };
+
+  WebotsBackend.prototype.getControllerTrace = function() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', this.endpoint + '/trace', false);
+    xhr.send(null);
+    if (xhr.status !== 200)
+      fail('trace HTTP ' + xhr.status);
+    return JSON.parse(xhr.responseText);
+  };
+
+  return {WebotsBackend: WebotsBackend};
+});

--- a/experiments/reactive-webots-adapter/webots_backend.js
+++ b/experiments/reactive-webots-adapter/webots_backend.js
@@ -22,6 +22,62 @@
     this.trace = [];
   }
 
+  // Capability preflight is deliberately separate from interpreter control
+  // flow. It walks the already-compiled AST once, before execution, so a
+  // mission asking for an unavailable Webots capability cannot partially act
+  // (for example TAKEOFF) and only fail when the unsupported sensor is first
+  // reached at runtime.
+  WebotsBackend.prototype.assertCapabilities = function(ast) {
+    function expression(node) {
+      if (!node || typeof node.kind !== 'string')
+        fail('invalid AST expression during capability preflight');
+      if (node.kind === 'number') return;
+      if (node.kind === 'range') {
+        if (node.direction !== 'front')
+          fail('capability unavailable: range(' + node.direction + ')');
+        return;
+      }
+      if (node.kind === 'compare') {
+        expression(node.left); expression(node.right); return;
+      }
+      if (node.kind === 'logic') {
+        expression(node.left); expression(node.right); return;
+      }
+      fail('capability unavailable: expression ' + node.kind);
+    }
+
+    function sequence(items) {
+      if (!Array.isArray(items))
+        fail('invalid AST sequence during capability preflight');
+      items.forEach(function(statement) {
+        if (!statement || typeof statement.kind !== 'string')
+          fail('invalid AST statement during capability preflight');
+        if (statement.kind === 'takeoff' || statement.kind === 'land') return;
+        if (statement.kind === 'move') {
+          if (statement.direction !== 'forward' && statement.direction !== 'left')
+            fail('capability unavailable: move(' + statement.direction + ')');
+          return;
+        }
+        if (statement.kind === 'if') {
+          expression(statement.condition);
+          sequence(statement.then || []);
+          sequence(statement.else || []);
+          return;
+        }
+        if (statement.kind === 'repeat') {
+          sequence(statement.body || []);
+          return;
+        }
+        fail('capability unavailable: ' + statement.kind);
+      });
+    }
+
+    if (!ast || ast.version !== 1 || ast.semantics !== 'webeeblocks-experimental-ast')
+      fail('unsupported AST envelope during capability preflight');
+    sequence(ast.program);
+    return true;
+  };
+
   WebotsBackend.prototype.rpc = function(payload) {
     var xhr = new XMLHttpRequest();
     xhr.open('POST', this.endpoint + '/rpc', false);

--- a/worlds/experimental_reactive_webots_adapter.wbt
+++ b/worlds/experimental_reactive_webots_adapter.wbt
@@ -1,0 +1,52 @@
+#VRML_SIM R2025a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"
+
+WorldInfo {
+  basicTimeStep 32
+  randomSeed 1
+  optimalThreadCount 1
+  title "WebeeBlocks experimental reactive Webots adapter"
+}
+Viewpoint {
+  orientation -0.45 0.47 0.76 1.05
+  position -2.4 -2.4 2.2
+  follow "Reactive Crazyflie"
+}
+TexturedBackground { }
+TexturedBackgroundLight { }
+Floor { size 4 4 }
+
+# Two narrow physical obstacles are deliberately arranged so that real
+# range_front samples drive the three repeat iterations through:
+#   near -> LEFT, clear -> FORWARD, near -> LEFT.
+DEF FIRST_OBSTACLE Solid {
+  translation 0.45 0 0.55
+  children [
+    Shape {
+      appearance PBRAppearance { baseColor 0.85 0.15 0.1 roughness 0.6 }
+      geometry Box { size 0.06 0.12 1.1 }
+    }
+  ]
+  boundingObject Box { size 0.06 0.12 1.1 }
+}
+DEF SECOND_OBSTACLE Solid {
+  translation 0.70 0.30 0.55
+  children [
+    Shape {
+      appearance PBRAppearance { baseColor 0.9 0.55 0.05 roughness 0.6 }
+      geometry Box { size 0.06 0.12 1.1 }
+    }
+  ]
+  boundingObject Box { size 0.06 0.12 1.1 }
+}
+
+DEF REACTIVE_CF Crazyflie {
+  name "Reactive Crazyflie"
+  controller "experimental_reactive_webots_adapter"
+  supervisor TRUE
+  synchronization TRUE
+}


### PR DESCRIPTION
## Experimental scope

B3 only. Stacked on frozen draft #46. The `webots-ci` release candidate and `main` remain untouched.

## Question

Can the already-proved chain

`real Blockly 2020 → #44 semantic compiler → AST → #45 interpreter`

work unchanged when the scripted backend is replaced by a minimal Webots adapter using a real `range_front` sensor and real Webots movement effects?

## Experiment

The exact reactive Blockly fixture from #46 is reused:

`takeoff → repeat 3 { if range(front)<0.5 then left 0.3 else forward 0.3 } → land`.

A native Webots R2025a Crazyflie is placed in a deterministic two-obstacle fixture. The browser executes the unchanged compiler/interpreter chain. The adapter maps only `takeoff`, `move(forward|left)`, `readRange(front)` and `land` to a small Webots-side RPC controller.

CI must prove the causal trace:

`takeoff → range(real) → left → range(real) → forward → range(real) → left → land`

with three distinct sensor reads, threshold-dependent branch changes, and actual Webots node movement in the commanded axes.

## Fail-closed

A second real Blockly workspace requests `range(left)`. The compiler may produce that AST, but this deliberately minimal adapter does not provide the capability. Execution must fail before any Webots RPC/action is recorded.

## Important limitation

The Webots-side action adapter is intentionally **kinematic** (Supervisor pose updates). It proves the Webots sensor/interpreter/action seam and real geometry, not motor/PID flight behavior. No claim is made about backend-B parity, physical Multi-ranger behavior, cflib, Crazyradio or a real Crazyflie.

## Stop criterion

If the dedicated Webots R2025a gate is green and Verification finds no semantic false positive, freeze this draft. Do not add language features or merge toward `webots-ci` before human-trial feedback and explicit Lead arbitration.