### PR TITLE
Experiment: probe real Crazyflie capabilities read-only

### DIFF
--- a/.github/workflows/experimental-real-crazyflie-c0.yml
+++ b/.github/workflows/experimental-real-crazyflie-c0.yml
@@ -1,0 +1,68 @@
+name: Experimental real Crazyflie C0 read-only probe
+
+on:
+  pull_request:
+    branches:
+      - webots-ci
+    paths:
+      - 'experiments/real-crazyflie-capability-probe/**'
+      - '.github/workflows/experimental-real-crazyflie-c0.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  c0-read-only:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pinned cflib
+        run: python -m pip install 'cflib==0.1.32'
+
+      - name: Compile probe
+        run: python -m py_compile experiments/real-crazyflie-capability-probe/c0_probe.py
+
+      - name: Run fail-closed unit and static safety tests
+        run: python -m unittest -v experiments/real-crazyflie-capability-probe/test_c0_probe.py
+
+      - name: Run mock probe
+        run: |
+          python experiments/real-crazyflie-capability-probe/c0_probe.py \
+            --output /tmp/c0-mock-report.json
+          python - <<'PY'
+          import json
+          report = json.load(open('/tmp/c0-mock-report.json'))
+          assert report['status'] == 'OK'
+          assert report['mode'] == 'mock'
+          assert report['physical_proof'] is False
+          assert report['flow_v2_detected'] is True
+          assert report['multiranger_detected'] is True
+          assert report['telemetry_complete'] is True
+          print(json.dumps(report, indent=2))
+          PY
+
+      - name: Assert no motorized cflib modules are imported
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+          path = Path('experiments/real-crazyflie-capability-probe/c0_probe.py')
+          tree = ast.parse(path.read_text())
+          forbidden = ('motion_commander', 'position_hl_commander', 'high_level_commander')
+          imports = []
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  imports.extend(a.name for a in node.names)
+              elif isinstance(node, ast.ImportFrom):
+                  imports.append(node.module or '')
+          bad = [name for name in imports if any(token in name.lower() for token in forbidden)]
+          assert not bad, f'forbidden motorized imports: {bad}'
+          print('PASS: no motorized cflib commander import path')
+          PY

--- a/experiments/real-crazyflie-capability-probe/README.md
+++ b/experiments/real-crazyflie-capability-probe/README.md
@@ -1,0 +1,64 @@
+# C0 — real Crazyflie read-only capability probe
+
+Experimental only. This directory is intentionally isolated from the frozen `webots-ci` release candidate.
+
+## Question
+
+Can WebeeBlocks establish a real Crazyradio/Crazyflie link, identify the expected Flow V2 + Multi-ranger decks, obtain read-only telemetry, and map a backend-neutral mission to possible cflib primitives **without any motor/arming path**?
+
+## Safety boundary
+
+C0 is telemetry-only. `c0_probe.py` does **not** import MotionCommander, Position/HighLevelCommander or any commander module, and exposes no setpoint, arming, takeoff, landing or motor API. The mapping shown in the report is text only and is never executed.
+
+The unit test statically parses the Python AST and fails if commander imports or motorized call names appear in executable code.
+
+## Mock / CI
+
+```bash
+python3 experiments/real-crazyflie-capability-probe/c0_probe.py
+python3 -m unittest -v experiments/real-crazyflie-capability-probe/test_c0_probe.py
+```
+
+A green mock/CI proves only the safety plumbing and fail-closed behavior. It is **not physical proof**.
+
+## Real read-only probe
+
+Requires `cflib==0.1.32` and the Crazyradio USB permissions normally required by cflib.
+
+Explicit URI is preferred when known:
+
+```bash
+python3 experiments/real-crazyflie-capability-probe/c0_probe.py \
+  --live \
+  --uri 'radio://0/80/2M/E7E7E7E7E7' \
+  --output c0-real-report.json
+```
+
+Or scan first:
+
+```bash
+python3 experiments/real-crazyflie-capability-probe/c0_probe.py --live --scan --output c0-real-report.json
+```
+
+The probe:
+
+1. initializes cflib drivers;
+2. opens only the selected link and waits for `fully_connected` with a bounded timeout;
+3. enumerates physical decks through cflib's deck-memory manager and requires Flow (`bcFlow*`) plus `bcMultiranger`;
+4. reads `range.front/back/left/right/up`, `motion.deltaX/deltaY`, `range.zrange`, and `stateEstimate.x/y/z` only;
+5. prints a display-only mapping from the sample WebeeBlocks mission to possible cflib MotionCommander primitives;
+6. closes the link in `finally` on every path.
+
+No firmware flashing is performed.
+
+## Why these signals
+
+Bitcraze's current cflib `Multiranger` utility uses the `range.front/back/left/right/up` log variables. The firmware documents `motion.deltaX/deltaY` as Flow-deck measurements and `range.zrange` as the downward range value. `stateEstimate.x/y/z` is read as estimator telemetry only.
+
+Deck names are obtained from the deck discovery/memory subsystem rather than inferred merely from the presence of log variables in the firmware TOC.
+
+## Stop criterion
+
+Freeze this draft once mock CI is green and Verification cannot find an indirect motorized path. Do not open C1 automatically.
+
+C0 becomes **physically demonstrated** only after a real run with the user's Crazyradio 2.0 + Crazyflie 2.1 + Flow Deck V2 + Multi-ranger and inspection of the produced values. Until then the hardware status is `NON TESTÉ`.

--- a/experiments/real-crazyflie-capability-probe/c0_probe.py
+++ b/experiments/real-crazyflie-capability-probe/c0_probe.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""C0 Crazyflie capability probe: connection + telemetry only, never motor control."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence
+
+RANGE_KEYS = ("range.front", "range.back", "range.left", "range.right", "range.up")
+FLOW_KEYS = ("motion.deltaX", "motion.deltaY", "range.zrange")
+STATE_KEYS = ("stateEstimate.x", "stateEstimate.y", "stateEstimate.z")
+REQUIRED_DECKS = ("bcFlow2", "bcMultiranger")
+
+# Strings only: this is a display-only mapping. No commander module is imported or called.
+MISSION_MAPPING = {
+    "TAKEOFF": "cflib.positioning.motion_commander:take_off(height_m)",
+    "FORWARD": "cflib.positioning.motion_commander:forward(distance_m)",
+    "LEFT": "cflib.positioning.motion_commander:left(distance_m)",
+    "RIGHT": "cflib.positioning.motion_commander:right(distance_m)",
+    "UP": "cflib.positioning.motion_commander:up(distance_m)",
+    "DOWN": "cflib.positioning.motion_commander:down(distance_m)",
+    "TURN": "cflib.positioning.motion_commander:turn_left_or_right(angle_deg)",
+    "LAND": "cflib.positioning.motion_commander:land()",
+}
+
+
+class ProbeError(RuntimeError):
+    pass
+
+
+class ReadOnlyPort(Protocol):
+    def init_drivers(self) -> None: ...
+    def scan_uris(self) -> Sequence[str]: ...
+    def connect(self, uri: str, timeout_s: float) -> None: ...
+    def deck_names(self) -> Sequence[str]: ...
+    def read_telemetry(self, timeout_s: float) -> Dict[str, float]: ...
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    mode: str
+    uri: str
+    connected: bool
+    decks: List[str]
+    flow_v2_detected: bool
+    multiranger_detected: bool
+    telemetry: Dict[str, float]
+    telemetry_complete: bool
+    mission_mapping: List[Dict[str, Any]]
+    physical_proof: bool
+
+
+def normalize_deck_name(name: str) -> str:
+    return name.strip().lower().replace("-", "")
+
+
+def has_deck(deck_names: Iterable[str], expected: str) -> bool:
+    target = normalize_deck_name(expected)
+    return any(normalize_deck_name(name) == target for name in deck_names)
+
+
+def compile_display_only_mapping(mission: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    result: List[Dict[str, Any]] = []
+    for index, command in enumerate(mission):
+        op = str(command.get("op", "")).upper()
+        if op not in MISSION_MAPPING:
+            raise ProbeError(f"unsupported semantic command at {index}: {op!r}")
+        result.append({"index": index, "semantic": command, "potential_cflib": MISSION_MAPPING[op]})
+    return result
+
+
+def validate_telemetry(values: Dict[str, float]) -> bool:
+    required = RANGE_KEYS + FLOW_KEYS + STATE_KEYS
+    for key in required:
+        if key not in values:
+            return False
+        value = values[key]
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            return False
+    return True
+
+
+def run_probe(
+    port: ReadOnlyPort,
+    *,
+    uri: Optional[str],
+    scan: bool,
+    connection_timeout_s: float,
+    telemetry_timeout_s: float,
+    mission: Sequence[Dict[str, Any]],
+    mode: str,
+) -> ProbeReport:
+    mapping = compile_display_only_mapping(mission)
+    connected = False
+    selected_uri = uri or ""
+    try:
+        port.init_drivers()
+        if scan:
+            uris = list(port.scan_uris())
+            if not uris:
+                raise ProbeError("no Crazyflie URI found")
+            if uri and uri not in uris:
+                raise ProbeError(f"requested URI not found by scan: {uri}")
+            selected_uri = uri or uris[0]
+        elif not selected_uri:
+            raise ProbeError("provide --uri or --scan")
+
+        port.connect(selected_uri, connection_timeout_s)
+        connected = True
+        decks = list(port.deck_names())
+        flow = has_deck(decks, "bcFlow2") or any("bcflow" in normalize_deck_name(d) for d in decks)
+        multiranger = has_deck(decks, "bcMultiranger") or any("multiranger" in normalize_deck_name(d) for d in decks)
+        if not flow or not multiranger:
+            missing = []
+            if not flow:
+                missing.append("Flow V2")
+            if not multiranger:
+                missing.append("Multi-ranger")
+            raise ProbeError("required deck(s) not detected: " + ", ".join(missing))
+
+        telemetry = port.read_telemetry(telemetry_timeout_s)
+        complete = validate_telemetry(telemetry)
+        if not complete:
+            raise ProbeError("required read-only telemetry was not received completely")
+
+        return ProbeReport(
+            mode=mode,
+            uri=selected_uri,
+            connected=True,
+            decks=decks,
+            flow_v2_detected=flow,
+            multiranger_detected=multiranger,
+            telemetry={key: float(telemetry[key]) for key in RANGE_KEYS + FLOW_KEYS + STATE_KEYS},
+            telemetry_complete=True,
+            mission_mapping=mapping,
+            physical_proof=(mode == "live"),
+        )
+    finally:
+        # Closing a read-only link is required on every success/error path.
+        port.close()
+
+
+class MockReadOnlyPort:
+    def __init__(self, *, uris=None, decks=None, telemetry=None, connect_error: Optional[Exception] = None):
+        self.uris = list(uris or ["radio://0/80/2M/E7E7E7E7E7"])
+        self.decks = list(decks or ["bcFlow2", "bcMultiranger"])
+        self.telemetry = dict(telemetry or _mock_telemetry())
+        self.connect_error = connect_error
+        self.initialized = False
+        self.connected = False
+        self.closed = False
+        self.actions: List[str] = []
+
+    def init_drivers(self) -> None:
+        self.initialized = True
+        self.actions.append("init_drivers")
+
+    def scan_uris(self) -> Sequence[str]:
+        self.actions.append("scan")
+        return self.uris
+
+    def connect(self, uri: str, timeout_s: float) -> None:
+        self.actions.append(f"connect:{uri}")
+        if self.connect_error:
+            raise self.connect_error
+        self.connected = True
+
+    def deck_names(self) -> Sequence[str]:
+        self.actions.append("deck_names")
+        return self.decks
+
+    def read_telemetry(self, timeout_s: float) -> Dict[str, float]:
+        self.actions.append("read_telemetry")
+        return self.telemetry
+
+    def close(self) -> None:
+        self.actions.append("close")
+        self.closed = True
+        self.connected = False
+
+
+def _mock_telemetry() -> Dict[str, float]:
+    return {
+        "range.front": 420.0,
+        "range.back": 910.0,
+        "range.left": 650.0,
+        "range.right": 700.0,
+        "range.up": 1200.0,
+        "motion.deltaX": 2.0,
+        "motion.deltaY": -1.0,
+        "range.zrange": 310.0,
+        "stateEstimate.x": 0.01,
+        "stateEstimate.y": -0.02,
+        "stateEstimate.z": 0.30,
+    }
+
+
+class CflibReadOnlyPort:
+    """The only cflib adapter in C0. It exposes no commander/setpoint API."""
+
+    def __init__(self, cache_dir: str = "./cache"):
+        self.cache_dir = cache_dir
+        self.cf = None
+        self._connected_event = threading.Event()
+        self._failure_event = threading.Event()
+        self._failure_message = ""
+
+    def init_drivers(self) -> None:
+        import cflib.crtp
+        cflib.crtp.init_drivers()
+
+    def scan_uris(self) -> Sequence[str]:
+        import cflib.crtp
+        return [item[0] if isinstance(item, tuple) else item for item in cflib.crtp.scan_interfaces()]
+
+    def _on_fully_connected(self, uri: str) -> None:
+        self._connected_event.set()
+
+    def _on_failure(self, uri: str, message: str) -> None:
+        self._failure_message = f"{uri}: {message}"
+        self._failure_event.set()
+        self._connected_event.set()
+
+    def connect(self, uri: str, timeout_s: float) -> None:
+        from cflib.crazyflie import Crazyflie
+        self.cf = Crazyflie(rw_cache=self.cache_dir)
+        self.cf.fully_connected.add_callback(self._on_fully_connected)
+        self.cf.connection_failed.add_callback(self._on_failure)
+        self.cf.connection_lost.add_callback(self._on_failure)
+        self.cf.open_link(uri)
+        if not self._connected_event.wait(timeout_s):
+            raise ProbeError(f"fully_connected timeout after {timeout_s:.1f}s")
+        if self._failure_event.is_set():
+            raise ProbeError("connection failed/lost: " + self._failure_message)
+
+    def deck_names(self) -> Sequence[str]:
+        if self.cf is None:
+            raise ProbeError("not connected")
+        from cflib.crazyflie.mem import MemoryElement
+        from cflib.crazyflie.mem import deck_memory
+        mems = self.cf.mem.get_mems(MemoryElement.TYPE_DECK_MEMORY)
+        if not mems:
+            raise ProbeError("no deck memory interface found")
+        decks = deck_memory.SyncDeckMemoryManager(mems[0]).query_decks()
+        return [deck.name for _, deck in sorted(decks.items())]
+
+    def read_telemetry(self, timeout_s: float) -> Dict[str, float]:
+        if self.cf is None:
+            raise ProbeError("not connected")
+        from cflib.crazyflie.log import LogConfig
+
+        result: Dict[str, float] = {}
+        done = threading.Event()
+        configs = []
+
+        range_flow = LogConfig(name="C0RangeFlow", period_in_ms=100)
+        for key in RANGE_KEYS + FLOW_KEYS:
+            range_flow.add_variable(key)
+        state = LogConfig(name="C0State", period_in_ms=100)
+        for key in STATE_KEYS:
+            state.add_variable(key, "float")
+        configs.extend([range_flow, state])
+
+        def received(_ts, data, _conf):
+            result.update(data)
+            if all(key in result for key in RANGE_KEYS + FLOW_KEYS + STATE_KEYS):
+                done.set()
+
+        def error(_conf, message):
+            self._failure_message = str(message)
+            self._failure_event.set()
+            done.set()
+
+        try:
+            for config in configs:
+                config.data_received_cb.add_callback(received)
+                config.error_cb.add_callback(error)
+                self.cf.log.add_config(config)
+                config.start()
+            if not done.wait(timeout_s):
+                raise ProbeError(f"telemetry timeout after {timeout_s:.1f}s")
+            if self._failure_event.is_set():
+                raise ProbeError("telemetry/link error: " + self._failure_message)
+            return result
+        finally:
+            for config in configs:
+                try:
+                    config.stop()
+                except Exception:
+                    pass
+                try:
+                    config.delete()
+                except Exception:
+                    pass
+
+    def close(self) -> None:
+        if self.cf is not None:
+            try:
+                self.cf.close_link()
+            finally:
+                self.cf = None
+
+
+DEFAULT_MISSION = [
+    {"op": "TAKEOFF", "height_m": 0.5},
+    {"op": "FORWARD", "distance_m": 0.5},
+    {"op": "TURN", "angle_deg": 90},
+    {"op": "LAND"},
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="WebeeBlocks C0 read-only Crazyflie capability probe")
+    parser.add_argument("--live", action="store_true", help="connect to real hardware; still telemetry-only")
+    parser.add_argument("--uri", help="explicit Crazyflie radio URI")
+    parser.add_argument("--scan", action="store_true", help="scan for Crazyflie URIs")
+    parser.add_argument("--connection-timeout", type=float, default=10.0)
+    parser.add_argument("--telemetry-timeout", type=float, default=5.0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if args.live:
+        port: ReadOnlyPort = CflibReadOnlyPort()
+        mode = "live"
+    else:
+        port = MockReadOnlyPort()
+        mode = "mock"
+        if not args.uri and not args.scan:
+            args.scan = True
+
+    try:
+        report = run_probe(
+            port,
+            uri=args.uri,
+            scan=args.scan,
+            connection_timeout_s=args.connection_timeout,
+            telemetry_timeout_s=args.telemetry_timeout,
+            mission=DEFAULT_MISSION,
+            mode=mode,
+        )
+    except Exception as exc:
+        print(json.dumps({"status": "ERROR", "mode": mode, "error": str(exc)}, indent=2))
+        return 2
+
+    payload = {"status": "OK", **asdict(report)}
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    print(text)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/real-crazyflie-capability-probe/test_c0_probe.py
+++ b/experiments/real-crazyflie-capability-probe/test_c0_probe.py
@@ -1,0 +1,107 @@
+import ast
+import importlib.util
+import pathlib
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("c0_probe", HERE / "c0_probe.py")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class C0ProbeTests(unittest.TestCase):
+    def test_mock_probe_succeeds_and_always_closes(self):
+        port = MODULE.MockReadOnlyPort()
+        report = MODULE.run_probe(
+            port,
+            uri=None,
+            scan=True,
+            connection_timeout_s=1,
+            telemetry_timeout_s=1,
+            mission=MODULE.DEFAULT_MISSION,
+            mode="mock",
+        )
+        self.assertTrue(report.flow_v2_detected)
+        self.assertTrue(report.multiranger_detected)
+        self.assertTrue(report.telemetry_complete)
+        self.assertFalse(report.physical_proof)
+        self.assertTrue(port.closed)
+        self.assertEqual(port.actions[-1], "close")
+
+    def test_missing_deck_fails_before_telemetry_and_closes(self):
+        port = MODULE.MockReadOnlyPort(decks=["bcFlow2"])
+        with self.assertRaisesRegex(MODULE.ProbeError, "Multi-ranger"):
+            MODULE.run_probe(
+                port, uri="radio://mock", scan=False,
+                connection_timeout_s=1, telemetry_timeout_s=1,
+                mission=MODULE.DEFAULT_MISSION, mode="mock")
+        self.assertNotIn("read_telemetry", port.actions)
+        self.assertTrue(port.closed)
+
+    def test_connection_failure_closes(self):
+        port = MODULE.MockReadOnlyPort(connect_error=MODULE.ProbeError("radio lost"))
+        with self.assertRaisesRegex(MODULE.ProbeError, "radio lost"):
+            MODULE.run_probe(
+                port, uri="radio://mock", scan=False,
+                connection_timeout_s=1, telemetry_timeout_s=1,
+                mission=MODULE.DEFAULT_MISSION, mode="mock")
+        self.assertTrue(port.closed)
+
+    def test_incomplete_telemetry_fails_closed(self):
+        telemetry = MODULE._mock_telemetry()
+        del telemetry["range.left"]
+        port = MODULE.MockReadOnlyPort(telemetry=telemetry)
+        with self.assertRaisesRegex(MODULE.ProbeError, "telemetry"):
+            MODULE.run_probe(
+                port, uri="radio://mock", scan=False,
+                connection_timeout_s=1, telemetry_timeout_s=1,
+                mission=MODULE.DEFAULT_MISSION, mode="mock")
+        self.assertTrue(port.closed)
+
+    def test_mapping_is_display_only_and_rejects_unknown_command(self):
+        mapping = MODULE.compile_display_only_mapping(MODULE.DEFAULT_MISSION)
+        self.assertEqual([m["semantic"]["op"] for m in mapping], ["TAKEOFF", "FORWARD", "TURN", "LAND"])
+        with self.assertRaisesRegex(MODULE.ProbeError, "unsupported"):
+            MODULE.compile_display_only_mapping([{"op": "MOTOR_RAW"}])
+
+    def test_source_has_no_motorized_import_or_call_path(self):
+        source = (HERE / "c0_probe.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        forbidden_import_fragments = (
+            "motion_commander", "position_hl_commander", "high_level_commander",
+        )
+        forbidden_call_fragments = (
+            "send_setpoint", "send_hover_setpoint", "send_position_setpoint",
+            "send_velocity_world_setpoint", "send_zdistance_setpoint",
+            "send_stop_setpoint", "send_notify_setpoint_stop",
+            "arming_request", "take_off", "land", "forward", "back",
+            "left", "right", "up", "down", "turn_left", "turn_right",
+        )
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                else:
+                    names = [node.module or ""]
+                for name in names:
+                    self.assertFalse(any(fragment in name.lower() for fragment in forbidden_import_fragments), name)
+            if isinstance(node, ast.Call):
+                func = node.func
+                parts = []
+                while isinstance(func, ast.Attribute):
+                    parts.append(func.attr)
+                    func = func.value
+                if isinstance(func, ast.Name):
+                    parts.append(func.id)
+                call_name = ".".join(reversed(parts)).lower()
+                self.assertFalse(any(fragment in call_name for fragment in forbidden_call_fragments), call_name)
+
+    def test_cflib_adapter_public_surface_is_read_only(self):
+        public = {name for name in dir(MODULE.CflibReadOnlyPort) if not name.startswith("_")}
+        self.assertEqual(public, {"close", "connect", "deck_names", "init_drivers", "read_telemetry", "scan_uris"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/real-crazyflie-capability-probe/test_c0_probe.py
+++ b/experiments/real-crazyflie-capability-probe/test_c0_probe.py
@@ -75,10 +75,14 @@ class C0ProbeTests(unittest.TestCase):
         forbidden_call_fragments = (
             "send_setpoint", "send_hover_setpoint", "send_position_setpoint",
             "send_velocity_world_setpoint", "send_zdistance_setpoint",
-            "send_stop_setpoint", "send_notify_setpoint_stop",
-            "arming_request", "take_off", "land", "forward", "back",
-            "left", "right", "up", "down", "turn_left", "turn_right",
+            "send_stop_setpoint", "send_notify_setpoint_stop", "arming_request",
         )
+        forbidden_call_leaves = {
+            "take_off", "land", "forward", "back", "left", "right", "up", "down",
+            "turn_left", "turn_right", "move_distance", "start_linear_motion",
+            "start_turn_left", "start_turn_right", "go_to", "start_trajectory",
+            "define_trajectory",
+        }
 
         for node in ast.walk(tree):
             if isinstance(node, (ast.Import, ast.ImportFrom)):
@@ -98,7 +102,9 @@ class C0ProbeTests(unittest.TestCase):
                 if isinstance(func, ast.Name):
                     parts.append(func.id)
                 call_name = ".".join(reversed(parts)).lower()
+                leaf = call_name.rsplit(".", 1)[-1]
                 self.assertFalse(any(fragment in call_name for fragment in forbidden_call_fragments), call_name)
+                self.assertNotIn(leaf, forbidden_call_leaves, call_name)
 
     def test_cflib_adapter_public_surface_is_read_only(self):
         public = {name for name in dir(MODULE.CflibReadOnlyPort) if not name.startswith("_")}

--- a/experiments/real-crazyflie-capability-probe/test_c0_probe.py
+++ b/experiments/real-crazyflie-capability-probe/test_c0_probe.py
@@ -1,11 +1,13 @@
 import ast
 import importlib.util
 import pathlib
+import sys
 import unittest
 
 HERE = pathlib.Path(__file__).resolve().parent
 SPEC = importlib.util.spec_from_file_location("c0_probe", HERE / "c0_probe.py")
 MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 


### PR DESCRIPTION
## Experimental scope

C0 only. This draft starts from frozen `webots-ci`; `main` and all product/runtime files remain untouched.

## Question

Can WebeeBlocks establish a Crazyradio/Crazyflie connection, identify the expected Flow V2 + Multi-ranger decks, collect read-only telemetry and show how a backend-neutral mission could map to cflib primitives **without any motor/arming path**?

## Safety boundary

Absolute C0 rule: no commander import, no arming, no takeoff/land execution, no motor command, no `send_*setpoint`, no firmware flashing.

The cflib adapter exposes only:

`init_drivers / scan_uris / connect / deck_names / read_telemetry / close`.

A Python-AST unit test rejects motorized commander imports/call paths. The displayed MotionCommander mapping is string data only and is never imported or executed.

## Probe behavior

- initializes cflib drivers;
- scans or accepts an explicit radio URI;
- waits for `fully_connected` with bounded timeout;
- enumerates physical deck names through cflib deck-memory discovery and requires Flow (`bcFlow*`) plus `bcMultiranger`;
- reads only `range.front/back/left/right/up`, `motion.deltaX/deltaY`, `range.zrange`, and `stateEstimate.x/y/z`;
- validates that all required telemetry arrived and is finite;
- prints a display-only mapping for a sample WebeeBlocks mission;
- closes the link in `finally` on every success/error path.

## CI proof / non-claim

The dedicated gate installs pinned `cflib==0.1.32`, runs unit/static safety tests and executes a mock probe. A green CI run proves only the plumbing, fail-closed behavior and absence of an obvious executable motor path. **It does not prove hardware.**

## Hardware stop criterion

Freeze this draft once mock CI is green and Verification cannot falsify the read-only boundary. C0 becomes physically demonstrated only after the user runs the probe on the real Crazyradio 2.0 + Crazyflie 2.1 + Flow Deck V2 + Multi-ranger and returns the report/values.

Do not open C1 automatically, and do not merge this experiment into `webots-ci` before the human trial and explicit Lead arbitration.