### PR TITLE
Experiment: prove modern Blockly Runtime v2 AST equivalence

### DIFF
--- a/.github/workflows/modern-blockly-experiment.yml
+++ b/.github/workflows/modern-blockly-experiment.yml
@@ -1,0 +1,29 @@
+name: Experimental modern Blockly semantic equivalence
+
+on:
+  pull_request:
+    paths:
+      - 'experiments/modern-blockly/**'
+      - 'plugins/robot_windows/blockly/webeeblocks/**'
+      - 'controllers/Blockly_Programs/CrazyflieReactiveV2.xml'
+      - '.github/workflows/modern-blockly-experiment.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  modern-blockly-ast:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install pinned Blockly experiment dependency
+        working-directory: experiments/modern-blockly
+        run: npm install --ignore-scripts --no-audit --no-fund
+      - name: Prove profile, XML migration, JSON round-trip and AST equivalence
+        working-directory: experiments/modern-blockly
+        run: npm test

--- a/.github/workflows/modern-blockly-experiment.yml
+++ b/.github/workflows/modern-blockly-experiment.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install pinned Blockly experiment dependency
         working-directory: experiments/modern-blockly
         run: npm install --ignore-scripts --no-audit --no-fund

--- a/experiments/modern-blockly/README.md
+++ b/experiments/modern-blockly/README.md
@@ -1,0 +1,37 @@
+# Modern Blockly foundation experiment (#55)
+
+Status: isolated experiment only. This branch must not modify `webots-ci` or `main`.
+
+## Gate
+Runtime v2 Webots/WWI #53 is technically converged and merged. Verification proved the causal Runtime v2 chain on head `914d7944…`; the local Ubuntu/Webots baseline remains a promotion gate only.
+
+## Fixed semantic boundary
+`activity -> Blockly -> webeeblocks-ast-v1 -> preflight -> interpreter -> backend`
+
+Runtime v2 must not reintroduce Python generation.
+
+## Baseline dependency hypothesis
+Start with pinned `blockly@13.2.1` from npm and a reproducible local bundle/build suitable for a Webots Robot Window. Do not rely on CDN/network access at runtime.
+
+## Small discriminating matrix
+Use one identical reactive Crazyflie program and one identical activity profile for every variant.
+
+1. Dependency/build: prove a pinned npm dependency can be bundled into a self-contained Robot Window asset and initialized offline.
+2. Semantic equivalence: compile the same acceptance workspace and require the same `webeeblocks-ast-v1` semantics as the current Runtime v2 fixture.
+3. Activity toolbox: generate visible toolbox and numeric/dropdown constraints from the same resolved activity profile; forbidden blocks/capabilities remain fail-closed in preflight.
+4. Serialization: JSON workspace save/load is canonical for new v2 projects. Import one historical XML fixture, compile it to the same AST, then save it as JSON and re-load with identical AST.
+5. Accessibility/keyboard: exercise keyboard-only block navigation/editing and record focus/operation failures; do not add the legacy keyboard-navigation plugin unless a demonstrated gap requires it.
+6. Renderer A/B: run the exact same workspace under `thrasos` and `zelos`. Compare block density/readability at the same viewport, field editing, mouse manipulation, keyboard focus/navigation, and any clipping/Robot Window rendering defects. Renderer choice must not change AST.
+
+## Pre-registered decision rules
+- Prefer the smallest reproducible dependency/build that works offline in the Robot Window and is maintainable through npm version pinning.
+- Reject any variant that changes AST semantics, weakens profile/preflight enforcement, or requires Python generation.
+- Prefer JSON for new Runtime v2 saves; keep XML only as an import/migration compatibility path.
+- Prefer Thrasos by default because Blockly documents it as the recommended renderer; choose Zelos only if the same-program school-use comparison demonstrates a concrete usability advantage without regressions.
+- Accessibility failures are blocking evidence for the tested interaction, not a reason to disable accessibility features.
+
+## Non-goals
+No new drone capabilities, teacher authoring UI, physical Crazyflie work, Runtime v1 removal, broad visual redesign, or product merge.
+
+## Stop criterion
+Freeze the experiment once the six questions above have discriminating evidence. Product promotion remains blocked until Emmanuel's local Runtime v2 baseline validation is satisfactory.

--- a/experiments/modern-blockly/README.md
+++ b/experiments/modern-blockly/README.md
@@ -3,12 +3,26 @@
 Status: isolated experiment only. This branch must not modify `webots-ci` or `main`.
 
 ## Gate
-Runtime v2 Webots/WWI #53 is technically converged and merged. Verification proved the causal Runtime v2 chain on head `914d7944…`; the local Ubuntu/Webots baseline remains a promotion gate only.
+Runtime v2 Webots/WWI #53 is technically converged and merged. Verification proved the causal Runtime v2 chain; the local Ubuntu/Webots baseline remains a promotion gate only.
 
 ## Fixed semantic boundary
 `activity -> Blockly -> webeeblocks-ast-v1 -> preflight -> interpreter -> backend`
 
 Runtime v2 must not reintroduce Python generation.
+
+## First Engineering increment
+This branch pins `blockly@13.2.1` and runs the current product Runtime v2 profile resolver, activity contract and semantic compiler directly against modern Blockly. It does not copy or fork the AST compiler.
+
+The dedicated gate must prove, for the existing `reactive-obstacle-v2` activity and `CrazyflieReactiveV2.xml` fixture:
+
+- the toolbox type list is derived from the resolved product profile;
+- product profile field bounds still constrain modern `FieldNumber` fields;
+- historical XML imports explicitly as `LEGACY_XML_MIGRATION=PASS` or fails loudly as a migration rejection;
+- the imported workspace compiles to the exact current `webeeblocks-ast-v1` oracle;
+- modern Blockly JSON save/load round-trips to the exact same AST;
+- the experiment runs against exactly Blockly 13.2.1.
+
+This is deliberately headless semantic evidence. It does **not** yet prove a Robot Window bundle, renderer choice, keyboard accessibility or Webots initialization.
 
 ## Baseline dependency hypothesis
 Start with pinned `blockly@13.2.1` from npm and a reproducible local bundle/build suitable for a Webots Robot Window. Do not rely on CDN/network access at runtime.

--- a/experiments/modern-blockly/ast_equivalence.js
+++ b/experiments/modern-blockly/ast_equivalence.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Blockly = require('blockly');
+require('blockly/blocks');
+
+const productRoot = path.resolve(__dirname, '../..');
+const Activities = require(path.join(productRoot, 'plugins/robot_windows/blockly/webeeblocks/activities.js'));
+const Profiles = require(path.join(productRoot, 'plugins/robot_windows/blockly/webeeblocks/activity_profiles.js'));
+const ActivityContract = require(path.join(productRoot, 'plugins/robot_windows/blockly/webeeblocks/activity_contract.js'));
+const SemanticAst = require(path.join(productRoot, 'plugins/robot_windows/blockly/webeeblocks/semantic_ast.js'));
+
+const PROFILE_ID = 'reactive-obstacle-v2';
+const FIXTURE = path.join(productRoot, 'controllers/Blockly_Programs/CrazyflieReactiveV2.xml');
+const EXPECTED_AST = {
+  version: 1,
+  semantics: 'webeeblocks-ast-v1',
+  program: [
+    {kind: 'takeoff', height_m: 0.5},
+    {
+      kind: 'repeat',
+      count: 3,
+      body: [{
+        kind: 'if',
+        condition: {
+          kind: 'compare',
+          op: 'LT',
+          left: {kind: 'range', direction: 'front', unit: 'm'},
+          right: {kind: 'number', value: 0.5}
+        },
+        then: [{kind: 'move', direction: 'left', distance_m: 0.3}],
+        else: [{kind: 'move', direction: 'forward', distance_m: 0.3}]
+      }]
+    },
+    {kind: 'land'}
+  ]
+};
+
+function bounds(profile, blockType, fieldName) {
+  const value = profile.parameterBounds && profile.parameterBounds[blockType] && profile.parameterBounds[blockType][fieldName];
+  if (!value)
+    throw new Error(`missing profile bounds for ${blockType}.${fieldName}`);
+  return value;
+}
+
+function numberField(name, value, constraint) {
+  return {
+    type: 'field_number',
+    name,
+    value,
+    min: constraint.min,
+    max: constraint.max,
+    precision: constraint.step
+  };
+}
+
+function registerRuntimeV2Blocks(profile) {
+  const takeoff = bounds(profile, 'webeeblocks_v2_takeoff', 'HEIGHT');
+  const move = bounds(profile, 'webeeblocks_v2_move', 'DISTANCE');
+  const vertical = bounds(profile, 'webeeblocks_v2_vertical', 'DISTANCE');
+  const turn = bounds(profile, 'webeeblocks_v2_turn', 'ANGLE');
+  const wait = bounds(profile, 'webeeblocks_v2_wait', 'SECONDS');
+  const speed = bounds(profile, 'webeeblocks_v2_speed', 'SPEED');
+
+  Blockly.common.defineBlocksWithJsonArray([
+    {
+      type: 'webeeblocks_v2_takeoff',
+      message0: 'décoller à %1 m',
+      args0: [numberField('HEIGHT', 0.5, takeoff)],
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_v2_move',
+      message0: '%1 de %2 m',
+      args0: [
+        {type: 'field_dropdown', name: 'DIRECTION', options: [['avancer', 'forward'], ['reculer', 'back'], ['gauche', 'left'], ['droite', 'right']]},
+        numberField('DISTANCE', 0.3, move)
+      ],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_v2_vertical',
+      message0: '%1 de %2 m',
+      args0: [
+        {type: 'field_dropdown', name: 'DIRECTION', options: [['monter', 'up'], ['descendre', 'down']]},
+        numberField('DISTANCE', 0.2, vertical)
+      ],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_v2_turn',
+      message0: 'tourner à %1 de %2 °',
+      args0: [
+        {type: 'field_dropdown', name: 'DIRECTION', options: [['gauche', 'left'], ['droite', 'right']]},
+        numberField('ANGLE', 90, turn)
+      ],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_v2_wait',
+      message0: 'attendre %1 s',
+      args0: [numberField('SECONDS', 1, wait)],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_v2_speed',
+      message0: 'vitesse %1 m/s',
+      args0: [numberField('SPEED', 0.3, speed)],
+      previousStatement: null,
+      nextStatement: null,
+      colour: 20
+    },
+    {
+      type: 'webeeblocks_v2_range',
+      message0: 'distance %1',
+      args0: [{type: 'field_dropdown', name: 'DIRECTION', options: profile.runtime.rangeDirections.map(direction => [direction, direction])}],
+      output: 'Number',
+      colour: 60
+    },
+    {
+      type: 'webeeblocks_v2_land',
+      message0: 'atterrir',
+      previousStatement: null,
+      colour: 20
+    }
+  ]);
+}
+
+function profileToolbox(profile) {
+  return {
+    kind: 'flyoutToolbox',
+    contents: profile.toolbox.map(type => ({kind: 'block', type}))
+  };
+}
+
+function assertProfileSurface(profile) {
+  const toolbox = profileToolbox(profile);
+  assert.deepEqual(toolbox.contents.map(entry => entry.type), profile.toolbox, 'toolbox must come directly from resolved activity profile');
+  for (const type of profile.toolbox)
+    assert.ok(Blockly.Blocks[type], `modern Blockly missing profile block ${type}`);
+
+  const workspace = new Blockly.Workspace();
+  const block = workspace.newBlock('webeeblocks_v2_takeoff');
+  ActivityContract.applyFieldBounds(profile, workspace);
+  const field = block.getField('HEIGHT');
+  field.setValue(99);
+  assert.equal(Number(field.getValue()), 1.5, 'profile max bound must clamp modern FieldNumber');
+  field.setValue(-99);
+  assert.equal(Number(field.getValue()), 0.2, 'profile min bound must clamp modern FieldNumber');
+  workspace.dispose();
+}
+
+function compileLegacyXml(profile) {
+  const xmlText = fs.readFileSync(FIXTURE, 'utf8');
+  const workspace = new Blockly.Workspace();
+  try {
+    const dom = Blockly.utils.xml.textToDom(xmlText);
+    Blockly.Xml.domToWorkspace(dom, workspace);
+    ActivityContract.preflightWorkspace(profile, workspace);
+    ActivityContract.applyFieldBounds(profile, workspace);
+    const ast = SemanticAst.compileWorkspace(workspace);
+    ActivityContract.preflightAst(profile, ast);
+    return {workspace, ast};
+  } catch (error) {
+    workspace.dispose();
+    console.error(`LEGACY_XML_MIGRATION=REJECT reason=${error.message}`);
+    throw error;
+  }
+}
+
+function roundTripJson(profile, sourceWorkspace, expectedAst) {
+  const state = Blockly.serialization.workspaces.save(sourceWorkspace);
+  const workspace = new Blockly.Workspace();
+  Blockly.serialization.workspaces.load(state, workspace);
+  ActivityContract.preflightWorkspace(profile, workspace);
+  ActivityContract.applyFieldBounds(profile, workspace);
+  const ast = SemanticAst.compileWorkspace(workspace);
+  ActivityContract.preflightAst(profile, ast);
+  assert.deepEqual(ast, expectedAst, 'JSON serialization must preserve Runtime v2 semantic AST exactly');
+  workspace.dispose();
+  return state;
+}
+
+function main() {
+  assert.equal(Blockly.VERSION, '13.2.1', 'experiment must run against the pinned Blockly release');
+  const profile = Profiles.resolveById(Activities.DOCUMENT, PROFILE_ID, Activities.BLOCK_CATALOG);
+  registerRuntimeV2Blocks(profile);
+  assertProfileSurface(profile);
+
+  const {workspace, ast} = compileLegacyXml(profile);
+  try {
+    assert.deepEqual(ast, EXPECTED_AST, 'modern Blockly legacy-XML import must produce the current Runtime v2 AST oracle');
+    console.log('LEGACY_XML_MIGRATION=PASS');
+    const jsonState = roundTripJson(profile, workspace, EXPECTED_AST);
+    console.log(`BLOCKLY_VERSION=${Blockly.VERSION}`);
+    console.log(`PROFILE=${profile.id}`);
+    console.log(`TOOLBOX_TYPES=${profile.toolbox.length}`);
+    console.log(`JSON_SERIALIZATION=PASS bytes=${Buffer.byteLength(JSON.stringify(jsonState))}`);
+    console.log(`AST_EQUIVALENCE=PASS ${JSON.stringify(ast)}`);
+  } finally {
+    workspace.dispose();
+  }
+}
+
+main();

--- a/experiments/modern-blockly/package.json
+++ b/experiments/modern-blockly/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "webeeblocks-modern-blockly-experiment",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Isolated Blockly v13 semantic-equivalence experiment for Runtime v2.",
+  "scripts": {
+    "test": "node ast_equivalence.js"
+  },
+  "dependencies": {
+    "blockly": "13.2.1"
+  }
+}

--- a/experiments/modern-blockly/package.json
+++ b/experiments/modern-blockly/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "description": "Isolated Blockly v13 semantic-equivalence experiment for Runtime v2.",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "test": "node ast_equivalence.js"
   },


### PR DESCRIPTION
## Objective
Start the isolated #55 preparation now that Runtime v2 #53 is technically converged and integrated. Prove the smallest semantic contract before any Robot Window/renderer migration.

## Scope
- pin `blockly@13.2.1` in the isolated experiment;
- resolve the existing product `reactive-obstacle-v2` activity profile;
- derive the toolbox type list and numeric bounds from that profile;
- import the existing `CrazyflieReactiveV2.xml` fixture with modern Blockly;
- compile it with the **current product** `semantic_ast.js` (no duplicated compiler) and require exact `webeeblocks-ast-v1` equivalence;
- save/load through modern Blockly JSON serialization and require the exact same AST;
- classify legacy XML import explicitly as PASS or migration rejection;
- dedicated experimental CI only.

## Non-goals
No Webots/PID/STOP change, no new drone capability, no Runtime v1 change, no renderer decision yet, no physical Crazyflie work, and no product promotion.

## Promotion gate
**DO NOT MERGE into `webots-ci` before Emmanuel's local Runtime v2 baseline test is satisfactory.** If that baseline reveals a defect, baseline repair takes priority and this experiment must be rebased/re-evaluated.

Closes no issue; preparation for #55 only.