### PR TITLE
Experiment: run modern Blockly through Runtime v2 WWI

### DIFF
--- a/.github/workflows/modern-blockly-experiment.yml
+++ b/.github/workflows/modern-blockly-experiment.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   modern-blockly:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -63,10 +63,16 @@ jobs:
         shell: bash
         run: bash experiments/modern-blockly/run_robot_window_gate.sh
 
+      - name: Prove modern Blockly through real Runtime v2 WWI
+        shell: bash
+        run: bash experiments/modern-blockly/run_wwi_gate.sh
+
       - name: Upload modern Blockly diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: modern-blockly-r2025a-experiment
-          path: ci-artifacts/modern-blockly/
+          path: |
+            ci-artifacts/modern-blockly/
+            ci-artifacts/modern-blockly-wwi/
           if-no-files-found: error

--- a/experiments/modern-blockly/run_wwi_gate.sh
+++ b/experiments/modern-blockly/run_wwi_gate.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+artifact_dir="$repo_root/ci-artifacts/modern-blockly-wwi"
+mkdir -p "$artifact_dir"
+
+docker run --rm -i \
+  -e LIBGL_ALWAYS_SOFTWARE=true \
+  -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+  -v "$repo_root:/workspace" \
+  -w /workspace \
+  cyberbotics/webots:R2025a-ubuntu22.04 \
+  bash -s <<'CONTAINER'
+set -euo pipefail
+artifact_dir=/workspace/ci-artifacts/modern-blockly-wwi
+plugin=/workspace/plugins/robot_windows/modern_blockly_v2_experiment
+world=/workspace/worlds/modern_blockly_v2_experiment.wbt
+wrapper=/workspace/experiments/modern-blockly/webots_browser.sh
+oracle=/workspace/experiments/modern-blockly/netlog_oracle.py
+mkdir -p "$artifact_dir"
+
+apt-get update >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+
+cp /workspace/experiments/modern-blockly/wwi_robot_window.html "$plugin/modern_blockly_v2_experiment.html"
+cp /workspace/experiments/modern-blockly/wwi_robot_window.js "$plugin/main.js"
+cp /usr/local/webots/resources/web/wwi/RobotWindow.js "$plugin/RobotWindow.js"
+cp /usr/local/webots/resources/web/wwi/request_methods.js "$plugin/request_methods.js"
+chmod +x "$wrapper" "$oracle"
+mkdir -p /root/.config/Cyberbotics
+printf '%s\n' '[RobotWindow]' 'browser=/workspace/experiments/modern-blockly/webots_browser.sh' 'newBrowserWindow=false' > /root/.config/Cyberbotics/Webots-R2025a.conf
+
+rm -f "$artifact_dir"/* /workspace/ci-artifacts/modern-blockly/browser-launch.log /workspace/ci-artifacts/modern-blockly/chrome.pid /workspace/ci-artifacts/modern-blockly/chrome-netlog.json
+python3 /workspace/tools/ci/runtime_wwi_event_server.py --output "$artifact_dir/browser-events.jsonl" >"$artifact_dir/event-server.log" 2>&1 &
+event_server_pid=$!
+sleep 0.5
+
+xvfb-run -a webots --stdout --stderr --batch --mode=realtime "$world" >"$artifact_dir/webots.log" 2>&1 &
+webots_pid=$!
+deadline=$((SECONDS + 75))
+done_seen=0
+while kill -0 "$webots_pid" 2>/dev/null; do
+  if [[ -s "$artifact_dir/browser-events.jsonl" ]] && grep -Fq '"event":"RUN_DONE"' "$artifact_dir/browser-events.jsonl"; then
+    done_seen=1
+    break
+  fi
+  if grep -Fq '"event":"ERROR"' "$artifact_dir/browser-events.jsonl" 2>/dev/null; then
+    break
+  fi
+  if (( SECONDS >= deadline )); then
+    break
+  fi
+  sleep 0.25
+done
+
+if (( done_seen == 0 )); then
+  echo '::error::modern Blockly WWI run did not reach RUN_DONE'
+  cat "$artifact_dir/browser-events.jsonl" 2>/dev/null || true
+  cat "$artifact_dir/webots.log" || true
+  kill -TERM "$webots_pid" 2>/dev/null || true
+  kill "$event_server_pid" 2>/dev/null || true
+  exit 1
+fi
+
+chrome_pid_file=/workspace/ci-artifacts/modern-blockly/chrome.pid
+if [[ ! -s "$chrome_pid_file" ]]; then
+  echo '::error::Chrome PID missing'
+  exit 1
+fi
+chrome_pid=$(cat "$chrome_pid_file")
+kill -TERM "$chrome_pid" 2>/dev/null || true
+for _ in $(seq 1 50); do kill -0 "$chrome_pid" 2>/dev/null || break; sleep 0.1; done
+if kill -0 "$chrome_pid" 2>/dev/null; then echo '::error::Chrome did not stop gracefully'; exit 1; fi
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = Path('/workspace/ci-artifacts/modern-blockly/chrome-netlog.json')
+with p.open('r', encoding='utf-8') as f: json.load(f)
+print('MODERN_BLOCKLY_WWI_NETLOG_COMPLETE=PASS')
+PY
+cp /workspace/ci-artifacts/modern-blockly/chrome-netlog.json "$artifact_dir/chrome-netlog.json"
+python3 "$oracle" "$artifact_dir/chrome-netlog.json"
+
+kill -TERM "$webots_pid" 2>/dev/null || true
+wait "$webots_pid" 2>/dev/null || true
+kill "$event_server_pid" 2>/dev/null || true
+wait "$event_server_pid" 2>/dev/null || true
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+root = Path('/workspace/ci-artifacts/modern-blockly-wwi')
+events_path = root / 'browser-events.jsonl'
+webots_path = root / 'webots.log'
+assert events_path.is_file() and events_path.stat().st_size > 0, events_path
+assert webots_path.is_file() and webots_path.stat().st_size > 0, webots_path
+events = [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+assert events and not any(e.get('event') == 'ERROR' for e in events), events
+names = [e['event'] for e in events]
+required = ['PAGE_LOADED','BLOCKLY_INITIALIZED','PROFILE_APPLIED','AST_EQUIVALENT','WWI_BOUND','RUN_STARTED','RUN_DONE']
+pos = [names.index(x) for x in required]
+assert pos == sorted(pos), (names, pos)
+rx = [e['detail']['message'] for e in events if e.get('event') == 'WWI_RX']
+tx = [e['detail']['message'] for e in events if e.get('event') == 'WWI_TX']
+assert any(' REQUEST ' in m and ' TAKEOFF ' in m for m in tx), tx
+assert sum(' RANGE front' in m for m in tx) == 3, tx
+assert any(' MOVE left ' in m for m in tx), tx
+assert any(' MOVE forward ' in m for m in tx), tx
+assert any(m.endswith(' LAND') for m in tx), tx
+assert any(' RESPONSE ' in m and ' OK' in m for m in rx), rx
+assert sum(' RESPONSE ' in m and ' VALUE ' in m for m in rx) == 3, rx
+log = webots_path.read_text(errors='replace')
+for marker in ['TRACE TAKEOFF', 'TRACE RANGE front', 'TRACE MOVE left', 'TRACE MOVE forward', 'TRACE LAND']:
+    assert marker in log, marker
+assert 'FATAL' not in log and 'UNSAFE_OR_TIMEOUT' not in log, log
+print('MODERN_BLOCKLY_WWI_CAUSAL_CHAIN=PASS')
+PY
+CONTAINER

--- a/experiments/modern-blockly/run_wwi_gate.sh
+++ b/experiments/modern-blockly/run_wwi_gate.sh
@@ -17,6 +17,7 @@ artifact_dir=/workspace/ci-artifacts/modern-blockly-wwi
 plugin=/workspace/plugins/robot_windows/modern_blockly_v2_experiment
 world=/workspace/worlds/modern_blockly_v2_experiment.wbt
 wrapper=/workspace/experiments/modern-blockly/webots_browser.sh
+close_chrome=/workspace/experiments/modern-blockly/close_chrome_cdp.py
 oracle=/workspace/experiments/modern-blockly/netlog_oracle.py
 mkdir -p "$artifact_dir"
 
@@ -49,9 +50,39 @@ for name, blob_sha in expected.items():
         raise SystemExit(f'{name}: unexpected R2025a Git blob {actual}, expected {blob_sha}')
 print('WEBOTS_R2025A_WWI_MODULES=PASS')
 PY
-chmod +x "$wrapper" "$oracle"
+chmod +x "$wrapper" "$close_chrome" "$oracle"
 mkdir -p /root/.config/Cyberbotics
 printf '%s\n' '[RobotWindow]' 'browser=/workspace/experiments/modern-blockly/webots_browser.sh' 'newBrowserWindow=false' > /root/.config/Cyberbotics/Webots-R2025a.conf
+
+stop_chrome() {
+  local pid_file=$1
+  if [[ ! -s "$pid_file" ]]; then
+    echo '::error::Chrome PID missing'
+    return 1
+  fi
+  local chrome_pid
+  chrome_pid=$(cat "$pid_file")
+
+  # Match the already-proven #58 shutdown contract: request Browser.close over
+  # DevTools so --log-net-log can finish writing valid JSON. Signals are cleanup
+  # fallback only and never count as a successful WWI oracle run.
+  if ! python3 "$close_chrome"; then
+    echo '::error::Could not request graceful Chrome Browser.close'
+    kill -TERM "$chrome_pid" 2>/dev/null || true
+    return 1
+  fi
+
+  for _ in $(seq 1 100); do
+    kill -0 "$chrome_pid" 2>/dev/null || break
+    sleep 0.1
+  done
+  if kill -0 "$chrome_pid" 2>/dev/null; then
+    echo '::error::Chrome did not exit after Browser.close'
+    kill -TERM "$chrome_pid" 2>/dev/null || true
+    return 1
+  fi
+  echo 'CHROME_GRACEFUL_SHUTDOWN_WWI=PASS'
+}
 
 rm -f "$artifact_dir"/* /workspace/ci-artifacts/modern-blockly/browser-launch.log /workspace/ci-artifacts/modern-blockly/chrome.pid /workspace/ci-artifacts/modern-blockly/chrome-netlog.json
 python3 /workspace/tools/ci/runtime_wwi_event_server.py --output "$artifact_dir/browser-events.jsonl" >"$artifact_dir/event-server.log" 2>&1 &
@@ -85,15 +116,7 @@ if (( done_seen == 0 )); then
   exit 1
 fi
 
-chrome_pid_file=/workspace/ci-artifacts/modern-blockly/chrome.pid
-if [[ ! -s "$chrome_pid_file" ]]; then
-  echo '::error::Chrome PID missing'
-  exit 1
-fi
-chrome_pid=$(cat "$chrome_pid_file")
-kill -TERM "$chrome_pid" 2>/dev/null || true
-for _ in $(seq 1 50); do kill -0 "$chrome_pid" 2>/dev/null || break; sleep 0.1; done
-if kill -0 "$chrome_pid" 2>/dev/null; then echo '::error::Chrome did not stop gracefully'; exit 1; fi
+stop_chrome /workspace/ci-artifacts/modern-blockly/chrome.pid
 
 python3 - <<'PY'
 import json

--- a/experiments/modern-blockly/run_wwi_gate.sh
+++ b/experiments/modern-blockly/run_wwi_gate.sh
@@ -27,8 +27,28 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/n
 
 cp /workspace/experiments/modern-blockly/wwi_robot_window.html "$plugin/modern_blockly_v2_experiment.html"
 cp /workspace/experiments/modern-blockly/wwi_robot_window.js "$plugin/main.js"
-cp /usr/local/webots/resources/web/wwi/RobotWindow.js "$plugin/RobotWindow.js"
-cp /usr/local/webots/resources/web/wwi/request_methods.js "$plugin/request_methods.js"
+# The R2025a Docker image does not ship resources/web/wwi. Provision the exact
+# upstream R2025a modules during the online CI setup phase, then verify their
+# immutable Git blob identities before the offline Robot Window runtime starts.
+wwi_source_base=https://raw.githubusercontent.com/cyberbotics/webots/R2025a/resources/web/wwi
+wget -q -O "$plugin/RobotWindow.js" "$wwi_source_base/RobotWindow.js"
+wget -q -O "$plugin/request_methods.js" "$wwi_source_base/request_methods.js"
+python3 - <<'PY'
+from hashlib import sha1
+from pathlib import Path
+
+expected = {
+    'RobotWindow.js': 'e8e92bb35663160b16a7c25ab2338a6f06ade62a',
+    'request_methods.js': '9b13416f4004b85570fa74fbefd68f386fa6cc72',
+}
+root = Path('/workspace/plugins/robot_windows/modern_blockly_v2_experiment')
+for name, blob_sha in expected.items():
+    data = (root / name).read_bytes()
+    actual = sha1(f'blob {len(data)}\0'.encode() + data).hexdigest()
+    if actual != blob_sha:
+        raise SystemExit(f'{name}: unexpected R2025a Git blob {actual}, expected {blob_sha}')
+print('WEBOTS_R2025A_WWI_MODULES=PASS')
+PY
 chmod +x "$wrapper" "$oracle"
 mkdir -p /root/.config/Cyberbotics
 printf '%s\n' '[RobotWindow]' 'browser=/workspace/experiments/modern-blockly/webots_browser.sh' 'newBrowserWindow=false' > /root/.config/Cyberbotics/Webots-R2025a.conf

--- a/experiments/modern-blockly/wwi_robot_window.html
+++ b/experiments/modern-blockly/wwi_robot_window.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>WebeeBlocks Modern Blockly WWI Experiment</title>
+  <style>
+    html, body { height: 100%; margin: 0; font-family: sans-serif; }
+    body { display: grid; grid-template-rows: auto 1fr; }
+    header { padding: 8px 12px; border-bottom: 1px solid #ccc; }
+    #blocklyDiv { min-height: 0; }
+  </style>
+  <script src="vendor/blockly_compressed.js"></script>
+  <script src="vendor/blocks_compressed.js"></script>
+  <script src="vendor/msg/en.js"></script>
+  <script src="../blockly/google-blockly-31ee4ea/blocks/crazyflie_v2.js"></script>
+  <script src="../blockly/webeeblocks/activity_profiles.js"></script>
+  <script src="../blockly/webeeblocks/activities.js"></script>
+  <script src="../blockly/webeeblocks/semantic_ast.js"></script>
+  <script src="../blockly/webeeblocks/activity_contract.js"></script>
+  <script src="../blockly/webeeblocks/interpreter.js"></script>
+  <script src="../blockly/webeeblocks/wwi_backend.js"></script>
+  <script src="fixture_data.js"></script>
+</head>
+<body>
+  <header><strong id="status">PAGE_LOADED</strong></header>
+  <main id="blocklyDiv"></main>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/experiments/modern-blockly/wwi_robot_window.js
+++ b/experiments/modern-blockly/wwi_robot_window.js
@@ -1,0 +1,106 @@
+'use strict';
+
+(function() {
+  const PROFILE_ID = 'reactive-obstacle-v2';
+  let sequence = 0;
+  let reportChain = Promise.resolve();
+
+  function canonical(value) {
+    if (Array.isArray(value)) return value.map(canonical);
+    if (value && typeof value === 'object') {
+      const result = {};
+      Object.keys(value).sort().forEach(key => { result[key] = canonical(value[key]); });
+      return result;
+    }
+    return value;
+  }
+
+  function sameJson(left, right) {
+    return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+  }
+
+  function report(event, detail) {
+    const payload = {seq: sequence++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
+    reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    }));
+    return reportChain;
+  }
+
+  function toolboxFromProfile(profile) {
+    return {kind: 'flyoutToolbox', contents: profile.toolbox.map(type => ({kind: 'block', type}))};
+  }
+
+  async function main() {
+    document.getElementById('status').textContent = 'PAGE_LOADED';
+    await report('PAGE_LOADED', {href: location.href, origin: location.origin});
+
+    if (!window.Blockly || Blockly.VERSION !== '13.2.1')
+      throw new Error(`unexpected Blockly version: ${window.Blockly && Blockly.VERSION}`);
+    if (!window.WebeeBlocksInterpreter || !window.WebeeBlocksWwiBackend)
+      throw new Error('Runtime v2 interpreter/WWI backend missing');
+
+    await report('BLOCKLY_INITIALIZED', {version: Blockly.VERSION});
+    const profile = WebeeBlocksActivityProfiles.resolveById(
+      WebeeBlocksActivities.DOCUMENT,
+      PROFILE_ID,
+      WebeeBlocksActivities.BLOCK_CATALOG
+    );
+    const workspace = Blockly.inject('blocklyDiv', {
+      toolbox: toolboxFromProfile(profile),
+      scrollbars: true,
+      sounds: false,
+      media: 'vendor/media/'
+    });
+    WebeeBlocksActivityContract.applyFieldBounds(profile, workspace);
+    await report('PROFILE_APPLIED', {profile: profile.id});
+
+    const fixture = window.WebeeBlocksModernBlocklyFixture;
+    Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(fixture.xml), workspace);
+    WebeeBlocksActivityContract.preflightWorkspace(profile, workspace);
+    WebeeBlocksActivityContract.applyFieldBounds(profile, workspace);
+    const ast = WebeeBlocksSemanticAst.compileWorkspace(workspace);
+    const facts = WebeeBlocksActivityContract.preflightAst(profile, ast);
+    if (!sameJson(ast, fixture.expectedAst))
+      throw new Error(`AST mismatch: actual=${JSON.stringify(ast)} expected=${JSON.stringify(fixture.expectedAst)}`);
+    await report('AST_EQUIVALENT', {ast});
+
+    const module = await import('./RobotWindow.js');
+    const robotWindow = new module.default();
+    const backend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000});
+    const originalSend = robotWindow.send.bind(robotWindow);
+    robotWindow.send = function(message) {
+      report('WWI_TX', {message});
+      return originalSend(message);
+    };
+    robotWindow.receive = function(message) {
+      report('WWI_RX', {message});
+      backend.handleMessage(message);
+    };
+    WebeeBlocksActivityContract.preflightBackend(profile, facts, backend);
+    await report('WWI_BOUND', {capabilities: backend.capabilities});
+
+    document.getElementById('status').textContent = 'RUNNING';
+    await report('RUN_STARTED', null);
+    await WebeeBlocksInterpreter.run(ast, backend, {maxSteps: 1000});
+    document.getElementById('status').textContent = 'DONE';
+    await report('RUN_DONE', null);
+    await reportChain;
+    console.log('WEBEEBLOCKS_MODERN_BLOCKLY_WWI_PASS');
+  }
+
+  window.addEventListener('error', event => {
+    report('ERROR', {message: event.message, filename: event.filename, line: event.lineno});
+  });
+  window.addEventListener('unhandledrejection', event => report('ERROR', {message: String(event.reason)}));
+  window.addEventListener('load', () => {
+    main().catch(async error => {
+      document.getElementById('status').textContent = 'ERROR';
+      await report('ERROR', {message: error && error.stack ? error.stack : String(error)});
+      await reportChain;
+      console.error(error);
+    });
+  });
+})();


### PR DESCRIPTION
## Objective
Close the next #55 causal seam after #58: prove that the same pinned modern Blockly 13.2.1 workspace and exact `webeeblocks-ast-v1` can execute through the **existing Runtime v2 WWI backend and interpreter** inside a real Webots R2025a Robot Window.

## Stack
This draft is intentionally stacked on #58 (`engineering/modern-blockly-robot-window`). #58 remains frozen as the offline initialization/AST proof; this PR adds only the WWI execution seam.

## Scope
- reuse the exact modern Blockly bundle/profile/XML fixture/AST proof from #58;
- load the existing product `interpreter.js` and `wwi_backend.js` rather than creating a bridge or second runtime;
- provision the exact upstream R2025a `RobotWindow.js` + `request_methods.js` during the online CI setup phase, verify their Git blob identities, then run the Robot Window offline; the official R2025a Docker image does not ship `resources/web/wwi`;
- launch the unchanged `crazyflie_runtime_v2` controller in real Webots R2025a;
- require the causal order `PAGE_LOADED -> BLOCKLY_INITIALIZED -> PROFILE_APPLIED -> AST_EQUIVALENT -> WWI_BOUND -> RUN_STARTED -> RUN_DONE`;
- record and assert real WWI requests/responses plus controller traces for TAKEOFF, three fresh front-range reads, left/forward movement decisions and LAND;
- retain the independent Chrome NetLog oracle from #58 so successful external HTTP(S) runtime traffic still fails.

## Non-goals
No renderer/accessibility decision, no new block or drone capability, no PID/STOP/backend/controller behavior change, no Runtime v1 change, no physical Crazyflie, no product promotion.

## Fail-closed evidence
The gate fails if the AST differs, profile/backend preflight fails, WWI requests time out, expected sensor/action requests are absent, controller traces are absent, the run reports FATAL/UNSAFE timeout, the pinned R2025a WWI modules do not match their expected Git blobs, or an external HTTP(S) runtime request succeeds/remains unresolved.

## Promotion
Draft experiment only. Do not merge this stacked PR directly into `webots-ci`; Lead will decide the smallest productization PR after this seam is green and independently verified.