### PR TITLE
Gate Runtime v2 UI on backend READY

### DIFF
--- a/.github/workflows/runtime-v2-webots-wwi.yml
+++ b/.github/workflows/runtime-v2-webots-wwi.yml
@@ -84,7 +84,7 @@ jobs:
             exit 1
           fi
 
-      - name: Prove fresh range decisions and dynamic STOP actions
+      - name: Prove pre-READY gate, fresh range decisions and dynamic STOP actions
         shell: bash
         run: |
           set -euo pipefail
@@ -92,6 +92,8 @@ jobs:
           EVENTS=ci-artifacts/runtime-v2-webots/browser-events.jsonl
           test -s ci-artifacts/runtime-v2-webots/browser-launch.log
           test -s "$EVENTS"
+          grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 CI READY_DELAY_BEGIN' "$LOG"
+          grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 CI READY_DELAY_END' "$LOG"
           grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 READY' "$LOG"
           ! grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 FATAL' "$LOG"
           ! grep -Fq 'ERROR:' "$LOG"
@@ -124,12 +126,35 @@ jobs:
           assert ranges[0] < 0.5 and ranges[1] >= 0.5 and ranges[2] < 0.5, ranges
 
           events = [json.loads(line) for line in Path('ci-artifacts/runtime-v2-webots/browser-events.jsonl').read_text().splitlines() if line.strip()]
-          assert not any(e.get('event') == 'ERROR' for e in events), events
-          assert any(e.get('event') == 'AST' for e in events), events
+          assert not any(e.get('event') in ('ERROR', 'WINDOW_ERROR', 'UNHANDLED_REJECTION') for e in events), events
+
+          def first_index(predicate, label):
+              for index, event in enumerate(events):
+                  if predicate(event):
+                      return index
+              raise AssertionError('missing event: ' + label)
+
+          pre = first_index(lambda e: e.get('event') == 'PRE_READY', 'PRE_READY')
+          guard = first_index(lambda e: e.get('event') == 'PRE_READY_GUARD_OK', 'PRE_READY_GUARD_OK')
+          ready_rx = first_index(lambda e: e.get('event') == 'WWI_RX' and e.get('detail') == 'WEBEEBLOCKS_RUNTIME_V2 READY', 'READY WWI_RX')
+          ready = first_index(lambda e: e.get('event') == 'READY', 'READY')
+          ast = first_index(lambda e: e.get('event') == 'AST', 'AST')
+          submit = first_index(lambda e: e.get('event') == 'SUBMIT', 'SUBMIT')
+          done = first_index(lambda e: e.get('event') == 'DONE', 'DONE')
+          assert pre < guard < ready_rx < ready < ast < submit < done, [(e.get('event'), e.get('detail')) for e in events]
+
+          pre_detail = events[pre]['detail']
+          guard_detail = events[guard]['detail']
+          ready_detail = events[ready]['detail']
+          assert pre_detail['backendReady'] is False and pre_detail['submitDisabled'] is True and pre_detail['state'] == 'INITIALISATION', pre_detail
+          assert guard_detail['backendReady'] is False and guard_detail['submitDisabled'] is True and guard_detail['state'] == 'INITIALISATION', guard_detail
+          assert guard_detail['backendNextId'] == pre_detail['backendNextId'], (pre_detail, guard_detail)
+          assert guard_detail['backendPending'] == 0 and guard_detail['astEvents'] == 0 and guard_detail['runtimeRunning'] is False, guard_detail
+          assert ready_detail['backendReady'] is True and ready_detail['submitDisabled'] is False and ready_detail['state'] == 'PRÊT', ready_detail
+
           states = [e.get('detail', {}).get('state') for e in events if e.get('event') == 'STATE' and isinstance(e.get('detail'), dict)]
           assert 'EN VOL' in states and 'TERMINÉ' in states, states
-          assert any(e.get('event') == 'DONE' for e in events), events
-          print('PASS: real Blockly -> AST -> shared interpreter -> RobotWindow WWI -> dynamic PID/STOP -> fresh range decisions.')
+          print('PASS: causal pre-READY guard -> real READY -> Blockly AST -> RobotWindow WWI -> dynamic PID/STOP -> fresh range decisions.')
           PY
 
       - name: Upload Runtime v2 diagnostics

--- a/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
+++ b/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
@@ -16,6 +16,7 @@
     this.nextId = 1;
     this.pending = Object.create(null);
     this.ready = false;
+    this.readyWaiters = [];
     this.capabilities = Object.freeze({
       actions: ['takeoff', 'move', 'land'],
       rangeDirections: ['front'],
@@ -23,6 +24,22 @@
       verticalDirections: []
     });
   }
+
+  RuntimeV2WwiBackend.prototype.waitUntilReady = function() {
+    if (this.ready)
+      return Promise.resolve();
+    var self = this;
+    return new Promise(function(resolve, reject) {
+      var waiter = {resolve: resolve, reject: reject, timer: null};
+      waiter.timer = setTimeout(function() {
+        var index = self.readyWaiters.indexOf(waiter);
+        if (index !== -1)
+          self.readyWaiters.splice(index, 1);
+        reject(new Error('Runtime v2 READY timeout'));
+      }, self.timeoutMs);
+      self.readyWaiters.push(waiter);
+    });
+  };
 
   RuntimeV2WwiBackend.prototype._request = function(parts) {
     var self = this;
@@ -49,6 +66,11 @@
       return false;
     if (message === PREFIX + ' READY') {
       this.ready = true;
+      var waiters = this.readyWaiters.splice(0);
+      waiters.forEach(function(waiter) {
+        clearTimeout(waiter.timer);
+        waiter.resolve();
+      });
       return true;
     }
     var match = message.match(/^WEBEEBLOCKS_RUNTIME_V2 RESPONSE (\d+) (OK|VALUE ([^\s]+)|ERR ([A-Z0-9_]+))$/);

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -68,7 +68,7 @@ function receiveMessage(value) {
 }
 
 async function runProgram() {
-  if (runtimeRunning || !runtimeBackend)
+  if (runtimeRunning || !runtimeBackend || !runtimeBackend.ready)
     return;
   var submit = document.getElementById('submit');
   submit.disabled = true;
@@ -93,7 +93,7 @@ async function runProgram() {
     console.error(error);
     setRuntimeStatus('ERREUR', error && error.message ? error.message : String(error));
   } finally {
-    submit.disabled = false;
+    submit.disabled = !runtimeBackend.ready;
   }
 }
 
@@ -130,13 +130,15 @@ window.onload = async function() {
   try {
     var module = await import('https://cyberbotics.com/wwi/R2025a/RobotWindow.js');
     robotWindow = new module.default();
-    robotWindow.receive = receiveMessage;
     runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000});
+    robotWindow.receive = receiveMessage;
+    setRuntimeStatus('INITIALISATION', 'Attente du Runtime v2');
+    await runtimeBackend.waitUntilReady();
     document.getElementById('submit').disabled = false;
     setRuntimeStatus('PRÊT', 'Runtime v2 connecté');
   } catch (error) {
     console.error(error);
-    setRuntimeStatus('ERREUR', 'Connexion Robot Window impossible');
+    setRuntimeStatus('ERREUR', error && error.message ? error.message : 'Connexion Robot Window impossible');
   }
 };
 

--- a/tools/ci/prepare_runtime_v2_webots.py
+++ b/tools/ci/prepare_runtime_v2_webots.py
@@ -4,8 +4,40 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+controller_path = ROOT / 'controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c'
 fixture = (ROOT / 'controllers/Blockly_Programs/CrazyflieReactiveV2.xml').read_text(encoding='utf-8')
 html = html_path.read_text(encoding='utf-8')
+
+# CI-only discrimination seam: keep the real controller alive but intentionally
+# postpone READY long enough for the real Robot Window to prove its pre-READY
+# behavior. This mutation happens only in the checked-out CI working tree.
+controller = controller_path.read_text(encoding='utf-8')
+needle = '  send_text(PREFIX " READY");\n'
+replacement = r'''  printf(PREFIX " CI READY_DELAY_BEGIN time=%.3f\n", wb_robot_get_time());
+  fflush(stdout);
+  while (wb_robot_get_time() < 12.0) {
+    if (wb_robot_step(step) == -1) {
+      wb_robot_cleanup();
+      return 1;
+    }
+  }
+  position = wb_gps_get_values(gps);
+  rpy = wb_inertial_unit_get_roll_pitch_yaw(imu);
+  target_x = position[0];
+  target_y = position[1];
+  target_z = position[2];
+  target_yaw = rpy[2];
+  previous_x = position[0];
+  previous_y = position[1];
+  previous_z = position[2];
+  previous_time = wb_robot_get_time();
+  printf(PREFIX " CI READY_DELAY_END time=%.3f\n", previous_time);
+  fflush(stdout);
+  send_text(PREFIX " READY");
+'''
+if needle not in controller:
+    raise SystemExit('Runtime v2 READY injection point not found')
+controller_path.write_text(controller.replace(needle, replacement, 1), encoding='utf-8')
 
 script = r'''
 <script>
@@ -13,6 +45,7 @@ script = r'''
   function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
   let seq = 0;
   let chain = Promise.resolve();
+  let astEvents = 0;
   function report(event, detail) {
     const payload = {seq: seq++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
     chain = chain.then(() => fetch('http://127.0.0.1:8765/event', {
@@ -36,6 +69,11 @@ script = r'''
       hasWorkspace: !!window.workspace,
       hasRobotWindow: !!window.robotWindow,
       hasBackend: !!window.runtimeBackend,
+      backendReady: window.runtimeBackend ? window.runtimeBackend.ready : null,
+      backendNextId: window.runtimeBackend ? window.runtimeBackend.nextId : null,
+      backendPending: window.runtimeBackend ? Object.keys(window.runtimeBackend.pending || {}).length : null,
+      runtimeRunning: !!window.runtimeRunning,
+      astEvents: astEvents,
       submitDisabled: submit ? submit.disabled : null,
       state: state ? state.textContent : null,
       detail: detail ? detail.textContent : null
@@ -60,18 +98,59 @@ script = r'''
   }));
   window.addEventListener('unhandledrejection', event => report('UNHANDLED_REJECTION', String(event.reason)));
   window.addEventListener('webeeblocks-runtime-v2', event => report('STATE', event.detail));
-  window.addEventListener('webeeblocks-runtime-v2-ast', event => report('AST', event.detail));
+  window.addEventListener('webeeblocks-runtime-v2-ast', event => {
+    astEvents += 1;
+    report('AST', event.detail);
+  });
   window.addEventListener('webeeblocks-wwi', event => report('WWI_RX', String(event.detail)));
 
   try {
     await report('HARNESS_START', snapshot());
-    await waitFor(() => window.workspace && window.runtimeBackend && document.getElementById('submit') && !document.getElementById('submit').disabled, 'Runtime v2 ready', 20000);
-    await report('READY', runtimeBackend.capabilities);
+
+    // The CI controller intentionally withholds READY until simulation time 12 s.
+    // Observe the actual product UI during that interval, with a valid program
+    // already loaded so an old eager runProgram() would generate AST/WWI traffic.
+    await waitFor(() => window.workspace && window.runtimeBackend && window.robotWindow,
+      'Runtime v2 pre-READY objects', 12000);
     workspace.clear();
     Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(__FIXTURE__), workspace);
+    await sleep(50);
+
+    const submit = document.getElementById('submit');
+    const state = document.getElementById('runtimeState');
+    const preNextId = runtimeBackend.nextId;
+    if (runtimeBackend.ready !== false)
+      throw new Error('backend became ready before delayed controller READY: ' + JSON.stringify(snapshot()));
+    if (!submit.disabled)
+      throw new Error('Submit enabled before controller READY: ' + JSON.stringify(snapshot()));
+    if (state.textContent !== 'INITIALISATION')
+      throw new Error('UI not INITIALISATION before controller READY: ' + JSON.stringify(snapshot()));
+    await report('PRE_READY', snapshot());
+
+    // Exercise both user click semantics and the public run function. Neither may
+    // compile an AST nor emit a product request while backend.ready is false.
+    submit.click();
+    await window.runProgram();
+    await sleep(300);
+    if (astEvents !== 0)
+      throw new Error('AST generated before controller READY');
+    if (runtimeBackend.nextId !== preNextId)
+      throw new Error('WWI request id consumed before controller READY');
+    if (Object.keys(runtimeBackend.pending || {}).length !== 0)
+      throw new Error('pending WWI request exists before controller READY');
+    if (window.runtimeRunning)
+      throw new Error('runtime entered running state before controller READY');
+    if (!submit.disabled || state.textContent !== 'INITIALISATION' || runtimeBackend.ready !== false)
+      throw new Error('pre-READY guard changed UI/backend state: ' + JSON.stringify(snapshot()));
+    await report('PRE_READY_GUARD_OK', snapshot());
+
+    await waitFor(() => runtimeBackend.ready === true, 'controller READY message', 20000);
+    await waitFor(() => !submit.disabled && state.textContent === 'PRÊT', 'post-READY UI enable', 2000);
+    await report('READY', snapshot());
+
     const ast = WebeeBlocksSemanticAst.compileWorkspace(workspace);
     await report('FIXTURE_AST', ast);
-    document.getElementById('submit').click();
+    submit.click();
     await report('SUBMIT', 'clicked');
     await waitFor(() => document.getElementById('runtimeState').textContent === 'TERMINÉ', 'Runtime v2 completion', 70000);
     await report('DONE', document.getElementById('runtimeDetail').textContent);
@@ -88,4 +167,4 @@ script = r'''
 '''.replace('__FIXTURE__', json.dumps(fixture))
 
 html_path.write_text(html + '\n' + script, encoding='utf-8')
-print('Prepared Runtime v2 real Robot Window harness.')
+print('Prepared Runtime v2 real Robot Window harness with causal pre-READY discrimination.')


### PR DESCRIPTION
## Objective
Productize the readiness seam identified by Verification after #59 before changing the Runtime v2 Blockly bundle.

## Scope
- add `waitUntilReady()` to the existing product WWI backend;
- construct the backend before installing the Robot Window receive handler;
- keep `Lancer le vol` disabled until the controller has actually emitted `WEBEEBLOCKS_RUNTIME_V2 READY`;
- refuse `runProgram()` while the backend is not ready.

## Why this increment first
#59 is now `PROVEN_BY_TEST + VERIFIED_BY_CI`, but its audit found `RUN_STARTED`/TAKEOFF could be initiated before the controller READY message arrived. No premature controller action occurred in the experiment, yet that race consumes request timeout and can expose a misleading UI state on slow startup. This is the smallest product prerequisite before swapping Runtime v2 to the proven modern Blockly bundle.

## Non-goals
No Blockly version change yet, no renderer/accessibility work, no new blocks, no AST/profile/interpreter changes, no PID/STOP/controller changes, no Runtime v1 change, no `main` change.

## Evidence
The existing `Runtime v2 Webots WWI` gate must remain green on this branch and now exercises the product Robot Window with the button gated by the real READY message.

## Remaining work after this PR
If CI + Verification are clean, open the next focused productization increment for the pinned/offline Blockly 13.2.1 bundle and preserved AST/WWI behavior proven by #57/#58/#59.
