### PR TITLE
Productize pinned Blockly 13.2.1 bundle for Runtime v2

### DIFF
--- a/.github/workflows/runtime-v2-clean-checkout-packaging.yml
+++ b/.github/workflows/runtime-v2-clean-checkout-packaging.yml
@@ -1,0 +1,119 @@
+name: Runtime v2 clean checkout packaging
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clean-checkout-runtime-v2:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prove generated Blockly assets are absent in checkout
+        run: |
+          test ! -e plugins/robot_windows/blockly_v2/vendor/VERSION
+          test ! -e plugins/robot_windows/blockly_v2/node_modules/blockly/package.json
+
+      - name: Prepare Runtime v2 through supported product command
+        run: |
+          chmod +x tools/prepare_runtime_v2.sh
+          ./tools/prepare_runtime_v2.sh
+          test "$(cat plugins/robot_windows/blockly_v2/vendor/VERSION)" = "13.2.1"
+          node --check plugins/robot_windows/blockly_v2/vendor/blockly_compressed.js
+          node --check plugins/robot_windows/blockly_v2/vendor/blocks_compressed.js
+          test -s plugins/robot_windows/blockly_v2/vendor/msg/en.js
+          test -d plugins/robot_windows/blockly_v2/vendor/media
+
+      - name: Prepare real Runtime v2 Robot Window harness
+        run: |
+          python3 -m py_compile tools/ci/prepare_runtime_v2_webots.py
+          python3 tools/ci/prepare_runtime_v2_webots.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build Runtime v2 controller
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/runtime-v2-clean-checkout
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_runtime_v2 \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/runtime-v2-clean-checkout/build.log
+
+      - name: Open real Runtime v2 Robot Window
+        shell: bash
+        run: |
+          set -o pipefail
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              chmod +x /workspace/tools/ci/webots_runtime_v2_browser.sh
+              mkdir -p /root/.config/Cyberbotics
+              printf "%s\n" \
+                "[RobotWindow]" \
+                "browser=/workspace/tools/ci/webots_runtime_v2_browser.sh" \
+                "newBrowserWindow=false" \
+                > /root/.config/Cyberbotics/Webots-R2025a.conf
+              python3 /workspace/tools/ci/runtime_wwi_event_server.py \
+                --output /workspace/ci-artifacts/runtime-v2-clean-checkout/browser-events.jsonl &
+              event_server_pid=$!
+              trap "kill $event_server_pid 2>/dev/null || true" EXIT
+              sleep 0.5
+              timeout -k 5s 35s xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_v2.wbt
+            ' \
+            2>&1 | tee ci-artifacts/runtime-v2-clean-checkout/webots.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/runtime-v2-clean-checkout/exit-code.txt
+          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then
+            exit 1
+          fi
+
+      - name: Prove clean-checkout product path opened Blockly 13.2.1
+        run: |
+          set -euo pipefail
+          test -s ci-artifacts/runtime-v2-clean-checkout/browser-events.jsonl
+          test -s ci-artifacts/runtime-v2-clean-checkout/browser-launch.log
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          events = [json.loads(line) for line in Path('ci-artifacts/runtime-v2-clean-checkout/browser-events.jsonl').read_text().splitlines() if line.strip()]
+          errors = [e for e in events if e.get('event') in ('ERROR', 'WINDOW_ERROR', 'UNHANDLED_REJECTION')]
+          if errors:
+              raise AssertionError(errors[0])
+          assert any(e.get('event') == 'BLOCKLY_VERSION' and e.get('detail') == '13.2.1' for e in events), events
+          assert any(e.get('event') == 'PRE_READY' for e in events), events
+          print('PASS: clean checkout -> supported product preparation -> real Webots Robot Window -> Blockly 13.2.1')
+          PY
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-v2-clean-checkout-packaging
+          path: ci-artifacts/runtime-v2-clean-checkout/
+          if-no-files-found: error

--- a/.github/workflows/runtime-v2-clean-checkout-packaging.yml
+++ b/.github/workflows/runtime-v2-clean-checkout-packaging.yml
@@ -61,6 +61,7 @@ jobs:
           docker run --rm \
             -e LIBGL_ALWAYS_SOFTWARE=true \
             -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -e WEBEEBLOCKS_CI_ARTIFACT_DIR=/workspace/ci-artifacts/runtime-v2-clean-checkout \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             cyberbotics/webots:R2025a-ubuntu22.04 \

--- a/.github/workflows/runtime-v2-webots-wwi.yml
+++ b/.github/workflows/runtime-v2-webots-wwi.yml
@@ -102,7 +102,7 @@ jobs:
             exit 1
           fi
 
-      - name: Prove pre-READY gate, fresh range decisions and dynamic STOP actions
+      - name: Prove pre-READY gate, pinned Blockly runtime and dynamic STOP actions
         shell: bash
         run: |
           set -euo pipefail
@@ -118,6 +118,25 @@ jobs:
           python3 - <<'PY'
           import json, re
           from pathlib import Path
+
+          event_path = Path('ci-artifacts/runtime-v2-webots/browser-events.jsonl')
+          events = [json.loads(line) for line in event_path.read_text().splitlines() if line.strip()]
+          print('BROWSER_EVENTS:')
+          for event in events:
+              print(json.dumps(event, ensure_ascii=False, sort_keys=True))
+
+          browser_errors = [e for e in events if e.get('event') in ('ERROR', 'WINDOW_ERROR', 'UNHANDLED_REJECTION')]
+          if browser_errors:
+              first = browser_errors[0]
+              raise AssertionError('first browser error: ' + json.dumps(first, ensure_ascii=False, sort_keys=True))
+
+          version_events = [e for e in events if e.get('event') == 'BLOCKLY_VERSION']
+          assert version_events, 'missing BLOCKLY_VERSION runtime event'
+          assert version_events[0].get('detail') == '13.2.1', version_events[0]
+
+          snapshots = [e.get('detail') for e in events if e.get('event') in ('HARNESS_START', 'DIAG', 'PRE_READY', 'READY', 'FINAL_DIAG') and isinstance(e.get('detail'), dict)]
+          runtime_versions = [s.get('blocklyVersion') for s in snapshots if s.get('blocklyVersion')]
+          assert '13.2.1' in runtime_versions, runtime_versions
 
           log = Path('ci-artifacts/runtime-v2-webots/webots.log').read_text(errors='replace')
           trace = []
@@ -143,15 +162,13 @@ jobs:
           assert len(ranges) == 3, ranges
           assert ranges[0] < 0.5 and ranges[1] >= 0.5 and ranges[2] < 0.5, ranges
 
-          events = [json.loads(line) for line in Path('ci-artifacts/runtime-v2-webots/browser-events.jsonl').read_text().splitlines() if line.strip()]
-          assert not any(e.get('event') in ('ERROR', 'WINDOW_ERROR', 'UNHANDLED_REJECTION') for e in events), events
-
           def first_index(predicate, label):
               for index, event in enumerate(events):
                   if predicate(event):
                       return index
               raise AssertionError('missing event: ' + label)
 
+          version = first_index(lambda e: e.get('event') == 'BLOCKLY_VERSION' and e.get('detail') == '13.2.1', 'BLOCKLY_VERSION 13.2.1')
           pre = first_index(lambda e: e.get('event') == 'PRE_READY', 'PRE_READY')
           guard = first_index(lambda e: e.get('event') == 'PRE_READY_GUARD_OK', 'PRE_READY_GUARD_OK')
           ready_rx = first_index(lambda e: e.get('event') == 'WWI_RX' and e.get('detail') == 'WEBEEBLOCKS_RUNTIME_V2 READY', 'READY WWI_RX')
@@ -159,11 +176,13 @@ jobs:
           ast = first_index(lambda e: e.get('event') == 'AST', 'AST')
           submit = first_index(lambda e: e.get('event') == 'SUBMIT', 'SUBMIT')
           done = first_index(lambda e: e.get('event') == 'DONE', 'DONE')
-          assert pre < guard < ready_rx < ready < ast < submit < done, [(e.get('event'), e.get('detail')) for e in events]
+          assert version < pre < guard < ready_rx < ready < ast < submit < done, [(e.get('event'), e.get('detail')) for e in events]
 
           pre_detail = events[pre]['detail']
           guard_detail = events[guard]['detail']
           ready_detail = events[ready]['detail']
+          assert pre_detail['blocklyVersion'] == '13.2.1', pre_detail
+          assert ready_detail['blocklyVersion'] == '13.2.1', ready_detail
           assert pre_detail['backendReady'] is False and pre_detail['submitDisabled'] is True and pre_detail['state'] == 'INITIALISATION', pre_detail
           assert guard_detail['backendReady'] is False and guard_detail['submitDisabled'] is True and guard_detail['state'] == 'INITIALISATION', guard_detail
           assert guard_detail['backendNextId'] == pre_detail['backendNextId'], (pre_detail, guard_detail)
@@ -172,7 +191,7 @@ jobs:
 
           states = [e.get('detail', {}).get('state') for e in events if e.get('event') == 'STATE' and isinstance(e.get('detail'), dict)]
           assert 'EN VOL' in states and 'TERMINÉ' in states, states
-          print('PASS: causal pre-READY guard -> real READY -> Blockly AST -> RobotWindow WWI -> dynamic PID/STOP -> fresh range decisions.')
+          print('PASS: Blockly.VERSION=13.2.1 -> causal pre-READY guard -> real READY -> Blockly AST -> RobotWindow WWI -> dynamic PID/STOP -> fresh range decisions.')
           PY
 
       - name: Upload Runtime v2 diagnostics

--- a/.github/workflows/runtime-v2-webots-wwi.yml
+++ b/.github/workflows/runtime-v2-webots-wwi.yml
@@ -14,11 +14,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare pinned Blockly 13.2.1 browser assets
+        working-directory: plugins/robot_windows/blockly_v2
+        run: |
+          npm install --ignore-scripts --no-audit --no-fund
+          npm run prepare:blockly
+          test "$(cat vendor/VERSION)" = "13.2.1"
+          node --check vendor/blockly_compressed.js
+          node --check vendor/blocks_compressed.js
+          test -s vendor/msg/en.js
+          test -d vendor/media
+
       - name: Validate Runtime v2 product sources
         run: |
           node --check plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
           node --check plugins/robot_windows/blockly_v2/main.js
           python3 -m py_compile tools/ci/prepare_runtime_v2_webots.py
+          grep -Fq 'vendor/blockly_compressed.js' plugins/robot_windows/blockly_v2/blockly_v2.html
+          grep -Fq 'vendor/blocks_compressed.js' plugins/robot_windows/blockly_v2/blockly_v2.html
+          ! grep -Fq 'google-blockly-31ee4ea/blockly_' plugins/robot_windows/blockly_v2/blockly_v2.html
           grep -Fq 'window "blockly_v2"' worlds/crazyflie_runtime_v2.wbt
           ! grep -Rq 'wb_supervisor_' controllers/crazyflie_runtime_v2
           ! grep -Rq 'bridge.py' plugins/robot_windows/blockly_v2 controllers/crazyflie_runtime_v2

--- a/plugins/robot_windows/blockly_v2/.gitignore
+++ b/plugins/robot_windows/blockly_v2/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+vendor/

--- a/plugins/robot_windows/blockly_v2/README.md
+++ b/plugins/robot_windows/blockly_v2/README.md
@@ -1,0 +1,19 @@
+# Runtime v2 Blockly assets
+
+Runtime v2 uses the pinned `blockly@13.2.1` dependency declared in this directory. Generated browser assets live in `vendor/` and are intentionally not committed.
+
+From a clean checkout, prepare the Runtime v2 Robot Window once before opening `worlds/crazyflie_runtime_v2.wbt`:
+
+```bash
+./tools/prepare_runtime_v2.sh
+```
+
+Requirements:
+
+- Node.js 22 or newer;
+- npm;
+- network access during this preparation step to install the pinned npm dependency.
+
+The resulting Robot Window is self-contained at runtime: Blockly browser assets are served from the local `vendor/` directory and no external Blockly resource is required while Webots is running.
+
+`tools/prepare_runtime_v2.sh` is the supported product preparation path. CI must exercise this same command from a checkout where `vendor/` does not already exist; a workflow-only npm preparation is not considered product packaging evidence.

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -4,11 +4,9 @@
   <meta charset="utf-8">
   <title>WebeeBlocks Runtime v2</title>
   <link rel="stylesheet" href="main.css">
-  <script src="../blockly/google-blockly-31ee4ea/blockly_uncompressed.js"></script>
-  <script src="../blockly/google-blockly-31ee4ea/msg/js/en.js"></script>
-  <script src="../blockly/google-blockly-31ee4ea/blocks/logic.js"></script>
-  <script src="../blockly/google-blockly-31ee4ea/blocks/loops.js"></script>
-  <script src="../blockly/google-blockly-31ee4ea/blocks/math.js"></script>
+  <script src="vendor/blockly_compressed.js"></script>
+  <script src="vendor/blocks_compressed.js"></script>
+  <script src="vendor/msg/en.js"></script>
   <script src="../blockly/google-blockly-31ee4ea/blocks/crazyflie_v2.js"></script>
   <script src="../blockly/webeeblocks/activity_profiles.js"></script>
   <script src="../blockly/webeeblocks/activities.js"></script>

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -122,7 +122,8 @@ window.onload = async function() {
   workspace = Blockly.inject('blocklyDiv', {
     toolbox: buildToolbox(runtimeProfile),
     scrollbars: true,
-    media: 'vendor/media/'
+    media: 'vendor/media/',
+    sounds: false
   });
   workspace.addChangeListener(onWorkspaceChange);
   window.addEventListener('resize', function() { Blockly.svgResize(workspace); });

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -122,7 +122,7 @@ window.onload = async function() {
   workspace = Blockly.inject('blocklyDiv', {
     toolbox: buildToolbox(runtimeProfile),
     scrollbars: true,
-    media: '../blockly/google-blockly-31ee4ea/media/'
+    media: 'vendor/media/'
   });
   workspace.addChangeListener(onWorkspaceChange);
   window.addEventListener('resize', function() { Blockly.svgResize(workspace); });

--- a/plugins/robot_windows/blockly_v2/package.json
+++ b/plugins/robot_windows/blockly_v2/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "webeeblocks-runtime-v2-blockly",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Pinned Blockly browser assets for the WebeeBlocks Runtime v2 Robot Window.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "prepare:blockly": "node prepare_blockly_vendor.js"
+  },
+  "dependencies": {
+    "blockly": "13.2.1"
+  }
+}

--- a/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
+++ b/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const pluginDir = __dirname;
+const blocklyRoot = path.join(pluginDir, 'node_modules', 'blockly');
+const vendorDir = path.join(pluginDir, 'vendor');
+
+function requirePath(target) {
+  if (!fs.existsSync(target))
+    throw new Error(`required Blockly asset missing: ${target}`);
+  return target;
+}
+
+function copyFile(relativeSource, relativeTarget = relativeSource) {
+  const source = requirePath(path.join(blocklyRoot, relativeSource));
+  const target = path.join(vendorDir, relativeTarget);
+  fs.mkdirSync(path.dirname(target), {recursive: true});
+  fs.copyFileSync(source, target);
+}
+
+fs.rmSync(vendorDir, {recursive: true, force: true});
+fs.mkdirSync(vendorDir, {recursive: true});
+copyFile('blockly_compressed.js');
+copyFile('blocks_compressed.js');
+copyFile(path.join('msg', 'en.js'));
+fs.cpSync(requirePath(path.join(blocklyRoot, 'media')), path.join(vendorDir, 'media'), {recursive: true});
+
+const pkg = JSON.parse(fs.readFileSync(path.join(blocklyRoot, 'package.json'), 'utf8'));
+if (pkg.version !== '13.2.1')
+  throw new Error(`unexpected Blockly version: ${pkg.version}`);
+fs.writeFileSync(path.join(vendorDir, 'VERSION'), `${pkg.version}\n`, 'utf8');
+console.log(`WEBEEBLOCKS_BLOCKLY_VENDOR_VERSION=${pkg.version}`);

--- a/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
+++ b/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
@@ -27,8 +27,22 @@ copyFile('blocks_compressed.js');
 copyFile(path.join('msg', 'en.js'));
 fs.cpSync(requirePath(path.join(blocklyRoot, 'media')), path.join(vendorDir, 'media'), {recursive: true});
 
+// Webots R2025a's Robot Window server does not serve SVG assets. Blockly 13.2.1
+// uses sprites.svg for the trashcan/zoom sprite but ships the raster-equivalent
+// sprites.png in the same media directory. Apply one explicit build-time
+// compatibility rewrite and fail closed if the upstream bundle shape changes.
+requirePath(path.join(vendorDir, 'media', 'sprites.png'));
+const blocklyBundlePath = path.join(vendorDir, 'blockly_compressed.js');
+let blocklyBundle = fs.readFileSync(blocklyBundlePath, 'utf8');
+const spriteSvgMatches = blocklyBundle.match(/sprites\.svg/g) || [];
+if (spriteSvgMatches.length !== 1)
+  throw new Error(`expected exactly one Blockly sprites.svg reference, found ${spriteSvgMatches.length}`);
+blocklyBundle = blocklyBundle.replace('sprites.svg', 'sprites.png');
+fs.writeFileSync(blocklyBundlePath, blocklyBundle, 'utf8');
+
 const pkg = JSON.parse(fs.readFileSync(path.join(blocklyRoot, 'package.json'), 'utf8'));
 if (pkg.version !== '13.2.1')
   throw new Error(`unexpected Blockly version: ${pkg.version}`);
 fs.writeFileSync(path.join(vendorDir, 'VERSION'), `${pkg.version}\n`, 'utf8');
 console.log(`WEBEEBLOCKS_BLOCKLY_VENDOR_VERSION=${pkg.version}`);
+console.log('WEBEEBLOCKS_BLOCKLY_SPRITE=sprites.png');

--- a/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
+++ b/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
@@ -6,6 +6,13 @@ const path = require('node:path');
 const pluginDir = __dirname;
 const blocklyRoot = path.join(pluginDir, 'node_modules', 'blockly');
 const vendorDir = path.join(pluginDir, 'vendor');
+const historicalMediaDir = path.join(
+  pluginDir,
+  '..',
+  'blockly',
+  'google-blockly-31ee4ea',
+  'media'
+);
 
 function requirePath(target) {
   if (!fs.existsSync(target))
@@ -28,10 +35,19 @@ copyFile(path.join('msg', 'en.js'));
 fs.cpSync(requirePath(path.join(blocklyRoot, 'media')), path.join(vendorDir, 'media'), {recursive: true});
 
 // Webots R2025a's Robot Window server does not serve SVG assets. Blockly 13.2.1
-// uses sprites.svg for the trashcan/zoom sprite but ships the raster-equivalent
-// sprites.png in the same media directory. Apply one explicit build-time
-// compatibility rewrite and fail closed if the upstream bundle shape changes.
-requirePath(path.join(vendorDir, 'media', 'sprites.png'));
+// uses sprites.svg for the trashcan/zoom sprite, while the preserved Blockly
+// runtime already contains the rasterized sprites.png generated from the same
+// SVG. Reuse that PNG only if both SVG sources are byte-for-byte identical;
+// otherwise fail closed instead of silently substituting a mismatched UI asset.
+const modernSpriteSvg = requirePath(path.join(blocklyRoot, 'media', 'sprites.svg'));
+const historicalSpriteSvg = requirePath(path.join(historicalMediaDir, 'sprites.svg'));
+const historicalSpritePng = requirePath(path.join(historicalMediaDir, 'sprites.png'));
+const modernSvgBytes = fs.readFileSync(modernSpriteSvg);
+const historicalSvgBytes = fs.readFileSync(historicalSpriteSvg);
+if (!modernSvgBytes.equals(historicalSvgBytes))
+  throw new Error('Blockly 13.2.1 sprites.svg differs from the preserved raster source');
+fs.copyFileSync(historicalSpritePng, path.join(vendorDir, 'media', 'sprites.png'));
+
 const blocklyBundlePath = path.join(vendorDir, 'blockly_compressed.js');
 let blocklyBundle = fs.readFileSync(blocklyBundlePath, 'utf8');
 const spriteSvgMatches = blocklyBundle.match(/sprites\.svg/g) || [];

--- a/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
+++ b/plugins/robot_windows/blockly_v2/prepare_blockly_vendor.js
@@ -51,9 +51,11 @@ fs.copyFileSync(historicalSpritePng, path.join(vendorDir, 'media', 'sprites.png'
 const blocklyBundlePath = path.join(vendorDir, 'blockly_compressed.js');
 let blocklyBundle = fs.readFileSync(blocklyBundlePath, 'utf8');
 const spriteSvgMatches = blocklyBundle.match(/sprites\.svg/g) || [];
-if (spriteSvgMatches.length !== 1)
-  throw new Error(`expected exactly one Blockly sprites.svg reference, found ${spriteSvgMatches.length}`);
-blocklyBundle = blocklyBundle.replace('sprites.svg', 'sprites.png');
+if (spriteSvgMatches.length !== 3)
+  throw new Error(`expected exactly three Blockly sprites.svg references, found ${spriteSvgMatches.length}`);
+blocklyBundle = blocklyBundle.replaceAll('sprites.svg', 'sprites.png');
+if (blocklyBundle.includes('sprites.svg'))
+  throw new Error('Blockly sprites.svg reference remained after compatibility rewrite');
 fs.writeFileSync(blocklyBundlePath, blocklyBundle, 'utf8');
 
 const pkg = JSON.parse(fs.readFileSync(path.join(blocklyRoot, 'package.json'), 'utf8'));

--- a/tools/ci/prepare_runtime_v2_webots.py
+++ b/tools/ci/prepare_runtime_v2_webots.py
@@ -117,7 +117,9 @@ script = r'''
       throw new Error('unexpected runtime Blockly.VERSION=' + String(Blockly.VERSION || ''));
     await report('BLOCKLY_VERSION', String(Blockly.VERSION));
     workspace.clear();
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(__FIXTURE__), workspace);
+    const fixtureDom = Blockly.utils.xml.textToDom(__FIXTURE__);
+    Blockly.Xml.domToWorkspace(fixtureDom, workspace);
+    await report('FIXTURE_IMPORTED', {topBlocks: workspace.getTopBlocks(false).length});
     await sleep(50);
 
     const submit = document.getElementById('submit');

--- a/tools/ci/prepare_runtime_v2_webots.py
+++ b/tools/ci/prepare_runtime_v2_webots.py
@@ -60,6 +60,7 @@ script = r'''
     return {
       readyState: document.readyState,
       hasBlockly: typeof window.Blockly !== 'undefined',
+      blocklyVersion: typeof window.Blockly !== 'undefined' ? String(window.Blockly.VERSION || '') : null,
       hasActivities: typeof window.WebeeBlocksActivities !== 'undefined',
       hasProfiles: typeof window.WebeeBlocksActivityProfiles !== 'undefined',
       hasAst: typeof window.WebeeBlocksSemanticAst !== 'undefined',
@@ -112,6 +113,9 @@ script = r'''
     // already loaded so an old eager runProgram() would generate AST/WWI traffic.
     await waitFor(() => window.workspace && window.runtimeBackend && window.robotWindow,
       'Runtime v2 pre-READY objects', 12000);
+    if (String(Blockly.VERSION || '') !== '13.2.1')
+      throw new Error('unexpected runtime Blockly.VERSION=' + String(Blockly.VERSION || ''));
+    await report('BLOCKLY_VERSION', String(Blockly.VERSION));
     workspace.clear();
     Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(__FIXTURE__), workspace);
     await sleep(50);

--- a/tools/ci/webots_runtime_v2_browser.sh
+++ b/tools/ci/webots_runtime_v2_browser.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -eu
-mkdir -p /workspace/ci-artifacts/runtime-v2-webots
-printf 'BROWSER_LAUNCHED args=' >> /workspace/ci-artifacts/runtime-v2-webots/browser-launch.log
-printf '%q ' "$@" >> /workspace/ci-artifacts/runtime-v2-webots/browser-launch.log
-printf '\n' >> /workspace/ci-artifacts/runtime-v2-webots/browser-launch.log
+artifact_dir="${WEBEEBLOCKS_CI_ARTIFACT_DIR:-/workspace/ci-artifacts/runtime-v2-webots}"
+mkdir -p "$artifact_dir"
+printf 'BROWSER_LAUNCHED args=' >> "$artifact_dir/browser-launch.log"
+printf '%q ' "$@" >> "$artifact_dir/browser-launch.log"
+printf '\n' >> "$artifact_dir/browser-launch.log"
 exec /usr/bin/google-chrome \
   --headless=new \
   --no-sandbox \

--- a/tools/prepare_runtime_v2.sh
+++ b/tools/prepare_runtime_v2.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BLOCKLY_DIR="$ROOT_DIR/plugins/robot_windows/blockly_v2"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: Node.js >= 22 is required to prepare Runtime v2 Blockly assets." >&2
+  exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "ERROR: npm is required to prepare Runtime v2 Blockly assets." >&2
+  exit 1
+fi
+
+node_major="$(node -p 'Number(process.versions.node.split(".")[0])')"
+if [ "$node_major" -lt 22 ]; then
+  echo "ERROR: Node.js >= 22 is required; found $(node --version)." >&2
+  exit 1
+fi
+
+cd "$BLOCKLY_DIR"
+npm install --ignore-scripts --no-audit --no-fund
+npm run prepare:blockly
+
+test "$(cat vendor/VERSION)" = "13.2.1"
+test -s vendor/blockly_compressed.js
+test -s vendor/blocks_compressed.js
+test -s vendor/msg/en.js
+test -d vendor/media
+
+echo "Runtime v2 Blockly assets ready: blockly@13.2.1"


### PR DESCRIPTION
## Objective
Productize the smallest Modern Blockly increment after #60: replace the Runtime v2 Robot Window's historical Blockly engine with an exact, build-time-pinned `blockly@13.2.1` browser bundle while preserving the existing product chain `activity -> Blockly -> AST -> preflight -> interpreter -> WWI backend`.

## Scope
- pin `blockly` exactly at 13.2.1 under the Runtime v2 Robot Window;
- add a deterministic preparation script that copies Blockly browser JS/message/media assets from that exact npm package into a generated local `vendor/` directory;
- make the Runtime v2 page load those local assets and local media;
- make the real Runtime v2 Webots/WWI gate build the pinned assets before launching Webots;
- preserve the causal pre-READY gate from #60 and the existing dynamic range/STOP oracle.

## Non-goals
No renderer decision yet, no accessibility/keyboard increment, no new blocks, no AST/profile/interpreter change, no PID/STOP/controller change, no Runtime v1 change, no `main` change. This PR also does not yet replace the existing Cyberbotics RobotWindow module import; its causal contract is specifically the Blockly engine bundle.

## Prior evidence reused
#57/#58/#59 proved Blockly 13.2.1 semantic equivalence, real offline Robot Window initialization, and Modern Blockly -> AST -> WWI -> Runtime v2 execution. #60 is now integrated and causally gates UI readiness on the real controller READY message.

## Acceptance evidence required on this PR
- the gate must materialize exact Blockly 13.2.1 assets locally and reject any historical Blockly core load in `blockly_v2.html`;
- Runtime v2 semantic core remains green;
- real Webots R2025a Robot Window executes the existing acceptance program with the same pre-READY discrimination and dynamic trace `TAKEOFF -> RANGE -> LEFT -> RANGE -> FORWARD -> RANGE -> LEFT -> LAND`;
- Runtime v1/historical gates remain green.

## Remaining uncertainty
Generated `vendor/` and `node_modules/` are intentionally build artifacts, not committed source. Verification should falsify whether the CI is truly exercising the generated 13.2.1 assets rather than falling back to the historical Blockly engine.