### PR TITLE
Experiment: probe Runtime v2 native keyboard accessibility

### DIFF
--- a/.github/workflows/experimental-runtime-v2-keyboard-a11y.yml
+++ b/.github/workflows/experimental-runtime-v2-keyboard-a11y.yml
@@ -1,0 +1,112 @@
+name: Experimental Runtime v2 keyboard accessibility
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  keyboard-a11y:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare pinned Blockly 13.2.1 browser assets
+        working-directory: plugins/robot_windows/blockly_v2
+        run: |
+          npm install --ignore-scripts --no-audit --no-fund
+          npm run prepare:blockly
+          test "$(cat vendor/VERSION)" = "13.2.1"
+
+      - name: Re-prove unchanged Runtime v2 semantic core
+        run: python3 tools/ci/run_runtime_v2_core_harness.py
+
+      - name: Prepare actual Runtime v2 Robot Window
+        run: python3 tools/ci/prepare_runtime_v2_webots.py
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build unchanged Runtime v2 controller
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/runtime-v2-keyboard-a11y
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_runtime_v2 \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/runtime-v2-keyboard-a11y/build.log
+
+      - name: Probe keyboard and ARIA in real Runtime v2 Robot Window
+        shell: bash
+        run: |
+          set -o pipefail
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -e WEBEEBLOCKS_CI_ARTIFACT_DIR=/workspace/ci-artifacts/runtime-v2-keyboard-a11y \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -euo pipefail
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates python3-websocket >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              chmod +x /workspace/experiments/runtime-v2-keyboard-a11y/browser.sh
+              mkdir -p /root/.config/Cyberbotics
+              printf "%s\n" \
+                "[RobotWindow]" \
+                "browser=/workspace/experiments/runtime-v2-keyboard-a11y/browser.sh" \
+                "newBrowserWindow=false" \
+                > /root/.config/Cyberbotics/Webots-R2025a.conf
+              xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_v2.wbt \
+                > /workspace/ci-artifacts/runtime-v2-keyboard-a11y/webots.log 2>&1 &
+              webots_pid=$!
+              cleanup() { kill "$webots_pid" 2>/dev/null || true; wait "$webots_pid" 2>/dev/null || true; }
+              trap cleanup EXIT
+              python3 /workspace/experiments/runtime-v2-keyboard-a11y/probe.py \
+                > /workspace/ci-artifacts/runtime-v2-keyboard-a11y/keyboard-probe.json
+            '
+          code=$?
+          set -e
+          echo "$code" | tee ci-artifacts/runtime-v2-keyboard-a11y/exit-code.txt
+          exit "$code"
+
+      - name: Validate experimental evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s ci-artifacts/runtime-v2-keyboard-a11y/browser-launch.log
+          test -s ci-artifacts/runtime-v2-keyboard-a11y/webots.log
+          test -s ci-artifacts/runtime-v2-keyboard-a11y/keyboard-probe.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          result=json.loads(Path('ci-artifacts/runtime-v2-keyboard-a11y/keyboard-probe.json').read_text())
+          assert result['version']=='13.2.1', result
+          assert result['initial']['ariaCount'] > 0, result
+          native=result['native']
+          registered=result['afterRegisterNavigationShortcuts']
+          assert native['toolboxFocused'] or (registered and registered['toolboxFocused']), result
+          print('PASS: real Runtime v2 Robot Window exposes ARIA metadata and keyboard-only Blockly toolbox focus in the discriminating probe.')
+          PY
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: experimental-runtime-v2-keyboard-a11y
+          path: ci-artifacts/runtime-v2-keyboard-a11y/
+          if-no-files-found: error

--- a/experiments/runtime-v2-keyboard-a11y/README.md
+++ b/experiments/runtime-v2-keyboard-a11y/README.md
@@ -1,0 +1,36 @@
+# Runtime v2 keyboard/accessibility experiment
+
+## Question
+
+With the current Runtime v2 Robot Window and pinned Blockly 13.2.1, can a user reach Blockly with real keyboard events and obtain useful navigation/accessibility semantics **without any WebeeBlocks product change**?
+
+## Scope
+
+This experiment starts from the current `webots-ci` product after #62. It keeps the current renderer unchanged and runs the real `blockly_v2` Robot Window through Webots R2025a.
+
+The probe uses Chrome DevTools Protocol only as test instrumentation to inject real keyboard events and inspect focus/ARIA state. The Robot Window, Blockly workspace, activity profile, AST/runtime code and Webots controller are the product versions from `webots-ci`.
+
+The experiment first runs with Blockly exactly as productized. If keyboard-only toolbox focus is not obtainable, it calls only Blockly core `Blockly.ShortcutItems.registerNavigationShortcuts()` and repeats the same probe. This is a discriminating experiment, not a proposed product fix.
+
+## Evidence collected
+
+- pinned runtime `Blockly.VERSION`;
+- active-element/focus path after Tab navigation;
+- toolbox/category focus observation;
+- Blockly keyboard accessibility mode;
+- registered shortcut names;
+- count of DOM nodes exposing ARIA roles/labels;
+- whether the same probe improves after `registerNavigationShortcuts()`.
+
+## Non-goals
+
+- no renderer comparison (Thrasos/Zelos comes later);
+- no product accessibility patch;
+- no new block, activity, AST, backend, PID/STOP or world;
+- no Runtime v1 change;
+- no physical Crazyflie;
+- no merge to `main`.
+
+## Interpretation
+
+A green gate proves only the observed keyboard/ARIA contract exercised by this probe. If both native and `registerNavigationShortcuts()` paths fail to provide useful toolbox focus, the experiment should remain red/UNPROVEN and the next step belongs to Lab/Verification rather than adding arbitrary shortcuts.

--- a/experiments/runtime-v2-keyboard-a11y/browser.sh
+++ b/experiments/runtime-v2-keyboard-a11y/browser.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eu
+artifact_dir="${WEBEEBLOCKS_CI_ARTIFACT_DIR:-/workspace/ci-artifacts/runtime-v2-keyboard-a11y}"
+mkdir -p "$artifact_dir"
+printf 'BROWSER_LAUNCHED args=' >> "$artifact_dir/browser-launch.log"
+printf '%q ' "$@" >> "$artifact_dir/browser-launch.log"
+printf '\n' >> "$artifact_dir/browser-launch.log"
+exec /usr/bin/google-chrome \
+  --headless=new \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --disable-background-networking \
+  --no-first-run \
+  --no-default-browser-check \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222 \
+  --remote-allow-origins='*' \
+  --enable-logging=stderr \
+  --v=1 \
+  "$@"

--- a/experiments/runtime-v2-keyboard-a11y/probe.py
+++ b/experiments/runtime-v2-keyboard-a11y/probe.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import json, sys, time, urllib.request
+import websocket
+
+CDP='http://127.0.0.1:9222/json'
+
+def targets():
+    with urllib.request.urlopen(CDP, timeout=2) as response:
+        return json.load(response)
+
+def wait_target(timeout=30):
+    end=time.time()+timeout
+    while time.time()<end:
+        try:
+            for target in targets():
+                if target.get('type')=='page' and 'blockly_v2' in target.get('url',''):
+                    return target
+        except Exception:
+            pass
+        time.sleep(.2)
+    raise RuntimeError('Runtime v2 Robot Window target not found')
+
+class Cdp:
+    def __init__(self, url):
+        self.ws=websocket.create_connection(url, timeout=5)
+        self.seq=0
+    def call(self, method, params=None):
+        self.seq+=1; ident=self.seq
+        self.ws.send(json.dumps({'id':ident,'method':method,'params':params or {}}))
+        while True:
+            msg=json.loads(self.ws.recv())
+            if msg.get('id')==ident:
+                if 'error' in msg: raise RuntimeError(msg['error'])
+                return msg.get('result',{})
+    def eval(self, expr):
+        result=self.call('Runtime.evaluate', {'expression':expr,'returnByValue':True,'awaitPromise':True})
+        if result.get('exceptionDetails'): raise RuntimeError(result['exceptionDetails'])
+        return result.get('result',{}).get('value')
+    def key(self, key, code=None, text=None):
+        code=code or key
+        base={'key':key,'code':code,'windowsVirtualKeyCode': 9 if key=='Tab' else 0}
+        self.call('Input.dispatchKeyEvent', dict(base, type='keyDown'))
+        if text:
+            self.call('Input.dispatchKeyEvent', {'type':'char','text':text,'key':key,'code':code})
+        self.call('Input.dispatchKeyEvent', dict(base, type='keyUp'))
+
+SNAP="""(() => {
+ const a=document.activeElement;
+ const toolbox=document.querySelector('.blocklyToolbox');
+ const selected=document.querySelector('.blocklyToolboxCategory[aria-selected="true"]');
+ const aria=[...document.querySelectorAll('[role],[aria-label],[aria-labelledby],[aria-describedby]')];
+ return {
+  activeTag:a&&a.tagName, activeClass:a&&a.getAttribute&&a.getAttribute('class'), activeRole:a&&a.getAttribute&&a.getAttribute('role'),
+  activeInBlockly:!!(a&&a.closest&&a.closest('#blocklyDiv')),
+  activeInToolbox:!!(a&&a.closest&&a.closest('.blocklyToolbox')),
+  toolboxVisible:!!(toolbox && getComputedStyle(toolbox).display!=='none'),
+  selectedCategory:selected&&selected.textContent&&selected.textContent.trim(),
+  ariaCount:aria.length,
+  blockAriaCount:[...document.querySelectorAll('.blocklyBlockCanvas [role], .blocklyBlockCanvas [aria-label]')].length,
+  keyboardAccessibilityMode: !!(window.workspace && window.workspace.keyboardAccessibilityMode),
+  shortcutNames: Blockly.ShortcutRegistry && Blockly.ShortcutRegistry.registry ? Object.keys(Blockly.ShortcutRegistry.registry.getRegistry()) : []
+ };
+})()"""
+
+def exercise(cdp):
+    cdp.eval("document.activeElement && document.activeElement.blur(); document.body.setAttribute('tabindex','-1'); document.body.focus(); true")
+    snaps=[]
+    for _ in range(16):
+        cdp.key('Tab','Tab')
+        s=cdp.eval(SNAP); snaps.append(s)
+        if s and s.get('activeInBlockly'): break
+    cdp.key('t','KeyT','t')
+    time.sleep(.2)
+    after=cdp.eval(SNAP)
+    return {'tabs':snaps,'afterT':after,'toolboxFocused':bool(after and after.get('activeInToolbox'))}
+
+def main():
+    cdp=Cdp(wait_target()['webSocketDebuggerUrl'])
+    cdp.call('Runtime.enable')
+    end=time.time()+30
+    while time.time()<end:
+        version=cdp.eval("window.Blockly && Blockly.VERSION")
+        if version=='13.2.1' and cdp.eval("!!window.workspace"): break
+        time.sleep(.2)
+    else: raise RuntimeError('Blockly 13.2.1 workspace not initialized')
+    initial=cdp.eval(SNAP)
+    native=exercise(cdp)
+    registered=None
+    if not native['toolboxFocused']:
+        available=cdp.eval("!!(Blockly.ShortcutItems && Blockly.ShortcutItems.registerNavigationShortcuts)")
+        if available:
+            cdp.eval("Blockly.ShortcutItems.registerNavigationShortcuts(); true")
+            registered=exercise(cdp)
+    result={'version':'13.2.1','initial':initial,'native':native,'afterRegisterNavigationShortcuts':registered}
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if initial.get('ariaCount',0) <= 0:
+        raise RuntimeError('no ARIA/role metadata found in real Robot Window')
+    if not native['toolboxFocused'] and not (registered and registered['toolboxFocused']):
+        raise RuntimeError('keyboard-only toolbox focus failed before and after registerNavigationShortcuts()')
+
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
## Objective
Answer the next interface uncertainty on the current `webots-ci` baseline after merged #69: does the current Blockly 13.2.1 Runtime v2 Robot Window expose useful keyboard/accessibility behavior before any renderer or product change?

## Scope
- branch is realigned directly on the current `webots-ci` product baseline;
- keep the current Runtime v2 renderer unchanged;
- launch the real `blockly_v2` Robot Window through Webots R2025a;
- use Chrome DevTools Protocol only as CI instrumentation to inject real keyboard events and inspect focus/ARIA state;
- first exercise the product **without any manual shortcut registration**;
- only if useful toolbox focus is absent, call Blockly core `Blockly.ShortcutItems.registerNavigationShortcuts()` and replay the identical probe;
- record `Blockly.VERSION`, focus path, toolbox/category state, `keyboardAccessibilityMode`, registered shortcut names and DOM ARIA/role counts;
- re-prove the unchanged Runtime v2 semantic core before the browser probe.

## Non-goals
No product accessibility patch, no Thrasos/Zelos comparison, no new blocks or activities, no AST/profile/interpreter/backend/PID/STOP/world change, no Runtime v1 change, no physical Crazyflie, no `main` change.

## Fail-closed evidence
The experimental gate fails if the real Runtime v2 Robot Window is not reached, Blockly is not 13.2.1, no ARIA/role metadata is exposed, or keyboard-only toolbox focus cannot be obtained both before and after the single Lab-authorized `registerNavigationShortcuts()` counter-step.

A red result is informative and must not be repaired by inventing arbitrary shortcuts in this PR; it should be returned to Lab/Verification for interpretation.

## Stop criterion
Once the native-vs-core-registration keyboard/ARIA behavior is measured causally in the real Robot Window and audited, freeze this experiment. Renderer comparison comes later and must reuse the same scenario while changing only the renderer.