### PR TITLE
Experiment: compare Runtime v2 Thrasos vs Zelos — closed evidence

### DIFF
--- a/.github/workflows/experimental-runtime-v2-renderer-ab.yml
+++ b/.github/workflows/experimental-runtime-v2-renderer-ab.yml
@@ -1,0 +1,113 @@
+name: Experimental Runtime v2 renderer A/B
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renderer-ab:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare pinned Blockly 13.2.1 product assets
+        run: |
+          ./tools/prepare_runtime_v2.sh
+          test "$(cat plugins/robot_windows/blockly_v2/vendor/VERSION)" = "13.2.1"
+
+      - name: Re-prove unchanged Runtime v2 semantic core
+        run: python3 tools/ci/run_runtime_v2_core_harness.py
+
+      - name: Prepare renderer-only experimental seam
+        run: |
+          python3 experiments/runtime-v2-renderer-ab/prepare.py
+          python3 -m py_compile experiments/runtime-v2-renderer-ab/prepare.py experiments/runtime-v2-renderer-ab/probe.py
+          bash -n experiments/runtime-v2-renderer-ab/browser.sh experiments/runtime-v2-renderer-ab/run.sh
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build unchanged Runtime v2 controller
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/runtime-v2-renderer-ab
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_runtime_v2 \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/runtime-v2-renderer-ab/build.log
+
+      - name: Run identical Runtime v2 Robot Window under Thrasos and Zelos
+        shell: bash
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash /workspace/experiments/runtime-v2-renderer-ab/run.sh
+
+      - name: Compare semantic equality and objective evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s ci-artifacts/runtime-v2-renderer-ab/thrasos/metrics.json
+          test -s ci-artifacts/runtime-v2-renderer-ab/zelos/metrics.json
+          test -s ci-artifacts/runtime-v2-renderer-ab/thrasos/workspace-1366x768.png
+          test -s ci-artifacts/runtime-v2-renderer-ab/zelos/workspace-1366x768.png
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root=Path('ci-artifacts/runtime-v2-renderer-ab')
+          results={name:json.loads((root/name/'metrics.json').read_text()) for name in ('thrasos','zelos')}
+          t,z=results['thrasos'],results['zelos']
+          assert t['renderer']=='thrasos' and z['renderer']=='zelos'
+          assert t['initial']['version']=='13.2.1' and z['initial']['version']=='13.2.1'
+          assert t['initial']['rendererMatchesRegistry'] is True, t['initial']
+          assert z['initial']['rendererMatchesRegistry'] is True, z['initial']
+          assert t['ast']==z['ast'], (t['ast'],z['ast'])
+          assert t['ast']['semantics']=='webeeblocks-ast-v1'
+          assert t['initial']['counts']['blocks']==z['initial']['counts']['blocks']
+          assert t['initial']['counts']['topBlocks']==z['initial']['counts']['topBlocks']
+          assert t['initial']['viewport']['width']==z['initial']['viewport']['width']==1366
+          assert t['initial']['viewport']['height']==z['initial']['viewport']['height']==768
+
+          comparison={
+            'semantic_runtime': {'ast_identical': True, 'blockly_version': '13.2.1'},
+            'thrasos': {
+              'renderer_class': t['initial']['rendererClassName'],
+              'geometry': t['initial']['geometry'], 'counts': t['initial']['counts'],
+              'keyboard': {k:v for k,v in t['keyboard'].items() if k!='steps'}
+            },
+            'zelos': {
+              'renderer_class': z['initial']['rendererClassName'],
+              'geometry': z['initial']['geometry'], 'counts': z['initial']['counts'],
+              'keyboard': {k:v for k,v in z['keyboard'].items() if k!='steps'}
+            },
+            'decision': 'UNASSESSED_BY_HARNESS',
+            'note': 'Screenshots and metrics are evidence; aesthetic/pedagogical recommendation is intentionally not automated.'
+          }
+          (root/'comparison.json').write_text(json.dumps(comparison,ensure_ascii=False,indent=2))
+          print(json.dumps(comparison,ensure_ascii=False,indent=2))
+          PY
+
+      - name: Upload A/B evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: experimental-runtime-v2-renderer-ab
+          path: ci-artifacts/runtime-v2-renderer-ab/
+          if-no-files-found: error

--- a/experiments/runtime-v2-renderer-ab/README.md
+++ b/experiments/runtime-v2-renderer-ab/README.md
@@ -1,0 +1,24 @@
+# Runtime v2 renderer A/B experiment (#73)
+
+This experiment compares Blockly 13.2.1 **Thrasos** and **Zelos** inside the real Webots R2025a Runtime v2 Robot Window.
+
+Only the renderer query parameter varies between the two fresh Webots runs. Activity/profile, toolbox, fixture workspace, semantic AST compiler, interpreter, WWI backend, PID/STOP controller and world all remain the product versions from `webots-ci`.
+
+## Evidence
+
+For each renderer the probe records:
+
+- exact `webeeblocks-ast-v1` output;
+- actual renderer registry match;
+- 1366×768 screenshot;
+- workspace/toolbox/flyout/zoom/trash geometry;
+- block extents and block counts;
+- the native keyboard path: Tab into toolbox, ArrowDown/Up, category activation, flyout block reachability, and workspace focus return.
+
+Unsupported keyboard steps are data, not automatic failures. The experiment does **not** register WebeeBlocks-specific shortcuts to obtain a green result.
+
+The harness fails on semantic mismatch, wrong renderer, missing screenshots/metrics, or inability to instantiate the real Robot Window. It deliberately does not select a visual winner automatically. Recommendation must follow the pre-registered order in issue #73 and be independently audited.
+
+## Non-goals
+
+No renderer productization, theme/CSS redesign, new blocks or activities, debug, project files, physical Crazyflie work, PID/STOP change, Runtime v1 change, or `main` change.

--- a/experiments/runtime-v2-renderer-ab/browser.sh
+++ b/experiments/runtime-v2-renderer-ab/browser.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -eu
+renderer="${WEBEEBLOCKS_RENDERER:?WEBEEBLOCKS_RENDERER must be thrasos or zelos}"
+case "$renderer" in
+  thrasos|zelos) ;;
+  *) echo "invalid renderer: $renderer" >&2; exit 2 ;;
+esac
+artifact_dir="${WEBEEBLOCKS_CI_ARTIFACT_DIR:-/workspace/ci-artifacts/runtime-v2-renderer-ab/$renderer}"
+mkdir -p "$artifact_dir"
+printf 'BROWSER_LAUNCHED renderer=%s args=' "$renderer" >> "$artifact_dir/browser-launch.log"
+
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == http://* || "$arg" == https://* ]]; then
+    if [[ "$arg" == *\?* ]]; then
+      arg="${arg}&renderer=${renderer}"
+    else
+      arg="${arg}?renderer=${renderer}"
+    fi
+  fi
+  printf '%q ' "$arg" >> "$artifact_dir/browser-launch.log"
+  args+=("$arg")
+done
+printf '\n' >> "$artifact_dir/browser-launch.log"
+
+exec /usr/bin/google-chrome \
+  --headless=new \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --disable-background-networking \
+  --no-first-run \
+  --no-default-browser-check \
+  --window-size=1366,768 \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222 \
+  --remote-allow-origins='*' \
+  "${args[@]}"

--- a/experiments/runtime-v2-renderer-ab/prepare.py
+++ b/experiments/runtime-v2-renderer-ab/prepare.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+html = html_path.read_text(encoding='utf-8')
+
+needle = '  <script src="main.js"></script>\n'
+if needle not in html:
+    raise SystemExit('Runtime v2 main.js script tag not found')
+
+bootstrap = r'''  <script id="webeeblocks-renderer-ab-bootstrap">
+  (function() {
+    const requested = new URLSearchParams(window.location.search).get('renderer');
+    if (requested !== 'thrasos' && requested !== 'zelos')
+      throw new Error('renderer A/B: expected ?renderer=thrasos or ?renderer=zelos');
+    const originalInject = Blockly.inject.bind(Blockly);
+    Blockly.inject = function(container, options) {
+      const merged = Object.assign({}, options || {}, {renderer: requested});
+      const ws = originalInject(container, merged);
+      window.__WEBEEBLOCKS_RENDERER_VARIANT = requested;
+      return ws;
+    };
+  })();
+  </script>
+'''
+
+html_path.write_text(html.replace(needle, bootstrap + needle, 1), encoding='utf-8')
+print('Prepared Runtime v2 renderer A/B seam; only the renderer query parameter varies between runs.')

--- a/experiments/runtime-v2-renderer-ab/probe.py
+++ b/experiments/runtime-v2-renderer-ab/probe.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import json
+import time
+import urllib.request
+from pathlib import Path
+
+import websocket
+
+CDP = 'http://127.0.0.1:9222/json'
+
+
+def targets():
+    with urllib.request.urlopen(CDP, timeout=2) as response:
+        return json.load(response)
+
+
+def wait_target(timeout=30):
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            for target in targets():
+                if target.get('type') == 'page' and 'blockly_v2' in target.get('url', ''):
+                    return target
+        except Exception:
+            pass
+        time.sleep(0.2)
+    raise RuntimeError('Runtime v2 Robot Window target not found')
+
+
+class Cdp:
+    def __init__(self, url):
+        self.ws = websocket.create_connection(url, timeout=5)
+        self.seq = 0
+
+    def call(self, method, params=None):
+        self.seq += 1
+        ident = self.seq
+        self.ws.send(json.dumps({'id': ident, 'method': method, 'params': params or {}}))
+        while True:
+            msg = json.loads(self.ws.recv())
+            if msg.get('id') == ident:
+                if 'error' in msg:
+                    raise RuntimeError(msg['error'])
+                return msg.get('result', {})
+
+    def eval(self, expr):
+        result = self.call('Runtime.evaluate', {
+            'expression': expr,
+            'returnByValue': True,
+            'awaitPromise': True,
+        })
+        if result.get('exceptionDetails'):
+            raise RuntimeError(result['exceptionDetails'])
+        return result.get('result', {}).get('value')
+
+    def key(self, key, code=None):
+        code = code or key
+        vk = {'Tab': 9, 'Enter': 13, 'Escape': 27, 'ArrowDown': 40, 'ArrowUp': 38}.get(key, 0)
+        base = {'key': key, 'code': code, 'windowsVirtualKeyCode': vk, 'nativeVirtualKeyCode': vk}
+        self.call('Input.dispatchKeyEvent', dict(base, type='keyDown'))
+        self.call('Input.dispatchKeyEvent', dict(base, type='keyUp'))
+
+    def screenshot(self, path):
+        data = self.call('Page.captureScreenshot', {'format': 'png', 'fromSurface': True})['data']
+        Path(path).write_bytes(base64.b64decode(data))
+
+
+SNAPSHOT = r'''(() => {
+  const a = document.activeElement;
+  const rect = el => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return {x:r.x,y:r.y,width:r.width,height:r.height,right:r.right,bottom:r.bottom};
+  };
+  const toolbox = document.querySelector('.blocklyToolbox');
+  const flyout = document.querySelector('.blocklyFlyout');
+  const workspaceSvg = document.querySelector('#blocklyDiv .blocklySvg');
+  const zoom = document.querySelector('.blocklyZoom');
+  const trash = document.querySelector('.blocklyTrash');
+  const selected = document.querySelector('.blocklyToolboxCategory[aria-selected="true"], .blocklyTreeRow[aria-selected="true"]');
+  const blocks = workspace ? workspace.getAllBlocks(false).map(b => {
+    const root = b.getSvgRoot && b.getSvgRoot();
+    return {type:b.type, rect:rect(root)};
+  }) : [];
+  const allRects = blocks.map(b => b.rect).filter(Boolean);
+  const extent = allRects.length ? {
+    left:Math.min(...allRects.map(r=>r.x)), top:Math.min(...allRects.map(r=>r.y)),
+    right:Math.max(...allRects.map(r=>r.right)), bottom:Math.max(...allRects.map(r=>r.bottom))
+  } : null;
+  if (extent) { extent.width=extent.right-extent.left; extent.height=extent.bottom-extent.top; }
+  const className = workspace && workspace.getRenderer && workspace.getRenderer().getClassName ? workspace.getRenderer().getClassName() : null;
+  const expected = window.__WEBEEBLOCKS_RENDERER_VARIANT;
+  let registryMatch = false;
+  try {
+    const R = Blockly.registry.getClass(Blockly.registry.Type.RENDERER, expected, true);
+    registryMatch = !!(workspace && workspace.getRenderer() instanceof R);
+  } catch (_) {}
+  return {
+    version:String(Blockly.VERSION || ''), expectedRenderer:expected, rendererClassName:className, rendererMatchesRegistry:registryMatch,
+    viewport:{width:innerWidth,height:innerHeight,devicePixelRatio:devicePixelRatio},
+    active:{tag:a&&a.tagName,role:a&&a.getAttribute&&a.getAttribute('role'),label:a&&a.getAttribute&&a.getAttribute('aria-label'),text:a&&a.textContent&&a.textContent.trim().slice(0,80),
+      inBlockly:!!(a&&a.closest&&a.closest('#blocklyDiv')), inToolbox:!!(a&&a.closest&&a.closest('.blocklyToolbox')), inFlyout:!!(a&&a.closest&&a.closest('.blocklyFlyout'))},
+    selectedCategory:selected&&selected.textContent&&selected.textContent.trim(),
+    geometry:{blocklyDiv:rect(document.getElementById('blocklyDiv')), workspaceSvg:rect(workspaceSvg), toolbox:rect(toolbox), flyout:rect(flyout), zoom:rect(zoom), trash:rect(trash), blockExtent:extent},
+    counts:{blocks:blocks.length, topBlocks:workspace?workspace.getTopBlocks(false).length:0, toolboxCategories:document.querySelectorAll('.blocklyToolboxCategory,.blocklyTreeRow').length, flyoutBlocks:document.querySelectorAll('.blocklyFlyout .blocklyDraggable').length},
+    blocks:blocks
+  };
+})()'''
+
+
+def wait_ready(cdp, timeout=30):
+    end = time.time() + timeout
+    while time.time() < end:
+        value = cdp.eval("({version:window.Blockly&&Blockly.VERSION,workspace:!!window.workspace,renderer:window.__WEBEEBLOCKS_RENDERER_VARIANT||null})")
+        if value and value.get('version') == '13.2.1' and value.get('workspace') and value.get('renderer'):
+            return value
+        time.sleep(0.2)
+    raise RuntimeError('Blockly 13.2.1 workspace did not initialize')
+
+
+def keyboard_path(cdp):
+    cdp.eval("document.activeElement&&document.activeElement.blur();document.body.setAttribute('tabindex','-1');document.body.focus();true")
+    steps = []
+
+    def snap(name):
+        value = cdp.eval(SNAPSHOT)
+        steps.append({'step': name, 'snapshot': value})
+        return value
+
+    snap('body_focus')
+    entered = False
+    for index in range(16):
+        cdp.key('Tab', 'Tab')
+        state = snap(f'tab_{index+1}')
+        if state['active']['inToolbox']:
+            entered = True
+            break
+
+    arrow_down = arrow_up = opened = flyout_reached = workspace_returned = False
+    if entered:
+        before = steps[-1]['snapshot'].get('selectedCategory')
+        cdp.key('ArrowDown', 'ArrowDown')
+        down = snap('arrow_down')
+        arrow_down = down.get('selectedCategory') != before or down['active']['inToolbox']
+        before_up = down.get('selectedCategory')
+        cdp.key('ArrowUp', 'ArrowUp')
+        up = snap('arrow_up')
+        arrow_up = up.get('selectedCategory') != before_up or up['active']['inToolbox']
+        cdp.key('Enter', 'Enter')
+        opened_state = snap('activate_category')
+        opened = bool(opened_state['geometry']['flyout'] and opened_state['geometry']['flyout']['width'] > 0)
+        for index in range(12):
+            cdp.key('Tab', 'Tab')
+            state = snap(f'flyout_tab_{index+1}')
+            if state['active']['inFlyout']:
+                flyout_reached = True
+                break
+        cdp.key('Escape', 'Escape')
+        snap('escape_from_flyout')
+        for index in range(16):
+            cdp.key('Tab', 'Tab')
+            state = snap(f'workspace_tab_{index+1}')
+            if state['active']['inBlockly'] and not state['active']['inToolbox'] and not state['active']['inFlyout']:
+                workspace_returned = True
+                break
+
+    return {
+        'toolboxEntry': entered,
+        'arrowDown': arrow_down,
+        'arrowUp': arrow_up,
+        'categoryActivation': opened,
+        'flyoutBlockReachable': flyout_reached,
+        'workspaceFocusReturn': workspace_returned,
+        'steps': steps,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--renderer', required=True, choices=['thrasos', 'zelos'])
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--screenshot', required=True)
+    args = parser.parse_args()
+
+    cdp = Cdp(wait_target()['webSocketDebuggerUrl'])
+    cdp.call('Runtime.enable')
+    cdp.call('Page.enable')
+    wait_ready(cdp)
+
+    fixture = Path(args.fixture).read_text(encoding='utf-8')
+    cdp.eval("workspace.clear();Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(%s),workspace);Blockly.svgResize(workspace);true" % json.dumps(fixture))
+    time.sleep(0.5)
+    ast = cdp.eval("WebeeBlocksSemanticAst.compileWorkspace(workspace)")
+    initial = cdp.eval(SNAPSHOT)
+    if initial.get('expectedRenderer') != args.renderer or not initial.get('rendererMatchesRegistry'):
+        raise RuntimeError('renderer registry mismatch: ' + json.dumps(initial, ensure_ascii=False))
+    if ast.get('semantics') != 'webeeblocks-ast-v1':
+        raise RuntimeError('unexpected AST semantics: ' + json.dumps(ast))
+
+    keyboard = keyboard_path(cdp)
+    final = cdp.eval(SNAPSHOT)
+    cdp.screenshot(args.screenshot)
+    result = {'renderer': args.renderer, 'ast': ast, 'initial': initial, 'keyboard': keyboard, 'final': final}
+    Path(args.output).write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding='utf-8')
+    try:
+        cdp.call('Browser.close')
+    except Exception:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/runtime-v2-renderer-ab/probe.py
+++ b/experiments/runtime-v2-renderer-ab/probe.py
@@ -139,24 +139,32 @@ def keyboard_path(cdp):
             break
 
     arrow_down = arrow_up = opened = flyout_reached = workspace_returned = False
+    flyout_open_before = False
     if entered:
-        before = steps[-1]['snapshot'].get('selectedCategory')
+        before = steps[-1]['snapshot']
         cdp.key('ArrowDown', 'ArrowDown')
         down = snap('arrow_down')
-        arrow_down = down.get('selectedCategory') != before or down['active']['inToolbox']
-        before_up = down.get('selectedCategory')
+        arrow_down = (down.get('selectedCategory'), down['active'].get('text')) != (before.get('selectedCategory'), before['active'].get('text'))
+
+        before_up = down
         cdp.key('ArrowUp', 'ArrowUp')
         up = snap('arrow_up')
-        arrow_up = up.get('selectedCategory') != before_up or up['active']['inToolbox']
+        arrow_up = (up.get('selectedCategory'), up['active'].get('text')) != (before_up.get('selectedCategory'), before_up['active'].get('text'))
+
+        flyout = up['geometry'].get('flyout')
+        flyout_open_before = bool(flyout and flyout.get('width', 0) > 0)
         cdp.key('Enter', 'Enter')
         opened_state = snap('activate_category')
-        opened = bool(opened_state['geometry']['flyout'] and opened_state['geometry']['flyout']['width'] > 0)
+        flyout = opened_state['geometry'].get('flyout')
+        opened = bool(flyout and flyout.get('width', 0) > 0)
+
         for index in range(12):
             cdp.key('Tab', 'Tab')
             state = snap(f'flyout_tab_{index+1}')
             if state['active']['inFlyout']:
                 flyout_reached = True
                 break
+
         cdp.key('Escape', 'Escape')
         snap('escape_from_flyout')
         for index in range(16):
@@ -170,6 +178,7 @@ def keyboard_path(cdp):
         'toolboxEntry': entered,
         'arrowDown': arrow_down,
         'arrowUp': arrow_up,
+        'flyoutOpenBeforeActivation': flyout_open_before,
         'categoryActivation': opened,
         'flyoutBlockReachable': flyout_reached,
         'workspaceFocusReturn': workspace_returned,
@@ -188,7 +197,11 @@ def main():
     cdp = Cdp(wait_target()['webSocketDebuggerUrl'])
     cdp.call('Runtime.enable')
     cdp.call('Page.enable')
+    cdp.call('Emulation.setDeviceMetricsOverride', {
+        'width': 1366, 'height': 768, 'deviceScaleFactor': 1, 'mobile': False,
+    })
     wait_ready(cdp)
+    cdp.eval("window.dispatchEvent(new Event('resize'));Blockly.svgResize(workspace);true")
 
     fixture = Path(args.fixture).read_text(encoding='utf-8')
     cdp.eval("workspace.clear();Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(%s),workspace);Blockly.svgResize(workspace);true" % json.dumps(fixture))

--- a/experiments/runtime-v2-renderer-ab/run.sh
+++ b/experiments/runtime-v2-renderer-ab/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=/workspace
+OUT="$ROOT/ci-artifacts/runtime-v2-renderer-ab"
+FIXTURE="$ROOT/controllers/Blockly_Programs/CrazyflieReactiveV2.xml"
+mkdir -p "$OUT" /root/.config/Cyberbotics
+
+apt-get update >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates python3-websocket >/dev/null
+wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+chmod +x "$ROOT/experiments/runtime-v2-renderer-ab/browser.sh"
+printf '%s\n' \
+  '[RobotWindow]' \
+  'browser=/workspace/experiments/runtime-v2-renderer-ab/browser.sh' \
+  'newBrowserWindow=false' \
+  > /root/.config/Cyberbotics/Webots-R2025a.conf
+
+run_variant() {
+  renderer="$1"
+  dir="$OUT/$renderer"
+  mkdir -p "$dir"
+  export WEBEEBLOCKS_RENDERER="$renderer"
+  export WEBEEBLOCKS_CI_ARTIFACT_DIR="$dir"
+
+  xvfb-run -a webots --stdout --stderr --batch --mode=realtime "$ROOT/worlds/crazyflie_runtime_v2.wbt" \
+    > "$dir/webots.log" 2>&1 &
+  webots_pid=$!
+  cleanup_variant() {
+    kill "$webots_pid" 2>/dev/null || true
+    wait "$webots_pid" 2>/dev/null || true
+  }
+  trap cleanup_variant RETURN
+
+  python3 "$ROOT/experiments/runtime-v2-renderer-ab/probe.py" \
+    --renderer "$renderer" \
+    --fixture "$FIXTURE" \
+    --output "$dir/metrics.json" \
+    --screenshot "$dir/workspace-1366x768.png"
+
+  cleanup_variant
+  trap - RETURN
+}
+
+run_variant thrasos
+run_variant zelos

--- a/experiments/runtime-v2-renderer-ab/run.sh
+++ b/experiments/runtime-v2-renderer-ab/run.sh
@@ -16,6 +16,16 @@ printf '%s\n' \
   'newBrowserWindow=false' \
   > /root/.config/Cyberbotics/Webots-R2025a.conf
 
+current_webots_pid=""
+cleanup_current() {
+  if [[ -n "$current_webots_pid" ]]; then
+    kill "$current_webots_pid" 2>/dev/null || true
+    wait "$current_webots_pid" 2>/dev/null || true
+    current_webots_pid=""
+  fi
+}
+trap cleanup_current EXIT
+
 run_variant() {
   renderer="$1"
   dir="$OUT/$renderer"
@@ -25,12 +35,7 @@ run_variant() {
 
   xvfb-run -a webots --stdout --stderr --batch --mode=realtime "$ROOT/worlds/crazyflie_runtime_v2.wbt" \
     > "$dir/webots.log" 2>&1 &
-  webots_pid=$!
-  cleanup_variant() {
-    kill "$webots_pid" 2>/dev/null || true
-    wait "$webots_pid" 2>/dev/null || true
-  }
-  trap cleanup_variant RETURN
+  current_webots_pid=$!
 
   python3 "$ROOT/experiments/runtime-v2-renderer-ab/probe.py" \
     --renderer "$renderer" \
@@ -38,8 +43,7 @@ run_variant() {
     --output "$dir/metrics.json" \
     --screenshot "$dir/workspace-1366x768.png"
 
-  cleanup_variant
-  trap - RETURN
+  cleanup_current
 }
 
 run_variant thrasos


### PR DESCRIPTION
## Objective
Execute issue #73 as a strict A/B experiment in the real Runtime v2 Robot Window under Webots R2025a and recommend Thrasos / Zelos / ambiguous from auditable evidence.

## Result
Experiment completed and preserved as evidence; **closed without merge**.

- Blockly 13.2.1, AST and Runtime behavior were equivalent under Thrasos and Zelos.
- Keyboard path was equivalent in the tested scenario.
- Engineering inferred Zelos was clearer for novice nesting; Verification correctly kept the pedagogical preference ambiguous from CI alone.
- Human local test on 2026-08-24 found that renderer-only switching did not create a meaningful visible modernization: both variants still felt like the historical/default Blockly interface.
- Product decision subsequently made explicitly: **Blockly 13.2.1 + Zelos is now the fixed technical UI foundation**, because Zelos aligns with the desired Scratch-familiar block geometry. The product goal is no longer renderer comparison; it is #75, a visibly modern WebeeBlocks interface built on Zelos.

This PR is historical experimental evidence only and must not be merged into `webots-ci`.