### PR TITLE
Add manual Runtime v2 project files (71-A)

### DIFF
--- a/.github/workflows/runtime-v2-project-files.yml
+++ b/.github/workflows/runtime-v2-project-files.yml
@@ -1,0 +1,133 @@
+name: Runtime v2 manual project files
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/robot_windows/blockly/webeeblocks/project_files.js'
+      - 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+      - 'plugins/robot_windows/blockly_v2/project_ui.js'
+      - 'plugins/robot_windows/blockly_v2/project_files.css'
+      - 'tools/ci/test_runtime_v2_project_files.js'
+      - 'tools/ci/prepare_runtime_v2_project_files.py'
+      - '.github/workflows/runtime-v2-project-files.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-v2-project-files:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare pinned Blockly 13.2.1 assets
+        run: ./tools/prepare_runtime_v2.sh
+
+      - name: Validate project file core contract
+        run: |
+          node --check plugins/robot_windows/blockly/webeeblocks/project_files.js
+          node --check plugins/robot_windows/blockly_v2/project_ui.js
+          node --check tools/ci/test_runtime_v2_project_files.js
+          python3 -m py_compile tools/ci/prepare_runtime_v2_project_files.py
+          node tools/ci/test_runtime_v2_project_files.js
+          ! grep -REi 'autosave|attemptHistory|scoreHistory|studentIdentity|moodle|cloudSync' \
+            plugins/robot_windows/blockly/webeeblocks/project_files.js \
+            plugins/robot_windows/blockly_v2/project_ui.js
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Build unchanged Runtime v2 controller
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/runtime-v2-project-files
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_runtime_v2 \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/runtime-v2-project-files/build.log
+
+      - name: Prepare real Robot Window project-file harness
+        run: python3 tools/ci/prepare_runtime_v2_project_files.py
+
+      - name: Exercise explicit Save As Open Save and fail-closed behavior
+        shell: bash
+        run: |
+          set -o pipefail
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -e WEBEEBLOCKS_CI_ARTIFACT_DIR=/workspace/ci-artifacts/runtime-v2-project-files \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              chmod +x /workspace/tools/ci/webots_runtime_v2_browser.sh
+              mkdir -p /workspace/ci-artifacts/runtime-v2-project-files /root/.config/Cyberbotics
+              printf "%s\n" \
+                "[RobotWindow]" \
+                "browser=/workspace/tools/ci/webots_runtime_v2_browser.sh" \
+                "newBrowserWindow=false" \
+                > /root/.config/Cyberbotics/Webots-R2025a.conf
+              python3 /workspace/tools/ci/runtime_wwi_event_server.py \
+                --output /workspace/ci-artifacts/runtime-v2-project-files/browser-events.jsonl &
+              server=$!
+              trap "kill $server 2>/dev/null || true" EXIT
+              sleep 0.5
+              timeout -k 5s 45s xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_v2.wbt
+            ' \
+            2>&1 | tee ci-artifacts/runtime-v2-project-files/webots.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/runtime-v2-project-files/exit-code.txt
+          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then exit "$code"; fi
+
+      - name: Validate causal project-file evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          event_path = Path('ci-artifacts/runtime-v2-project-files/browser-events.jsonl')
+          assert event_path.exists() and event_path.stat().st_size > 0, 'missing browser project-file evidence'
+          events = [json.loads(line) for line in event_path.read_text().splitlines() if line.strip()]
+          errors = [e for e in events if e.get('event') in ('ERROR','WINDOW_ERROR','UNHANDLED_REJECTION')]
+          assert not errors, errors[:1]
+          names = [e.get('event') for e in events]
+          for required in ('FILE_API_BOUNDARY','INITIAL_AST','SAVE_AS_OK','EDIT_NO_WRITE_OK','OPEN_ROUNDTRIP_OK','SAVE_UPDATE_OK','FAIL_CLOSED_OK','RUN_DEBUG_NO_WRITE_OK','PROJECT_FILES_TEST_COMPLETE'):
+              assert required in names, (required, names)
+          boundary = next(e['detail'] for e in events if e.get('event') == 'FILE_API_BOUNDARY')
+          assert set(boundary) == {'open','save','secureContext'}, boundary
+          save_as = next(e['detail'] for e in events if e.get('event') == 'SAVE_AS_OK')
+          save_update = next(e['detail'] for e in events if e.get('event') == 'SAVE_UPDATE_OK')
+          assert save_as['writes'] == 1, save_as
+          assert save_update['writes'] == 2, save_update
+          no_write = next(e['detail'] for e in events if e.get('event') == 'RUN_DEBUG_NO_WRITE_OK')
+          assert no_write['writes'] == 2, no_write
+          assert save_update['ast']['semantics'] == 'webeeblocks-ast-v1', save_update
+          log = Path('ci-artifacts/runtime-v2-project-files/webots.log').read_text(errors='replace')
+          assert 'ERROR:' not in log, log[-2000:]
+          print('PASS: real R2025a Robot Window explicit project round-trip/save/fail-closed; browser file API boundary=', boundary)
+          PY
+
+      - name: Upload project-file diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-v2-project-files-r2025a
+          path: ci-artifacts/runtime-v2-project-files/
+          if-no-files-found: error

--- a/plugins/robot_windows/blockly/webeeblocks/project_files.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_files.js
@@ -36,13 +36,44 @@
     return base.toLowerCase().endsWith(EXTENSION) ? base : base + EXTENSION;
   }
 
+  function validateWorkspaceFields(profile, workspace) {
+    var definitions = profile.parameterBounds || {};
+    workspace.getAllBlocks(false).forEach(function(block) {
+      var fields = definitions[block.type] || {};
+      Object.keys(fields).forEach(function(fieldName) {
+        var field = block.getField(fieldName);
+        if (!field || typeof field.getValue !== 'function') fail('workspace field unavailable: ' + block.type + '.' + fieldName);
+        var value = Number(field.getValue());
+        var bounds = fields[fieldName];
+        if (!Number.isFinite(value) || value < bounds.min || value > bounds.max)
+          fail('workspace field outside profile bounds: ' + block.type + '.' + fieldName);
+      });
+    });
+  }
+
+  function optionalAst(profile, workspace, options) {
+    try {
+      var ast = options.semanticAst.compileWorkspace(workspace);
+      options.activityContract.preflightAst(profile, ast);
+      if (ast.semantics !== SEMANTICS) fail('unsupported AST semantics: ' + String(ast.semantics));
+      return ast;
+    } catch (error) {
+      var message = String(error && error.message || error);
+      var incomplete = [
+        'Crazyflie program must have exactly one top-level sequence',
+        'program must start with takeoff and end with land',
+        'missing value input '
+      ].some(function(fragment) { return message.indexOf(fragment) >= 0; });
+      if (incomplete) return null;
+      throw error;
+    }
+  }
+
   function createProject(profile, workspace, options) {
     requireDependencies(options);
     if (!profile || typeof profile.id !== 'string') fail('current activity unavailable');
     options.activityContract.preflightWorkspace(profile, workspace);
-    var ast = options.semanticAst.compileWorkspace(workspace);
-    options.activityContract.preflightAst(profile, ast);
-    if (ast.semantics !== SEMANTICS) fail('unsupported AST semantics: ' + String(ast.semantics));
+    validateWorkspaceFields(profile, workspace);
     return {
       format: FORMAT,
       version: VERSION,
@@ -82,9 +113,8 @@
     try {
       options.Blockly.serialization.workspaces.load(project.workspace, temporary);
       options.activityContract.preflightWorkspace(profile, temporary);
-      var ast = options.semanticAst.compileWorkspace(temporary);
-      options.activityContract.preflightAst(profile, ast);
-      if (ast.semantics !== project.activity.semantics) fail('workspace semantics mismatch');
+      validateWorkspaceFields(profile, temporary);
+      var ast = optionalAst(profile, temporary, options);
       return {project: project, profile: profile, ast: ast};
     } catch (error) {
       if (String(error && error.message || error).indexOf('project file: ') === 0) throw error;
@@ -116,7 +146,7 @@
       anchor.click();
       anchor.remove();
       browserWindow.setTimeout(function() { browserWindow.URL.revokeObjectURL(url); }, 0);
-      return Promise.resolve({handle: null, name: anchor.download, mode: 'download'});
+      return Promise.resolve({handle: null, name: normalizeName(name), mode: 'download'});
     }
     function upload() {
       return new Promise(function(resolve, reject) {
@@ -200,9 +230,13 @@
         options.workspace.clear();
         options.Blockly.serialization.workspaces.load(validated.project.workspace, options.workspace);
         options.activityContract.applyFieldBounds(validated.profile, options.workspace);
-        var loadedAst = options.semanticAst.compileWorkspace(options.workspace);
-        options.activityContract.preflightAst(validated.profile, loadedAst);
-        if (!sameJson(loadedAst, validated.ast)) fail('loaded workspace differs from validated project');
+        options.activityContract.preflightWorkspace(validated.profile, options.workspace);
+        validateWorkspaceFields(validated.profile, options.workspace);
+        if (validated.ast) {
+          var loadedAst = options.semanticAst.compileWorkspace(options.workspace);
+          options.activityContract.preflightAst(validated.profile, loadedAst);
+          if (!sameJson(loadedAst, validated.ast)) fail('loaded workspace differs from validated project');
+        }
       } catch (error) {
         try { restore(before); } catch (rollbackError) { console.error('WebeeBlocks project rollback failed', rollbackError); }
         throw error;

--- a/plugins/robot_windows/blockly/webeeblocks/project_files.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_files.js
@@ -1,0 +1,253 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksProjectFiles = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  var FORMAT = 'webeeblocks-project';
+  var VERSION = 1;
+  var SEMANTICS = 'webeeblocks-ast-v1';
+  var EXTENSION = '.webeeblocks.json';
+  var ROOT_KEYS = ['activity', 'format', 'version', 'workspace'];
+  var ACTIVITY_KEYS = ['id', 'semantics'];
+
+  function fail(message) { throw new Error('project file: ' + message); }
+  function isObject(value) { return value !== null && typeof value === 'object' && !Array.isArray(value); }
+  function sameJson(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
+  function sortedKeys(value) { return Object.keys(value).sort(); }
+  function requireExactKeys(value, expected, path) {
+    var actual = sortedKeys(value);
+    var wanted = expected.slice().sort();
+    if (!sameJson(actual, wanted)) fail(path + ' has unsupported fields: ' + actual.join(', '));
+  }
+  function requireString(value, path) {
+    if (typeof value !== 'string' || value.trim() === '') fail(path + ' must be a non-empty string');
+  }
+  function requireDependencies(options) {
+    ['Blockly', 'profiles', 'activitiesDocument', 'blockCatalog', 'semanticAst', 'activityContract'].forEach(function(key) {
+      if (!options || !options[key]) fail('missing dependency: ' + key);
+    });
+  }
+
+  function normalizeName(name) {
+    var base = typeof name === 'string' && name.trim() ? name.trim() : 'programme';
+    return base.toLowerCase().endsWith(EXTENSION) ? base : base + EXTENSION;
+  }
+
+  function createProject(profile, workspace, options) {
+    requireDependencies(options);
+    if (!profile || typeof profile.id !== 'string') fail('current activity unavailable');
+    options.activityContract.preflightWorkspace(profile, workspace);
+    var ast = options.semanticAst.compileWorkspace(workspace);
+    options.activityContract.preflightAst(profile, ast);
+    if (ast.semantics !== SEMANTICS) fail('unsupported AST semantics: ' + String(ast.semantics));
+    return {
+      format: FORMAT,
+      version: VERSION,
+      activity: {id: profile.id, semantics: SEMANTICS},
+      workspace: options.Blockly.serialization.workspaces.save(workspace)
+    };
+  }
+
+  function encodeProject(profile, workspace, options) {
+    return JSON.stringify(createProject(profile, workspace, options), null, 2) + '\n';
+  }
+
+  function parseProject(text) {
+    var value;
+    try { value = JSON.parse(String(text)); }
+    catch (error) { fail('invalid JSON'); }
+    if (!isObject(value)) fail('root must be an object');
+    requireExactKeys(value, ROOT_KEYS, 'root');
+    if (value.format !== FORMAT) fail('unsupported format');
+    if (value.version !== VERSION) fail('unsupported version: ' + String(value.version));
+    if (!isObject(value.activity)) fail('activity must be an object');
+    requireExactKeys(value.activity, ACTIVITY_KEYS, 'activity');
+    requireString(value.activity.id, 'activity.id');
+    if (value.activity.semantics !== SEMANTICS) fail('unsupported AST semantics: ' + String(value.activity.semantics));
+    if (!isObject(value.workspace)) fail('workspace must be an object');
+    return value;
+  }
+
+  function validateProjectText(text, currentProfile, options) {
+    requireDependencies(options);
+    var project = parseProject(text);
+    var profile = options.profiles.resolveById(options.activitiesDocument, project.activity.id, options.blockCatalog);
+    if (!currentProfile || profile.world !== currentProfile.world)
+      fail('activity is incompatible with the current Webots world');
+
+    var temporary = new options.Blockly.Workspace();
+    try {
+      options.Blockly.serialization.workspaces.load(project.workspace, temporary);
+      options.activityContract.preflightWorkspace(profile, temporary);
+      var ast = options.semanticAst.compileWorkspace(temporary);
+      options.activityContract.preflightAst(profile, ast);
+      if (ast.semantics !== project.activity.semantics) fail('workspace semantics mismatch');
+      return {project: project, profile: profile, ast: ast};
+    } catch (error) {
+      if (String(error && error.message || error).indexOf('project file: ') === 0) throw error;
+      fail('invalid workspace: ' + String(error && error.message || error));
+    } finally {
+      if (temporary && typeof temporary.dispose === 'function') temporary.dispose();
+    }
+  }
+
+  function createBrowserTransport(browserWindow, documentObject) {
+    if (!browserWindow || !documentObject) fail('browser transport requires window and document');
+    var nativeAccess = typeof browserWindow.showOpenFilePicker === 'function' && typeof browserWindow.showSaveFilePicker === 'function';
+
+    function pickerOptions() {
+      return {
+        types: [{description: 'Projet WebeeBlocks', accept: {'application/json': [EXTENSION]}}],
+        excludeAcceptAllOption: false,
+        multiple: false
+      };
+    }
+    function download(name, text) {
+      var blob = new browserWindow.Blob([text], {type: 'application/json'});
+      var url = browserWindow.URL.createObjectURL(blob);
+      var anchor = documentObject.createElement('a');
+      anchor.href = url;
+      anchor.download = normalizeName(name);
+      anchor.style.display = 'none';
+      documentObject.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      browserWindow.setTimeout(function() { browserWindow.URL.revokeObjectURL(url); }, 0);
+      return Promise.resolve({handle: null, name: anchor.download, mode: 'download'});
+    }
+    function upload() {
+      return new Promise(function(resolve, reject) {
+        var input = documentObject.createElement('input');
+        input.type = 'file';
+        input.accept = EXTENSION + ',application/json';
+        input.style.display = 'none';
+        documentObject.body.appendChild(input);
+        input.addEventListener('change', function() {
+          var file = input.files && input.files[0];
+          input.remove();
+          if (!file) { reject(new Error('project file: open cancelled')); return; }
+          file.text().then(function(text) { resolve({handle: null, name: file.name, text: text, mode: 'upload'}); }, reject);
+        }, {once: true});
+        input.click();
+      });
+    }
+    async function writeHandle(handle, text) {
+      var writable = await handle.createWritable();
+      try { await writable.write(text); }
+      finally { await writable.close(); }
+    }
+    return {
+      nativeFileSystemAccess: nativeAccess,
+      async open() {
+        if (!nativeAccess) return upload();
+        var handles = await browserWindow.showOpenFilePicker(pickerOptions());
+        if (!handles || handles.length !== 1) fail('open cancelled');
+        var file = await handles[0].getFile();
+        return {handle: handles[0], name: file.name, text: await file.text(), mode: 'native'};
+      },
+      async saveAs(name, text) {
+        if (!nativeAccess) return download(name, text);
+        var handle = await browserWindow.showSaveFilePicker(Object.assign({suggestedName: normalizeName(name)}, pickerOptions()));
+        await writeHandle(handle, text);
+        return {handle: handle, name: handle.name || normalizeName(name), mode: 'native'};
+      },
+      async save(target, name, text) {
+        if (target && typeof target.createWritable === 'function') {
+          await writeHandle(target, text);
+          return {handle: target, name: target.name || normalizeName(name), mode: 'native'};
+        }
+        return download(name, text);
+      }
+    };
+  }
+
+  function createManager(options) {
+    requireDependencies(options);
+    if (!options.workspace || typeof options.getProfile !== 'function' || typeof options.setProfile !== 'function' || !options.transport)
+      fail('manager dependencies incomplete');
+    var targetHandle = null;
+    var targetName = null;
+    var applying = false;
+
+    function dependencies() {
+      return {
+        Blockly: options.Blockly,
+        profiles: options.profiles,
+        activitiesDocument: options.activitiesDocument,
+        blockCatalog: options.blockCatalog,
+        semanticAst: options.semanticAst,
+        activityContract: options.activityContract
+      };
+    }
+    function currentBytes() { return encodeProject(options.getProfile(), options.workspace, dependencies()); }
+    function snapshot() {
+      return {profile: options.getProfile(), workspace: options.Blockly.serialization.workspaces.save(options.workspace)};
+    }
+    function restore(saved) {
+      options.setProfile(saved.profile);
+      options.workspace.clear();
+      options.Blockly.serialization.workspaces.load(saved.workspace, options.workspace);
+      options.activityContract.applyFieldBounds(saved.profile, options.workspace);
+    }
+    function applyValidated(validated) {
+      var before = snapshot();
+      applying = true;
+      try {
+        options.setProfile(validated.profile);
+        options.workspace.clear();
+        options.Blockly.serialization.workspaces.load(validated.project.workspace, options.workspace);
+        options.activityContract.applyFieldBounds(validated.profile, options.workspace);
+        var loadedAst = options.semanticAst.compileWorkspace(options.workspace);
+        options.activityContract.preflightAst(validated.profile, loadedAst);
+        if (!sameJson(loadedAst, validated.ast)) fail('loaded workspace differs from validated project');
+      } catch (error) {
+        try { restore(before); } catch (rollbackError) { console.error('WebeeBlocks project rollback failed', rollbackError); }
+        throw error;
+      } finally { applying = false; }
+    }
+    return {
+      async open() {
+        var opened = await options.transport.open();
+        var validated = validateProjectText(opened.text, options.getProfile(), dependencies());
+        applyValidated(validated);
+        targetHandle = opened.handle || null;
+        targetName = normalizeName(opened.name || validated.profile.id);
+        return {name: targetName, ast: validated.ast, mode: opened.mode || null};
+      },
+      async saveAs(name) {
+        var result = await options.transport.saveAs(normalizeName(name || targetName || options.getProfile().id), currentBytes());
+        targetHandle = result.handle || null;
+        targetName = normalizeName(result.name || name || options.getProfile().id);
+        return {name: targetName, mode: result.mode || null};
+      },
+      async save() {
+        if (!targetName) return this.saveAs(options.getProfile().id);
+        var result = await options.transport.save(targetHandle, targetName, currentBytes());
+        targetHandle = result.handle || targetHandle;
+        targetName = normalizeName(result.name || targetName);
+        return {name: targetName, mode: result.mode || null};
+      },
+      currentName: function() { return targetName; },
+      isApplying: function() { return applying; },
+      nativeFileSystemAccess: !!options.transport.nativeFileSystemAccess,
+      encodeCurrent: currentBytes
+    };
+  }
+
+  return {
+    FORMAT: FORMAT,
+    VERSION: VERSION,
+    SEMANTICS: SEMANTICS,
+    EXTENSION: EXTENSION,
+    normalizeName: normalizeName,
+    createProject: createProject,
+    encodeProject: encodeProject,
+    parseProject: parseProject,
+    validateProjectText: validateProjectText,
+    createBrowserTransport: createBrowserTransport,
+    createManager: createManager
+  };
+});

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -6,6 +6,7 @@
   <title>WebeeBlocks Runtime v2</title>
   <link rel="stylesheet" href="main.css">
   <link rel="stylesheet" href="execution_observer.css">
+  <link rel="stylesheet" href="project_files.css">
   <script src="vendor/blockly_compressed.js"></script>
   <script src="vendor/blocks_compressed.js"></script>
   <script src="vendor/msg/en.js"></script>

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -17,6 +17,7 @@
   <script src="../blockly/webeeblocks/execution_observer.js"></script>
   <script src="../blockly/webeeblocks/runtime_outcome.js"></script>
   <script src="../blockly/webeeblocks/activity_contract.js"></script>
+  <script src="../blockly/webeeblocks/project_files.js"></script>
   <script src="../blockly/webeeblocks/wwi_backend.js"></script>
 </head>
 <body>
@@ -25,11 +26,17 @@
       <h1 id="activityTitle">WebeeBlocks</h1>
       <p id="activityGoal"></p>
     </div>
-    <button id="submit" disabled>Lancer le vol</button>
+    <div id="primaryActions" aria-label="Projet et exécution">
+      <button id="projectOpen" type="button">Ouvrir</button>
+      <button id="projectSave" type="button">Enregistrer</button>
+      <button id="projectSaveAs" type="button">Enregistrer sous</button>
+      <button id="submit" disabled>Lancer le vol</button>
+    </div>
   </header>
   <section id="statusPanel" aria-live="polite">
     <span id="statusLabel">État : <strong id="runtimeState">INITIALISATION</strong></span>
     <span id="runtimeDetail"></span>
+    <span id="projectFileState">Projet non enregistré</span>
   </section>
   <section id="debugPanel" hidden aria-label="Observation de l’exécution">
     <label id="stepModeLabel"><input id="stepMode" type="checkbox"> Pas à pas</label>

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -56,5 +56,6 @@
     </nav>
   </main>
   <script src="main.js"></script>
+  <script src="project_ui.js"></script>
 </body>
 </html>

--- a/plugins/robot_windows/blockly_v2/project_files.css
+++ b/plugins/robot_windows/blockly_v2/project_files.css
@@ -1,0 +1,24 @@
+#primaryActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+#projectFileState {
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--wb-muted);
+}
+
+#projectFileState[data-error="true"] { color: #a1362c; }
+
+@media (max-width: 850px) {
+  #primaryActions { gap: 5px; }
+  #primaryActions button { padding-inline: 9px; }
+  #projectFileState { display: none; }
+}

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -56,13 +56,6 @@
     return manager && manager.currentName() ? manager.currentName() : runtimeProfile.id + WebeeBlocksProjectFiles.EXTENSION;
   }
 
-  function promptName() {
-    var existing = suggestedName();
-    var base = existing.endsWith(WebeeBlocksProjectFiles.EXTENSION) ? existing.slice(0, -WebeeBlocksProjectFiles.EXTENSION.length) : existing;
-    var chosen = window.prompt('Nom du projet', base);
-    return chosen === null ? null : WebeeBlocksProjectFiles.normalizeName(chosen);
-  }
-
   window.addEventListener('load', function() {
     if (!workspace || !runtimeProfile) {
       fileState('Fichiers projet indisponibles', true);
@@ -83,10 +76,16 @@
       transport: transport
     });
     window.WebeeBlocksProjectManager = manager;
-    document.body.dataset.projectFileMode = manager.nativeFileSystemAccess ? 'native' : 'upload-download';
+    document.body.dataset.projectFileMode = manager.nativeFileSystemAccess ? 'native' : 'unavailable';
     window.dispatchEvent(new CustomEvent('webeeblocks-project-files-ready', {
       detail: {nativeFileSystemAccess: manager.nativeFileSystemAccess}
     }));
+
+    if (!manager.nativeFileSystemAccess) {
+      fileState('Fichiers projet indisponibles dans ce navigateur', true);
+      setButtonsDisabled(true);
+      return;
+    }
 
     document.getElementById('projectOpen').addEventListener('click', function() {
       operation('open', async function() {
@@ -98,24 +97,15 @@
     });
 
     document.getElementById('projectSaveAs').addEventListener('click', function() {
-      var name = manager.nativeFileSystemAccess ? suggestedName() : promptName();
-      if (name === null) return;
       operation('save-as', async function() {
-        var result = await manager.saveAs(name);
+        var result = await manager.saveAs(suggestedName());
         fileState('Projet : ' + result.name, false);
       });
     });
 
     document.getElementById('projectSave').addEventListener('click', function() {
       operation('save', async function() {
-        var result;
-        if (!manager.currentName() && !manager.nativeFileSystemAccess) {
-          var name = promptName();
-          if (name === null) return;
-          result = await manager.saveAs(name);
-        } else {
-          result = await manager.save();
-        }
+        var result = await manager.save();
         if (result) fileState('Projet : ' + result.name, false);
       });
     });

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -1,0 +1,123 @@
+(function() {
+  'use strict';
+
+  var manager = null;
+  var busy = false;
+
+  function fileState(text, error) {
+    var target = document.getElementById('projectFileState');
+    if (target) {
+      target.textContent = text;
+      target.dataset.error = error ? 'true' : 'false';
+    }
+  }
+
+  function diagnostic(operation, error) {
+    console.error('WebeeBlocks project ' + operation + ' failed', error);
+    window.dispatchEvent(new CustomEvent('webeeblocks-project-file-diagnostic', {
+      detail: {
+        operation: operation,
+        technicalMessage: error && error.message ? error.message : String(error)
+      }
+    }));
+  }
+
+  function setButtonsDisabled(disabled) {
+    ['projectOpen', 'projectSave', 'projectSaveAs'].forEach(function(id) {
+      var button = document.getElementById(id);
+      if (button) button.disabled = disabled;
+    });
+  }
+
+  async function operation(name, action) {
+    if (busy) return;
+    busy = true;
+    setButtonsDisabled(true);
+    try { return await action(); }
+    catch (error) {
+      diagnostic(name, error);
+      fileState(name === 'open' ? 'Impossible d’ouvrir ce projet' : 'Impossible d’enregistrer ce projet', true);
+      return null;
+    } finally {
+      busy = false;
+      setButtonsDisabled(false);
+    }
+  }
+
+  function applyProfile(profile) {
+    runtimeProfile = profile;
+    document.getElementById('activityTitle').textContent = profile.brief.visible ? profile.brief.title : 'WebeeBlocks';
+    document.getElementById('activityGoal').textContent = profile.brief.visible ? profile.brief.goal : '';
+    if (workspace && typeof workspace.updateToolbox === 'function') workspace.updateToolbox(buildToolbox(profile));
+    WebeeBlocksActivityContract.applyFieldBounds(profile, workspace);
+  }
+
+  function suggestedName() {
+    return manager && manager.currentName() ? manager.currentName() : runtimeProfile.id + WebeeBlocksProjectFiles.EXTENSION;
+  }
+
+  function promptName() {
+    var existing = suggestedName();
+    var base = existing.endsWith(WebeeBlocksProjectFiles.EXTENSION) ? existing.slice(0, -WebeeBlocksProjectFiles.EXTENSION.length) : existing;
+    var chosen = window.prompt('Nom du projet', base);
+    return chosen === null ? null : WebeeBlocksProjectFiles.normalizeName(chosen);
+  }
+
+  window.addEventListener('load', function() {
+    if (!workspace || !runtimeProfile) {
+      fileState('Fichiers projet indisponibles', true);
+      return;
+    }
+
+    var transport = WebeeBlocksProjectFiles.createBrowserTransport(window, document);
+    manager = WebeeBlocksProjectFiles.createManager({
+      Blockly: Blockly,
+      profiles: WebeeBlocksActivityProfiles,
+      activitiesDocument: WebeeBlocksActivities.DOCUMENT,
+      blockCatalog: WebeeBlocksActivities.BLOCK_CATALOG,
+      semanticAst: WebeeBlocksSemanticAst,
+      activityContract: WebeeBlocksActivityContract,
+      workspace: workspace,
+      getProfile: function() { return runtimeProfile; },
+      setProfile: applyProfile,
+      transport: transport
+    });
+    window.WebeeBlocksProjectManager = manager;
+    document.body.dataset.projectFileMode = manager.nativeFileSystemAccess ? 'native' : 'upload-download';
+    window.dispatchEvent(new CustomEvent('webeeblocks-project-files-ready', {
+      detail: {nativeFileSystemAccess: manager.nativeFileSystemAccess}
+    }));
+
+    document.getElementById('projectOpen').addEventListener('click', function() {
+      operation('open', async function() {
+        var result = await manager.open();
+        runtimeTerminal = false;
+        fileState('Projet : ' + result.name, false);
+        if (runtimeBackend && runtimeBackend.ready) setRuntimeStatus('PRÊT', 'Projet ouvert');
+      });
+    });
+
+    document.getElementById('projectSaveAs').addEventListener('click', function() {
+      var name = manager.nativeFileSystemAccess ? suggestedName() : promptName();
+      if (name === null) return;
+      operation('save-as', async function() {
+        var result = await manager.saveAs(name);
+        fileState('Projet : ' + result.name, false);
+      });
+    });
+
+    document.getElementById('projectSave').addEventListener('click', function() {
+      operation('save', async function() {
+        var result;
+        if (!manager.currentName() && !manager.nativeFileSystemAccess) {
+          var name = promptName();
+          if (name === null) return;
+          result = await manager.saveAs(name);
+        } else {
+          result = await manager.save();
+        }
+        if (result) fileState('Projet : ' + result.name, false);
+      });
+    });
+  });
+})();

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[2]
+html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+fixture = (ROOT / 'controllers/Blockly_Programs/CrazyflieReactiveV2.xml').read_text(encoding='utf-8')
+html = html_path.read_text(encoding='utf-8')
+
+seam = '  <script src="project_ui.js"></script>\n'
+if seam not in html:
+    raise SystemExit('project_ui.js seam not found')
+
+fake_api = r'''
+  <script>
+  window.__webeeblocksCiRealFileApi = {
+    open: typeof window.showOpenFilePicker === 'function',
+    save: typeof window.showSaveFilePicker === 'function',
+    secureContext: window.isSecureContext === true
+  };
+  window.__webeeblocksCiFileStore = {bytes: '', writes: 0, names: [], handle: null};
+  window.__webeeblocksCiFileStore.handle = {
+    name: 'ci-roundtrip.webeeblocks.json',
+    async createWritable() {
+      return {
+        async write(text) {
+          window.__webeeblocksCiFileStore.bytes = String(text);
+          window.__webeeblocksCiFileStore.writes += 1;
+          window.__webeeblocksCiFileStore.names.push('ci-roundtrip.webeeblocks.json');
+        },
+        async close() {}
+      };
+    },
+    async getFile() {
+      return {name: this.name, text: async () => window.__webeeblocksCiFileStore.bytes};
+    }
+  };
+  window.showSaveFilePicker = async function() { return window.__webeeblocksCiFileStore.handle; };
+  window.showOpenFilePicker = async function() { return [window.__webeeblocksCiFileStore.handle]; };
+  </script>
+'''
+
+harness = r'''
+  <script>
+  (function() {
+    function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+    let seq = 0;
+    let reportChain = Promise.resolve();
+    function report(event, detail) {
+      const payload = {seq: seq++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
+      reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
+        method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload)
+      }));
+      return reportChain;
+    }
+    async function waitFor(predicate, label, timeoutMs) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        if (predicate()) return;
+        await sleep(25);
+      }
+      throw new Error('timeout waiting for ' + label);
+    }
+    function currentAst() { return WebeeBlocksSemanticAst.compileWorkspace(workspace); }
+    function same(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
+    function click(id) { document.getElementById(id).click(); }
+    function firstMove() { return workspace.getBlocksByType('webeeblocks_v2_move', false)[0]; }
+    async function expectOpenError(bytes, expectedAst, writes, label) {
+      window.__webeeblocksCiFileStore.bytes = bytes;
+      click('projectOpen');
+      await waitFor(() => document.getElementById('projectFileState').dataset.error === 'true', label + ' error', 3000);
+      if (!same(currentAst(), expectedAst)) throw new Error(label + ' replaced current valid AST');
+      if (window.__webeeblocksCiFileStore.writes !== writes) throw new Error(label + ' caused write');
+      document.getElementById('projectFileState').dataset.error = 'false';
+    }
+
+    window.addEventListener('error', e => report('WINDOW_ERROR', {message:e.message, filename:e.filename, lineno:e.lineno}));
+    window.addEventListener('unhandledrejection', e => report('UNHANDLED_REJECTION', String(e.reason)));
+
+    window.addEventListener('load', async function() {
+      try {
+        await waitFor(() => window.workspace && window.WebeeBlocksProjectManager, 'project manager', 10000);
+        await report('FILE_API_BOUNDARY', window.__webeeblocksCiRealFileApi);
+        if (String(Blockly.VERSION) !== '13.2.1') throw new Error('unexpected Blockly version ' + Blockly.VERSION);
+        if (!document.getElementById('projectOpen') || !document.getElementById('projectSave') || !document.getElementById('projectSaveAs'))
+          throw new Error('manual project buttons missing');
+
+        workspace.clear();
+        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(__FIXTURE__), workspace);
+        const initialAst = currentAst();
+        await report('INITIAL_AST', initialAst);
+
+        click('projectSaveAs');
+        await waitFor(() => window.__webeeblocksCiFileStore.writes === 1, 'Save As write', 3000);
+        const savedBytes = window.__webeeblocksCiFileStore.bytes;
+        const savedObject = JSON.parse(savedBytes);
+        if (JSON.stringify(Object.keys(savedObject).sort()) !== JSON.stringify(['activity','format','version','workspace']))
+          throw new Error('unexpected project root fields');
+        if (savedObject.format !== 'webeeblocks-project' || savedObject.version !== 1)
+          throw new Error('unexpected project format/version');
+        if (savedObject.activity.id !== 'reactive-obstacle-v2' || savedObject.activity.semantics !== 'webeeblocks-ast-v1')
+          throw new Error('unexpected activity compatibility fields');
+        for (const forbidden of ['identity','attempt','result','score','debug','progress','history']) {
+          if (savedBytes.toLowerCase().includes('"' + forbidden)) throw new Error('forbidden stored field ' + forbidden);
+        }
+        await report('SAVE_AS_OK', {bytes:savedBytes.length, writes:1});
+
+        firstMove().setFieldValue('0.8', 'DISTANCE');
+        await sleep(150);
+        if (window.__webeeblocksCiFileStore.writes !== 1) throw new Error('workspace edit triggered persistence write');
+        await report('EDIT_NO_WRITE_OK', {writes:window.__webeeblocksCiFileStore.writes});
+
+        window.__webeeblocksCiFileStore.bytes = savedBytes;
+        click('projectOpen');
+        await waitFor(() => same(currentAst(), initialAst), 'Open AST restoration', 3000);
+        if (window.__webeeblocksCiFileStore.writes !== 1) throw new Error('Open triggered persistence write');
+        await report('OPEN_ROUNDTRIP_OK', currentAst());
+
+        firstMove().setFieldValue('0.7', 'DISTANCE');
+        const editedAst = currentAst();
+        click('projectSave');
+        await waitFor(() => window.__webeeblocksCiFileStore.writes === 2, 'explicit Save write', 3000);
+        const editedBytes = window.__webeeblocksCiFileStore.bytes;
+        firstMove().setFieldValue('0.4', 'DISTANCE');
+        window.__webeeblocksCiFileStore.bytes = editedBytes;
+        click('projectOpen');
+        await waitFor(() => same(currentAst(), editedAst), 'edited Save AST restoration', 3000);
+        await report('SAVE_UPDATE_OK', {writes:window.__webeeblocksCiFileStore.writes, ast:currentAst()});
+
+        const stableAst = currentAst();
+        const stableWrites = window.__webeeblocksCiFileStore.writes;
+        await expectOpenError('{bad json', stableAst, stableWrites, 'malformed');
+        const unsupported = JSON.parse(editedBytes); unsupported.version = 999;
+        await expectOpenError(JSON.stringify(unsupported), stableAst, stableWrites, 'version');
+        const incompatible = JSON.parse(editedBytes); incompatible.activity.id = 'unknown-profile';
+        await expectOpenError(JSON.stringify(incompatible), stableAst, stableWrites, 'activity');
+        const forbidden = JSON.parse(editedBytes); forbidden.history = [{score:1}];
+        await expectOpenError(JSON.stringify(forbidden), stableAst, stableWrites, 'history');
+        await report('FAIL_CLOSED_OK', {writes:window.__webeeblocksCiFileStore.writes, ast:currentAst()});
+
+        // Execution/debug state changes are not persistence triggers: only explicit file actions above wrote.
+        window.dispatchEvent(new CustomEvent('webeeblocks-runtime-v2', {detail:{state:'EN VOL'}}));
+        window.dispatchEvent(new CustomEvent('webeeblocks-debug-active', {detail:{blockId:'ci'}}));
+        await sleep(100);
+        if (window.__webeeblocksCiFileStore.writes !== stableWrites)
+          throw new Error('runtime/debug event triggered persistence write');
+        await report('RUN_DEBUG_NO_WRITE_OK', {writes:window.__webeeblocksCiFileStore.writes});
+        await report('PROJECT_FILES_TEST_COMPLETE', {ast:currentAst(), fileApi:window.__webeeblocksCiRealFileApi});
+      } catch (error) {
+        await report('ERROR', error && error.stack ? error.stack : String(error));
+      }
+    });
+  })();
+  </script>
+'''.replace('__FIXTURE__', json.dumps(fixture))
+
+html = html.replace(seam, fake_api + seam + harness, 1)
+html_path.write_text(html, encoding='utf-8')

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -5,6 +5,12 @@ import json
 ROOT = Path(__file__).resolve().parents[2]
 html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
 fixture = (ROOT / 'controllers/Blockly_Programs/CrazyflieReactiveV2.xml').read_text(encoding='utf-8')
+simple_run = '''<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="webeeblocks_v2_takeoff" id="ci_project_takeoff" x="40" y="40">
+    <field name="HEIGHT">0.5</field>
+    <next><block type="webeeblocks_v2_land" id="ci_project_land"></block></next>
+  </block>
+</xml>'''
 html = html_path.read_text(encoding='utf-8')
 
 seam = '  <script src="project_ui.js"></script>\n'
@@ -46,6 +52,7 @@ harness = r'''
     function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
     let seq = 0;
     let reportChain = Promise.resolve();
+    let debugPauseCount = 0;
     function report(event, detail) {
       const payload = {seq: seq++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
       reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
@@ -65,6 +72,10 @@ harness = r'''
     function same(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
     function click(id) { document.getElementById(id).click(); }
     function firstMove() { return workspace.getBlocksByType('webeeblocks_v2_move', false)[0]; }
+    function loadXml(xml) {
+      workspace.clear();
+      Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), workspace);
+    }
     async function expectOpenError(bytes, expectedAst, writes, label) {
       window.__webeeblocksCiFileStore.bytes = bytes;
       click('projectOpen');
@@ -76,6 +87,7 @@ harness = r'''
 
     window.addEventListener('error', e => report('WINDOW_ERROR', {message:e.message, filename:e.filename, lineno:e.lineno}));
     window.addEventListener('unhandledrejection', e => report('UNHANDLED_REJECTION', String(e.reason)));
+    window.addEventListener('webeeblocks-debug-paused', () => { debugPauseCount += 1; });
 
     window.addEventListener('load', async function() {
       try {
@@ -84,9 +96,9 @@ harness = r'''
         if (String(Blockly.VERSION) !== '13.2.1') throw new Error('unexpected Blockly version ' + Blockly.VERSION);
         if (!document.getElementById('projectOpen') || !document.getElementById('projectSave') || !document.getElementById('projectSaveAs'))
           throw new Error('manual project buttons missing');
+        if (document.body.dataset.projectFileMode !== 'native') throw new Error('R2025a project file mode is not native');
 
-        workspace.clear();
-        Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(__FIXTURE__), workspace);
+        loadXml(__FIXTURE__);
         const initialAst = currentAst();
         await report('INITIAL_AST', initialAst);
 
@@ -138,13 +150,28 @@ harness = r'''
         await expectOpenError(JSON.stringify(forbidden), stableAst, stableWrites, 'history');
         await report('FAIL_CLOSED_OK', {writes:window.__webeeblocksCiFileStore.writes, ast:currentAst()});
 
-        // Execution/debug state changes are not persistence triggers: only explicit file actions above wrote.
-        window.dispatchEvent(new CustomEvent('webeeblocks-runtime-v2', {detail:{state:'EN VOL'}}));
-        window.dispatchEvent(new CustomEvent('webeeblocks-debug-active', {detail:{blockId:'ci'}}));
-        await sleep(100);
-        if (window.__webeeblocksCiFileStore.writes !== stableWrites)
-          throw new Error('runtime/debug event triggered persistence write');
-        await report('RUN_DEBUG_NO_WRITE_OK', {writes:window.__webeeblocksCiFileStore.writes});
+        // Exercise the real Runtime v2 run path and the real #67 step controls.
+        loadXml(__SIMPLE_RUN__);
+        const writesBeforeRun = window.__webeeblocksCiFileStore.writes;
+        document.getElementById('stepMode').checked = true;
+        const runPromise = window.runProgram();
+        await waitFor(() => debugPauseCount >= 1 && document.getElementById('stepNext').disabled === false,
+          'first real debug pause', 5000);
+        if (window.__webeeblocksCiFileStore.writes !== writesBeforeRun)
+          throw new Error('starting real debug run triggered persistence write');
+        click('stepNext');
+        await waitFor(() => debugPauseCount >= 2 && document.getElementById('stepNext').disabled === false,
+          'second real debug pause', 20000);
+        if (window.__webeeblocksCiFileStore.writes !== writesBeforeRun)
+          throw new Error('real Pas suivant triggered persistence write');
+        click('stepContinue');
+        await runPromise;
+        if (document.getElementById('runtimeState').textContent !== 'TERMINÉ')
+          throw new Error('real debug run did not complete');
+        if (window.__webeeblocksCiFileStore.writes !== writesBeforeRun)
+          throw new Error('real run/debug completion triggered persistence write');
+        document.getElementById('stepMode').checked = false;
+        await report('RUN_DEBUG_NO_WRITE_OK', {writes:window.__webeeblocksCiFileStore.writes, pauses:debugPauseCount});
         await report('PROJECT_FILES_TEST_COMPLETE', {ast:currentAst(), fileApi:window.__webeeblocksCiRealFileApi});
       } catch (error) {
         await report('ERROR', error && error.stack ? error.stack : String(error));
@@ -152,7 +179,7 @@ harness = r'''
     });
   })();
   </script>
-'''.replace('__FIXTURE__', json.dumps(fixture))
+'''.replace('__FIXTURE__', json.dumps(fixture)).replace('__SIMPLE_RUN__', json.dumps(simple_run))
 
 html = html.replace(seam, fake_api + seam + harness, 1)
 html_path.write_text(html, encoding='utf-8')

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -152,6 +152,8 @@ harness = r'''
 
         // Exercise the real Runtime v2 run path and the real #67 step controls.
         loadXml(__SIMPLE_RUN__);
+        await waitFor(() => window.runtimeBackend && window.runtimeBackend.ready === true,
+          'Runtime v2 ready before debug run', 15000);
         const writesBeforeRun = window.__webeeblocksCiFileStore.writes;
         document.getElementById('stepMode').checked = true;
         const runPromise = window.runProgram();

--- a/tools/ci/test_runtime_v2_project_files.js
+++ b/tools/ci/test_runtime_v2_project_files.js
@@ -60,6 +60,21 @@ function memoryTransport() {
   };
 }
 
+function managerFor(workspace, profileRef, transport) {
+  return ProjectFiles.createManager({
+    Blockly,
+    profiles:Profiles,
+    activitiesDocument:Activities.DOCUMENT,
+    blockCatalog:Activities.BLOCK_CATALOG,
+    semanticAst:SemanticAst,
+    activityContract:ActivityContract,
+    workspace,
+    getProfile:() => profileRef.value,
+    setProfile:profile => { profileRef.value = profile; },
+    transport
+  });
+}
+
 async function expectRejectedWithoutMutation(manager, transport, text, workspace, profileRef, label) {
   const beforeAst = ast(workspace, profileRef.value);
   const beforeState = Blockly.serialization.workspaces.save(workspace);
@@ -72,22 +87,10 @@ async function expectRejectedWithoutMutation(manager, transport, text, workspace
 }
 
 (async function() {
-  let liveWorkspace = buildWorkspace(0.3);
   const profileRef = {value:Profiles.resolveById(Activities.DOCUMENT, 'reactive-obstacle-v2', Activities.BLOCK_CATALOG)};
+  const liveWorkspace = buildWorkspace(0.3);
   const transport = memoryTransport();
-  const options = {
-    Blockly,
-    profiles:Profiles,
-    activitiesDocument:Activities.DOCUMENT,
-    blockCatalog:Activities.BLOCK_CATALOG,
-    semanticAst:SemanticAst,
-    activityContract:ActivityContract,
-    workspace:liveWorkspace,
-    getProfile:() => profileRef.value,
-    setProfile:profile => { profileRef.value = profile; },
-    transport
-  };
-  const manager = ProjectFiles.createManager(options);
+  const manager = managerFor(liveWorkspace, profileRef, transport);
 
   const initialAst = ast(liveWorkspace, profileRef.value);
   const saved = await manager.saveAs('eleve');
@@ -136,7 +139,25 @@ async function expectRejectedWithoutMutation(manager, transport, text, workspace
   await expectRejectedWithoutMutation(manager, transport, JSON.stringify(extraHistory), liveWorkspace, profileRef, 'unsupported history field');
   const invalidWorkspace = JSON.parse(validText); invalidWorkspace.workspace = {blocks:{languageVersion:0,blocks:[{type:'does_not_exist'}]}};
   await expectRejectedWithoutMutation(manager, transport, JSON.stringify(invalidWorkspace), liveWorkspace, profileRef, 'invalid workspace');
-
   assert.strictEqual(transport.state.writes.length, writesBeforeSave + 1, 'failed opens caused persistence writes');
-  console.log('PASS project-files: explicit round-trip/save/fail-closed/no-autosave');
+
+  // A student must be able to save unfinished work. It is a valid project even
+  // though it is not yet a valid executable flight AST.
+  const incompleteProfile = {value:Profiles.resolveById(Activities.DOCUMENT, 'reactive-obstacle-v2', Activities.BLOCK_CATALOG)};
+  const incomplete = new Blockly.Workspace();
+  const takeoffOnly = incomplete.newBlock('webeeblocks_v2_takeoff');
+  takeoffOnly.setFieldValue('0.8', 'HEIGHT');
+  const incompleteTransport = memoryTransport();
+  const incompleteManager = managerFor(incomplete, incompleteProfile, incompleteTransport);
+  await incompleteManager.saveAs('en-cours');
+  assert.strictEqual(incompleteTransport.state.writes.length, 1, 'incomplete project was not explicitly saved');
+  const incompleteBytes = incompleteTransport.state.currentText;
+  incomplete.clear();
+  incompleteTransport.state.openText = incompleteBytes;
+  const reopenedIncomplete = await incompleteManager.open();
+  assert.strictEqual(reopenedIncomplete.ast, null, 'incomplete project unexpectedly compiled as executable AST');
+  assert.strictEqual(incomplete.getBlocksByType('webeeblocks_v2_takeoff', false).length, 1, 'incomplete workspace was not restored');
+  assert.strictEqual(incompleteTransport.state.writes.length, 1, 'opening incomplete project caused a write');
+
+  console.log('PASS project-files: explicit round-trip/save/fail-closed/no-autosave/incomplete-work');
 })().catch(error => { console.error(error); process.exit(1); });

--- a/tools/ci/test_runtime_v2_project_files.js
+++ b/tools/ci/test_runtime_v2_project_files.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const ROOT = path.resolve(__dirname, '../..');
+const Blockly = require(path.join(ROOT, 'plugins/robot_windows/blockly_v2/node_modules/blockly'));
+const Profiles = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/activity_profiles.js'));
+const Activities = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/activities.js'));
+const SemanticAst = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/semantic_ast.js'));
+const ActivityContract = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/activity_contract.js'));
+const ProjectFiles = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/project_files.js'));
+
+Blockly.defineBlocksWithJsonArray([
+  {type:'webeeblocks_v2_takeoff', message0:'takeoff %1', args0:[{type:'field_number',name:'HEIGHT',value:1,min:0.2,max:1.5,precision:0.1}], previousStatement:null,nextStatement:null},
+  {type:'webeeblocks_v2_move', message0:'move %1 %2', args0:[{type:'field_dropdown',name:'DIRECTION',options:[['forward','forward'],['left','left']]},{type:'field_number',name:'DISTANCE',value:0.3,min:0.1,max:2,precision:0.1}], previousStatement:null,nextStatement:null},
+  {type:'webeeblocks_v2_land', message0:'land', previousStatement:null}
+]);
+
+function buildWorkspace(distance) {
+  const workspace = new Blockly.Workspace();
+  const takeoff = workspace.newBlock('webeeblocks_v2_takeoff');
+  const move = workspace.newBlock('webeeblocks_v2_move');
+  const land = workspace.newBlock('webeeblocks_v2_land');
+  takeoff.setFieldValue('1', 'HEIGHT');
+  move.setFieldValue('forward', 'DIRECTION');
+  move.setFieldValue(String(distance), 'DISTANCE');
+  takeoff.nextConnection.connect(move.previousConnection);
+  move.nextConnection.connect(land.previousConnection);
+  return workspace;
+}
+
+function ast(workspace, profile) {
+  ActivityContract.preflightWorkspace(profile, workspace);
+  const value = SemanticAst.compileWorkspace(workspace);
+  ActivityContract.preflightAst(profile, value);
+  return value;
+}
+
+function memoryTransport() {
+  const state = {writes:[], openText:null, currentText:null};
+  const handle = {name:'eleve.webeeblocks.json', token:'same-target'};
+  return {
+    state,
+    nativeFileSystemAccess:true,
+    async open() {
+      if (state.openText === null) throw new Error('no open fixture');
+      return {handle, name:handle.name, text:state.openText, mode:'test'};
+    },
+    async saveAs(name, text) {
+      state.currentText = text;
+      state.writes.push({kind:'saveAs',name,text,handle});
+      return {handle,name,mode:'test'};
+    },
+    async save(target, name, text) {
+      assert.strictEqual(target, handle, 'Save must reuse chosen file handle');
+      state.currentText = text;
+      state.writes.push({kind:'save',name,text,handle:target});
+      return {handle:target,name,mode:'test'};
+    }
+  };
+}
+
+async function expectRejectedWithoutMutation(manager, transport, text, workspace, profileRef, label) {
+  const beforeAst = ast(workspace, profileRef.value);
+  const beforeState = Blockly.serialization.workspaces.save(workspace);
+  transport.state.openText = text;
+  let rejected = false;
+  try { await manager.open(); } catch (error) { rejected = true; }
+  assert(rejected, label + ' must reject');
+  assert.deepStrictEqual(ast(workspace, profileRef.value), beforeAst, label + ' changed AST');
+  assert.deepStrictEqual(Blockly.serialization.workspaces.save(workspace), beforeState, label + ' changed workspace');
+}
+
+(async function() {
+  let liveWorkspace = buildWorkspace(0.3);
+  const profileRef = {value:Profiles.resolveById(Activities.DOCUMENT, 'reactive-obstacle-v2', Activities.BLOCK_CATALOG)};
+  const transport = memoryTransport();
+  const options = {
+    Blockly,
+    profiles:Profiles,
+    activitiesDocument:Activities.DOCUMENT,
+    blockCatalog:Activities.BLOCK_CATALOG,
+    semanticAst:SemanticAst,
+    activityContract:ActivityContract,
+    workspace:liveWorkspace,
+    getProfile:() => profileRef.value,
+    setProfile:profile => { profileRef.value = profile; },
+    transport
+  };
+  const manager = ProjectFiles.createManager(options);
+
+  const initialAst = ast(liveWorkspace, profileRef.value);
+  const saved = await manager.saveAs('eleve');
+  assert.strictEqual(saved.name, 'eleve.webeeblocks.json');
+  assert.strictEqual(transport.state.writes.length, 1);
+  const project = JSON.parse(transport.state.currentText);
+  assert.deepStrictEqual(Object.keys(project).sort(), ['activity','format','version','workspace']);
+  assert.deepStrictEqual(Object.keys(project.activity).sort(), ['id','semantics']);
+  assert.strictEqual(project.format, 'webeeblocks-project');
+  assert.strictEqual(project.version, 1);
+  assert.strictEqual(project.activity.id, 'reactive-obstacle-v2');
+  assert.strictEqual(project.activity.semantics, 'webeeblocks-ast-v1');
+  ['identity','attempt','result','score','debug','progress','history'].forEach(word => {
+    assert(!transport.state.currentText.toLowerCase().includes('"' + word), 'forbidden project data: ' + word);
+  });
+
+  // Editing/compiling is deliberately persistence-inert.
+  liveWorkspace.getBlocksByType('webeeblocks_v2_move', false)[0].setFieldValue('0.8','DISTANCE');
+  ast(liveWorkspace, profileRef.value);
+  assert.strictEqual(transport.state.writes.length, 1, 'workspace edit caused implicit persistence write');
+
+  // Re-open the explicit Save As bytes and recover the exact full AST.
+  transport.state.openText = transport.state.currentText;
+  await manager.open();
+  assert.deepStrictEqual(ast(liveWorkspace, profileRef.value), initialAst, 'round-trip AST differs');
+
+  // Explicit Save updates the same chosen target; no hidden version/history file exists.
+  liveWorkspace.getBlocksByType('webeeblocks_v2_move', false)[0].setFieldValue('0.7','DISTANCE');
+  const editedAst = ast(liveWorkspace, profileRef.value);
+  const writesBeforeSave = transport.state.writes.length;
+  await manager.save();
+  assert.strictEqual(transport.state.writes.length, writesBeforeSave + 1, 'explicit Save did not write once');
+  assert.strictEqual(transport.state.writes.at(-1).kind, 'save');
+  transport.state.openText = transport.state.currentText;
+  liveWorkspace.getBlocksByType('webeeblocks_v2_move', false)[0].setFieldValue('0.4','DISTANCE');
+  await manager.open();
+  assert.deepStrictEqual(ast(liveWorkspace, profileRef.value), editedAst, 'Save bytes did not restore edited AST');
+
+  const validText = manager.encodeCurrent();
+  await expectRejectedWithoutMutation(manager, transport, '{bad json', liveWorkspace, profileRef, 'malformed JSON');
+  const unknownVersion = JSON.parse(validText); unknownVersion.version = 999;
+  await expectRejectedWithoutMutation(manager, transport, JSON.stringify(unknownVersion), liveWorkspace, profileRef, 'unknown version');
+  const unknownActivity = JSON.parse(validText); unknownActivity.activity.id = 'unknown-profile';
+  await expectRejectedWithoutMutation(manager, transport, JSON.stringify(unknownActivity), liveWorkspace, profileRef, 'unknown activity');
+  const extraHistory = JSON.parse(validText); extraHistory.history = [{score:1}];
+  await expectRejectedWithoutMutation(manager, transport, JSON.stringify(extraHistory), liveWorkspace, profileRef, 'unsupported history field');
+  const invalidWorkspace = JSON.parse(validText); invalidWorkspace.workspace = {blocks:{languageVersion:0,blocks:[{type:'does_not_exist'}]}};
+  await expectRejectedWithoutMutation(manager, transport, JSON.stringify(invalidWorkspace), liveWorkspace, profileRef, 'invalid workspace');
+
+  assert.strictEqual(transport.state.writes.length, writesBeforeSave + 1, 'failed opens caused persistence writes');
+  console.log('PASS project-files: explicit round-trip/save/fail-closed/no-autosave');
+})().catch(error => { console.error(error); process.exit(1); });


### PR DESCRIPTION
## Objective
Implement issue #71 increment 71-A from current `webots-ci`: explicit local **Ouvrir / Enregistrer / Enregistrer sous** for portable, versioned Runtime v2 student project files. `main` remains untouched.

## Product scope
- strict JSON project format: `format`, `version`, `activity {id, semantics}`, and Blockly modern workspace serialization only;
- no identity, progress, attempt/result/score/debug/runtime history, generated code, backend state, autosave or cloud state;
- project-file validity is deliberately separate from executable-program validity: an unfinished but structurally valid student workspace can be saved and reopened;
- opening validates JSON/version/activity/world compatibility and the workspace on a temporary Blockly workspace before touching the current valid project; when the loaded workspace is already executable, its complete AST is also computed and checked;
- if live application unexpectedly fails, restore the previous profile/workspace;
- Save As explicitly chooses/creates the target; later Save reuses the selected native file handle;
- no write is wired to workspace edit, execution or debug events.

## Browser boundary
The real R2025a Robot Window reports `showOpenFilePicker=true`, `showSaveFilePicker=true`, and `isSecureContext=true`. 71-A is therefore explicitly bounded to that native File System Access path in the supported Webots R2025a student environment. The UI disables project-file actions and shows a student-visible `Fichiers projet indisponibles dans ce navigateur` state when that native boundary is absent; upload/download fallback behavior is not claimed as equivalent Save semantics in 71-A. CI injects deterministic native-style handles only as harness instrumentation after recording the real browser boundary.

## Discriminating evidence
Focused gates must prove:
1. real Blockly 13.2.1 workspace → explicit Save As bytes → edit without write → Open → exact full `webeeblocks-ast-v1` restoration;
2. explicit later Save updates the same selected target, then reopening restores the edited full AST;
3. unfinished allowed work can also be saved/reopened without requiring a valid flight AST;
4. malformed JSON, unknown version/activity, forbidden extra history field and invalid workspace are rejected before replacing the current valid AST/workspace;
5. one real Runtime v2 execution with actual #67 Pas suivant/Continuer controls causes no persistence write;
6. file format contains no forbidden history/identity/runtime state;
7. inherited Runtime v1/v2/WWI/#67 gates remain non-regressed.

## Non-goals
No autosave, version history, account/cloud/Moodle, student identity, attempts/results/scores/debug persistence, #66 activities, variables, new blocks/worlds, physical backend, AST/interpreter/PID/STOP changes, browser-server workaround, or `main`.

Draft until the causal R2025a gate + inherited CI are green and independent Verification has no blocking contradiction.