### PR TITLE
Fix Chrome and Firefox project files (71-B)

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/project_files.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_files.js
@@ -10,6 +10,7 @@
   var VERSION = 1;
   var SEMANTICS = 'webeeblocks-ast-v1';
   var EXTENSION = '.webeeblocks.json';
+  var PICKER_EXTENSION = '.json';
   var ROOT_KEYS = ['activity', 'format', 'version', 'workspace'];
   var ACTIVITY_KEYS = ['id', 'semantics'];
 
@@ -130,7 +131,7 @@
 
     function pickerOptions() {
       return {
-        types: [{description: 'Projet WebeeBlocks', accept: {'application/json': [EXTENSION]}}],
+        types: [{description: 'Projet WebeeBlocks', accept: {'application/json': [PICKER_EXTENSION]}}],
         excludeAcceptAllOption: false,
         multiple: false
       };
@@ -145,21 +146,40 @@
       documentObject.body.appendChild(anchor);
       anchor.click();
       anchor.remove();
-      browserWindow.setTimeout(function() { browserWindow.URL.revokeObjectURL(url); }, 0);
-      return Promise.resolve({handle: null, name: normalizeName(name), mode: 'download'});
+      // Keep the blob URL alive long enough for Firefox to consume the
+      // download. Revoking it on the next tick can race the browser.
+      browserWindow.setTimeout(function() { browserWindow.URL.revokeObjectURL(url); }, 60000);
+      return Promise.resolve({handle: null, name: normalizeName(name), mode: 'download-copy'});
     }
     function upload() {
       return new Promise(function(resolve, reject) {
         var input = documentObject.createElement('input');
+        var settled = false;
         input.type = 'file';
         input.accept = EXTENSION + ',application/json';
         input.style.display = 'none';
         documentObject.body.appendChild(input);
+
+        function finish(callback) {
+          if (settled) return;
+          settled = true;
+          input.remove();
+          callback();
+        }
         input.addEventListener('change', function() {
           var file = input.files && input.files[0];
-          input.remove();
-          if (!file) { reject(new Error('project file: open cancelled')); return; }
-          file.text().then(function(text) { resolve({handle: null, name: file.name, text: text, mode: 'upload'}); }, reject);
+          if (!file) {
+            finish(function() { reject(new Error('project file: open cancelled')); });
+            return;
+          }
+          finish(function() {
+            file.text().then(function(text) {
+              resolve({handle: null, name: file.name, text: text, mode: 'upload'});
+            }, reject);
+          });
+        }, {once: true});
+        input.addEventListener('cancel', function() {
+          finish(function() { reject(new Error('project file: open cancelled')); });
         }, {once: true});
         input.click();
       });
@@ -276,6 +296,7 @@
     VERSION: VERSION,
     SEMANTICS: SEMANTICS,
     EXTENSION: EXTENSION,
+    PICKER_EXTENSION: PICKER_EXTENSION,
     normalizeName: normalizeName,
     createProject: createProject,
     encodeProject: encodeProject,

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -22,6 +22,11 @@
     }));
   }
 
+  function isCancellation(error) {
+    var message = String(error && error.message || error || '');
+    return !!(error && error.name === 'AbortError') || message.indexOf('open cancelled') >= 0;
+  }
+
   function setButtonsDisabled(disabled) {
     ['projectOpen', 'projectSave', 'projectSaveAs'].forEach(function(id) {
       var button = document.getElementById(id);
@@ -35,6 +40,10 @@
     setButtonsDisabled(true);
     try { return await action(); }
     catch (error) {
+      if (isCancellation(error)) {
+        fileState(name === 'open' ? 'Ouverture annulée' : 'Enregistrement annulé', false);
+        return null;
+      }
       diagnostic(name, error);
       fileState(name === 'open' ? 'Impossible d’ouvrir ce projet' : 'Impossible d’enregistrer ce projet', true);
       return null;
@@ -76,16 +85,14 @@
       transport: transport
     });
     window.WebeeBlocksProjectManager = manager;
-    document.body.dataset.projectFileMode = manager.nativeFileSystemAccess ? 'native' : 'unavailable';
+    var projectFileMode = manager.nativeFileSystemAccess ? 'native' : 'fallback';
+    document.body.dataset.projectFileMode = projectFileMode;
     window.dispatchEvent(new CustomEvent('webeeblocks-project-files-ready', {
-      detail: {nativeFileSystemAccess: manager.nativeFileSystemAccess}
+      detail: {nativeFileSystemAccess: manager.nativeFileSystemAccess, mode: projectFileMode}
     }));
 
-    if (!manager.nativeFileSystemAccess) {
-      fileState('Fichiers projet indisponibles dans ce navigateur', true);
-      setButtonsDisabled(true);
-      return;
-    }
+    if (!manager.nativeFileSystemAccess)
+      fileState('Mode compatible : Enregistrer crée une nouvelle copie', false);
 
     document.getElementById('projectOpen').addEventListener('click', function() {
       operation('open', async function() {
@@ -99,14 +106,18 @@
     document.getElementById('projectSaveAs').addEventListener('click', function() {
       operation('save-as', async function() {
         var result = await manager.saveAs(suggestedName());
-        fileState('Projet : ' + result.name, false);
+        fileState(result.mode === 'download-copy'
+          ? 'Nouvelle copie proposée au téléchargement : ' + result.name
+          : 'Projet : ' + result.name, false);
       });
     });
 
     document.getElementById('projectSave').addEventListener('click', function() {
       operation('save', async function() {
         var result = await manager.save();
-        if (result) fileState('Projet : ' + result.name, false);
+        if (result) fileState(result.mode === 'download-copy'
+          ? 'Nouvelle copie proposée au téléchargement : ' + result.name
+          : 'Projet : ' + result.name, false);
       });
     });
   });

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -50,7 +50,7 @@ fake_api = r'''
         if (mime.indexOf('/') <= 0 || mime.indexOf('/') === mime.length - 1)
           throw new TypeError('invalid picker MIME type');
         type.accept[mime].forEach(function(extension) {
-          if (typeof extension !== 'string' || !/^\\.[A-Za-z0-9]+$/.test(extension) ||
+          if (typeof extension !== 'string' || !/^\.[A-Za-z0-9]+$/.test(extension) ||
               Array.from(extension).length > 16)
             throw new TypeError('invalid picker extension: ' + extension);
         });

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -47,10 +47,11 @@ fake_api = r'''
       throw new TypeError('missing picker types');
     options.types.forEach(function(type) {
       Object.keys(type.accept || {}).forEach(function(mime) {
-        if (!/^[^/]+\\/[^/]+$/.test(mime)) throw new TypeError('invalid picker MIME type');
+        if (mime.indexOf('/') <= 0 || mime.indexOf('/') === mime.length - 1)
+          throw new TypeError('invalid picker MIME type');
         type.accept[mime].forEach(function(extension) {
-          if (typeof extension !== 'string' || extension[0] !== '.' || extension.length < 2 ||
-              Array.from(extension).length > 16 || /[\\\\/:*?"<>|]/.test(extension.slice(1)))
+          if (typeof extension !== 'string' || !/^\\.[A-Za-z0-9]+$/.test(extension) ||
+              Array.from(extension).length > 16)
             throw new TypeError('invalid picker extension: ' + extension);
         });
       });

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -41,8 +41,42 @@ fake_api = r'''
       return {name: this.name, text: async () => window.__webeeblocksCiFileStore.bytes};
     }
   };
-  window.showSaveFilePicker = async function() { return window.__webeeblocksCiFileStore.handle; };
-  window.showOpenFilePicker = async function() { return [window.__webeeblocksCiFileStore.handle]; };
+  window.__webeeblocksCiPickerOptions = [];
+  function validatePickerOptions(options) {
+    if (!options || !Array.isArray(options.types) || options.types.length === 0)
+      throw new TypeError('missing picker types');
+    options.types.forEach(function(type) {
+      Object.keys(type.accept || {}).forEach(function(mime) {
+        if (!/^[^/]+\\/[^/]+$/.test(mime)) throw new TypeError('invalid picker MIME type');
+        type.accept[mime].forEach(function(extension) {
+          if (typeof extension !== 'string' || extension[0] !== '.' || extension.length < 2 ||
+              Array.from(extension).length > 16 || /[\\\\/:*?"<>|]/.test(extension.slice(1)))
+            throw new TypeError('invalid picker extension: ' + extension);
+        });
+      });
+    });
+  }
+  (function proveOldSuffixRejected() {
+    var rejected = false;
+    try {
+      validatePickerOptions({types:[{accept:{'application/json':['.webeeblocks.json']}}]});
+    } catch (error) {
+      rejected = error instanceof TypeError;
+    }
+    if (!rejected) throw new Error('old compound picker suffix was not rejected');
+  })();
+  window.showSaveFilePicker = async function(options) {
+    validatePickerOptions(options);
+    if (!String(options.suggestedName || '').endsWith('.webeeblocks.json'))
+      throw new TypeError('full WebeeBlocks suggested name missing');
+    window.__webeeblocksCiPickerOptions.push({kind:'save', options:options});
+    return window.__webeeblocksCiFileStore.handle;
+  };
+  window.showOpenFilePicker = async function(options) {
+    validatePickerOptions(options);
+    window.__webeeblocksCiPickerOptions.push({kind:'open', options:options});
+    return [window.__webeeblocksCiFileStore.handle];
+  };
   </script>
 '''
 
@@ -137,6 +171,18 @@ harness = r'''
         window.__webeeblocksCiFileStore.bytes = editedBytes;
         click('projectOpen');
         await waitFor(() => same(currentAst(), editedAst), 'edited Save AST restoration', 3000);
+        if (window.__webeeblocksCiPickerOptions.length < 4)
+          throw new Error('native picker options were not exercised on Save As/Open/Save/Open');
+        for (const entry of window.__webeeblocksCiPickerOptions) {
+          const extensions = entry.options.types[0].accept['application/json'];
+          if (JSON.stringify(extensions) !== JSON.stringify(['.json']))
+            throw new Error('unexpected native picker extensions ' + JSON.stringify(extensions));
+        }
+        await report('PICKER_OPTIONS_OK', window.__webeeblocksCiPickerOptions.map(entry => ({
+          kind:entry.kind,
+          extensions:entry.options.types[0].accept['application/json'],
+          suggestedName:entry.options.suggestedName || null
+        })));
         await report('SAVE_UPDATE_OK', {writes:window.__webeeblocksCiFileStore.writes, ast:currentAst()});
 
         const stableAst = currentAst();

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -172,8 +172,8 @@ harness = r'''
         window.__webeeblocksCiFileStore.bytes = editedBytes;
         click('projectOpen');
         await waitFor(() => same(currentAst(), editedAst), 'edited Save AST restoration', 3000);
-        if (window.__webeeblocksCiPickerOptions.length < 4)
-          throw new Error('native picker options were not exercised on Save As/Open/Save/Open');
+        if (window.__webeeblocksCiPickerOptions.length !== 3)
+          throw new Error('native picker options were not exercised on Save As/Open/Open');
         for (const entry of window.__webeeblocksCiPickerOptions) {
           const extensions = entry.options.types[0].accept['application/json'];
           if (JSON.stringify(extensions) !== JSON.stringify(['.json']))

--- a/tools/ci/test_runtime_v2_project_files.js
+++ b/tools/ci/test_runtime_v2_project_files.js
@@ -86,7 +86,136 @@ async function expectRejectedWithoutMutation(manager, transport, text, workspace
   assert.deepStrictEqual(Blockly.serialization.workspaces.save(workspace), beforeState, label + ' changed workspace');
 }
 
+
+function validatePickerOptions(options) {
+  assert(options && Array.isArray(options.types) && options.types.length > 0, 'picker types missing');
+  options.types.forEach(type => {
+    Object.entries(type.accept || {}).forEach(([mime, extensions]) => {
+      assert(/^[^/]+\/[^/]+$/.test(mime), 'invalid picker MIME type');
+      extensions.forEach(extension => {
+        assert(extension.startsWith('.') && extension.length > 1, 'picker extension must start with a dot');
+        assert(Array.from(extension).length <= 16, 'picker extension exceeds the native 16-code-point limit');
+        assert(!/[\\/:*?"<>|]/.test(extension.slice(1)), 'picker extension contains invalid suffix characters');
+      });
+    });
+  });
+}
+
+function fakeBrowser(options = {}) {
+  const state = {downloads:[], revoked:[], revokeDelays:[], removed:0, nativeOptions:[], writes:0};
+  const handle = {
+    name:'eleve.webeeblocks.json',
+    async createWritable() {
+      return {
+        async write(text) { state.writes += 1; state.nativeBytes = String(text); },
+        async close() {}
+      };
+    },
+    async getFile() {
+      return {name:this.name, text:async () => state.nativeBytes || '{"native":true}'};
+    }
+  };
+  const browserWindow = {
+    Blob: class {
+      constructor(parts, blobOptions) { this.parts = parts; this.type = blobOptions && blobOptions.type; }
+    },
+    URL: {
+      createObjectURL(blob) { state.blob = blob; return 'blob:webeeblocks-test'; },
+      revokeObjectURL(url) { state.revoked.push(url); }
+    },
+    setTimeout(callback, delay) {
+      state.revokeDelays.push(delay);
+      callback();
+    }
+  };
+  if (options.native) {
+    browserWindow.showSaveFilePicker = async picker => {
+      state.nativeOptions.push({kind:'save', picker});
+      validatePickerOptions(picker);
+      return handle;
+    };
+    browserWindow.showOpenFilePicker = async picker => {
+      state.nativeOptions.push({kind:'open', picker});
+      validatePickerOptions(picker);
+      return [handle];
+    };
+  }
+  const documentObject = {
+    body:{appendChild() {}},
+    createElement(tag) {
+      const listeners = {};
+      const element = {
+        tagName:tag.toUpperCase(),
+        style:{},
+        files:null,
+        addEventListener(name, callback) { listeners[name] = callback; },
+        remove() { state.removed += 1; },
+        click() {
+          if (tag === 'a') {
+            state.downloads.push({name:this.download, href:this.href});
+            return;
+          }
+          if (options.cancelUpload) {
+            listeners.cancel();
+            return;
+          }
+          this.files = [{
+            name:'ouvert.webeeblocks.json',
+            text:async () => options.openText || '{"fallback":true}'
+          }];
+          listeners.change();
+        }
+      };
+      return element;
+    }
+  };
+  return {state, handle, browserWindow, documentObject};
+}
+
+async function exerciseBrowserTransports() {
+  assert.throws(() => validatePickerOptions({
+    types:[{accept:{'application/json':['.webeeblocks.json']}}]
+  }), /16-code-point/, 'old compound suffix must reproduce the native browser rejection');
+
+  const native = fakeBrowser({native:true});
+  const nativeTransport = ProjectFiles.createBrowserTransport(native.browserWindow, native.documentObject);
+  assert.strictEqual(nativeTransport.nativeFileSystemAccess, true);
+  const nativeSave = await nativeTransport.saveAs('eleve', '{"native":1}');
+  assert.strictEqual(nativeSave.mode, 'native');
+  const saveOptions = native.state.nativeOptions.find(entry => entry.kind === 'save').picker;
+  assert.strictEqual(saveOptions.suggestedName, 'eleve.webeeblocks.json');
+  assert.deepStrictEqual(saveOptions.types[0].accept, {'application/json':['.json']});
+  await nativeTransport.open();
+  assert.strictEqual(native.state.nativeOptions.length, 2, 'both native pickers must inspect the real options');
+  await nativeTransport.save(native.handle, 'eleve.webeeblocks.json', '{"native":2}');
+  assert.strictEqual(native.state.writes, 2, 'native Save must reuse and write the selected handle');
+
+  const fallback = fakeBrowser({openText:'{"fallback":1}'});
+  const fallbackTransport = ProjectFiles.createBrowserTransport(fallback.browserWindow, fallback.documentObject);
+  assert.strictEqual(fallbackTransport.nativeFileSystemAccess, false);
+  const opened = await fallbackTransport.open();
+  assert.strictEqual(opened.mode, 'upload');
+  assert.strictEqual(opened.name, 'ouvert.webeeblocks.json');
+  assert.strictEqual(opened.text, '{"fallback":1}');
+  const fallbackSaveAs = await fallbackTransport.saveAs('eleve', '{"fallback":2}');
+  const fallbackSave = await fallbackTransport.save(null, fallbackSaveAs.name, '{"fallback":3}');
+  assert.strictEqual(fallbackSaveAs.mode, 'download-copy');
+  assert.strictEqual(fallbackSave.mode, 'download-copy');
+  assert.deepStrictEqual(fallback.state.downloads.map(item => item.name),
+    ['eleve.webeeblocks.json','eleve.webeeblocks.json']);
+  assert.strictEqual(fallback.state.blob.type, 'application/json');
+  assert(fallback.state.revokeDelays.every(delay => delay >= 1000),
+    'fallback blob URL must not be revoked on the next tick');
+
+  const cancelled = fakeBrowser({cancelUpload:true});
+  const cancelledTransport = ProjectFiles.createBrowserTransport(cancelled.browserWindow, cancelled.documentObject);
+  await assert.rejects(cancelledTransport.open(), /open cancelled/);
+  assert.strictEqual(cancelled.state.removed, 1, 'cancelled input must be cleaned up');
+}
+
 (async function() {
+  await exerciseBrowserTransports();
+
   const profileRef = {value:Profiles.resolveById(Activities.DOCUMENT, 'reactive-obstacle-v2', Activities.BLOCK_CATALOG)};
   const liveWorkspace = buildWorkspace(0.3);
   const transport = memoryTransport();


### PR DESCRIPTION
Closes the repair increment of #71 (71-B). Targets `webots-ci` only.

## Scope

- keep `*.webeeblocks.json` as the visible/default project filename;
- use the valid `.json` accept suffix for native Chromium/Edge pickers;
- expose the existing local upload/download transport when native File System Access is unavailable;
- make fallback `Save` and `Save As` explicitly report **Nouvelle copie proposée au téléchargement**;
- settle and clean up a cancelled fallback file input;
- avoid revoking a fallback Blob URL on the next tick.

## Causal gates

The project-file unit gate now:
- reproduces rejection of the previous 17-code-point `.webeeblocks.json` picker suffix;
- captures and validates the exact native Open/Save As options;
- proves the full suggested filename remains `*.webeeblocks.json`;
- exercises fallback Open, Save As and subsequent Save as two explicit downloads;
- proves input cancellation settles and cleans up;
- preserves the existing full-AST round-trip, incomplete-project save, fail-closed and no-implicit-write checks.

The real R2025a project-file harness no longer uses a picker double that ignores arguments. Its fake native API validates the exact options and refuses the old compound suffix before returning a handle.

## Non-goals

No format/version change; no autosave/history/account/cloud/server; no activity/localization/reset work; no AST/interpreter/WWI/PID/STOP change; no physical backend work; no `main` change.

## Remaining evidence boundary

Automated fallback interception proves file bytes, requested filename and download invocation, not that Firefox physically committed a file to the Downloads folder. Final acceptance therefore still requires the preregistered human Linux/Webots R2025a matrix:

1. Chrome: Open / Save As / same-file Save / reopen.
2. Firefox: Open / Save As download / Save creates a clearly announced new copy / reopen.
3. Invalid project remains fail-closed in both browsers.

Windows remains tracked separately by #81.