### PR TITLE
Prove native Webots Qt file broker handshake (71-C1)

### DIFF
--- a/.github/workflows/runtime-v2-native-file-broker.yml
+++ b/.github/workflows/runtime-v2-native-file-broker.yml
@@ -43,8 +43,11 @@ jobs:
             cyberbotics/webots:R2025a-ubuntu22.04 \
             bash -lc '
               set -e
+              echo "WEBOTS_HOME=$WEBOTS_HOME"
+              find "$WEBOTS_HOME/include" -maxdepth 3 -type f \
+                \( -name QByteArray -o -name QFileDialog -o -name QSaveFile \) -print | sort
               make -C controllers/crazyflie_runtime_v2 clean
-              make -C controllers/crazyflie_runtime_v2
+              make -C controllers/crazyflie_runtime_v2 VERBOSE=1
               g++ -std=c++17 \
                 -Icontrollers/crazyflie_runtime_v2 \
                 -isystem "$WEBOTS_HOME/include/qt/QtCore" \

--- a/.github/workflows/runtime-v2-native-file-broker.yml
+++ b/.github/workflows/runtime-v2-native-file-broker.yml
@@ -1,0 +1,128 @@
+name: Runtime v2 native file broker
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  native-file-broker:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate protocol sources
+        run: |
+          node --check plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
+          node tools/ci/test_native_file_broker.js
+          python3 -m py_compile tools/ci/prepare_runtime_v2_native_file_broker.py
+          grep -Fq 'native_file_broker.js' plugins/robot_windows/blockly_v2/blockly_v2.html
+          ! grep -Rq 'wb_robot_wwi_receive_text' controllers/crazyflie_runtime_v2/file_broker.cpp
+
+      - name: Prepare pinned Blockly 13.2.1 browser assets
+        working-directory: plugins/robot_windows/blockly_v2
+        run: |
+          npm install --ignore-scripts --no-audit --no-fund
+          npm run prepare:blockly
+          test "$(cat vendor/VERSION)" = "13.2.1"
+
+      - name: Pull official Webots R2025a image
+        run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
+
+      - name: Prove Webots-bundled Qt build and injectable provider
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/runtime-v2-native-file-broker
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              make -C controllers/crazyflie_runtime_v2 clean
+              make -C controllers/crazyflie_runtime_v2
+              g++ -std=c++17 \
+                -Icontrollers/crazyflie_runtime_v2 \
+                -isystem "$WEBOTS_HOME/include/qt/QtCore" \
+                -isystem "$WEBOTS_HOME/include/qt/QtGui" \
+                -isystem "$WEBOTS_HOME/include/qt/QtWidgets" \
+                tools/ci/test_native_file_broker.cpp \
+                controllers/crazyflie_runtime_v2/file_broker.cpp \
+                -L"$WEBOTS_HOME/lib/webots" -lQt6Core -lQt6Gui -lQt6Widgets \
+                -o /tmp/test_native_file_broker
+              LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots:${LD_LIBRARY_PATH:-}" /tmp/test_native_file_broker
+            ' 2>&1 | tee ci-artifacts/runtime-v2-native-file-broker/build.log
+
+      - name: Prepare actual Robot Window handshake harness
+        run: python3 tools/ci/prepare_runtime_v2_native_file_broker.py
+
+      - name: Run actual Robot Window handshake
+        shell: bash
+        run: |
+          set -o pipefail
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              chmod +x /workspace/tools/ci/webots_native_file_broker_browser.sh
+              mkdir -p /root/.config/Cyberbotics
+              printf "%s\n" "[RobotWindow]" \
+                "browser=/workspace/tools/ci/webots_native_file_broker_browser.sh" \
+                "newBrowserWindow=false" > /root/.config/Cyberbotics/Webots-R2025a.conf
+              python3 /workspace/tools/ci/runtime_wwi_event_server.py \
+                --output /workspace/ci-artifacts/runtime-v2-native-file-broker/browser-events.jsonl &
+              server=$!
+              trap "kill $server 2>/dev/null || true" EXIT
+              sleep 0.5
+              timeout -k 5s 35s xvfb-run -a webots --stdout --stderr --batch --mode=realtime \
+                /workspace/worlds/crazyflie_runtime_v2.wbt
+            ' 2>&1 | tee ci-artifacts/runtime-v2-native-file-broker/webots.log
+          code=${PIPESTATUS[0]}
+          set -e
+          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then exit "$code"; fi
+
+      - name: Validate causal handshake evidence
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          events = [json.loads(line) for line in Path('ci-artifacts/runtime-v2-native-file-broker/browser-events.jsonl').read_text().splitlines() if line.strip()]
+          errors = [event for event in events if event.get('event') in ('WINDOW_ERROR', 'UNHANDLED_REJECTION', 'ERROR')]
+          assert not errors, errors
+          caps = [event['detail'] for event in events if event.get('event') == 'FILE_BROKER_CAPABILITIES']
+          assert len(caps) == 1, events
+          assert caps[0] == {
+              'protocol': 1,
+              'provider': 'qt6-qfiledialog',
+              'providerInjectable': True,
+              'operationsReady': False,
+              'canonicalExtension': '.wbb',
+          }, caps[0]
+          assert any(event.get('event') == 'FILE_BROKER_TEST_COMPLETE' for event in events), events
+          log = Path('ci-artifacts/runtime-v2-native-file-broker/webots.log').read_text(errors='replace')
+          assert 'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES' in log, log[-3000:]
+          assert 'WEBEEBLOCKS_RUNTIME_V2 READY' in log, log[-3000:]
+          assert 'FATAL' not in log, log[-3000:]
+          print('PASS: actual R2025a Robot Window -> existing WWI dispatcher -> Qt-linked broker capability handshake')
+          PY
+
+      - name: Upload native broker diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-v2-native-file-broker-r2025a
+          path: ci-artifacts/runtime-v2-native-file-broker/
+          if-no-files-found: error

--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -6,20 +6,17 @@ WBCXXFLAGS += -std=c++17
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+HOST_UNAME := $(shell uname -s)
 
-ifeq ($(OSTYPE),windows)
+ifeq ($(OS),Windows_NT)
  QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
  DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/msys64/mingw64/bin" -lQt6Core -lQt6Gui -lQt6Widgets
  INCLUDE += -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
-endif
-
-ifeq ($(OSTYPE),linux)
+else ifeq ($(HOST_UNAME),Linux)
  QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
  DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/lib/webots" -lQt6Core -lQt6Gui -lQt6Widgets
  INCLUDE += -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
-endif
-
-ifeq ($(OSTYPE),darwin)
+else ifeq ($(HOST_UNAME),Darwin)
  FRAMEWORKS_DIR = $(WEBOTS_HOME)/Contents/Frameworks
  INCLUDE += -F"$(FRAMEWORKS_DIR)"
  FRAMEWORKS += -F"$(FRAMEWORKS_DIR)" -framework QtCore -framework QtGui -framework QtWidgets

--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -1,5 +1,6 @@
 C_SOURCES = crazyflie_runtime_v2.c ../crazyflie_square/pid_controller.c
 CXX_SOURCES = file_broker.cpp
+USE_C_API = true
 CFLAGS = -I../crazyflie_square
 WBCXXFLAGS += -std=c++17
 null :=

--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -6,7 +6,6 @@ WBCXXFLAGS += -std=c++17
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
-include $(WEBOTS_HOME_PATH)/resources/Makefile.include
 
 ifeq ($(OSTYPE),windows)
  QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
@@ -25,3 +24,5 @@ ifeq ($(OSTYPE),darwin)
  INCLUDE += -F"$(FRAMEWORKS_DIR)"
  FRAMEWORKS += -F"$(FRAMEWORKS_DIR)" -framework QtCore -framework QtGui -framework QtWidgets
 endif
+
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -1,6 +1,26 @@
 C_SOURCES = crazyflie_runtime_v2.c ../crazyflie_square/pid_controller.c
+CXX_SOURCES = file_broker.cpp
 CFLAGS = -I../crazyflie_square
+WBCXXFLAGS += -std=c++17
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 include $(WEBOTS_HOME_PATH)/resources/Makefile.include
+
+ifeq ($(OSTYPE),windows)
+ QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
+ DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/msys64/mingw64/bin" -lQt6Core -lQt6Gui -lQt6Widgets
+ INCLUDE += -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
+endif
+
+ifeq ($(OSTYPE),linux)
+ QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
+ DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/lib/webots" -lQt6Core -lQt6Gui -lQt6Widgets
+ INCLUDE += -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
+endif
+
+ifeq ($(OSTYPE),darwin)
+ FRAMEWORKS_DIR = $(WEBOTS_HOME)/Contents/Frameworks
+ INCLUDE += -F"$(FRAMEWORKS_DIR)"
+ FRAMEWORKS += -F"$(FRAMEWORKS_DIR)" -framework QtCore -framework QtGui -framework QtWidgets
+endif

--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -12,6 +12,7 @@
 #include <webots/robot.h>
 
 #include "pid_controller.h"
+#include "file_broker_c.h"
 
 #define PI 3.14159265358979323846
 #define PREFIX "WEBEEBLOCKS_RUNTIME_V2"
@@ -184,6 +185,12 @@ static void trace_land(void) {
 int main(void) {
   wb_robot_init();
   const int step = (int)wb_robot_get_basic_time_step();
+  WbFileBroker *file_broker = wb_file_broker_create_qt();
+  if (!file_broker) {
+    fprintf(stderr, "WEBEEBLOCKS_FILE_BROKER_V1 FATAL Qt provider initialization failed\n");
+    wb_robot_cleanup();
+    return 1;
+  }
 
   WbDeviceTag m1 = wb_robot_get_device("m1_motor");
   WbDeviceTag m2 = wb_robot_get_device("m2_motor");
@@ -196,6 +203,7 @@ int main(void) {
 
   if (!m1 || !m2 || !m3 || !m4 || !gps || !imu || !gyro || !range_front) {
     fprintf(stderr, PREFIX " FATAL missing required Webots device\n");
+    wb_file_broker_destroy(file_broker);
     wb_robot_cleanup();
     return 1;
   }
@@ -292,6 +300,11 @@ int main(void) {
 
     const char *message;
     while ((message = wb_robot_wwi_receive_text()) != NULL) {
+      char broker_response[512];
+      if (wb_file_broker_handle_message(file_broker, message, broker_response, sizeof(broker_response))) {
+        send_text(broker_response);
+        continue;
+      }
       if (strncmp(message, PREFIX " REQUEST ", strlen(PREFIX " REQUEST ")) != 0)
         continue;
       request_t request = parse_request(message);
@@ -472,6 +485,7 @@ int main(void) {
   }
 
   stop_motors(m1, m2, m3, m4);
+  wb_file_broker_destroy(file_broker);
   wb_robot_cleanup();
   return 0;
 }

--- a/controllers/crazyflie_runtime_v2/file_broker.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.cpp
@@ -1,0 +1,100 @@
+#include "file_broker.hpp"
+#include "file_broker_c.h"
+
+#include <QByteArray>
+#include <QFileDialog>
+#include <QIODevice>
+#include <QSaveFile>
+#include <QString>
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <regex>
+#include <utility>
+
+namespace {
+
+constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1";
+
+class QtFileDialogProvider final : public webeeblocks::FileDialogProvider {
+public:
+  std::string name() const override { return "qt6-qfiledialog"; }
+
+  // These deliberately remain behind the provider seam during 71-C1. Their
+  // presence makes the build prove the exact Webots-bundled Qt APIs selected
+  // for the next transactional increment without opening a dialog in CI.
+  QString selectOpenFile() const {
+    return QFileDialog::getOpenFileName(nullptr, QStringLiteral("Ouvrir un projet WebeeBlocks"), QString(),
+                                        QStringLiteral("Projets WebeeBlocks (*.wbb *.webeeblocks.json *.json)"));
+  }
+
+  bool atomicWrite(const QString &path, const QByteArray &bytes) const {
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly) || file.write(bytes) != bytes.size())
+      return false;
+    return file.commit();
+  }
+};
+
+std::string safeProviderName(const std::string &value) {
+  static const std::regex safe("^[a-z0-9-]{1,48}$");
+  return std::regex_match(value, safe) ? value : "invalid-provider";
+}
+
+}  // namespace
+
+namespace webeeblocks {
+
+std::unique_ptr<FileDialogProvider> createQtFileDialogProvider() {
+  return std::make_unique<QtFileDialogProvider>();
+}
+
+FileBroker::FileBroker(std::unique_ptr<FileDialogProvider> provider) : mProvider(std::move(provider)) {
+}
+
+FileBroker::~FileBroker() = default;
+
+bool FileBroker::handleMessage(const char *message, char *response, std::size_t responseSize) const {
+  if (!message || !response || responseSize == 0 || !mProvider)
+    return false;
+  response[0] = '\0';
+
+  int requestId = -1;
+  char extra[2] = {0};
+  const std::string pattern = std::string(kPrefix) + " REQUEST %d CAPABILITIES %1s";
+  if (std::sscanf(message, pattern.c_str(), &requestId, extra) != 1 || requestId < 1)
+    return false;
+
+  const std::string provider = safeProviderName(mProvider->name());
+  const int written = std::snprintf(
+    response, responseSize,
+    "%s RESPONSE %d CAPABILITIES {\"protocol\":1,\"provider\":\"%s\",\"providerInjectable\":true,"
+    "\"operationsReady\":false,\"canonicalExtension\":\".wbb\"}",
+    kPrefix, requestId, provider.c_str());
+  return written > 0 && static_cast<std::size_t>(written) < responseSize;
+}
+
+}  // namespace webeeblocks
+
+struct WbFileBroker {
+  explicit WbFileBroker(std::unique_ptr<webeeblocks::FileDialogProvider> provider) : value(std::move(provider)) {}
+  webeeblocks::FileBroker value;
+};
+
+extern "C" WbFileBroker *wb_file_broker_create_qt(void) {
+  try {
+    return new WbFileBroker(webeeblocks::createQtFileDialogProvider());
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+extern "C" void wb_file_broker_destroy(WbFileBroker *broker) {
+  delete broker;
+}
+
+extern "C" int wb_file_broker_handle_message(const WbFileBroker *broker, const char *message, char *response,
+                                                size_t response_size) {
+  return broker && broker->value.handleMessage(message, response, response_size) ? 1 : 0;
+}

--- a/controllers/crazyflie_runtime_v2/file_broker.hpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.hpp
@@ -1,0 +1,36 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_HPP
+#define WEBEEBLOCKS_FILE_BROKER_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace webeeblocks {
+
+class FileDialogProvider {
+public:
+  virtual ~FileDialogProvider() = default;
+  virtual std::string name() const = 0;
+};
+
+std::unique_ptr<FileDialogProvider> createQtFileDialogProvider();
+
+class FileBroker {
+public:
+  explicit FileBroker(std::unique_ptr<FileDialogProvider> provider);
+  ~FileBroker();
+
+  FileBroker(const FileBroker &) = delete;
+  FileBroker &operator=(const FileBroker &) = delete;
+
+  // Returns true only for a syntactically valid broker request. The response
+  // is left empty for messages owned by another WWI protocol.
+  bool handleMessage(const char *message, char *response, std::size_t responseSize) const;
+
+private:
+  std::unique_ptr<FileDialogProvider> mProvider;
+};
+
+}  // namespace webeeblocks
+
+#endif

--- a/controllers/crazyflie_runtime_v2/file_broker_c.h
+++ b/controllers/crazyflie_runtime_v2/file_broker_c.h
@@ -1,0 +1,21 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_C_H
+#define WEBEEBLOCKS_FILE_BROKER_C_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct WbFileBroker WbFileBroker;
+
+WbFileBroker *wb_file_broker_create_qt(void);
+void wb_file_broker_destroy(WbFileBroker *broker);
+int wb_file_broker_handle_message(const WbFileBroker *broker, const char *message, char *response,
+                                  size_t response_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
+++ b/plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
@@ -1,0 +1,55 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksNativeFileBroker = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  var PREFIX = 'WEBEEBLOCKS_FILE_BROKER_V1';
+
+  function NativeFileBroker(robotWindow, options) {
+    if (!robotWindow || typeof robotWindow.send !== 'function') throw new Error('native file broker requires RobotWindow');
+    this.robotWindow = robotWindow;
+    this.timeoutMs = options && options.timeoutMs || 5000;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.capabilities = null;
+  }
+
+  NativeFileBroker.prototype.handleMessage = function(message) {
+    if (typeof message !== 'string' || message.indexOf(PREFIX + ' RESPONSE ') !== 0) return false;
+    var match = message.match(/^WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ([1-9][0-9]*) CAPABILITIES (\{.*\})$/);
+    if (!match) return true;
+    var id = Number(match[1]);
+    var pending = this.pending.get(id);
+    if (!pending) return true;
+    this.pending.delete(id);
+    clearTimeout(pending.timer);
+    try {
+      var capabilities = JSON.parse(match[2]);
+      if (capabilities.protocol !== 1 || capabilities.providerInjectable !== true || capabilities.operationsReady !== false ||
+          capabilities.canonicalExtension !== '.wbb')
+        throw new Error('native file broker capability contract mismatch');
+      this.capabilities = capabilities;
+      pending.resolve(capabilities);
+    } catch (error) { pending.reject(error); }
+    return true;
+  };
+
+  NativeFileBroker.prototype.requestCapabilities = function() {
+    var self = this;
+    var id = this.nextId++;
+    return new Promise(function(resolve, reject) {
+      var timer = setTimeout(function() {
+        self.pending.delete(id);
+        reject(new Error('native file broker capability timeout'));
+      }, self.timeoutMs);
+      self.pending.set(id, {resolve: resolve, reject: reject, timer: timer});
+      self.robotWindow.send(PREFIX + ' REQUEST ' + id + ' CAPABILITIES');
+    });
+  };
+
+  NativeFileBroker.PREFIX = PREFIX;
+  return NativeFileBroker;
+});

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -19,6 +19,7 @@
   <script src="../blockly/webeeblocks/runtime_outcome.js"></script>
   <script src="../blockly/webeeblocks/activity_contract.js"></script>
   <script src="../blockly/webeeblocks/project_files.js"></script>
+  <script src="../blockly/webeeblocks/native_file_broker.js"></script>
   <script src="../blockly/webeeblocks/wwi_backend.js"></script>
 </head>
 <body>

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -5,6 +5,7 @@ var runtimeBackend = null;
 var runtimeRunning = false;
 var runtimeTerminal = false;
 var runtimeDebug = null;
+var nativeFileBroker = null;
 
 var WEBEEBLOCKS_WORKSPACE_SCALE = 0.90;
 
@@ -112,6 +113,10 @@ function buildToolbox(profile) {
 }
 
 function receiveMessage(value) {
+  if (nativeFileBroker && nativeFileBroker.handleMessage(value)) {
+    window.dispatchEvent(new CustomEvent('webeeblocks-file-broker-wwi', {detail: value}));
+    return;
+  }
   if (runtimeBackend && runtimeBackend.handleMessage(value)) {
     window.dispatchEvent(new CustomEvent('webeeblocks-wwi', {detail: value}));
     return;
@@ -233,8 +238,11 @@ window.onload = async function() {
     var module = await import('https://cyberbotics.com/wwi/R2025a/RobotWindow.js');
     robotWindow = new module.default();
     runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true});
+    nativeFileBroker = new WebeeBlocksNativeFileBroker(robotWindow, {timeoutMs: 5000});
     robotWindow.receive = receiveMessage;
     setRuntimeStatus('INITIALISATION', 'Attente du Runtime v2');
+    var brokerCapabilities = await nativeFileBroker.requestCapabilities();
+    window.dispatchEvent(new CustomEvent('webeeblocks-native-file-broker-ready', {detail: brokerCapabilities}));
     await runtimeBackend.waitUntilReady();
     document.getElementById('submit').disabled = false;
     if (runtimeBackend.capabilities && runtimeBackend.capabilities.simulationDebug === true) document.getElementById('debugPanel').hidden = false;

--- a/tools/ci/prepare_runtime_v2_native_file_broker.py
+++ b/tools/ci/prepare_runtime_v2_native_file_broker.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+html = html_path.read_text(encoding='utf-8')
+seam = '  <script src="project_ui.js"></script>\n'
+if seam not in html:
+    raise SystemExit('project_ui.js seam not found')
+
+harness = r'''  <script>
+  (function() {
+    let sequence = 0;
+    let reportChain = Promise.resolve();
+    function report(event, detail) {
+      const payload = {seq: sequence++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
+      reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
+        method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload)
+      }));
+      return reportChain;
+    }
+    window.addEventListener('error', event => report('WINDOW_ERROR', event.message));
+    window.addEventListener('unhandledrejection', event => report('UNHANDLED_REJECTION', String(event.reason)));
+    window.addEventListener('webeeblocks-native-file-broker-ready', async event => {
+      await report('FILE_BROKER_CAPABILITIES', event.detail);
+      await report('FILE_BROKER_TEST_COMPLETE', {runtimeState: document.getElementById('runtimeState').textContent});
+    });
+  })();
+  </script>
+'''
+
+html_path.write_text(html.replace(seam, harness + seam, 1), encoding='utf-8')

--- a/tools/ci/test_native_file_broker.cpp
+++ b/tools/ci/test_native_file_broker.cpp
@@ -1,0 +1,34 @@
+#include "file_broker.hpp"
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+
+class InjectedProvider final : public webeeblocks::FileDialogProvider {
+public:
+  std::string name() const override { return "ci-injected-dialog"; }
+};
+
+int main() {
+  webeeblocks::FileBroker broker(std::make_unique<InjectedProvider>());
+  char response[512];
+
+  assert(broker.handleMessage("WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 CAPABILITIES", response, sizeof(response)));
+  const std::string value(response);
+  assert(value.find("RESPONSE 7 CAPABILITIES") != std::string::npos);
+  assert(value.find("\"provider\":\"ci-injected-dialog\"") != std::string::npos);
+  assert(value.find("\"providerInjectable\":true") != std::string::npos);
+  assert(value.find("\"operationsReady\":false") != std::string::npos);
+  assert(value.find("\"canonicalExtension\":\".wbb\"") != std::string::npos);
+
+  std::memset(response, 'x', sizeof(response));
+  assert(!broker.handleMessage("WEBEEBLOCKS_RUNTIME_V2 REQUEST 7 RANGE front", response, sizeof(response)));
+  assert(response[0] == '\0');
+  assert(!broker.handleMessage("WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 CAPABILITIES trailing", response,
+                               sizeof(response)));
+
+  std::cout << "PASS: injectable native file broker capability contract\n";
+  return 0;
+}

--- a/tools/ci/test_native_file_broker.js
+++ b/tools/ci/test_native_file_broker.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('assert');
+const NativeFileBroker = require('../../plugins/robot_windows/blockly/webeeblocks/native_file_broker.js');
+
+(async function() {
+  const sent = [];
+  const broker = new NativeFileBroker({send: message => sent.push(message)}, {timeoutMs: 1000});
+  const pending = broker.requestCapabilities();
+  assert.deepStrictEqual(sent, ['WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 1 CAPABILITIES']);
+  assert.strictEqual(broker.handleMessage('WEBEEBLOCKS_RUNTIME_V2 READY'), false);
+  assert.strictEqual(broker.handleMessage(
+    'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES ' +
+    '{"protocol":1,"provider":"ci-injected-dialog","providerInjectable":true,"operationsReady":false,"canonicalExtension":".wbb"}'
+  ), true);
+  const capabilities = await pending;
+  assert.strictEqual(capabilities.provider, 'ci-injected-dialog');
+  assert.strictEqual(capabilities.operationsReady, false);
+  console.log('PASS: browser native file broker handshake parser');
+})().catch(error => { console.error(error); process.exit(1); });

--- a/tools/ci/webots_native_file_broker_browser.sh
+++ b/tools/ci/webots_native_file_broker_browser.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eu
+mkdir -p /workspace/ci-artifacts/runtime-v2-native-file-broker
+printf 'BROWSER_LAUNCHED args=' >> /workspace/ci-artifacts/runtime-v2-native-file-broker/browser-launch.log
+printf '%q ' "$@" >> /workspace/ci-artifacts/runtime-v2-native-file-broker/browser-launch.log
+printf '\n' >> /workspace/ci-artifacts/runtime-v2-native-file-broker/browser-launch.log
+exec /usr/bin/google-chrome \
+  --headless=new \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --disable-background-networking \
+  --no-first-run \
+  --no-default-browser-check \
+  "$@"


### PR DESCRIPTION
Closes the first causal stop of #71-C1 only.

## Authorized scope

- link a small C++ broker into the existing `crazyflie_runtime_v2` controller process against the Qt6 libraries bundled with Webots R2025a;
- route `WEBEEBLOCKS_FILE_BROKER_V1` through the existing WWI receive loop (no second WWI consumer);
- expose a strict browser-side capability handshake;
- keep the dialog provider injectable and prove injection independently;
- keep the future canonical extension explicit as `.wbb`.

## Honest boundary

This head deliberately returns `operationsReady=false`. It does **not** claim that Open / Save As / Save, a real `QFileDialog`, path retention, or `QSaveFile` writes are product-ready. The Qt provider compiles the selected `QFileDialog` and `QSaveFile` APIs, but no dialog is opened and no file is written in 71-C1.

If the real R2025a gate fails, classify it `PLATFORM` and stop. Do not add Blob/download, OPFS, server, cloud, second WWI consumer, or system-Qt dependency.

## Causal evidence

The new gate must prove:

1. clean R2025a controller build using `$WEBOTS_HOME/include/qt` and `$WEBOTS_HOME/lib/webots`;
2. an injected fake dialog provider changes the broker-reported provider in the C++ contract test;
3. the actual Robot Window sends `FILE_BROKER ... CAPABILITIES` through WWI and the actual controller responds;
4. the response is exactly protocol 1, provider `qt6-qfiledialog`, injectable=true, operationsReady=false, extension `.wbb`;
5. Runtime v2 still reaches `READY`.

Local prechecks already pass: JS syntax/parser test, Python syntax, shell syntax, and `git diff --check`.

## Non-goals

No project format mutation, no file operations, no UI button-state change, no AST/interpreter/backend/PID/STOP change, no activity/localization/reset work, no `main` change.

## Handoff

Verification should reject any green based only on a Node or C++ double. The required proof is the event from the actual R2025a Robot Window plus the controller log on this exact head. A green 71-C1 proves only the platform seam and authorizes the next transactional step inside the same WIP; it does not close #71.