### PR TITLE
[Deferred research] Native Webots/Qt bridge for Firefox project files

### DIFF
--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -48,6 +48,26 @@ jobs:
           mkdir -p ci-artifacts/runtime-v2-desktop-sdk-file-broker
           sha256sum "$RUNNER_TEMP/$WEBOTS_ARCHIVE" > ci-artifacts/runtime-v2-desktop-sdk-file-broker/archive.sha256
 
+      - name: Install official Webots R2025a EGL runtime prerequisite
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libegl1
+          artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          mkdir -p "$artifact_dir"
+          dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' libegl1 |
+            tee "$artifact_dir/egl-package.txt"
+          ldconfig -p | grep 'libEGL.so.1' |
+            tee "$artifact_dir/egl-ldconfig.txt"
+          readelf -d "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6" |
+            tee "$artifact_dir/qt6gui-dynamic.txt"
+          egl_path="$(ldconfig -p | awk '$1 == "libEGL.so.1" {print $NF; exit}')"
+          test -n "$egl_path"
+          egl_real_path="$(realpath "$egl_path")"
+          dpkg-query -S "$egl_real_path" |
+            tee "$artifact_dir/egl-package-owner.txt"
+          grep -Eq '^libegl1(:[^: ]+)?: ' "$artifact_dir/egl-package-owner.txt"
+
       - name: Prove bundled Qt substrate before compilation
         run: |
           set -euo pipefail
@@ -69,23 +89,33 @@ jobs:
             "$WEBOTS_HOME/lib/webots/qt/plugins/platforms/libqxcb.so" \
             > ci-artifacts/runtime-v2-desktop-sdk-file-broker/bundled-qt-paths.txt
 
-      - name: Build broker-enabled controller only against desktop SDK
+      - name: Build broker-enabled controller against Webots Qt and Ubuntu runtime EGL
         run: |
           set -euo pipefail
-          mkdir -p ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          mkdir -p "$artifact_dir"
           make -C controllers/crazyflie_runtime_v2 clean
           make -C controllers/crazyflie_runtime_v2 WEBEEBLOCKS_NATIVE_FILE_BROKER=1 VERBOSE=1 2>&1 |
-            tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/build.log
+            tee "$artifact_dir/build.log"
           controller=controllers/crazyflie_runtime_v2/crazyflie_runtime_v2
           test -x "$controller"
           LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" ldd "$controller" |
-            tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/ldd.log
-          qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' ci-artifacts/runtime-v2-desktop-sdk-file-broker/ldd.log)"
+            tee "$artifact_dir/ldd.log"
+
+          qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/ldd.log")"
           test "$(printf '%s\n' "$qt_lines" | wc -l)" -eq 3
           if printf '%s\n' "$qt_lines" | grep -vF "$WEBOTS_HOME/lib/webots/"; then
-            echo "Qt resolved outside the official desktop SDK" >&2
+            echo "Qt resolved outside the official Webots desktop SDK" >&2
             exit 1
           fi
+
+          egl_line="$(grep 'libEGL.so.1' "$artifact_dir/ldd.log")"
+          test -n "$egl_line"
+          egl_resolved="$(printf '%s\n' "$egl_line" | awk '{print $3; exit}')"
+          test -f "$egl_resolved"
+          dpkg-query -S "$(realpath "$egl_resolved")" |
+            tee "$artifact_dir/egl-ldd-package-owner.txt"
+          grep -Eq '^libegl1(:[^: ]+)?: ' "$artifact_dir/egl-ldd-package-owner.txt"
 
       - name: Prepare actual Robot Window handshake harness
         run: python3 tools/ci/prepare_runtime_v2_native_file_broker.py
@@ -96,12 +126,23 @@ jobs:
           chmod +x tools/ci/webots_native_file_broker_browser.sh
           mkdir -p "$HOME/.config/Cyberbotics" ci-artifacts/runtime-v2-desktop-sdk-file-broker
           browser_script="$GITHUB_WORKSPACE/tools/ci/webots_native_file_broker_browser.sh"
-          printf '%s\n' '[RobotWindow]' "browser=$browser_script" 'newBrowserWindow=false'             > "$HOME/.config/Cyberbotics/Webots-R2025a.conf"
-          python3 tools/ci/runtime_wwi_event_server.py             --output ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-events.jsonl &
+          printf '%s\n' \
+            '[RobotWindow]' \
+            "browser=$browser_script" \
+            'newBrowserWindow=false' \
+            > "$HOME/.config/Cyberbotics/Webots-R2025a.conf"
+          python3 tools/ci/runtime_wwi_event_server.py \
+            --output ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-events.jsonl &
           server=$!
           trap 'kill "$server" 2>/dev/null || true' EXIT
           set +e
-          LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots"           QT_PLUGIN_PATH="$WEBOTS_HOME/lib/webots/qt/plugins"           LIBGL_ALWAYS_SOFTWARE=true           WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true           timeout -k 5s 45s xvfb-run -a "$WEBOTS_HOME/webots" --stdout --stderr --batch --mode=realtime             "$GITHUB_WORKSPACE/worlds/crazyflie_runtime_v2.wbt" 2>&1 |
+          LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" \
+            QT_PLUGIN_PATH="$WEBOTS_HOME/lib/webots/qt/plugins" \
+            LIBGL_ALWAYS_SOFTWARE=true \
+            WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            timeout -k 5s 45s xvfb-run -a "$WEBOTS_HOME/webots" \
+              --stdout --stderr --batch --mode=realtime \
+              "$GITHUB_WORKSPACE/worlds/crazyflie_runtime_v2.wbt" 2>&1 |
             tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/webots.log
           code=${PIPESTATUS[0]}
           set -e
@@ -132,7 +173,7 @@ jobs:
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES' in log, log[-4000:]
           assert 'WEBEEBLOCKS_RUNTIME_V2 READY' in log, log[-4000:]
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 FATAL' not in log, log[-4000:]
-          print('PASS: official desktop R2025a SDK -> bundled Qt -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
+          print('PASS: official desktop R2025a SDK -> bundled Qt -> Ubuntu libegl1 runtime -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
           PY
 
       - name: Upload desktop SDK proof

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -113,7 +113,7 @@ jobs:
           grep -Eq '^libsndio7\.0(:[^: ]+)?: ' "$artifact_dir/sndio-package-owner.txt"
 
           LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" \
-            ldd "$WEBOTS_HOME/lib/webots/webots-bin" |
+            ldd "$WEBOTS_HOME/bin/webots-bin" |
             tee "$artifact_dir/webots-bin-ldd.txt"
           if grep -F 'not found' "$artifact_dir/webots-bin-ldd.txt"; then
             echo "Official R2025a runtime closure is incomplete" >&2

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -151,7 +151,7 @@ jobs:
           artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
           mkdir -p "$artifact_dir"
           make -C controllers/crazyflie_runtime_v2 clean
-          make -C controllers/crazyflie_runtime_v2 WEBEEBLOCKS_NATIVE_FILE_BROKER=1 VERBOSE=1 2>&1 |
+          make -C controllers/crazyflie_runtime_v2 WEBEEBLOCKS_NATIVE_FILE_BROKER=1 WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC=1 VERBOSE=1 2>&1 |
             tee "$artifact_dir/build.log"
           controller=controllers/crazyflie_runtime_v2/crazyflie_runtime_v2
           test -x "$controller"
@@ -184,6 +184,8 @@ jobs:
           log="$artifact_dir/webots.log"
           events="$artifact_dir/browser-events.jsonl"
           maps="$artifact_dir/controller-qt-maps.txt"
+          backtrace="$artifact_dir/controller-gdb-backtrace.txt"
+          diagnostic="$artifact_dir/controller-diagnostic.txt"
           controller="$GITHUB_WORKSPACE/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2"
           controller_real="$(realpath "$controller")"
           mkdir -p "$HOME/.config/Cyberbotics" "$artifact_dir"
@@ -206,6 +208,13 @@ jobs:
           }
           trap cleanup EXIT
 
+          gdb_path="$(command -v gdb)"
+          test -x "$gdb_path"
+          {
+            printf 'gdb_path=%s\\n' "$gdb_path"
+            "$gdb_path" --version | head -n 1
+          } > "$artifact_dir/gdb-provenance.txt"
+
           setsid env \
             LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" \
             QT_PLUGIN_PATH="$WEBOTS_HOME/lib/webots/qt/plugins" \
@@ -220,8 +229,56 @@ jobs:
 
           deadline=$((SECONDS + 45))
           controller_maps_proven=0
+          diagnostic_complete=0
           handshake_complete=0
           while [ "$SECONDS" -lt "$deadline" ]; do
+            if [ "$diagnostic_complete" -eq 0 ] &&
+               grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 DIAGNOSTIC_RENDEZVOUS' "$log"; then
+              pid="$(sed -n 's/.*DIAGNOSTIC_RENDEZVOUS pid=\\([0-9][0-9]*\\).*/\\1/p' "$log" | tail -n 1)"
+              test -n "$pid"
+              test -r "/proc/$pid/exe"
+              actual_exe="$(readlink -f "/proc/$pid/exe")"
+              test "$actual_exe" = "$controller_real"
+              test -r "/proc/$pid/status"
+              grep -Eq '^State:[[:space:]]+T' "/proc/$pid/status"
+
+              awk '/libQt6(Core|Gui|Widgets)\\.so\\.6/ {print $NF}' "/proc/$pid/maps" | sort -u > "$maps"
+              test "$(wc -l < "$maps")" -eq 3
+              test "$(grep -cF "$WEBOTS_HOME/lib/webots/" "$maps")" -eq 3
+
+              {
+                printf 'controller_pid=%s\\n' "$pid"
+                printf 'controller_exe=%s\\n' "$actual_exe"
+                printf 'controller_state_before_attach=%s\\n' "$(awk '/^State:/ {$1=""; sub(/^ /, ""); print}' "/proc/$pid/status")"
+                printf 'diagnostic_boundary=before-QApplication\\n'
+                printf 'environment_contract=unchanged-R2025a-Xvfb-runtime.ini-Webots-Qt\\n'
+              } | tee "$diagnostic"
+              cp "$diagnostic" "$artifact_dir/controller-process.txt"
+
+              set +e
+              sudo -n "$gdb_path" --batch --quiet -p "$pid" \
+                -ex 'set pagination off' \
+                -ex 'set confirm off' \
+                -ex 'set print thread-events off' \
+                -ex 'signal 0' \
+                -ex 'printf "\\nWEBEEBLOCKS_GDB_CAUSAL_STOP\\n"' \
+                -ex 'info program' \
+                -ex 'thread apply all bt full' \
+                > "$backtrace" 2>&1
+              gdb_code=$?
+              set -e
+              printf 'gdb_exit=%s\\n' "$gdb_code" | tee -a "$diagnostic"
+              cat "$backtrace"
+              test "$gdb_code" -eq 0
+              grep -Eq 'Program received signal SIG[A-Z0-9]+' "$backtrace"
+              grep -Eq '^#0[[:space:]]' "$backtrace"
+              grep -Eq 'QtFileDialogProvider|QApplication' "$backtrace"
+              diagnostic_complete=1
+
+              echo "C10 diagnostic captured; original product handshake remains intentionally unproven" >&2
+              exit 1
+            fi
+
             if grep -Eq "controller (exited with status: [1-9][0-9]*|crashed)|error while loading shared libraries:" "$log"; then
               cat "$log"
               echo "Controller failed before the file-broker handshake completed" >&2
@@ -309,6 +366,37 @@ jobs:
           assert 'controller crashed' not in log, log[-4000:]
           print('PASS: runtime.ini -> real controller Webots Qt maps -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
           PY
+
+      - name: Validate C10 real-controller crash evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          diagnostic="$artifact_dir/controller-diagnostic.txt"
+          backtrace="$artifact_dir/controller-gdb-backtrace.txt"
+          log="$artifact_dir/webots.log"
+          test -s "$diagnostic"
+          test -s "$backtrace"
+          grep -Fq 'diagnostic_boundary=before-QApplication' "$diagnostic"
+          grep -Fq 'environment_contract=unchanged-R2025a-Xvfb-runtime.ini-Webots-Qt' "$diagnostic"
+          grep -Eq '^controller_pid=[0-9]+
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-v2-desktop-sdk-file-broker-r2025a
+          path: ci-artifacts/runtime-v2-desktop-sdk-file-broker/
+          if-no-files-found: error
+ "$diagnostic"
+          grep -Fq "controller_exe=$GITHUB_WORKSPACE/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2" "$diagnostic"
+          grep -Fq 'gdb_exit=0' "$diagnostic"
+          grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 DIAGNOSTIC_RENDEZVOUS' "$log"
+          grep -Eq 'Program received signal SIG[A-Z0-9]+' "$backtrace"
+          grep -Eq '^#0[[:space:]]' "$backtrace"
+          grep -Eq 'QtFileDialogProvider|QApplication' "$backtrace"
+          ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$log"
+          ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$log"
+          printf '%s\\n' \
+            'PROVEN_DIAGNOSTIC: true Webots controller + unchanged C8 environment + exact signal + causal backtrace' \
+            'PRODUCT_GATE: intentionally still FAILURE / QApplication, QFileDialog and handshake UNPROVEN'
 
       - name: Upload desktop SDK proof
         if: always()

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Prove bundled Qt substrate before compilation
         run: |
           set -euo pipefail
-          test -f "$WEBOTS_HOME/include/qt/QtCore/QByteArray"
-          test -f "$WEBOTS_HOME/include/qt/QtWidgets/QFileDialog"
+          test -f "$WEBOTS_HOME/include/qt/QtCore/QtCore/QByteArray"
+          test -f "$WEBOTS_HOME/include/qt/QtWidgets/QtWidgets/QFileDialog"
           test -f "$WEBOTS_HOME/lib/webots/libQt6Core.so.6"
           test -f "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6"
           test -f "$WEBOTS_HOME/lib/webots/libQt6Widgets.so.6"
@@ -60,8 +60,8 @@ jobs:
           test -f "$WEBOTS_HOME/lib/webots/qt/plugins/platforms/libqxcb.so"
           "$WEBOTS_HOME/bin/qt/moc" --version
           printf '%s\n' \
-            "$WEBOTS_HOME/include/qt/QtCore/QByteArray" \
-            "$WEBOTS_HOME/include/qt/QtWidgets/QFileDialog" \
+            "$WEBOTS_HOME/include/qt/QtCore/QtCore/QByteArray" \
+            "$WEBOTS_HOME/include/qt/QtWidgets/QtWidgets/QFileDialog" \
             "$WEBOTS_HOME/lib/webots/libQt6Core.so.6" \
             "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6" \
             "$WEBOTS_HOME/lib/webots/libQt6Widgets.so.6" \

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -379,13 +379,7 @@ jobs:
           test -s "$backtrace"
           grep -Fq 'diagnostic_boundary=before-QApplication' "$diagnostic"
           grep -Fq 'environment_contract=unchanged-R2025a-Xvfb-runtime.ini-Webots-Qt' "$diagnostic"
-          grep -Eq '^controller_pid=[0-9]+
-        uses: actions/upload-artifact@v4
-        with:
-          name: runtime-v2-desktop-sdk-file-broker-r2025a
-          path: ci-artifacts/runtime-v2-desktop-sdk-file-broker/
-          if-no-files-found: error
- "$diagnostic"
+          grep -Eq '^controller_pid=[0-9]+$' "$diagnostic"
           grep -Fq "controller_exe=$GITHUB_WORKSPACE/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2" "$diagnostic"
           grep -Fq 'gdb_exit=0' "$diagnostic"
           grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 DIAGNOSTIC_RENDEZVOUS' "$log"

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -59,7 +59,15 @@ jobs:
           test -x "$WEBOTS_HOME/bin/qt/moc"
           test -f "$WEBOTS_HOME/lib/webots/qt/plugins/platforms/libqxcb.so"
           "$WEBOTS_HOME/bin/qt/moc" --version
-          dpkg-query -W -f='${binary:Package}\n' | ! grep -Eq '^qt6-base-dev(:|$)|^qt6-base-dev-tools(:|$)'
+          printf '%s\n' \
+            "$WEBOTS_HOME/include/qt/QtCore/QByteArray" \
+            "$WEBOTS_HOME/include/qt/QtWidgets/QFileDialog" \
+            "$WEBOTS_HOME/lib/webots/libQt6Core.so.6" \
+            "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6" \
+            "$WEBOTS_HOME/lib/webots/libQt6Widgets.so.6" \
+            "$WEBOTS_HOME/bin/qt/moc" \
+            "$WEBOTS_HOME/lib/webots/qt/plugins/platforms/libqxcb.so" \
+            > ci-artifacts/runtime-v2-desktop-sdk-file-broker/bundled-qt-paths.txt
 
       - name: Build broker-enabled controller only against desktop SDK
         run: |

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -31,6 +31,10 @@ jobs:
           ! grep -Rq 'wb_robot_wwi_receive_text' controllers/crazyflie_runtime_v2/file_broker.cpp
           ! grep -RqE 'QSaveFile|getOpenFileName|getSaveFileName|\.exec\(' controllers/crazyflie_runtime_v2/file_broker.cpp
           ! grep -RqE 'Blob|showOpenFilePicker|showSaveFilePicker|OPFS|IndexedDB' plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
+          test -f controllers/crazyflie_runtime_v2/runtime.ini
+          grep -Fxq '[environment variables for Linux]' controllers/crazyflie_runtime_v2/runtime.ini
+          grep -Fxq 'WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/lib/webots' controllers/crazyflie_runtime_v2/runtime.ini
+          ! grep -Eq 'LD_LIBRARY_PATH|/home/runner|/usr/lib/.*/libQt6' controllers/crazyflie_runtime_v2/runtime.ini
 
       - name: Prepare pinned Blockly 13.2.1 browser assets
         working-directory: plugins/robot_windows/blockly_v2
@@ -176,29 +180,103 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x tools/ci/webots_native_file_broker_browser.sh
-          mkdir -p "$HOME/.config/Cyberbotics" ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          log="$artifact_dir/webots.log"
+          events="$artifact_dir/browser-events.jsonl"
+          maps="$artifact_dir/controller-qt-maps.txt"
+          controller="$GITHUB_WORKSPACE/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2"
+          controller_real="$(realpath "$controller")"
+          mkdir -p "$HOME/.config/Cyberbotics" "$artifact_dir"
+          : > "$log"
           browser_script="$GITHUB_WORKSPACE/tools/ci/webots_native_file_broker_browser.sh"
           printf '%s\n' \
             '[RobotWindow]' \
             "browser=$browser_script" \
             'newBrowserWindow=false' \
             > "$HOME/.config/Cyberbotics/Webots-R2025a.conf"
-          python3 tools/ci/runtime_wwi_event_server.py \
-            --output ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-events.jsonl &
+          python3 tools/ci/runtime_wwi_event_server.py --output "$events" &
           server=$!
-          trap 'kill "$server" 2>/dev/null || true' EXIT
-          set +e
-          LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" \
+          launcher=''
+          cleanup() {
+            if [ -n "$launcher" ]; then
+              kill -TERM -- "-$launcher" 2>/dev/null || true
+              wait "$launcher" 2>/dev/null || true
+            fi
+            kill "$server" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          setsid env \
+            LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" \
             QT_PLUGIN_PATH="$WEBOTS_HOME/lib/webots/qt/plugins" \
+            QT_DEBUG_PLUGINS=1 \
             LIBGL_ALWAYS_SOFTWARE=true \
             WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
             timeout -k 5s 45s xvfb-run -a "$WEBOTS_HOME/webots" \
               --stdout --stderr --batch --mode=realtime \
-              "$GITHUB_WORKSPACE/worlds/crazyflie_runtime_v2.wbt" 2>&1 |
-            tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/webots.log
-          code=${PIPESTATUS[0]}
-          set -e
-          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then exit "$code"; fi
+              "$GITHUB_WORKSPACE/worlds/crazyflie_runtime_v2.wbt" \
+              > "$log" 2>&1 &
+          launcher=$!
+
+          deadline=$((SECONDS + 45))
+          controller_maps_proven=0
+          handshake_complete=0
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            if grep -Eq "controller (exited with status: [1-9][0-9]*|crashed)|error while loading shared libraries:" "$log"; then
+              cat "$log"
+              echo "Controller failed before the file-broker handshake completed" >&2
+              exit 1
+            fi
+
+            if [ "$controller_maps_proven" -eq 0 ]; then
+              while read -r pid; do
+                [ -n "$pid" ] || continue
+                [ -r "/proc/$pid/exe" ] || continue
+                [ "$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)" = "$controller_real" ] || continue
+                [ -r "/proc/$pid/maps" ] || continue
+                awk '/libQt6(Core|Gui|Widgets)\.so\.6/ {print $NF}' "/proc/$pid/maps" | sort -u > "$maps"
+                if [ "$(wc -l < "$maps")" -eq 3 ]; then
+                  test "$(grep -cF "$WEBOTS_HOME/lib/webots/" "$maps")" -eq 3
+                  grep -Fq "$WEBOTS_HOME/lib/webots/libQt6Core.so.6" "$maps"
+                  grep -Fq "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6" "$maps"
+                  grep -Fq "$WEBOTS_HOME/lib/webots/libQt6Widgets.so.6" "$maps"
+                  printf 'controller_pid=%s\n' "$pid" > "$artifact_dir/controller-process.txt"
+                  controller_maps_proven=1
+                  break
+                fi
+              done < <(pgrep -f 'controllers/crazyflie_runtime_v2/crazyflie_runtime_v2' || true)
+            fi
+
+            if [ "$controller_maps_proven" -eq 1 ] && \
+               grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$log" && \
+               [ -s "$events" ] && grep -Fq 'FILE_BROKER_TEST_COMPLETE' "$events"; then
+              handshake_complete=1
+              break
+            fi
+
+            if ! kill -0 "$launcher" 2>/dev/null; then
+              set +e
+              wait "$launcher"
+              code=$?
+              set -e
+              launcher=''
+              cat "$log"
+              echo "Webots exited before the causal handshake completed (code=$code)" >&2
+              exit 1
+            fi
+            sleep 0.1
+          done
+
+          if [ "$handshake_complete" -ne 1 ]; then
+            cat "$log"
+            echo "Timed out before real-controller Qt provenance and handshake completion" >&2
+            exit 1
+          fi
+
+          cleanup
+          launcher=''
+          trap - EXIT
+          cat "$log"
 
       - name: Validate causal handshake evidence
         run: |
@@ -219,13 +297,17 @@ jobs:
               'canonicalExtension': '.wbb',
           }, caps[0]
           assert any(event.get('event') == 'FILE_BROKER_TEST_COMPLETE' for event in events), events
+          maps = (root / 'controller-qt-maps.txt').read_text().splitlines()
+          assert len(maps) == 3, maps
+          assert all('/webots/lib/webots/libQt6' in path for path in maps), maps
           log = (root / 'webots.log').read_text(errors='replace')
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' in log, log[-4000:]
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' in log, log[-4000:]
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES' in log, log[-4000:]
           assert 'WEBEEBLOCKS_RUNTIME_V2 READY' in log, log[-4000:]
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 FATAL' not in log, log[-4000:]
-          print('PASS: official desktop R2025a SDK -> complete official Ubuntu runtime closure -> bundled Qt -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
+          assert 'controller crashed' not in log, log[-4000:]
+          print('PASS: runtime.ini -> real controller Webots Qt maps -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
           PY
 
       - name: Upload desktop SDK proof

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -1,0 +1,134 @@
+name: Runtime v2 desktop SDK file broker proof
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  WEBOTS_ARCHIVE: webots-R2025a-x86-64.tar.bz2
+  WEBOTS_URL: https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
+  WEBOTS_SHA256: c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38
+
+jobs:
+  desktop-sdk-file-broker:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate bounded protocol sources
+        run: |
+          set -euo pipefail
+          node --check plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
+          node tools/ci/test_native_file_broker.js
+          python3 -m py_compile tools/ci/prepare_runtime_v2_native_file_broker.py
+          grep -Fq 'native_file_broker.js' plugins/robot_windows/blockly_v2/blockly_v2.html
+          ! grep -Rq 'wb_robot_wwi_receive_text' controllers/crazyflie_runtime_v2/file_broker.cpp
+          ! grep -RqE 'QSaveFile|getOpenFileName|getSaveFileName|\.exec\(' controllers/crazyflie_runtime_v2/file_broker.cpp
+          ! grep -RqE 'Blob|showOpenFilePicker|showSaveFilePicker|OPFS|IndexedDB' plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
+
+      - name: Prepare pinned Blockly 13.2.1 browser assets
+        working-directory: plugins/robot_windows/blockly_v2
+        run: |
+          npm install --ignore-scripts --no-audit --no-fund
+          npm run prepare:blockly
+          test "$(cat vendor/VERSION)" = "13.2.1"
+
+      - name: Download pinned official Webots R2025a desktop SDK
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 --output "$RUNNER_TEMP/$WEBOTS_ARCHIVE" "$WEBOTS_URL"
+          echo "$WEBOTS_SHA256  $RUNNER_TEMP/$WEBOTS_ARCHIVE" | sha256sum --check
+          tar -xjf "$RUNNER_TEMP/$WEBOTS_ARCHIVE" -C "$RUNNER_TEMP"
+          test -x "$RUNNER_TEMP/webots/webots"
+          echo "WEBOTS_HOME=$RUNNER_TEMP/webots" >> "$GITHUB_ENV"
+
+      - name: Prove bundled Qt substrate before compilation
+        run: |
+          set -euo pipefail
+          test -f "$WEBOTS_HOME/include/qt/QtCore/QByteArray"
+          test -f "$WEBOTS_HOME/include/qt/QtWidgets/QFileDialog"
+          test -f "$WEBOTS_HOME/lib/webots/libQt6Core.so.6"
+          test -f "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6"
+          test -f "$WEBOTS_HOME/lib/webots/libQt6Widgets.so.6"
+          test -x "$WEBOTS_HOME/bin/qt/moc"
+          test -f "$WEBOTS_HOME/lib/webots/qt/plugins/platforms/libqxcb.so"
+          "$WEBOTS_HOME/bin/qt/moc" --version
+          dpkg-query -W -f='${binary:Package}\n' | ! grep -Eq '^qt6-base-dev(:|$)|^qt6-base-dev-tools(:|$)'
+
+      - name: Build broker-enabled controller only against desktop SDK
+        run: |
+          set -euo pipefail
+          mkdir -p ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          make -C controllers/crazyflie_runtime_v2 clean
+          make -C controllers/crazyflie_runtime_v2 WEBEEBLOCKS_NATIVE_FILE_BROKER=1 VERBOSE=1 2>&1 |
+            tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/build.log
+          controller=controllers/crazyflie_runtime_v2/crazyflie_runtime_v2
+          test -x "$controller"
+          LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" ldd "$controller" |
+            tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/ldd.log
+          qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' ci-artifacts/runtime-v2-desktop-sdk-file-broker/ldd.log)"
+          test "$(printf '%s\n' "$qt_lines" | wc -l)" -eq 3
+          if printf '%s\n' "$qt_lines" | grep -vF "$WEBOTS_HOME/lib/webots/"; then
+            echo "Qt resolved outside the official desktop SDK" >&2
+            exit 1
+          fi
+
+      - name: Prepare actual Robot Window handshake harness
+        run: python3 tools/ci/prepare_runtime_v2_native_file_broker.py
+
+      - name: Run Qt initialization and actual Robot Window handshake
+        run: |
+          set -euo pipefail
+          chmod +x tools/ci/webots_native_file_broker_browser.sh
+          mkdir -p "$HOME/.config/Cyberbotics" ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          browser_script="$GITHUB_WORKSPACE/tools/ci/webots_native_file_broker_browser.sh"
+          printf '%s\n' '[RobotWindow]' "browser=$browser_script" 'newBrowserWindow=false'             > "$HOME/.config/Cyberbotics/Webots-R2025a.conf"
+          python3 tools/ci/runtime_wwi_event_server.py             --output ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-events.jsonl &
+          server=$!
+          trap 'kill "$server" 2>/dev/null || true' EXIT
+          set +e
+          LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots"           QT_PLUGIN_PATH="$WEBOTS_HOME/lib/webots/qt/plugins"           LIBGL_ALWAYS_SOFTWARE=true           WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true           timeout -k 5s 45s xvfb-run -a "$WEBOTS_HOME/webots" --stdout --stderr --batch --mode=realtime             "$GITHUB_WORKSPACE/worlds/crazyflie_runtime_v2.wbt" 2>&1 |
+            tee ci-artifacts/runtime-v2-desktop-sdk-file-broker/webots.log
+          code=${PIPESTATUS[0]}
+          set -e
+          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then exit "$code"; fi
+
+      - name: Validate causal handshake evidence
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('ci-artifacts/runtime-v2-desktop-sdk-file-broker')
+          events = [json.loads(line) for line in (root / 'browser-events.jsonl').read_text().splitlines() if line.strip()]
+          errors = [event for event in events if event.get('event') in ('WINDOW_ERROR', 'UNHANDLED_REJECTION', 'ERROR')]
+          assert not errors, errors
+          caps = [event['detail'] for event in events if event.get('event') == 'FILE_BROKER_CAPABILITIES']
+          assert len(caps) == 1, events
+          assert caps[0] == {
+              'protocol': 1,
+              'provider': 'qt6-qfiledialog-constructed',
+              'providerInjectable': True,
+              'operationsReady': False,
+              'canonicalExtension': '.wbb',
+          }, caps[0]
+          assert any(event.get('event') == 'FILE_BROKER_TEST_COMPLETE' for event in events), events
+          log = (root / 'webots.log').read_text(errors='replace')
+          assert 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' in log, log[-4000:]
+          assert 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' in log, log[-4000:]
+          assert 'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES' in log, log[-4000:]
+          assert 'WEBEEBLOCKS_RUNTIME_V2 READY' in log, log[-4000:]
+          assert 'WEBEEBLOCKS_FILE_BROKER_V1 FATAL' not in log, log[-4000:]
+          print('PASS: official desktop R2025a SDK -> bundled Qt -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
+          PY
+
+      - name: Upload desktop SDK proof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-v2-desktop-sdk-file-broker-r2025a
+          path: ci-artifacts/runtime-v2-desktop-sdk-file-broker/
+          if-no-files-found: error

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -45,6 +45,8 @@ jobs:
           tar -xjf "$RUNNER_TEMP/$WEBOTS_ARCHIVE" -C "$RUNNER_TEMP"
           test -x "$RUNNER_TEMP/webots/webots"
           echo "WEBOTS_HOME=$RUNNER_TEMP/webots" >> "$GITHUB_ENV"
+          mkdir -p ci-artifacts/runtime-v2-desktop-sdk-file-broker
+          sha256sum "$RUNNER_TEMP/$WEBOTS_ARCHIVE" > ci-artifacts/runtime-v2-desktop-sdk-file-broker/archive.sha256
 
       - name: Prove bundled Qt substrate before compilation
         run: |

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -11,6 +11,8 @@ env:
   WEBOTS_ARCHIVE: webots-R2025a-x86-64.tar.bz2
   WEBOTS_URL: https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
   WEBOTS_SHA256: c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38
+  WEBOTS_RUNTIME_RECIPE_URL: https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh
+  WEBOTS_RUNTIME_RECIPE_BLOB_SHA: 4593476be2c985580a0e1738671f4b5bae81f669
 
 jobs:
   desktop-sdk-file-broker:
@@ -48,35 +50,75 @@ jobs:
           mkdir -p ci-artifacts/runtime-v2-desktop-sdk-file-broker
           sha256sum "$RUNNER_TEMP/$WEBOTS_ARCHIVE" > ci-artifacts/runtime-v2-desktop-sdk-file-broker/archive.sha256
 
-      - name: Install official Webots R2025a EGL and GLU runtime prerequisites
+      - name: Install complete official Webots R2025a Linux runtime closure
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends libegl1 libglu1-mesa
           artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
           mkdir -p "$artifact_dir"
-          dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' libegl1 libglu1-mesa |
+
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          curl --fail --location --retry 3 --output "$recipe" "$WEBOTS_RUNTIME_RECIPE_URL"
+          actual_blob_sha="$(git hash-object "$recipe")"
+          test "$actual_blob_sha" = "$WEBOTS_RUNTIME_RECIPE_BLOB_SHA"
+          cp "$recipe" "$artifact_dir/linux_runtime_dependencies-R2025a.sh"
+          printf '%s\n' \
+            "tag=R2025a" \
+            "url=$WEBOTS_RUNTIME_RECIPE_URL" \
+            "git_blob_sha=$actual_blob_sha" \
+            > "$artifact_dir/runtime-recipe-provenance.txt"
+
+          direct_packages=(
+            lsb-release g++ make libavcodec-extra libglu1-mesa libegl1
+            libxkbcommon-x11-dev libxcb-keysyms1 libxcb-image0 libxcb-icccm4
+            libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcomposite-dev
+            libxtst6 libnss3 libxcb-cursor0 xvfb ffmpeg
+          )
+          printf '%s\n' "${direct_packages[@]}" > "$artifact_dir/runtime-direct-packages.txt"
+
+          sudo env CI=true bash "$recipe"
+
+          dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' \
+            "${direct_packages[@]}" |
             tee "$artifact_dir/runtime-packages.txt"
+          dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' \
+            libsndio7.0 |
+            tee "$artifact_dir/runtime-transitive-packages.txt"
+          ! grep -Fxq 'libsndio7.0' "$artifact_dir/runtime-direct-packages.txt"
+
           ldconfig -p | grep 'libEGL.so.1' |
             tee "$artifact_dir/egl-ldconfig.txt"
           ldconfig -p | grep 'libGLU.so.1' |
             tee "$artifact_dir/glu-ldconfig.txt"
+          ldconfig -p | grep 'libsndio.so.7' |
+            tee "$artifact_dir/sndio-ldconfig.txt"
           readelf -d "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6" |
             tee "$artifact_dir/qt6gui-dynamic.txt"
 
           egl_path="$(ldconfig -p | awk '$1 == "libEGL.so.1" {print $NF; exit}')"
           test -n "$egl_path"
-          egl_real_path="$(realpath "$egl_path")"
-          dpkg-query -S "$egl_real_path" |
+          dpkg-query -S "$(realpath "$egl_path")" |
             tee "$artifact_dir/egl-package-owner.txt"
           grep -Eq '^libegl1(:[^: ]+)?: ' "$artifact_dir/egl-package-owner.txt"
 
           glu_path="$(ldconfig -p | awk '$1 == "libGLU.so.1" {print $NF; exit}')"
           test -n "$glu_path"
-          glu_real_path="$(realpath "$glu_path")"
-          dpkg-query -S "$glu_real_path" |
+          dpkg-query -S "$(realpath "$glu_path")" |
             tee "$artifact_dir/glu-package-owner.txt"
           grep -Eq '^libglu1-mesa(:[^: ]+)?: ' "$artifact_dir/glu-package-owner.txt"
+
+          sndio_path="$(ldconfig -p | awk '$1 == "libsndio.so.7" {print $NF; exit}')"
+          test -n "$sndio_path"
+          dpkg-query -S "$(realpath "$sndio_path")" |
+            tee "$artifact_dir/sndio-package-owner.txt"
+          grep -Eq '^libsndio7\.0(:[^: ]+)?: ' "$artifact_dir/sndio-package-owner.txt"
+
+          LD_LIBRARY_PATH="$WEBOTS_HOME/lib/webots" \
+            ldd "$WEBOTS_HOME/lib/webots/webots-bin" |
+            tee "$artifact_dir/webots-bin-ldd.txt"
+          if grep -F 'not found' "$artifact_dir/webots-bin-ldd.txt"; then
+            echo "Official R2025a runtime closure is incomplete" >&2
+            exit 1
+          fi
 
       - name: Prove bundled Qt substrate before compilation
         run: |
@@ -99,7 +141,7 @@ jobs:
             "$WEBOTS_HOME/lib/webots/qt/plugins/platforms/libqxcb.so" \
             > ci-artifacts/runtime-v2-desktop-sdk-file-broker/bundled-qt-paths.txt
 
-      - name: Build broker-enabled controller against Webots Qt and Ubuntu runtime EGL
+      - name: Build broker-enabled controller against Webots Qt and official Ubuntu runtime
         run: |
           set -euo pipefail
           artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
@@ -183,7 +225,7 @@ jobs:
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES' in log, log[-4000:]
           assert 'WEBEEBLOCKS_RUNTIME_V2 READY' in log, log[-4000:]
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 FATAL' not in log, log[-4000:]
-          print('PASS: official desktop R2025a SDK -> bundled Qt -> Ubuntu libegl1/libglu1-mesa runtime -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
+          print('PASS: official desktop R2025a SDK -> complete official Ubuntu runtime closure -> bundled Qt -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
           PY
 
       - name: Upload desktop SDK proof

--- a/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
+++ b/.github/workflows/runtime-v2-desktop-sdk-file-broker.yml
@@ -48,25 +48,35 @@ jobs:
           mkdir -p ci-artifacts/runtime-v2-desktop-sdk-file-broker
           sha256sum "$RUNNER_TEMP/$WEBOTS_ARCHIVE" > ci-artifacts/runtime-v2-desktop-sdk-file-broker/archive.sha256
 
-      - name: Install official Webots R2025a EGL runtime prerequisite
+      - name: Install official Webots R2025a EGL and GLU runtime prerequisites
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends libegl1
+          sudo apt-get install --yes --no-install-recommends libegl1 libglu1-mesa
           artifact_dir=ci-artifacts/runtime-v2-desktop-sdk-file-broker
           mkdir -p "$artifact_dir"
-          dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' libegl1 |
-            tee "$artifact_dir/egl-package.txt"
+          dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' libegl1 libglu1-mesa |
+            tee "$artifact_dir/runtime-packages.txt"
           ldconfig -p | grep 'libEGL.so.1' |
             tee "$artifact_dir/egl-ldconfig.txt"
+          ldconfig -p | grep 'libGLU.so.1' |
+            tee "$artifact_dir/glu-ldconfig.txt"
           readelf -d "$WEBOTS_HOME/lib/webots/libQt6Gui.so.6" |
             tee "$artifact_dir/qt6gui-dynamic.txt"
+
           egl_path="$(ldconfig -p | awk '$1 == "libEGL.so.1" {print $NF; exit}')"
           test -n "$egl_path"
           egl_real_path="$(realpath "$egl_path")"
           dpkg-query -S "$egl_real_path" |
             tee "$artifact_dir/egl-package-owner.txt"
           grep -Eq '^libegl1(:[^: ]+)?: ' "$artifact_dir/egl-package-owner.txt"
+
+          glu_path="$(ldconfig -p | awk '$1 == "libGLU.so.1" {print $NF; exit}')"
+          test -n "$glu_path"
+          glu_real_path="$(realpath "$glu_path")"
+          dpkg-query -S "$glu_real_path" |
+            tee "$artifact_dir/glu-package-owner.txt"
+          grep -Eq '^libglu1-mesa(:[^: ]+)?: ' "$artifact_dir/glu-package-owner.txt"
 
       - name: Prove bundled Qt substrate before compilation
         run: |
@@ -173,7 +183,7 @@ jobs:
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES' in log, log[-4000:]
           assert 'WEBEEBLOCKS_RUNTIME_V2 READY' in log, log[-4000:]
           assert 'WEBEEBLOCKS_FILE_BROKER_V1 FATAL' not in log, log[-4000:]
-          print('PASS: official desktop R2025a SDK -> bundled Qt -> Ubuntu libegl1 runtime -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
+          print('PASS: official desktop R2025a SDK -> bundled Qt -> Ubuntu libegl1/libglu1-mesa runtime -> QFileDialog construction -> sole WWI dispatcher -> real Robot Window')
           PY
 
       - name: Upload desktop SDK proof

--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -1,5 +1,16 @@
 C_SOURCES = crazyflie_runtime_v2.c ../crazyflie_square/pid_controller.c
 CFLAGS = -I../crazyflie_square
+
+# 71-C3 keeps the native broker out of ordinary Runtime v2 builds. Only the
+# desktop-SDK proof gate opts in, so Docker-based product gates remain causal.
+ifeq ($(WEBEEBLOCKS_NATIVE_FILE_BROKER),1)
+ CXX_SOURCES = file_broker.cpp
+ USE_C_API = true
+ CFLAGS += -std=c++17 -DWEBEEBLOCKS_NATIVE_FILE_BROKER
+ QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
+ DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/lib/webots" -lQt6Core -lQt6Gui -lQt6Widgets
+ INCLUDE += -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
+endif
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))

--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -11,6 +11,12 @@ ifeq ($(WEBEEBLOCKS_NATIVE_FILE_BROKER),1)
  DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/lib/webots" -lQt6Core -lQt6Gui -lQt6Widgets
  INCLUDE += -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
 endif
+
+# C10 diagnostic rendezvous is compiled only by the dedicated desktop-SDK
+# workflow. Ordinary Runtime v2 builds contain neither the pause nor debug flags.
+ifeq ($(WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC),1)
+ CFLAGS += -DWEBEEBLOCKS_QT_CRASH_DIAGNOSTIC -g -O0
+endif
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))

--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -12,6 +12,9 @@
 #include <webots/robot.h>
 
 #include "pid_controller.h"
+#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+#include "file_broker_c.h"
+#endif
 
 #define PI 3.14159265358979323846
 #define PREFIX "WEBEEBLOCKS_RUNTIME_V2"
@@ -185,6 +188,15 @@ int main(void) {
   wb_robot_init();
   const int step = (int)wb_robot_get_basic_time_step();
 
+#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+  WbFileBroker *file_broker = wb_file_broker_create_qt();
+  if (!file_broker) {
+    fprintf(stderr, "WEBEEBLOCKS_FILE_BROKER_V1 FATAL Qt provider initialization failed\n");
+    wb_robot_cleanup();
+    return 1;
+  }
+#endif
+
   WbDeviceTag m1 = wb_robot_get_device("m1_motor");
   WbDeviceTag m2 = wb_robot_get_device("m2_motor");
   WbDeviceTag m3 = wb_robot_get_device("m3_motor");
@@ -196,6 +208,9 @@ int main(void) {
 
   if (!m1 || !m2 || !m3 || !m4 || !gps || !imu || !gyro || !range_front) {
     fprintf(stderr, PREFIX " FATAL missing required Webots device\n");
+#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+    wb_file_broker_destroy(file_broker);
+#endif
     wb_robot_cleanup();
     return 1;
   }
@@ -292,6 +307,13 @@ int main(void) {
 
     const char *message;
     while ((message = wb_robot_wwi_receive_text()) != NULL) {
+#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+      char broker_response[512];
+      if (wb_file_broker_handle_message(file_broker, message, broker_response, sizeof(broker_response))) {
+        send_text(broker_response);
+        continue;
+      }
+#endif
       if (strncmp(message, PREFIX " REQUEST ", strlen(PREFIX " REQUEST ")) != 0)
         continue;
       request_t request = parse_request(message);
@@ -472,6 +494,9 @@ int main(void) {
   }
 
   stop_motors(m1, m2, m3, m4);
+#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+  wb_file_broker_destroy(file_broker);
+#endif
   wb_robot_cleanup();
   return 0;
 }

--- a/controllers/crazyflie_runtime_v2/file_broker.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.cpp
@@ -1,9 +1,9 @@
 #include "file_broker.hpp"
 #include "file_broker_c.h"
 
-#include <QApplication>
-#include <QCoreApplication>
-#include <QFileDialog>
+#include <QtWidgets/QApplication>
+#include <QtCore/QCoreApplication>
+#include <QtWidgets/QFileDialog>
 
 #include <array>
 #include <cstdio>

--- a/controllers/crazyflie_runtime_v2/file_broker.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.cpp
@@ -1,0 +1,95 @@
+#include "file_broker.hpp"
+#include "file_broker_c.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QFileDialog>
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1";
+
+class QtFileDialogProvider final : public webeeblocks::FileDialogProvider {
+public:
+  QtFileDialogProvider() {
+    std::strcpy(mProgramName.data(), "webeeblocks-file-broker");
+    mArgv[0] = mProgramName.data();
+    mArgv[1] = nullptr;
+    if (!QCoreApplication::instance())
+      mApplication = std::make_unique<QApplication>(mArgc, mArgv.data());
+    if (!qobject_cast<QApplication *>(QCoreApplication::instance()))
+      throw std::runtime_error("Qt application is not a QApplication");
+    std::puts("WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED");
+    mDialog = std::make_unique<QFileDialog>();
+    std::puts("WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED");
+    std::fflush(stdout);
+  }
+
+  std::string name() const override { return "qt6-qfiledialog-constructed"; }
+
+private:
+  int mArgc = 1;
+  std::array<char, 64> mProgramName{};
+  std::array<char *, 2> mArgv{};
+  std::unique_ptr<QApplication> mApplication;
+  std::unique_ptr<QFileDialog> mDialog;
+};
+
+std::string safeProviderName(const std::string &value) {
+  static const std::regex safe("^[a-z0-9-]{1,48}$");
+  return std::regex_match(value, safe) ? value : "invalid-provider";
+}
+}  // namespace
+
+namespace webeeblocks {
+std::unique_ptr<FileDialogProvider> createQtFileDialogProvider() {
+  return std::make_unique<QtFileDialogProvider>();
+}
+
+FileBroker::FileBroker(std::unique_ptr<FileDialogProvider> provider) : mProvider(std::move(provider)) {}
+FileBroker::~FileBroker() = default;
+
+bool FileBroker::handleMessage(const char *message, char *response, std::size_t responseSize) const {
+  if (!message || !response || responseSize == 0 || !mProvider)
+    return false;
+  response[0] = '\0';
+  int requestId = -1;
+  char extra[2] = {0};
+  const std::string pattern = std::string(kPrefix) + " REQUEST %d CAPABILITIES %1s";
+  if (std::sscanf(message, pattern.c_str(), &requestId, extra) != 1 || requestId < 1)
+    return false;
+  const std::string provider = safeProviderName(mProvider->name());
+  const int written = std::snprintf(
+    response, responseSize,
+    "%s RESPONSE %d CAPABILITIES {\"protocol\":1,\"provider\":\"%s\",\"providerInjectable\":true,"
+    "\"operationsReady\":false,\"canonicalExtension\":\".wbb\"}",
+    kPrefix, requestId, provider.c_str());
+  return written > 0 && static_cast<std::size_t>(written) < responseSize;
+}
+}  // namespace webeeblocks
+
+struct WbFileBroker {
+  explicit WbFileBroker(std::unique_ptr<webeeblocks::FileDialogProvider> provider) : value(std::move(provider)) {}
+  webeeblocks::FileBroker value;
+};
+
+extern "C" WbFileBroker *wb_file_broker_create_qt(void) {
+  try {
+    return new WbFileBroker(webeeblocks::createQtFileDialogProvider());
+  } catch (const std::exception &error) {
+    std::fprintf(stderr, "WEBEEBLOCKS_FILE_BROKER_V1 FATAL %s\n", error.what());
+    return nullptr;
+  }
+}
+extern "C" void wb_file_broker_destroy(WbFileBroker *broker) { delete broker; }
+extern "C" int wb_file_broker_handle_message(const WbFileBroker *broker, const char *message, char *response,
+                                               size_t response_size) {
+  return broker && broker->value.handleMessage(message, response, response_size) ? 1 : 0;
+}

--- a/controllers/crazyflie_runtime_v2/file_broker.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.cpp
@@ -7,6 +7,10 @@
 
 #include <array>
 #include <cstdio>
+#ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+#include <csignal>
+#include <unistd.h>
+#endif
 #include <cstring>
 #include <memory>
 #include <regex>
@@ -22,6 +26,12 @@ public:
     std::strcpy(mProgramName.data(), "webeeblocks-file-broker");
     mArgv[0] = mProgramName.data();
     mArgv[1] = nullptr;
+#ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+    std::fprintf(stderr, "WEBEEBLOCKS_FILE_BROKER_V1 DIAGNOSTIC_RENDEZVOUS pid=%ld before=QApplication\\n",
+                 static_cast<long>(::getpid()));
+    std::fflush(stderr);
+    ::raise(SIGSTOP);
+#endif
     if (!QCoreApplication::instance())
       mApplication = std::make_unique<QApplication>(mArgc, mArgv.data());
     if (!qobject_cast<QApplication *>(QCoreApplication::instance()))

--- a/controllers/crazyflie_runtime_v2/file_broker.hpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.hpp
@@ -1,0 +1,33 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_HPP
+#define WEBEEBLOCKS_FILE_BROKER_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace webeeblocks {
+
+class FileDialogProvider {
+public:
+  virtual ~FileDialogProvider() = default;
+  virtual std::string name() const = 0;
+};
+
+std::unique_ptr<FileDialogProvider> createQtFileDialogProvider();
+
+class FileBroker {
+public:
+  explicit FileBroker(std::unique_ptr<FileDialogProvider> provider);
+  ~FileBroker();
+
+  FileBroker(const FileBroker &) = delete;
+  FileBroker &operator=(const FileBroker &) = delete;
+
+  bool handleMessage(const char *message, char *response, std::size_t responseSize) const;
+
+private:
+  std::unique_ptr<FileDialogProvider> mProvider;
+};
+
+}  // namespace webeeblocks
+#endif

--- a/controllers/crazyflie_runtime_v2/file_broker_c.h
+++ b/controllers/crazyflie_runtime_v2/file_broker_c.h
@@ -1,0 +1,19 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_C_H
+#define WEBEEBLOCKS_FILE_BROKER_C_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct WbFileBroker WbFileBroker;
+WbFileBroker *wb_file_broker_create_qt(void);
+void wb_file_broker_destroy(WbFileBroker *broker);
+int wb_file_broker_handle_message(const WbFileBroker *broker, const char *message, char *response,
+                                  size_t response_size);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/controllers/crazyflie_runtime_v2/runtime.ini
+++ b/controllers/crazyflie_runtime_v2/runtime.ini
@@ -1,5 +1,5 @@
 ; Runtime v2 native broker uses the Qt libraries shipped with Webots.
-; Webots reads this file for the controller process and prepends
+; Official Webots controller runtime.ini mechanism: prepend
 ; WEBOTS_LIBRARY_PATH to the platform library search path.
 
 [environment variables for Linux]

--- a/controllers/crazyflie_runtime_v2/runtime.ini
+++ b/controllers/crazyflie_runtime_v2/runtime.ini
@@ -1,0 +1,6 @@
+; Runtime v2 native broker uses the Qt libraries shipped with Webots.
+; Webots reads this file for the controller process and prepends
+; WEBOTS_LIBRARY_PATH to the platform library search path.
+
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/lib/webots

--- a/plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
+++ b/plugins/robot_windows/blockly/webeeblocks/native_file_broker.js
@@ -1,0 +1,49 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksNativeFileBroker = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+  var PREFIX = 'WEBEEBLOCKS_FILE_BROKER_V1';
+
+  function NativeFileBroker(robotWindow, options) {
+    if (!robotWindow || typeof robotWindow.send !== 'function') throw new Error('native file broker requires RobotWindow');
+    this.robotWindow = robotWindow;
+    this.timeoutMs = options && options.timeoutMs || 5000;
+    this.nextId = 1;
+    this.pending = new Map();
+  }
+  NativeFileBroker.prototype.handleMessage = function(message) {
+    if (typeof message !== 'string' || message.indexOf(PREFIX + ' RESPONSE ') !== 0) return false;
+    var match = message.match(/^WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ([1-9][0-9]*) CAPABILITIES (\{.*\})$/);
+    if (!match) return true;
+    var pending = this.pending.get(Number(match[1]));
+    if (!pending) return true;
+    this.pending.delete(Number(match[1]));
+    clearTimeout(pending.timer);
+    try {
+      var capabilities = JSON.parse(match[2]);
+      if (capabilities.protocol !== 1 || capabilities.provider !== 'qt6-qfiledialog-constructed' ||
+          capabilities.providerInjectable !== true || capabilities.operationsReady !== false ||
+          capabilities.canonicalExtension !== '.wbb')
+        throw new Error('native file broker capability contract mismatch');
+      pending.resolve(capabilities);
+    } catch (error) { pending.reject(error); }
+    return true;
+  };
+  NativeFileBroker.prototype.requestCapabilities = function() {
+    var self = this;
+    var id = this.nextId++;
+    return new Promise(function(resolve, reject) {
+      var timer = setTimeout(function() {
+        self.pending.delete(id);
+        reject(new Error('native file broker capability timeout'));
+      }, self.timeoutMs);
+      self.pending.set(id, {resolve: resolve, reject: reject, timer: timer});
+      self.robotWindow.send(PREFIX + ' REQUEST ' + id + ' CAPABILITIES');
+    });
+  };
+  NativeFileBroker.PREFIX = PREFIX;
+  return NativeFileBroker;
+});

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -19,6 +19,7 @@
   <script src="../blockly/webeeblocks/runtime_outcome.js"></script>
   <script src="../blockly/webeeblocks/activity_contract.js"></script>
   <script src="../blockly/webeeblocks/project_files.js"></script>
+  <script src="../blockly/webeeblocks/native_file_broker.js"></script>
   <script src="../blockly/webeeblocks/wwi_backend.js"></script>
 </head>
 <body>

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -5,6 +5,7 @@ var runtimeBackend = null;
 var runtimeRunning = false;
 var runtimeTerminal = false;
 var runtimeDebug = null;
+var nativeFileBroker = null;
 
 var WEBEEBLOCKS_WORKSPACE_SCALE = 0.90;
 
@@ -112,6 +113,10 @@ function buildToolbox(profile) {
 }
 
 function receiveMessage(value) {
+  if (nativeFileBroker && nativeFileBroker.handleMessage(value)) {
+    window.dispatchEvent(new CustomEvent('webeeblocks-file-broker-wwi', {detail: value}));
+    return;
+  }
   if (runtimeBackend && runtimeBackend.handleMessage(value)) {
     window.dispatchEvent(new CustomEvent('webeeblocks-wwi', {detail: value}));
     return;
@@ -233,8 +238,14 @@ window.onload = async function() {
     var module = await import('https://cyberbotics.com/wwi/R2025a/RobotWindow.js');
     robotWindow = new module.default();
     runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true});
+    if (window.WEBEEBLOCKS_NATIVE_FILE_BROKER_PROBE === true)
+      nativeFileBroker = new WebeeBlocksNativeFileBroker(robotWindow, {timeoutMs: 5000});
     robotWindow.receive = receiveMessage;
     setRuntimeStatus('INITIALISATION', 'Attente du Runtime v2');
+    if (nativeFileBroker) {
+      var brokerCapabilities = await nativeFileBroker.requestCapabilities();
+      window.dispatchEvent(new CustomEvent('webeeblocks-native-file-broker-ready', {detail: brokerCapabilities}));
+    }
     await runtimeBackend.waitUntilReady();
     document.getElementById('submit').disabled = false;
     if (runtimeBackend.capabilities && runtimeBackend.capabilities.simulationDebug === true) document.getElementById('debugPanel').hidden = false;

--- a/tools/ci/prepare_runtime_v2_native_file_broker.py
+++ b/tools/ci/prepare_runtime_v2_native_file_broker.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+html = html_path.read_text(encoding='utf-8')
+main_seam = '  <script src="main.js"></script>\n'
+if main_seam not in html:
+    raise SystemExit('main.js seam not found')
+html = html.replace(main_seam, '  <script>window.WEBEEBLOCKS_NATIVE_FILE_BROKER_PROBE = true;</script>\n' + main_seam, 1)
+project_seam = '  <script src="project_ui.js"></script>\n'
+if project_seam not in html:
+    raise SystemExit('project_ui.js seam not found')
+harness = r'''  <script>
+  (function() {
+    let sequence = 0;
+    let reportChain = Promise.resolve();
+    function report(event, detail) {
+      const payload = {seq: sequence++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
+      reportChain = reportChain.then(() => fetch('http://127.0.0.1:8765/event', {
+        method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload)
+      }));
+      return reportChain;
+    }
+    window.addEventListener('error', event => report('WINDOW_ERROR', event.message));
+    window.addEventListener('unhandledrejection', event => report('UNHANDLED_REJECTION', String(event.reason)));
+    window.addEventListener('webeeblocks-native-file-broker-ready', async event => {
+      await report('FILE_BROKER_CAPABILITIES', event.detail);
+      await report('FILE_BROKER_TEST_COMPLETE', {runtimeState: document.getElementById('runtimeState').textContent});
+    });
+  })();
+  </script>
+'''
+html_path.write_text(html.replace(project_seam, harness + project_seam, 1), encoding='utf-8')

--- a/tools/ci/test_native_file_broker.cpp
+++ b/tools/ci/test_native_file_broker.cpp
@@ -1,0 +1,27 @@
+#include "file_broker.hpp"
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+
+class InjectedProvider final : public webeeblocks::FileDialogProvider {
+public:
+  std::string name() const override { return "ci-injected-dialog"; }
+};
+
+int main() {
+  webeeblocks::FileBroker broker(std::make_unique<InjectedProvider>());
+  char response[512];
+  assert(broker.handleMessage("WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 CAPABILITIES", response, sizeof(response)));
+  const std::string value(response);
+  assert(value.find("RESPONSE 7 CAPABILITIES") != std::string::npos);
+  assert(value.find("\"provider\":\"ci-injected-dialog\"") != std::string::npos);
+  assert(value.find("\"operationsReady\":false") != std::string::npos);
+  std::memset(response, 'x', sizeof(response));
+  assert(!broker.handleMessage("WEBEEBLOCKS_RUNTIME_V2 REQUEST 7 RANGE front", response, sizeof(response)));
+  assert(response[0] == '\0');
+  assert(!broker.handleMessage("WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 CAPABILITIES trailing", response, sizeof(response)));
+  std::cout << "PASS: injectable capability-only broker contract\n";
+}

--- a/tools/ci/test_native_file_broker.js
+++ b/tools/ci/test_native_file_broker.js
@@ -1,0 +1,17 @@
+'use strict';
+const assert = require('assert');
+const NativeFileBroker = require('../../plugins/robot_windows/blockly/webeeblocks/native_file_broker.js');
+
+(async function() {
+  const sent = [];
+  const broker = new NativeFileBroker({send: message => sent.push(message)}, {timeoutMs: 1000});
+  const pending = broker.requestCapabilities();
+  assert.deepStrictEqual(sent, ['WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 1 CAPABILITIES']);
+  assert.strictEqual(broker.handleMessage('WEBEEBLOCKS_RUNTIME_V2 READY'), false);
+  assert.strictEqual(broker.handleMessage(
+    'WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 1 CAPABILITIES ' +
+    '{"protocol":1,"provider":"qt6-qfiledialog-constructed","providerInjectable":true,"operationsReady":false,"canonicalExtension":".wbb"}'
+  ), true);
+  assert.strictEqual((await pending).operationsReady, false);
+  console.log('PASS: browser capability-only broker handshake parser');
+})().catch(error => { console.error(error); process.exit(1); });

--- a/tools/ci/webots_native_file_broker_browser.sh
+++ b/tools/ci/webots_native_file_broker_browser.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+mkdir -p "$ROOT/ci-artifacts/runtime-v2-desktop-sdk-file-broker"
+printf 'BROWSER_LAUNCHED args=' >> "$ROOT/ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-launch.log"
+printf '%q ' "$@" >> "$ROOT/ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-launch.log"
+printf '\n' >> "$ROOT/ci-artifacts/runtime-v2-desktop-sdk-file-broker/browser-launch.log"
+CHROME="$(command -v google-chrome || command -v google-chrome-stable || true)"
+test -n "$CHROME"
+exec "$CHROME" --headless=new --no-sandbox --disable-gpu --disable-dev-shm-usage   --disable-background-networking --no-first-run --no-default-browser-check "$@"


### PR DESCRIPTION
## Deferred — preserved for #87

This PR is intentionally **closed without merge** after the product sequencing decision of 26 August 2026.

#71 no longer requires Firefox parity for short-term classroom acceptance. The supported acceptance path is now Google Chrome on Linux; Firefox parity and the native Webots/Qt bridge are tracked in **#87**.

Nothing in this PR is declared production-ready and nothing from this branch should be merged into `webots-ci` merely to close #71.

## Preserved evidence

Final research head at deferral: `fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c`.
Base observed for C10: `webots-ci@5676e959d615999dc1d8bd775226fbb13742c3ee`.

Established across #86:

- official Webots R2025a desktop SDK contains Qt 6.5.3 headers/libs/moc/plugins;
- official Linux runtime dependency closure was pinned and exercised;
- controller-local `runtime.ini` with `WEBOTS_LIBRARY_PATH` gets the true Webots-launched controller to Webots-bundled Qt;
- the old `libQt6Core.so.6` loader failure was eliminated;
- `libqxcb.so` is loaded in the real Webots/Xvfb launch;
- the controller then crashes during `QApplication` initialization before `QT_APP_INITIALIZED`, before `QFileDialog`, and before the broker handshake;
- C8 run `32983674490` failed correctly on that real crash;
- C10 run `32989542721` proved the diagnostic mechanism currently stops fail-closed because `gdb` is absent from the runner; no signal/backtrace is fabricated.

The next bounded experiment, when #87 is explicitly reactivated, is to capture the true controller signal/exit and first usable causal backtrace in the unchanged Webots/Xvfb/runtime.ini environment.

## Status

`DEFERRED_RESEARCH / NOT_MERGED / FIREFOX_TRACK=#87`

Branch/history are retained as audit evidence. Do not automatically reopen this PR as the active #71 path.

`main` remains strictly out of scope.