### PR TITLE
Fix Chrome .wbb project file workflow (71-D1)

### DIFF
--- a/.github/workflows/runtime-v2-project-files.yml
+++ b/.github/workflows/runtime-v2-project-files.yml
@@ -108,7 +108,7 @@ jobs:
           errors = [e for e in events if e.get('event') in ('ERROR','WINDOW_ERROR','UNHANDLED_REJECTION')]
           assert not errors, errors[:1]
           names = [e.get('event') for e in events]
-          for required in ('FILE_API_BOUNDARY','INITIAL_AST','SAVE_AS_OK','EDIT_NO_WRITE_OK','OPEN_ROUNDTRIP_OK','SAVE_UPDATE_OK','FAIL_CLOSED_OK','RUN_DEBUG_NO_WRITE_OK','PROJECT_FILES_TEST_COMPLETE'):
+          for required in ('FILE_API_BOUNDARY','INITIAL_AST','SAVE_AS_OK','CANCELLATION_STATE_OK','EDIT_NO_WRITE_OK','OPEN_ROUNDTRIP_OK','PICKER_OPTIONS_OK','SAVE_UPDATE_OK','FAIL_CLOSED_OK','RUN_DEBUG_NO_WRITE_OK','PROJECT_FILES_TEST_COMPLETE'):
               assert required in names, (required, names)
           boundary = next(e['detail'] for e in events if e.get('event') == 'FILE_API_BOUNDARY')
           assert set(boundary) == {'open','save','secureContext'}, boundary

--- a/plugins/robot_windows/blockly/webeeblocks/project_files.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_files.js
@@ -9,7 +9,9 @@
   var FORMAT = 'webeeblocks-project';
   var VERSION = 1;
   var SEMANTICS = 'webeeblocks-ast-v1';
-  var EXTENSION = '.webeeblocks.json';
+  var EXTENSION = '.wbb';
+  var LEGACY_EXTENSION = '.webeeblocks.json';
+  var OPEN_EXTENSIONS = ['.wbb', '.json'];
   var ROOT_KEYS = ['activity', 'format', 'version', 'workspace'];
   var ACTIVITY_KEYS = ['id', 'semantics'];
 
@@ -33,7 +35,18 @@
 
   function normalizeName(name) {
     var base = typeof name === 'string' && name.trim() ? name.trim() : 'programme';
-    return base.toLowerCase().endsWith(EXTENSION) ? base : base + EXTENSION;
+    var lower = base.toLowerCase();
+    if (lower.endsWith(EXTENSION)) return base;
+    if (lower.endsWith(LEGACY_EXTENSION))
+      base = base.slice(0, -LEGACY_EXTENSION.length);
+    else if (lower.endsWith('.json'))
+      base = base.slice(0, -'.json'.length);
+    return base + EXTENSION;
+  }
+
+  function preserveSelectedName(name) {
+    if (typeof name !== 'string' || !name.trim()) fail('selected file has no name');
+    return name.trim();
   }
 
   function validateWorkspaceFields(profile, workspace) {
@@ -126,45 +139,28 @@
 
   function createBrowserTransport(browserWindow, documentObject) {
     if (!browserWindow || !documentObject) fail('browser transport requires window and document');
-    var nativeAccess = typeof browserWindow.showOpenFilePicker === 'function' && typeof browserWindow.showSaveFilePicker === 'function';
+    var nativeAccess = typeof browserWindow.showOpenFilePicker === 'function' &&
+      typeof browserWindow.showSaveFilePicker === 'function';
 
-    function pickerOptions() {
+    function openPickerOptions() {
       return {
-        types: [{description: 'Projet WebeeBlocks', accept: {'application/json': [EXTENSION]}}],
+        types: [{description: 'Projet WebeeBlocks', accept: {'application/json': OPEN_EXTENSIONS.slice()}}],
         excludeAcceptAllOption: false,
         multiple: false
       };
     }
-    function download(name, text) {
-      var blob = new browserWindow.Blob([text], {type: 'application/json'});
-      var url = browserWindow.URL.createObjectURL(blob);
-      var anchor = documentObject.createElement('a');
-      anchor.href = url;
-      anchor.download = normalizeName(name);
-      anchor.style.display = 'none';
-      documentObject.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      browserWindow.setTimeout(function() { browserWindow.URL.revokeObjectURL(url); }, 0);
-      return Promise.resolve({handle: null, name: normalizeName(name), mode: 'download'});
+    function savePickerOptions(name) {
+      return {
+        suggestedName: normalizeName(name),
+        types: [{description: 'Projet WebeeBlocks', accept: {'application/json': [EXTENSION]}}],
+        excludeAcceptAllOption: true
+      };
     }
-    function upload() {
-      return new Promise(function(resolve, reject) {
-        var input = documentObject.createElement('input');
-        input.type = 'file';
-        input.accept = EXTENSION + ',application/json';
-        input.style.display = 'none';
-        documentObject.body.appendChild(input);
-        input.addEventListener('change', function() {
-          var file = input.files && input.files[0];
-          input.remove();
-          if (!file) { reject(new Error('project file: open cancelled')); return; }
-          file.text().then(function(text) { resolve({handle: null, name: file.name, text: text, mode: 'upload'}); }, reject);
-        }, {once: true});
-        input.click();
-      });
+    function requireNative() {
+      if (!nativeAccess) fail('File System Access unavailable; use Google Chrome');
     }
     async function writeHandle(handle, text) {
+      if (!handle || typeof handle.createWritable !== 'function') fail('current file handle unavailable');
       var writable = await handle.createWritable();
       try { await writable.write(text); }
       finally { await writable.close(); }
@@ -172,24 +168,23 @@
     return {
       nativeFileSystemAccess: nativeAccess,
       async open() {
-        if (!nativeAccess) return upload();
-        var handles = await browserWindow.showOpenFilePicker(pickerOptions());
-        if (!handles || handles.length !== 1) fail('open cancelled');
+        requireNative();
+        var handles = await browserWindow.showOpenFilePicker(openPickerOptions());
+        if (!handles || handles.length !== 1) fail('open returned no file');
         var file = await handles[0].getFile();
-        return {handle: handles[0], name: file.name, text: await file.text(), mode: 'native'};
+        return {handle: handles[0], name: preserveSelectedName(file.name), text: await file.text(), mode: 'native'};
       },
       async saveAs(name, text) {
-        if (!nativeAccess) return download(name, text);
-        var handle = await browserWindow.showSaveFilePicker(Object.assign({suggestedName: normalizeName(name)}, pickerOptions()));
+        requireNative();
+        var proposal = normalizeName(name);
+        var handle = await browserWindow.showSaveFilePicker(savePickerOptions(proposal));
         await writeHandle(handle, text);
-        return {handle: handle, name: handle.name || normalizeName(name), mode: 'native'};
+        return {handle: handle, name: preserveSelectedName(handle.name || proposal), mode: 'native'};
       },
       async save(target, name, text) {
-        if (target && typeof target.createWritable === 'function') {
-          await writeHandle(target, text);
-          return {handle: target, name: target.name || normalizeName(name), mode: 'native'};
-        }
-        return download(name, text);
+        requireNative();
+        await writeHandle(target, text);
+        return {handle: target, name: preserveSelectedName(target.name || name), mode: 'native'};
       }
     };
   }
@@ -248,23 +243,25 @@
         var validated = validateProjectText(opened.text, options.getProfile(), dependencies());
         applyValidated(validated);
         targetHandle = opened.handle || null;
-        targetName = normalizeName(opened.name || validated.profile.id);
+        targetName = preserveSelectedName(opened.name || validated.profile.id + EXTENSION);
         return {name: targetName, ast: validated.ast, mode: opened.mode || null};
       },
       async saveAs(name) {
-        var result = await options.transport.saveAs(normalizeName(name || targetName || options.getProfile().id), currentBytes());
+        var proposal = normalizeName(name || targetName || options.getProfile().id);
+        var result = await options.transport.saveAs(proposal, currentBytes());
         targetHandle = result.handle || null;
-        targetName = normalizeName(result.name || name || options.getProfile().id);
+        targetName = preserveSelectedName(result.name || proposal);
         return {name: targetName, mode: result.mode || null};
       },
       async save() {
-        if (!targetName) return this.saveAs(options.getProfile().id);
+        if (!targetHandle || !targetName) fail('no current file; use Save As');
         var result = await options.transport.save(targetHandle, targetName, currentBytes());
         targetHandle = result.handle || targetHandle;
-        targetName = normalizeName(result.name || targetName);
+        targetName = preserveSelectedName(result.name || targetName);
         return {name: targetName, mode: result.mode || null};
       },
       currentName: function() { return targetName; },
+      hasCurrentTarget: function() { return !!targetHandle && !!targetName; },
       isApplying: function() { return applying; },
       nativeFileSystemAccess: !!options.transport.nativeFileSystemAccess,
       encodeCurrent: currentBytes
@@ -276,7 +273,10 @@
     VERSION: VERSION,
     SEMANTICS: SEMANTICS,
     EXTENSION: EXTENSION,
+    LEGACY_EXTENSION: LEGACY_EXTENSION,
+    OPEN_EXTENSIONS: OPEN_EXTENSIONS.slice(),
     normalizeName: normalizeName,
+    preserveSelectedName: preserveSelectedName,
     createProject: createProject,
     encodeProject: encodeProject,
     parseProject: parseProject,

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -3,6 +3,7 @@
 
   var manager = null;
   var busy = false;
+  var supported = false;
 
   function fileState(text, error) {
     var target = document.getElementById('projectFileState');
@@ -22,25 +23,34 @@
     }));
   }
 
-  function setButtonsDisabled(disabled) {
-    ['projectOpen', 'projectSave', 'projectSaveAs'].forEach(function(id) {
-      var button = document.getElementById(id);
-      if (button) button.disabled = disabled;
-    });
+  function isCancellation(error) {
+    return !!error && (error.name === 'AbortError' || error.code === 20);
+  }
+
+  function renderButtons() {
+    var open = document.getElementById('projectOpen');
+    var save = document.getElementById('projectSave');
+    var saveAs = document.getElementById('projectSaveAs');
+    var locked = busy || !supported;
+    if (open) open.disabled = locked;
+    if (saveAs) saveAs.disabled = locked;
+    if (save) save.disabled = locked || !manager || !manager.hasCurrentTarget();
   }
 
   async function operation(name, action) {
-    if (busy) return;
+    if (busy || !supported) return null;
     busy = true;
-    setButtonsDisabled(true);
+    renderButtons();
     try { return await action(); }
     catch (error) {
-      diagnostic(name, error);
-      fileState(name === 'open' ? 'Impossible d’ouvrir ce projet' : 'Impossible d’enregistrer ce projet', true);
+      if (!isCancellation(error)) {
+        diagnostic(name, error);
+        fileState(name === 'open' ? 'Impossible d’ouvrir ce projet' : 'Impossible d’enregistrer ce projet', true);
+      }
       return null;
     } finally {
       busy = false;
-      setButtonsDisabled(false);
+      renderButtons();
     }
   }
 
@@ -53,12 +63,14 @@
   }
 
   function suggestedName() {
-    return manager && manager.currentName() ? manager.currentName() : runtimeProfile.id + WebeeBlocksProjectFiles.EXTENSION;
+    var base = manager && manager.currentName() ? manager.currentName() : runtimeProfile.id;
+    return WebeeBlocksProjectFiles.normalizeName(base);
   }
 
   window.addEventListener('load', function() {
     if (!workspace || !runtimeProfile) {
       fileState('Fichiers projet indisponibles', true);
+      renderButtons();
       return;
     }
 
@@ -76,16 +88,20 @@
       transport: transport
     });
     window.WebeeBlocksProjectManager = manager;
-    document.body.dataset.projectFileMode = manager.nativeFileSystemAccess ? 'native' : 'unavailable';
+    supported = manager.nativeFileSystemAccess;
+    document.body.dataset.projectFileMode = supported ? 'native' : 'unavailable';
     window.dispatchEvent(new CustomEvent('webeeblocks-project-files-ready', {
-      detail: {nativeFileSystemAccess: manager.nativeFileSystemAccess}
+      detail: {nativeFileSystemAccess: supported, mode: supported ? 'native' : 'unavailable'}
     }));
 
-    if (!manager.nativeFileSystemAccess) {
-      fileState('Fichiers projet indisponibles dans ce navigateur', true);
-      setButtonsDisabled(true);
+    if (!supported) {
+      fileState('Gestion des fichiers projet : utilisez Google Chrome', true);
+      renderButtons();
       return;
     }
+
+    fileState('Aucun fichier projet sélectionné', false);
+    renderButtons();
 
     document.getElementById('projectOpen').addEventListener('click', function() {
       operation('open', async function() {
@@ -106,7 +122,7 @@
     document.getElementById('projectSave').addEventListener('click', function() {
       operation('save', async function() {
         var result = await manager.save();
-        if (result) fileState('Projet : ' + result.name, false);
+        fileState('Projet : ' + result.name, false);
       });
     });
   });

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -26,13 +26,13 @@ fake_api = r'''
   };
   window.__webeeblocksCiFileStore = {bytes: '', writes: 0, names: [], handle: null};
   window.__webeeblocksCiFileStore.handle = {
-    name: 'ci-roundtrip.webeeblocks.json',
+    name: 'ci-roundtrip.wbb',
     async createWritable() {
       return {
         async write(text) {
           window.__webeeblocksCiFileStore.bytes = String(text);
           window.__webeeblocksCiFileStore.writes += 1;
-          window.__webeeblocksCiFileStore.names.push('ci-roundtrip.webeeblocks.json');
+          window.__webeeblocksCiFileStore.names.push('ci-roundtrip.wbb');
         },
         async close() {}
       };
@@ -41,8 +41,38 @@ fake_api = r'''
       return {name: this.name, text: async () => window.__webeeblocksCiFileStore.bytes};
     }
   };
-  window.showSaveFilePicker = async function() { return window.__webeeblocksCiFileStore.handle; };
-  window.showOpenFilePicker = async function() { return [window.__webeeblocksCiFileStore.handle]; };
+  window.__webeeblocksCiPickerOptions = [];
+  window.__webeeblocksCiCancelNext = null;
+  function validatePickerOptions(options) {
+    if (!options || !Array.isArray(options.types) || !options.types.length)
+      throw new TypeError('missing picker types');
+    options.types.forEach(function(type) {
+      Object.values(type.accept || {}).forEach(function(extensions) {
+        extensions.forEach(function(extension) {
+          if (!/^\.[A-Za-z0-9]+$/.test(extension) || Array.from(extension).length > 16)
+            throw new TypeError('invalid picker extension: ' + extension);
+        });
+      });
+    });
+  }
+  window.showSaveFilePicker = async function(options) {
+    validatePickerOptions(options);
+    window.__webeeblocksCiPickerOptions.push({kind:'save', options:options});
+    if (window.__webeeblocksCiCancelNext === 'save') {
+      window.__webeeblocksCiCancelNext = null;
+      throw new DOMException('cancelled', 'AbortError');
+    }
+    return window.__webeeblocksCiFileStore.handle;
+  };
+  window.showOpenFilePicker = async function(options) {
+    validatePickerOptions(options);
+    window.__webeeblocksCiPickerOptions.push({kind:'open', options:options});
+    if (window.__webeeblocksCiCancelNext === 'open') {
+      window.__webeeblocksCiCancelNext = null;
+      throw new DOMException('cancelled', 'AbortError');
+    }
+    return [window.__webeeblocksCiFileStore.handle];
+  };
   </script>
 '''
 
@@ -102,8 +132,31 @@ harness = r'''
         const initialAst = currentAst();
         await report('INITIAL_AST', initialAst);
 
+        if (document.getElementById('projectOpen').disabled ||
+            document.getElementById('projectSaveAs').disabled ||
+            !document.getElementById('projectSave').disabled)
+          throw new Error('initial project button state is not Open/SaveAs enabled and Save disabled');
         click('projectSaveAs');
         await waitFor(() => window.__webeeblocksCiFileStore.writes === 1, 'Save As write', 3000);
+        if (document.getElementById('projectSave').disabled)
+          throw new Error('Save did not enable after successful Save As');
+        const writesBeforeCancel = window.__webeeblocksCiFileStore.writes;
+        const stateBeforeCancel = document.getElementById('projectFileState').textContent;
+        window.__webeeblocksCiCancelNext = 'save';
+        click('projectSaveAs');
+        await sleep(150);
+        if (window.__webeeblocksCiFileStore.writes !== writesBeforeCancel ||
+            document.getElementById('projectFileState').textContent !== stateBeforeCancel ||
+            document.getElementById('projectSave').disabled)
+          throw new Error('Save As cancellation changed writes/state/target');
+        window.__webeeblocksCiCancelNext = 'open';
+        click('projectOpen');
+        await sleep(150);
+        if (window.__webeeblocksCiFileStore.writes !== writesBeforeCancel ||
+            document.getElementById('projectFileState').textContent !== stateBeforeCancel ||
+            document.getElementById('projectSave').disabled)
+          throw new Error('Open cancellation changed writes/state/target');
+        await report('CANCELLATION_STATE_OK', {writes:writesBeforeCancel});
         const savedBytes = window.__webeeblocksCiFileStore.bytes;
         const savedObject = JSON.parse(savedBytes);
         if (JSON.stringify(Object.keys(savedObject).sort()) !== JSON.stringify(['activity','format','version','workspace']))
@@ -137,6 +190,18 @@ harness = r'''
         window.__webeeblocksCiFileStore.bytes = editedBytes;
         click('projectOpen');
         await waitFor(() => same(currentAst(), editedAst), 'edited Save AST restoration', 3000);
+        const pickerCalls = window.__webeeblocksCiPickerOptions;
+        const savePicker = pickerCalls.find(entry => entry.kind === 'save').options;
+        const openPicker = pickerCalls.find(entry => entry.kind === 'open').options;
+        if (savePicker.suggestedName.slice(-4) !== '.wbb' ||
+            JSON.stringify(savePicker.types[0].accept['application/json']) !== JSON.stringify(['.wbb']) ||
+            JSON.stringify(openPicker.types[0].accept['application/json']) !== JSON.stringify(['.wbb','.json']))
+          throw new Error('product picker options are not the exact 71-D1 contract');
+        await report('PICKER_OPTIONS_OK', {
+          save:savePicker.types[0].accept['application/json'],
+          open:openPicker.types[0].accept['application/json'],
+          suggestedName:savePicker.suggestedName
+        });
         await report('SAVE_UPDATE_OK', {writes:window.__webeeblocksCiFileStore.writes, ast:currentAst()});
 
         const stableAst = currentAst();

--- a/tools/ci/test_runtime_v2_project_files.js
+++ b/tools/ci/test_runtime_v2_project_files.js
@@ -38,7 +38,7 @@ function ast(workspace, profile) {
 
 function memoryTransport() {
   const state = {writes:[], openText:null, currentText:null};
-  const handle = {name:'eleve.webeeblocks.json', token:'same-target'};
+  const handle = {name:'eleve.wbb', token:'same-target'};
   return {
     state,
     nativeFileSystemAccess:true,
@@ -86,15 +86,98 @@ async function expectRejectedWithoutMutation(manager, transport, text, workspace
   assert.deepStrictEqual(Blockly.serialization.workspaces.save(workspace), beforeState, label + ' changed workspace');
 }
 
+function validatePickerOptions(options) {
+  assert(options && Array.isArray(options.types) && options.types.length > 0, 'picker types missing');
+  for (const type of options.types) {
+    for (const [mime, extensions] of Object.entries(type.accept || {})) {
+      assert(/^[^/]+\/[^/]+$/.test(mime), 'invalid picker MIME type');
+      for (const extension of extensions) {
+        assert(/^\.[A-Za-z0-9]+$/.test(extension), 'invalid picker extension ' + extension);
+        assert(Array.from(extension).length <= 16, 'picker extension exceeds native limit');
+      }
+    }
+  }
+}
+
+function fakeNativeBrowser() {
+  const state = {options:[], writes:0, bytes:'', nextOpenName:'eleve.wbb'};
+  const handle = {
+    name:'eleve.wbb',
+    async createWritable() {
+      return {
+        async write(text) { state.bytes = String(text); state.writes += 1; },
+        async close() {}
+      };
+    },
+    async getFile() { return {name:state.nextOpenName, text:async () => state.bytes}; }
+  };
+  const browserWindow = {
+    async showSaveFilePicker(options) {
+      validatePickerOptions(options);
+      state.options.push({kind:'save', options});
+      return handle;
+    },
+    async showOpenFilePicker(options) {
+      validatePickerOptions(options);
+      state.options.push({kind:'open', options});
+      return [handle];
+    }
+  };
+  return {state, handle, browserWindow};
+}
+
+async function exerciseBrowserBoundary() {
+  assert.throws(() => validatePickerOptions({
+    types:[{accept:{'application/json':['.webeeblocks.json']}}]
+  }), /native limit/, 'historical compound suffix must be rejected');
+
+  const fake = fakeNativeBrowser();
+  const transport = ProjectFiles.createBrowserTransport(fake.browserWindow, {});
+  assert.strictEqual(transport.nativeFileSystemAccess, true);
+  const saved = await transport.saveAs('eleve.webeeblocks.json', '{"ok":1}');
+  assert.strictEqual(saved.name, 'eleve.wbb');
+  assert.strictEqual(fake.state.writes, 1);
+  const saveOptions = fake.state.options[0].options;
+  assert.strictEqual(saveOptions.suggestedName, 'eleve.wbb');
+  assert.deepStrictEqual(saveOptions.types[0].accept, {'application/json':['.wbb']});
+
+  for (const name of ['projet.wbb','ancien.webeeblocks.json','legacy.json']) {
+    fake.state.nextOpenName = name;
+    const opened = await transport.open();
+    assert.strictEqual(opened.name, name, 'opened OS filename must be preserved exactly');
+  }
+  const openOptions = fake.state.options.find(entry => entry.kind === 'open').options;
+  assert.deepStrictEqual(openOptions.types[0].accept, {'application/json':['.wbb','.json']});
+  await transport.save(fake.handle, 'eleve.wbb', '{"ok":2}');
+  assert.strictEqual(fake.state.writes, 2, 'Save must write the selected handle');
+
+  const unavailable = ProjectFiles.createBrowserTransport({}, {});
+  assert.strictEqual(unavailable.nativeFileSystemAccess, false);
+  await assert.rejects(unavailable.open(), /use Google Chrome/);
+  await assert.rejects(unavailable.saveAs('x', '{}'), /use Google Chrome/);
+  assert(!ProjectFiles.createBrowserTransport.toString().includes('Blob'), 'Blob fallback must not exist');
+  assert(!ProjectFiles.createBrowserTransport.toString().includes("createElement('input')"), 'input upload fallback must not exist');
+}
+
 (async function() {
+  await exerciseBrowserBoundary();
+  assert.strictEqual(ProjectFiles.EXTENSION, '.wbb');
+  assert.strictEqual(ProjectFiles.normalizeName('eleve'), 'eleve.wbb');
+  assert.strictEqual(ProjectFiles.normalizeName('eleve.webeeblocks.json'), 'eleve.wbb');
+  assert.strictEqual(ProjectFiles.normalizeName('eleve.json'), 'eleve.wbb');
+
   const profileRef = {value:Profiles.resolveById(Activities.DOCUMENT, 'reactive-obstacle-v2', Activities.BLOCK_CATALOG)};
   const liveWorkspace = buildWorkspace(0.3);
   const transport = memoryTransport();
   const manager = managerFor(liveWorkspace, profileRef, transport);
 
   const initialAst = ast(liveWorkspace, profileRef.value);
+  assert.strictEqual(manager.hasCurrentTarget(), false);
+  await assert.rejects(manager.save(), /no current file/);
+  assert.strictEqual(transport.state.writes.length, 0, 'Save without target reached transport');
   const saved = await manager.saveAs('eleve');
-  assert.strictEqual(saved.name, 'eleve.webeeblocks.json');
+  assert.strictEqual(manager.hasCurrentTarget(), true);
+  assert.strictEqual(saved.name, 'eleve.wbb');
   assert.strictEqual(transport.state.writes.length, 1);
   const project = JSON.parse(transport.state.currentText);
   assert.deepStrictEqual(Object.keys(project).sort(), ['activity','format','version','workspace']);
@@ -159,5 +242,11 @@ async function expectRejectedWithoutMutation(manager, transport, text, workspace
   assert.strictEqual(incomplete.getBlocksByType('webeeblocks_v2_takeoff', false).length, 1, 'incomplete workspace was not restored');
   assert.strictEqual(incompleteTransport.state.writes.length, 1, 'opening incomplete project caused a write');
 
-  console.log('PASS project-files: explicit round-trip/save/fail-closed/no-autosave/incomplete-work');
+  const fs = require('fs');
+  const uiSource = fs.readFileSync(path.join(ROOT, 'plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
+  assert(uiSource.includes("error.name === 'AbortError'"), 'UI must treat native cancellation neutrally');
+  assert(uiSource.includes('!manager.hasCurrentTarget()'), 'UI must disable Save without a current handle');
+  assert(uiSource.includes('utilisez Google Chrome'), 'unsupported-browser message must be explicit');
+  assert(!uiSource.includes('Nouvelle copie'), 'UI must not advertise download copies');
+  console.log('PASS project-files: Chrome .wbb/options/same-handle/state/fail-closed/no-fallback/no-autosave');
 })().catch(error => { console.error(error); process.exit(1); });

--- a/tools/ci/test_runtime_v2_project_files.js
+++ b/tools/ci/test_runtime_v2_project_files.js
@@ -92,8 +92,12 @@ function validatePickerOptions(options) {
     for (const [mime, extensions] of Object.entries(type.accept || {})) {
       assert(/^[^/]+\/[^/]+$/.test(mime), 'invalid picker MIME type');
       for (const extension of extensions) {
-        assert(/^\.[A-Za-z0-9]+$/.test(extension), 'invalid picker extension ' + extension);
+        // Chrome rejects overlong native suffixes before any WebeeBlocks
+        // interpretation. Keep this check first so the historical
+        // `.webeeblocks.json` regression is causally represented, then still
+        // validate the syntax of all suffixes that fit the native limit.
         assert(Array.from(extension).length <= 16, 'picker extension exceeds native limit');
+        assert(/^\.[A-Za-z0-9]+$/.test(extension), 'invalid picker extension ' + extension);
       }
     }
   }


### PR DESCRIPTION
## Objectif

Implémente le seul WIP autorisé **#71-D1** depuis `webots-ci@5676e959d615999dc1d8bd775226fbb13742c3ee`, uniquement pour la gestion explicite des fichiers projet sous Google Chrome/Linux.

## Produit

- nouveaux projets canoniques `.wbb` ;
- Save As transmet uniquement le filtre `.wbb` et un nom suggéré `.wbb` ;
- Open transmet `.wbb` + `.json`, couvrant les anciens `*.webeeblocks.json` ;
- le nom et le `FileSystemFileHandle` retournés par l’OS sont conservés exactement ;
- Save réécrit ce même handle ;
- Save sans cible échoue fail-closed et reste désactivé dans l’UI ;
- la machine d’état Open / Save / Save As est restaurée après succès, erreur et annulation ;
- `AbortError` est neutre ;
- sous navigateur sans File System Access complet, les actions sont désactivées avec message Chrome explicite ;
- suppression des chemins input-file et Blob/download afin qu’aucun faux Save/copie `(1)` ne soit possible.

## Gates causaux

- reproduction du rejet de l’ancien suffixe trop long ;
- validation stricte des options exactes passées aux deux pickers ;
- Save As → Save sur le même handle ;
- ouverture de `.wbb`, `*.webeeblocks.json` et `.json` sans altérer le nom ;
- Save sans cible sans appel transport ;
- annulations Open/Save As sans écriture ni changement d’état ;
- états UI initiaux et post-cible dans la vraie Robot Window R2025a ;
- round-trip workspace/AST, invalides fail-closed, travail incomplet et zéro écriture edit/run/debug ;
- événements `PICKER_OPTIONS_OK` et `CANCELLATION_STATE_OK` exigés par le validator.

## Non-goals

Pas de Firefox parity (#87), pont Qt/#86, wrapper, serveur/cloud/compte, OPFS, autosave/historique, activité/AST/interpréteur/backend, PID/STOP, Windows, Crazyflie physique ni `main`.

Draft jusqu’à CI complète puis audit Verification indépendant sur le head final exact. Le test humain Linux + Webots R2025a + Google Chrome reste requis après GO.