### PR TITLE
Add deterministic governance transition contract (84-G2)

### DIFF
--- a/.github/workflows/governance-transition-contract.yml
+++ b/.github/workflows/governance-transition-contract.yml
@@ -52,9 +52,20 @@ jobs:
               raise SystemExit("CANONICAL_ISSUE_22_BODY_MISSING")
           Path("/tmp/issue22.md").write_text(body, encoding="utf-8")
 
-          pulls = get("https://api.github.com/repos/djibian/webeeblocks/pulls?state=open&per_page=100")
-          if not isinstance(pulls, list):
-              raise SystemExit("OPEN_PRS_OBSERVATION_INVALID")
+          pulls = []
+          for page in range(1, 11):
+              batch = get(
+                  "https://api.github.com/repos/djibian/webeeblocks/pulls"
+                  f"?state=open&per_page=100&page={page}"
+              )
+              if not isinstance(batch, list):
+                  raise SystemExit("OPEN_PRS_OBSERVATION_INVALID")
+              pulls.extend(batch)
+              if len(batch) < 100:
+                  break
+          else:
+              raise SystemExit("OPEN_PRS_OBSERVATION_TOO_LARGE")
+
           Path("/tmp/open-prs.json").write_text(json.dumps(pulls), encoding="utf-8")
           PY
 

--- a/.github/workflows/governance-transition-contract.yml
+++ b/.github/workflows/governance-transition-contract.yml
@@ -1,0 +1,130 @@
+name: Governance transition contract G2
+
+on:
+  pull_request:
+    branches: [webots-ci]
+    paths:
+      - 'governance/**'
+      - 'tools/governance/**'
+      - '.github/workflows/governance-state-contract.yml'
+      - '.github/workflows/governance-transition-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  governance-transition-contract:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate G1 state and G2 transition causal tests
+        run: |
+          set -euo pipefail
+          cd tools/governance
+          python3 -m unittest -v test_state_contract.py test_transition_contract.py
+
+      - name: Fetch canonical #22 and open PR observations read-only
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import urllib.request
+          from pathlib import Path
+
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "User-Agent": "webeeblocks-governance-g2",
+          }
+
+          def get(url):
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.load(response)
+
+          issue = get("https://api.github.com/repos/djibian/webeeblocks/issues/22")
+          body = issue.get("body")
+          if not isinstance(body, str) or not body.strip():
+              raise SystemExit("CANONICAL_ISSUE_22_BODY_MISSING")
+          Path("/tmp/issue22.md").write_text(body, encoding="utf-8")
+
+          pulls = get("https://api.github.com/repos/djibian/webeeblocks/pulls?state=open&per_page=100")
+          if not isinstance(pulls, list):
+              raise SystemExit("OPEN_PRS_OBSERVATION_INVALID")
+          Path("/tmp/open-prs.json").write_text(json.dumps(pulls), encoding="utf-8")
+          PY
+
+      - name: Render canonical state and validate live transition
+        if: github.event_name == 'pull_request'
+        env:
+          PULL_REQUEST: '#${{ github.event.pull_request.number }}'
+          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+          HEAD_REF: '${{ github.event.pull_request.head.ref }}'
+          BASE_REF: '${{ github.event.pull_request.base.ref }}'
+          PR_STATUS: "${{ github.event.pull_request.draft && 'draft' || 'ready' }}"
+          LAST_PROGRESS_AT: '${{ github.event.pull_request.updated_at }}'
+        run: |
+          set -euo pipefail
+          python3 tools/governance/render_state.py \
+            --template governance/state.template.json \
+            --canonical-body /tmp/issue22.md \
+            --output /tmp/governance-state.json \
+            --pull-request "$PULL_REQUEST" \
+            --head-sha "$HEAD_SHA" \
+            --pr-status "$PR_STATUS" \
+            --last-progress-at "$LAST_PROGRESS_AT"
+
+          python3 - "$PULL_REQUEST" "$HEAD_SHA" "$HEAD_REF" "$BASE_REF" "$PR_STATUS" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          number, head_sha, head_ref, base_ref, status = sys.argv[1:]
+          pulls = json.loads(Path('/tmp/open-prs.json').read_text(encoding='utf-8'))
+
+          def normalise(item):
+              return {
+                  "number": f"#{item['number']}",
+                  "head_sha": item["head"]["sha"],
+                  "head_ref": item["head"]["ref"],
+                  "base_ref": item["base"]["ref"],
+                  "status": "draft" if item.get("draft") else "ready",
+              }
+
+          observation = {
+              "current_pr": {
+                  "number": number,
+                  "head_sha": head_sha,
+                  "head_ref": head_ref,
+                  "base_ref": base_ref,
+                  "status": status,
+              },
+              "open_prs": [normalise(item) for item in pulls],
+          }
+          Path('/tmp/governance-transition-observation.json').write_text(
+              json.dumps(observation, indent=2) + '\n', encoding='utf-8'
+          )
+          PY
+
+          PYTHONPATH=tools/governance python3 - <<'PY'
+          from state_contract import Observation, assert_coherent, load
+
+          state = load('/tmp/governance-state.json')
+          assert_coherent(state, Observation(
+              pr_number=state["pull_request"],
+              pr_head_sha=state["head_sha"],
+              pr_status=state["pr_status"],
+              ci_green=state["ci_state"]["status"] == "GREEN",
+              engineering_executed=False,
+              progress_made=False,
+              mutation_possible=True,
+          ))
+          PY
+
+          PYTHONPATH=tools/governance python3 tools/governance/transition_contract.py \
+            --state /tmp/governance-state.json \
+            --observation /tmp/governance-transition-observation.json

--- a/tools/governance/render_state.py
+++ b/tools/governance/render_state.py
@@ -32,6 +32,7 @@ CANONICAL_REQUIRED = {
     "engineering_handoff",
     "verification_verdict",
     "exact_head_ci",
+    "blocked_reason",
 }
 
 
@@ -95,6 +96,14 @@ def parse_ci(raw: str) -> dict:
     raise ValueError(f"CANONICAL_CI_STATE_INVALID:{raw}")
 
 
+def parse_blocked_reason(raw: str) -> str | None:
+    if raw == "NONE":
+        return None
+    if raw:
+        return raw
+    raise ValueError(f"CANONICAL_BLOCKED_REASON_INVALID:{raw}")
+
+
 def render_from_canonical(
     template: dict,
     values: dict[str, str],
@@ -133,6 +142,7 @@ def render_from_canonical(
             "engineering_handoff": parse_handoff(machine["engineering_handoff"]),
             "verification_verdict": parse_verdict(machine["verification_verdict"]),
             "ci_state": parse_ci(machine["exact_head_ci"]),
+            "blocked_reason": parse_blocked_reason(machine["blocked_reason"]),
             "authority": {
                 "state": machine["authority_state"],
                 "scope": machine["authority_scope"],

--- a/tools/governance/test_state_contract.py
+++ b/tools/governance/test_state_contract.py
@@ -33,6 +33,7 @@ def canonical_body(**overrides):
         "exact_head_ci": "24_OF_24_SUCCESS",
         "engineering_handoff": "FINAL@current-head",
         "verification_verdict": "PENDING_INDEPENDENT",
+        "blocked_reason": "NONE",
         "parallel_human_gate": "#71-D1",
         "parallel_human_gate_state": "PENDING",
     }
@@ -103,7 +104,34 @@ class GovernanceStateContractTests(unittest.TestCase):
             state["ci_state"],
             {"status": "GREEN", "summary": "24_OF_24_SUCCESS"},
         )
+        self.assertIsNone(state["blocked_reason"])
         self.assertEqual(validate_shape(state), [])
+
+    def test_canonical_blocked_reason_is_required_and_propagated(self):
+        missing = canonical_body().replace("blocked_reason=NONE\n", "")
+        with self.assertRaisesRegex(ValueError, "CANONICAL_FIELDS_MISSING:blocked_reason"):
+            render_from_canonical(
+                self.template,
+                {
+                    "pull_request": "#89",
+                    "head_sha": "current-head",
+                    "pr_status": "draft",
+                    "last_progress_at": "2026-08-27T12:38:24Z",
+                },
+                missing,
+            )
+
+        state = render_from_canonical(
+            self.template,
+            {
+                "pull_request": "#89",
+                "head_sha": "current-head",
+                "pr_status": "draft",
+                "last_progress_at": "2026-08-27T12:38:24Z",
+            },
+            canonical_body(blocked_reason="READY_TRANSITION_UNAVAILABLE"),
+        )
+        self.assertEqual(state["blocked_reason"], "READY_TRANSITION_UNAVAILABLE")
 
     def test_live_render_fails_closed_when_canonical_head_is_stale(self):
         with self.assertRaisesRegex(ValueError, "CANONICAL_GITHUB_HEAD_CONTRADICTION"):

--- a/tools/governance/test_transition_contract.py
+++ b/tools/governance/test_transition_contract.py
@@ -1,5 +1,8 @@
+import json
 import unittest
+from pathlib import Path
 
+from render_state import render_from_canonical
 from transition_contract import (
     PullRequestObservation,
     TransitionObservation,
@@ -9,6 +12,47 @@ from transition_contract import (
 
 HEAD = "a" * 40
 OTHER = "b" * 40
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_PATH = ROOT / "governance" / "state.template.json"
+
+
+def canonical_lead_body(blocked_reason="NONE"):
+    values = {
+        "current_wip": "#84-G2",
+        "stage": "LEAD_MERGE_READY",
+        "failure_class": "NONE",
+        "expected_role": "Lead",
+        "active_issue": "#84",
+        "active_pr": "#91",
+        "pr_status": "DRAFT",
+        "active_head_sha": HEAD,
+        "authority_scope": "#84-G2_ONLY",
+        "authority_state": "GRANTED",
+        "engineering_handoff": f"FINAL@{HEAD}",
+        "verification_verdict": f"GO@{HEAD}",
+        "exact_head_ci": "25_OF_25_SUCCESS",
+        "blocked_reason": blocked_reason,
+    }
+    lines = "\n".join(f"{key}={value}" for key, value in values.items())
+    return f"""## État machine canonique
+```text
+{lines}
+```
+"""
+
+
+def live_lead_state(blocked_reason="NONE"):
+    template = json.loads(TEMPLATE_PATH.read_text(encoding="utf-8"))
+    return render_from_canonical(
+        template,
+        {
+            "pull_request": "#91",
+            "head_sha": HEAD,
+            "pr_status": "draft",
+            "last_progress_at": "2026-08-27T14:12:12Z",
+        },
+        canonical_lead_body(blocked_reason),
+    )
 
 
 def pr(number="#91", head=HEAD, ref="engineering/governance-transition-contract-g2", base="webots-ci", status="draft"):
@@ -124,6 +168,22 @@ class TransitionContractTests(unittest.TestCase):
         self.assertIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
         s["blocked_reason"] = "READY_TRANSITION_UNAVAILABLE"
         self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
+
+    def test_live_canonical_blocker_propagates_to_g2(self):
+        s = live_lead_state("READY_TRANSITION_UNAVAILABLE")
+        self.assertEqual(s["blocked_reason"], "READY_TRANSITION_UNAVAILABLE")
+        self.assertNotIn(
+            "FINAL_GO_DRAFT_WITHOUT_BLOCKER",
+            evaluate_transition(s, self.obs()),
+        )
+
+    def test_live_canonical_no_blocker_still_requires_ready(self):
+        s = live_lead_state()
+        self.assertIsNone(s["blocked_reason"])
+        self.assertIn(
+            "FINAL_GO_DRAFT_WITHOUT_BLOCKER",
+            evaluate_transition(s, self.obs()),
+        )
 
     def test_handoff_cannot_skip_from_engineering_stage_to_final(self):
         s = state(engineering_handoff={"status": "FINAL", "head_sha": HEAD})

--- a/tools/governance/test_transition_contract.py
+++ b/tools/governance/test_transition_contract.py
@@ -1,0 +1,127 @@
+import unittest
+
+from transition_contract import (
+    PullRequestObservation,
+    TransitionObservation,
+    evaluate_transition,
+)
+
+
+HEAD = "a" * 40
+OTHER = "b" * 40
+
+
+def pr(number="#91", head=HEAD, ref="engineering/governance-transition-contract-g2", base="webots-ci", status="draft"):
+    return PullRequestObservation(number, head, ref, base, status)
+
+
+def state(**overrides):
+    base = {
+        "current_wip": "#84-G2",
+        "stage": "ENGINEERING_IN_PROGRESS",
+        "pull_request": "#91",
+        "head_sha": HEAD,
+        "pr_status": "draft",
+        "expected_role": "Engineering",
+        "engineering_handoff": {"status": "NONE", "head_sha": None},
+        "verification_verdict": {"status": "PENDING", "head_sha": None},
+        "ci_state": {"status": "PENDING", "summary": "PENDING"},
+        "blocked_reason": None,
+        "authority": {"state": "GRANTED", "scope": "#84-G2_ONLY"},
+    }
+    base.update(overrides)
+    return base
+
+
+class TransitionContractTests(unittest.TestCase):
+    def obs(self, current=None, open_prs=None):
+        current = pr() if current is None else current
+        open_prs = [current] if open_prs is None and current is not None else (open_prs or [])
+        return TransitionObservation(current, tuple(open_prs))
+
+    def test_coherent_engineering_in_progress(self):
+        self.assertEqual(evaluate_transition(state(), self.obs()), [])
+
+    def test_more_than_one_engineering_wip_fails(self):
+        second = pr(number="#92", head=OTHER, ref="engineering/other")
+        self.assertIn("MULTIPLE_ENGINEERING_WIP", evaluate_transition(state(), self.obs(open_prs=[pr(), second])))
+
+    def test_main_target_requires_distinct_main_authority(self):
+        main_pr = pr(base="main")
+        problems = evaluate_transition(state(), self.obs(current=main_pr, open_prs=[main_pr]))
+        self.assertIn("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY", problems)
+        authorized = state(authority={"state": "GRANTED", "scope": "MAIN_ONLY"})
+        self.assertNotIn("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY", evaluate_transition(authorized, self.obs(current=main_pr, open_prs=[main_pr])))
+
+    def test_verification_go_must_match_exact_head(self):
+        s = state(verification_verdict={"status": "GO", "head_sha": OTHER})
+        problems = evaluate_transition(s, self.obs())
+        self.assertIn("VERIFICATION_GO_NOT_EXACT_HEAD", problems)
+        self.assertIn("STALE_VERIFICATION_VERDICT", problems)
+
+    def test_skipped_absent_or_ambiguous_cannot_support_lead_merge_ready(self):
+        for status in ("SKIPPED", "AMBIGUOUS", "ABSENT", None):
+            with self.subTest(status=status):
+                s = state(
+                    stage="LEAD_MERGE_READY",
+                    expected_role="Lead",
+                    pr_status="ready",
+                    engineering_handoff={"status": "FINAL", "head_sha": HEAD},
+                    verification_verdict={"status": status, "head_sha": None},
+                    ci_state={"status": "GREEN", "summary": "SUCCESS"},
+                )
+                self.assertIn("INVALID_OR_MISSING_VERIFICATION_PRESENTED_AS_GO", evaluate_transition(s, self.obs(current=pr(status="ready"))))
+
+    def test_registry_pr_head_and_status_contradictions_fail(self):
+        observed = self.obs(current=pr(number="#99", head=OTHER, status="ready"), open_prs=[pr(number="#99", head=OTHER, status="ready")])
+        problems = evaluate_transition(state(), observed)
+        self.assertIn("REGISTRY_GITHUB_PR_CONTRADICTION", problems)
+        self.assertIn("REGISTRY_GITHUB_HEAD_CONTRADICTION", problems)
+        self.assertIn("REGISTRY_GITHUB_PR_STATUS_CONTRADICTION", problems)
+
+    def test_engineering_final_handoff_must_reference_final_head(self):
+        s = state(engineering_handoff={"status": "FINAL", "head_sha": OTHER})
+        self.assertIn("ENGINEERING_HANDOFF_NOT_FINAL_HEAD", evaluate_transition(s, self.obs()))
+
+    def test_expected_role_must_match_decisive_stage(self):
+        s = state(stage="VERIFICATION_READY", expected_role="Engineering")
+        self.assertIn("STALE_EXPECTED_ROLE_AFTER_TRANSITION", evaluate_transition(s, self.obs()))
+
+    def test_verification_ready_requires_final_handoff_and_green_ci(self):
+        s = state(stage="VERIFICATION_READY", expected_role="Verification")
+        self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", evaluate_transition(s, self.obs()))
+
+    def test_lead_merge_ready_requires_complete_exact_head_chain(self):
+        s = state(
+            stage="LEAD_MERGE_READY",
+            expected_role="Lead",
+            pr_status="ready",
+            engineering_handoff={"status": "FINAL", "head_sha": HEAD},
+            verification_verdict={"status": "GO", "head_sha": HEAD},
+            ci_state={"status": "GREEN", "summary": "24_OF_24_SUCCESS"},
+        )
+        self.assertEqual(evaluate_transition(s, self.obs(current=pr(status="ready"))), [])
+
+    def test_final_green_go_draft_requires_ready_or_blocker(self):
+        s = state(
+            stage="LEAD_MERGE_READY",
+            expected_role="Lead",
+            engineering_handoff={"status": "FINAL", "head_sha": HEAD},
+            verification_verdict={"status": "GO", "head_sha": HEAD},
+            ci_state={"status": "GREEN", "summary": "24_OF_24_SUCCESS"},
+        )
+        self.assertIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
+        s["blocked_reason"] = "READY_TRANSITION_UNAVAILABLE"
+        self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
+
+    def test_handoff_cannot_skip_from_engineering_stage_to_final(self):
+        s = state(engineering_handoff={"status": "FINAL", "head_sha": HEAD})
+        self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", evaluate_transition(s, self.obs()))
+
+    def test_registry_declaring_pr_when_github_has_none_fails(self):
+        observed = TransitionObservation(None, tuple())
+        self.assertIn("REGISTRY_DECLARES_MISSING_ACTIVE_PR", evaluate_transition(state(), observed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/governance/test_transition_contract.py
+++ b/tools/governance/test_transition_contract.py
@@ -47,7 +47,7 @@ class TransitionContractTests(unittest.TestCase):
         self.assertIn("MULTIPLE_ENGINEERING_WIP", evaluate_transition(state(), self.obs(open_prs=[pr(), second])))
 
     def test_main_target_requires_distinct_main_authority(self):
-        main_pr = pr(base="main")
+        main_pr = pr(base="main", ref="feature/not-engineering")
         problems = evaluate_transition(state(), self.obs(current=main_pr, open_prs=[main_pr]))
         self.assertIn("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY", problems)
         authorized = state(authority={"state": "GRANTED", "scope": "MAIN_ONLY"})

--- a/tools/governance/test_transition_contract.py
+++ b/tools/governance/test_transition_contract.py
@@ -194,7 +194,7 @@ class TransitionContractTests(unittest.TestCase):
         self.assertIn("STALE_VERIFICATION_VERDICT", problems)
         self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
 
-    def test_final_green_go_draft_requires_ready_or_blocker(self):
+    def test_final_green_go_draft_requires_ready_or_mechanical_blocker(self):
         s = state(
             stage="LEAD_MERGE_READY",
             expected_role="Lead",
@@ -208,12 +208,30 @@ class TransitionContractTests(unittest.TestCase):
         self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", problems)
         self.assertNotIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
 
+    def test_unrelated_blocker_does_not_exempt_draft_ready_transition(self):
+        for reason in ("PRODUCT_BUG", "CI_FLAKE", "anything"):
+            with self.subTest(reason=reason):
+                s = state(
+                    stage="LEAD_MERGE_READY",
+                    expected_role="Lead",
+                    blocked_reason=reason,
+                    engineering_handoff={"status": "FINAL", "head_sha": HEAD},
+                    verification_verdict={"status": "GO", "head_sha": HEAD},
+                    ci_state={"status": "GREEN", "summary": "SUCCESS"},
+                )
+                self.assertIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
+
     def test_live_canonical_blocker_propagates_to_g2(self):
         s = live_lead_state("READY_TRANSITION_UNAVAILABLE")
         self.assertEqual(s["blocked_reason"], "READY_TRANSITION_UNAVAILABLE")
         problems = evaluate_transition(s, self.obs())
         self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", problems)
         self.assertNotIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
+
+    def test_live_canonical_unrelated_blocker_does_not_exempt_ready(self):
+        s = live_lead_state("CI_FLAKE")
+        self.assertEqual(s["blocked_reason"], "CI_FLAKE")
+        self.assertIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
 
     def test_live_canonical_no_blocker_still_requires_ready(self):
         s = live_lead_state()

--- a/tools/governance/test_transition_contract.py
+++ b/tools/governance/test_transition_contract.py
@@ -146,6 +146,16 @@ class TransitionContractTests(unittest.TestCase):
         s = state(stage="VERIFICATION_READY", expected_role="Verification")
         self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", evaluate_transition(s, self.obs()))
 
+    def test_blocker_does_not_hide_verification_ready_prerequisites(self):
+        s = state(
+            stage="VERIFICATION_READY",
+            expected_role="Verification",
+            blocked_reason="READY_TRANSITION_UNAVAILABLE",
+            engineering_handoff={"status": "NONE", "head_sha": None},
+            ci_state={"status": "PENDING", "summary": "PENDING"},
+        )
+        self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", evaluate_transition(s, self.obs()))
+
     def test_lead_merge_ready_requires_complete_exact_head_chain(self):
         s = state(
             stage="LEAD_MERGE_READY",
@@ -157,6 +167,33 @@ class TransitionContractTests(unittest.TestCase):
         )
         self.assertEqual(evaluate_transition(s, self.obs(current=pr(status="ready"))), [])
 
+    def test_blocker_does_not_hide_missing_lead_chain_evidence(self):
+        s = state(
+            stage="LEAD_MERGE_READY",
+            expected_role="Lead",
+            blocked_reason="READY_TRANSITION_UNAVAILABLE",
+            engineering_handoff={"status": "NONE", "head_sha": None},
+            verification_verdict={"status": "PENDING", "head_sha": None},
+            ci_state={"status": "PENDING", "summary": "PENDING"},
+        )
+        problems = evaluate_transition(s, self.obs())
+        self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
+        self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", problems)
+
+    def test_blocker_does_not_hide_non_exact_go(self):
+        s = state(
+            stage="LEAD_MERGE_READY",
+            expected_role="Lead",
+            blocked_reason="READY_TRANSITION_UNAVAILABLE",
+            engineering_handoff={"status": "FINAL", "head_sha": HEAD},
+            verification_verdict={"status": "GO", "head_sha": OTHER},
+            ci_state={"status": "GREEN", "summary": "SUCCESS"},
+        )
+        problems = evaluate_transition(s, self.obs())
+        self.assertIn("VERIFICATION_GO_NOT_EXACT_HEAD", problems)
+        self.assertIn("STALE_VERIFICATION_VERDICT", problems)
+        self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
+
     def test_final_green_go_draft_requires_ready_or_blocker(self):
         s = state(
             stage="LEAD_MERGE_READY",
@@ -167,15 +204,16 @@ class TransitionContractTests(unittest.TestCase):
         )
         self.assertIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
         s["blocked_reason"] = "READY_TRANSITION_UNAVAILABLE"
-        self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", evaluate_transition(s, self.obs()))
+        problems = evaluate_transition(s, self.obs())
+        self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", problems)
+        self.assertNotIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
 
     def test_live_canonical_blocker_propagates_to_g2(self):
         s = live_lead_state("READY_TRANSITION_UNAVAILABLE")
         self.assertEqual(s["blocked_reason"], "READY_TRANSITION_UNAVAILABLE")
-        self.assertNotIn(
-            "FINAL_GO_DRAFT_WITHOUT_BLOCKER",
-            evaluate_transition(s, self.obs()),
-        )
+        problems = evaluate_transition(s, self.obs())
+        self.assertNotIn("FINAL_GO_DRAFT_WITHOUT_BLOCKER", problems)
+        self.assertNotIn("HANDOFF_SKIPS_REQUIRED_STAGE", problems)
 
     def test_live_canonical_no_blocker_still_requires_ready(self):
         s = live_lead_state()
@@ -187,6 +225,13 @@ class TransitionContractTests(unittest.TestCase):
 
     def test_handoff_cannot_skip_from_engineering_stage_to_final(self):
         s = state(engineering_handoff={"status": "FINAL", "head_sha": HEAD})
+        self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", evaluate_transition(s, self.obs()))
+
+    def test_blocker_does_not_hide_engineering_stage_final_handoff(self):
+        s = state(
+            blocked_reason="READY_TRANSITION_UNAVAILABLE",
+            engineering_handoff={"status": "FINAL", "head_sha": HEAD},
+        )
         self.assertIn("HANDOFF_SKIPS_REQUIRED_STAGE", evaluate_transition(s, self.obs()))
 
     def test_registry_declaring_pr_when_github_has_none_fails(self):

--- a/tools/governance/test_transition_contract.py
+++ b/tools/governance/test_transition_contract.py
@@ -42,8 +42,8 @@ class TransitionContractTests(unittest.TestCase):
     def test_coherent_engineering_in_progress(self):
         self.assertEqual(evaluate_transition(state(), self.obs()), [])
 
-    def test_more_than_one_engineering_wip_fails(self):
-        second = pr(number="#92", head=OTHER, ref="engineering/other")
+    def test_more_than_one_integration_wip_fails_regardless_of_branch_prefix(self):
+        second = pr(number="#92", head=OTHER, ref="feature/other")
         self.assertIn("MULTIPLE_ENGINEERING_WIP", evaluate_transition(state(), self.obs(open_prs=[pr(), second])))
 
     def test_main_target_requires_distinct_main_authority(self):
@@ -52,6 +52,13 @@ class TransitionContractTests(unittest.TestCase):
         self.assertIn("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY", problems)
         authorized = state(authority={"state": "GRANTED", "scope": "MAIN_ONLY"})
         self.assertNotIn("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY", evaluate_transition(authorized, self.obs(current=main_pr, open_prs=[main_pr])))
+
+    def test_main_authority_does_not_cover_unrelated_pr(self):
+        current = pr()
+        unrelated = pr(number="#92", head=OTHER, ref="release/unrelated", base="main")
+        authorized_current = state(authority={"state": "GRANTED", "scope": "MAIN_ONLY"})
+        problems = evaluate_transition(authorized_current, self.obs(current=current, open_prs=[current, unrelated]))
+        self.assertIn("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY", problems)
 
     def test_verification_go_must_match_exact_head(self):
         s = state(verification_verdict={"status": "GO", "head_sha": OTHER})
@@ -82,6 +89,10 @@ class TransitionContractTests(unittest.TestCase):
     def test_engineering_final_handoff_must_reference_final_head(self):
         s = state(engineering_handoff={"status": "FINAL", "head_sha": OTHER})
         self.assertIn("ENGINEERING_HANDOFF_NOT_FINAL_HEAD", evaluate_transition(s, self.obs()))
+
+    def test_unknown_stage_fails_closed(self):
+        s = state(stage="VERIFICATON_READY", expected_role="Verification")
+        self.assertIn("UNKNOWN_TRANSITION_STAGE", evaluate_transition(s, self.obs()))
 
     def test_expected_role_must_match_decisive_stage(self):
         s = state(stage="VERIFICATION_READY", expected_role="Engineering")

--- a/tools/governance/transition_contract.py
+++ b/tools/governance/transition_contract.py
@@ -84,7 +84,7 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
     if len(engineering_prs) > 1:
         problems.append("MULTIPLE_ENGINEERING_WIP")
 
-    for pr in engineering_prs:
+    for pr in observed.open_prs:
         if pr.base_ref == "main" and not _main_authorized(state):
             problems.append("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY")
 

--- a/tools/governance/transition_contract.py
+++ b/tools/governance/transition_contract.py
@@ -142,8 +142,9 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
     if required_role and expected_role != required_role:
         problems.append("STALE_EXPECTED_ROLE_AFTER_TRANSITION")
 
+    # Blockers represent mechanical inability, never missing governance evidence.
     if stage in {"ENGINEERING_READY", "ENGINEERING_IN_PROGRESS", "CI_RUNNING"}:
-        if handoff_status == "FINAL" and not blocked:
+        if handoff_status == "FINAL":
             problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
 
     if stage == "VERIFICATION_READY":
@@ -151,9 +152,9 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
             handoff_status != "FINAL"
             or handoff_head != canonical_head
             or ci_status != "GREEN"
-        ) and not blocked:
+        ):
             problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
-        if verdict_status not in {"PENDING", None} and not blocked:
+        if verdict_status not in {"PENDING", None}:
             problems.append("VERIFICATION_READY_WITH_PREEXISTING_FINAL_VERDICT")
 
     if stage == "LEAD_MERGE_READY":
@@ -163,8 +164,9 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
             or ci_status != "GREEN"
             or verdict_status != "GO"
             or verdict_head != canonical_head
-        ) and not blocked:
+        ):
             problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
+        # Only the mechanical Draft -> Ready transition may be blocker-aware.
         if canonical_status == "draft" and not blocked:
             problems.append("FINAL_GO_DRAFT_WITHOUT_BLOCKER")
 

--- a/tools/governance/transition_contract.py
+++ b/tools/governance/transition_contract.py
@@ -15,6 +15,7 @@ ROLE_BY_STAGE = {
     "VERIFICATION_READY": "Verification",
     "LEAD_MERGE_READY": "Lead",
 }
+VALID_STAGES = set(ROLE_BY_STAGE)
 
 
 @dataclass(frozen=True)
@@ -66,9 +67,14 @@ def load_observation(path: str | Path) -> TransitionObservation:
     return TransitionObservation(current_pr=current_pr, open_prs=open_prs)
 
 
-def _main_authorized(state: dict[str, Any]) -> bool:
+def _main_authorized(state: dict[str, Any], pr: PullRequestObservation) -> bool:
     authority = state.get("authority") or {}
-    return authority.get("state") == "GRANTED" and authority.get("scope") == "MAIN_ONLY"
+    return (
+        authority.get("state") == "GRANTED"
+        and authority.get("scope") == "MAIN_ONLY"
+        and state.get("pull_request") == pr.number
+        and state.get("head_sha") == pr.head_sha
+    )
 
 
 def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) -> list[str]:
@@ -77,15 +83,18 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
     blocked = bool(state.get("blocked_reason"))
     current = observed.current_pr
 
-    engineering_prs = [
+    # Fail closed on any concurrent integration PR, regardless of branch naming.
+    # Within this repository, an open PR targeting webots-ci is conservatively
+    # treated as an active Engineering/integration WIP candidate.
+    integration_wips = [
         pr for pr in observed.open_prs
-        if pr.head_ref.startswith("engineering/")
+        if pr.base_ref == "webots-ci"
     ]
-    if len(engineering_prs) > 1:
+    if len(integration_wips) > 1:
         problems.append("MULTIPLE_ENGINEERING_WIP")
 
     for pr in observed.open_prs:
-        if pr.base_ref == "main" and not _main_authorized(state):
+        if pr.base_ref == "main" and not _main_authorized(state, pr):
             problems.append("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY")
 
     canonical_pr = state.get("pull_request")
@@ -110,6 +119,9 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
     ci_status = (state.get("ci_state") or {}).get("status")
     stage = state.get("stage")
     expected_role = state.get("expected_role")
+
+    if stage not in VALID_STAGES:
+        problems.append("UNKNOWN_TRANSITION_STAGE")
 
     if handoff_status == "FINAL" and handoff_head != canonical_head:
         problems.append("ENGINEERING_HANDOFF_NOT_FINAL_HEAD")

--- a/tools/governance/transition_contract.py
+++ b/tools/governance/transition_contract.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Deterministic, read-only transition validator for WebeeBlocks governance G2."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+FINAL_VERDICTS = {"GO", "NO_GO", "UNPROVEN"}
+ROLE_BY_STAGE = {
+    "ENGINEERING_READY": "Engineering",
+    "ENGINEERING_IN_PROGRESS": "Engineering",
+    "CI_RUNNING": "Engineering",
+    "VERIFICATION_READY": "Verification",
+    "LEAD_MERGE_READY": "Lead",
+}
+
+
+@dataclass(frozen=True)
+class PullRequestObservation:
+    number: str
+    head_sha: str
+    head_ref: str
+    base_ref: str
+    status: str
+
+
+@dataclass(frozen=True)
+class TransitionObservation:
+    current_pr: PullRequestObservation | None
+    open_prs: tuple[PullRequestObservation, ...]
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _normalise_pr(raw: dict[str, Any]) -> PullRequestObservation:
+    number = raw.get("number")
+    if isinstance(number, int):
+        number = f"#{number}"
+    if not isinstance(number, str) or not number.startswith("#"):
+        raise ValueError("INVALID_OBSERVED_PR_NUMBER")
+    status = raw.get("status")
+    if status not in {"draft", "ready"}:
+        raise ValueError("INVALID_OBSERVED_PR_STATUS")
+    values = {
+        "head_sha": raw.get("head_sha"),
+        "head_ref": raw.get("head_ref"),
+        "base_ref": raw.get("base_ref"),
+    }
+    if not all(isinstance(value, str) and value for value in values.values()):
+        raise ValueError("INVALID_OBSERVED_PR")
+    return PullRequestObservation(number=number, status=status, **values)
+
+
+def load_observation(path: str | Path) -> TransitionObservation:
+    payload = load_json(path)
+    open_raw = payload.get("open_prs")
+    if not isinstance(open_raw, list):
+        raise ValueError("INVALID_OPEN_PRS_OBSERVATION")
+    open_prs = tuple(_normalise_pr(item) for item in open_raw)
+    current_raw = payload.get("current_pr")
+    current_pr = None if current_raw is None else _normalise_pr(current_raw)
+    return TransitionObservation(current_pr=current_pr, open_prs=open_prs)
+
+
+def _main_authorized(state: dict[str, Any]) -> bool:
+    authority = state.get("authority") or {}
+    return authority.get("state") == "GRANTED" and authority.get("scope") == "MAIN_ONLY"
+
+
+def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) -> list[str]:
+    """Return explicit transition violations. Empty means transition-coherent."""
+    problems: list[str] = []
+    blocked = bool(state.get("blocked_reason"))
+    current = observed.current_pr
+
+    engineering_prs = [
+        pr for pr in observed.open_prs
+        if pr.head_ref.startswith("engineering/")
+    ]
+    if len(engineering_prs) > 1:
+        problems.append("MULTIPLE_ENGINEERING_WIP")
+
+    for pr in engineering_prs:
+        if pr.base_ref == "main" and not _main_authorized(state):
+            problems.append("MAIN_TARGET_WITHOUT_DISTINCT_AUTHORITY")
+
+    canonical_pr = state.get("pull_request")
+    canonical_head = state.get("head_sha")
+    canonical_status = state.get("pr_status")
+    if current is not None:
+        if canonical_pr != current.number:
+            problems.append("REGISTRY_GITHUB_PR_CONTRADICTION")
+        if canonical_head != current.head_sha:
+            problems.append("REGISTRY_GITHUB_HEAD_CONTRADICTION")
+        if canonical_status != current.status:
+            problems.append("REGISTRY_GITHUB_PR_STATUS_CONTRADICTION")
+    elif canonical_pr is not None:
+        problems.append("REGISTRY_DECLARES_MISSING_ACTIVE_PR")
+
+    handoff = state.get("engineering_handoff") or {}
+    handoff_status = handoff.get("status")
+    handoff_head = handoff.get("head_sha")
+    verdict = state.get("verification_verdict") or {}
+    verdict_status = verdict.get("status")
+    verdict_head = verdict.get("head_sha")
+    ci_status = (state.get("ci_state") or {}).get("status")
+    stage = state.get("stage")
+    expected_role = state.get("expected_role")
+
+    if handoff_status == "FINAL" and handoff_head != canonical_head:
+        problems.append("ENGINEERING_HANDOFF_NOT_FINAL_HEAD")
+
+    if verdict_status == "GO":
+        if not verdict_head or verdict_head != canonical_head:
+            problems.append("VERIFICATION_GO_NOT_EXACT_HEAD")
+    elif verdict_status in {None, "SKIPPED", "AMBIGUOUS", "ABSENT"}:
+        if stage == "LEAD_MERGE_READY":
+            problems.append("INVALID_OR_MISSING_VERIFICATION_PRESENTED_AS_GO")
+    elif verdict_status not in {"PENDING", "NO_GO", "UNPROVEN"}:
+        problems.append("INVALID_OR_AMBIGUOUS_VERIFICATION_VERDICT")
+
+    if verdict_status in FINAL_VERDICTS and verdict_head != canonical_head:
+        problems.append("STALE_VERIFICATION_VERDICT")
+
+    required_role = ROLE_BY_STAGE.get(stage)
+    if required_role and expected_role != required_role:
+        problems.append("STALE_EXPECTED_ROLE_AFTER_TRANSITION")
+
+    if stage in {"ENGINEERING_READY", "ENGINEERING_IN_PROGRESS", "CI_RUNNING"}:
+        if handoff_status == "FINAL" and not blocked:
+            problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
+
+    if stage == "VERIFICATION_READY":
+        if (
+            handoff_status != "FINAL"
+            or handoff_head != canonical_head
+            or ci_status != "GREEN"
+        ) and not blocked:
+            problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
+        if verdict_status not in {"PENDING", None} and not blocked:
+            problems.append("VERIFICATION_READY_WITH_PREEXISTING_FINAL_VERDICT")
+
+    if stage == "LEAD_MERGE_READY":
+        if (
+            handoff_status != "FINAL"
+            or handoff_head != canonical_head
+            or ci_status != "GREEN"
+            or verdict_status != "GO"
+            or verdict_head != canonical_head
+        ) and not blocked:
+            problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
+        if canonical_status == "draft" and not blocked:
+            problems.append("FINAL_GO_DRAFT_WITHOUT_BLOCKER")
+
+    return problems
+
+
+def assert_transition_coherent(state: dict[str, Any], observed: TransitionObservation) -> None:
+    problems = evaluate_transition(state, observed)
+    if problems:
+        raise ValueError(";".join(dict.fromkeys(problems)))
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--observation", required=True)
+    args = parser.parse_args()
+    state = load_json(args.state)
+    observed = load_observation(args.observation)
+    assert_transition_coherent(state, observed)
+    print(
+        "GOVERNANCE_TRANSITION_OK "
+        f"wip={state.get('current_wip')} stage={state.get('stage')} "
+        f"role={state.get('expected_role')} pr={state.get('pull_request')} "
+        f"head={state.get('head_sha')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance/transition_contract.py
+++ b/tools/governance/transition_contract.py
@@ -16,6 +16,7 @@ ROLE_BY_STAGE = {
     "LEAD_MERGE_READY": "Lead",
 }
 VALID_STAGES = set(ROLE_BY_STAGE)
+READY_TRANSITION_BLOCKERS = {"READY_TRANSITION_UNAVAILABLE"}
 
 
 @dataclass(frozen=True)
@@ -80,7 +81,8 @@ def _main_authorized(state: dict[str, Any], pr: PullRequestObservation) -> bool:
 def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) -> list[str]:
     """Return explicit transition violations. Empty means transition-coherent."""
     problems: list[str] = []
-    blocked = bool(state.get("blocked_reason"))
+    blocked_reason = state.get("blocked_reason")
+    ready_transition_blocked = blocked_reason in READY_TRANSITION_BLOCKERS
     current = observed.current_pr
 
     # Fail closed on any concurrent integration PR, regardless of branch naming.
@@ -166,8 +168,9 @@ def evaluate_transition(state: dict[str, Any], observed: TransitionObservation) 
             or verdict_head != canonical_head
         ):
             problems.append("HANDOFF_SKIPS_REQUIRED_STAGE")
-        # Only the mechanical Draft -> Ready transition may be blocker-aware.
-        if canonical_status == "draft" and not blocked:
+        # Only an explicitly recognized mechanical Draft -> Ready failure exempts
+        # the mechanical Ready transition; unrelated blockers must not.
+        if canonical_status == "draft" and not ready_transition_blocked:
             problems.append("FINAL_GO_DRAFT_WITHOUT_BLOCKER")
 
     return problems


### PR DESCRIPTION
## Objective

Implements only **#84-G2** from `webots-ci@d76da76432cbca6d29c020c8aaf2594ff803dfef`.

## Scope

Adds a deterministic, read-only transition validator above the integrated G1 state contract. It observes canonical governance state plus GitHub PR facts and fails closed on illegal or stale transitions.

### Causal rules
- more than one Engineering WIP;
- PR targeting `main` without distinct `MAIN_ONLY` authority;
- canonical PR/head/status contradicting GitHub;
- Verification GO not bound to the exact current head;
- skipped/absent/ambiguous Verification used as merge authority;
- final Engineering handoff not bound to the final head;
- stale `expected_role` after a decisive stage;
- skipped handoff stages;
- `FINAL + CI_GREEN + GO + DRAFT` without explicit blocker.

## Non-goals

No G3 recovery policy, no G4 event-driven mutation, no product code, no new merge authority, no secrets/permissions/rulesets/protections, and no `main` change.

Draft until exact-head CI and independent Verification.