### PR TITLE
Add bounded governance recovery policy (84-G3)

### DIFF
--- a/.github/workflows/governance-recovery-contract.yml
+++ b/.github/workflows/governance-recovery-contract.yml
@@ -29,7 +29,8 @@ jobs:
           python3 -m unittest -v \
             test_state_contract.py \
             test_transition_contract.py \
-            test_recovery_contract.py
+            test_recovery_contract.py \
+            test_recovery_hardening.py
 
       - name: Fetch canonical #22 and open PR observations read-only
         if: github.event_name == 'pull_request'

--- a/.github/workflows/governance-recovery-contract.yml
+++ b/.github/workflows/governance-recovery-contract.yml
@@ -1,0 +1,150 @@
+name: Governance bounded recovery contract G3
+
+on:
+  pull_request:
+    branches: [webots-ci]
+    paths:
+      - 'governance/**'
+      - 'tools/governance/**'
+      - '.github/workflows/governance-state-contract.yml'
+      - '.github/workflows/governance-transition-contract.yml'
+      - '.github/workflows/governance-recovery-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  governance-recovery-contract:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate G1, G2 and G3 causal tests
+        run: |
+          set -euo pipefail
+          cd tools/governance
+          python3 -m unittest -v \
+            test_state_contract.py \
+            test_transition_contract.py \
+            test_recovery_contract.py
+
+      - name: Fetch canonical #22 and open PR observations read-only
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import urllib.request
+          from pathlib import Path
+
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "User-Agent": "webeeblocks-governance-g3",
+          }
+
+          def get(url):
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.load(response)
+
+          issue = get("https://api.github.com/repos/djibian/webeeblocks/issues/22")
+          body = issue.get("body")
+          if not isinstance(body, str) or not body.strip():
+              raise SystemExit("CANONICAL_ISSUE_22_BODY_MISSING")
+          Path("/tmp/issue22.md").write_text(body, encoding="utf-8")
+
+          pulls = []
+          for page in range(1, 11):
+              batch = get(
+                  "https://api.github.com/repos/djibian/webeeblocks/pulls"
+                  f"?state=open&per_page=100&page={page}"
+              )
+              if not isinstance(batch, list):
+                  raise SystemExit("OPEN_PRS_OBSERVATION_INVALID")
+              pulls.extend(batch)
+              if len(batch) < 100:
+                  break
+          else:
+              raise SystemExit("OPEN_PRS_OBSERVATION_TOO_LARGE")
+
+          Path("/tmp/open-prs.json").write_text(json.dumps(pulls), encoding="utf-8")
+          PY
+
+      - name: Validate live state, transition and recovery decision
+        if: github.event_name == 'pull_request'
+        env:
+          PULL_REQUEST: '#${{ github.event.pull_request.number }}'
+          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+          HEAD_REF: '${{ github.event.pull_request.head.ref }}'
+          BASE_REF: '${{ github.event.pull_request.base.ref }}'
+          PR_STATUS: "${{ github.event.pull_request.draft && 'draft' || 'ready' }}"
+          LAST_PROGRESS_AT: '${{ github.event.pull_request.updated_at }}'
+        run: |
+          set -euo pipefail
+          python3 tools/governance/render_state.py \
+            --template governance/state.template.json \
+            --canonical-body /tmp/issue22.md \
+            --output /tmp/governance-state.json \
+            --pull-request "$PULL_REQUEST" \
+            --head-sha "$HEAD_SHA" \
+            --pr-status "$PR_STATUS" \
+            --last-progress-at "$LAST_PROGRESS_AT"
+
+          python3 - "$PULL_REQUEST" "$HEAD_SHA" "$HEAD_REF" "$BASE_REF" "$PR_STATUS" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          number, head_sha, head_ref, base_ref, status = sys.argv[1:]
+          pulls = json.loads(Path('/tmp/open-prs.json').read_text(encoding='utf-8'))
+
+          def normalise(item):
+              return {
+                  "number": f"#{item['number']}",
+                  "head_sha": item["head"]["sha"],
+                  "head_ref": item["head"]["ref"],
+                  "base_ref": item["base"]["ref"],
+                  "status": "draft" if item.get("draft") else "ready",
+              }
+
+          observation = {
+              "current_pr": {
+                  "number": number,
+                  "head_sha": head_sha,
+                  "head_ref": head_ref,
+                  "base_ref": base_ref,
+                  "status": status,
+              },
+              "open_prs": [normalise(item) for item in pulls],
+          }
+          Path('/tmp/governance-transition-observation.json').write_text(
+              json.dumps(observation, indent=2) + '\n', encoding='utf-8'
+          )
+          PY
+
+          PYTHONPATH=tools/governance python3 - <<'PY'
+          from state_contract import Observation, assert_coherent, load
+
+          state = load('/tmp/governance-state.json')
+          assert_coherent(state, Observation(
+              pr_number=state["pull_request"],
+              pr_head_sha=state["head_sha"],
+              pr_status=state["pr_status"],
+              ci_green=state["ci_state"]["status"] == "GREEN",
+              engineering_executed=False,
+              progress_made=False,
+              mutation_possible=True,
+          ))
+          PY
+
+          PYTHONPATH=tools/governance python3 tools/governance/transition_contract.py \
+            --state /tmp/governance-state.json \
+            --observation /tmp/governance-transition-observation.json
+
+          PYTHONPATH=tools/governance python3 tools/governance/recovery_contract.py \
+            --state /tmp/governance-state.json \
+            --canonical-body /tmp/issue22.md \
+            --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/tools/governance/recovery_contract.py
+++ b/tools/governance/recovery_contract.py
@@ -165,6 +165,13 @@ def validate_recovery_state(state: dict[str, Any]) -> list[str]:
             problems.append("RECOVERY_METADATA_WITHOUT_FAILURE")
         return problems
 
+    if (
+        failure_class in VALID_FAILURE_CLASSES
+        and failure_class not in RETRYABLE_FAILURE_CLASSES
+        and retry_count != 0
+    ):
+        problems.append("RETRY_COUNT_ON_NON_RETRYABLE_FAILURE")
+
     signature = recovery.get("incident_signature")
     incident_head = recovery.get("incident_head_sha")
     if not isinstance(signature, str) or not signature:

--- a/tools/governance/recovery_contract.py
+++ b/tools/governance/recovery_contract.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Deterministic, read-only bounded recovery policy for WebeeBlocks governance G3."""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+VALID_FAILURE_CLASSES = {
+    "NONE",
+    "TRANSIENT",
+    "HARNESS_ORACLE",
+    "PRODUCT",
+    "HUMAN_GATE",
+    "AUTHORITY",
+    "PLATFORM",
+}
+RETRYABLE_FAILURE_CLASSES = {"TRANSIENT", "HARNESS_ORACLE"}
+MAX_RETRIES = 2
+RETRY_WINDOW_SECONDS = 6 * 60 * 60
+VALID_EXECUTOR_STATUS = {"AVAILABLE", "UNAVAILABLE", "UNKNOWN"}
+VALID_ROLES = {"Lead", "Lab", "Engineering", "Verification"}
+CI_JOB_TARGET_RE = re.compile(r"^CI_JOB:(\d+):(\d+)$")
+ROLE_TARGET_RE = re.compile(r"^ROLE:(Lead|Lab|Engineering|Verification)$")
+MACHINE_BLOCK_RE = re.compile(
+    r"## État machine canonique\s*```text\s*(.*?)```",
+    re.DOTALL,
+)
+CANONICAL_RECOVERY_REQUIRED = {
+    "failure_class",
+    "retry_count",
+    "recovery_incident_signature",
+    "recovery_incident_head_sha",
+    "retry_window_started_at",
+    "retry_target",
+    "cause_established",
+    "executor_status",
+}
+
+
+@dataclass(frozen=True)
+class RecoveryDecision:
+    action: str
+    next_role: str | None
+    retry_allowed: bool
+    blocker_reason: str | None
+    blocks_independent_wip: bool
+    retry_target: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def parse_utc(raw: str) -> datetime:
+    try:
+        value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"INVALID_RECOVERY_TIMESTAMP:{raw}") from exc
+    if value.tzinfo is None:
+        raise ValueError(f"INVALID_RECOVERY_TIMESTAMP:{raw}")
+    return value.astimezone(timezone.utc)
+
+
+def _is_specific_retry_target(target: str | None) -> bool:
+    if target is None:
+        return False
+    return bool(CI_JOB_TARGET_RE.fullmatch(target) or ROLE_TARGET_RE.fullmatch(target))
+
+
+def parse_machine_block(body: str) -> dict[str, str]:
+    match = MACHINE_BLOCK_RE.search(body)
+    if not match:
+        raise ValueError("CANONICAL_MACHINE_BLOCK_MISSING")
+    values: dict[str, str] = {}
+    for raw_line in match.group(1).splitlines():
+        line = raw_line.strip()
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    missing = sorted(CANONICAL_RECOVERY_REQUIRED - values.keys())
+    if missing:
+        raise ValueError("CANONICAL_RECOVERY_FIELDS_MISSING:" + ",".join(missing))
+    return values
+
+
+def _parse_none(raw: str) -> str | None:
+    return None if raw == "NONE" else raw
+
+
+def _parse_bool(raw: str, field: str) -> bool:
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    raise ValueError(f"CANONICAL_{field.upper()}_INVALID:{raw}")
+
+
+def apply_canonical_recovery(state: dict[str, Any], body: str) -> dict[str, Any]:
+    machine = parse_machine_block(body)
+    canonical_failure = machine["failure_class"]
+    if state.get("failure_class") != canonical_failure:
+        raise ValueError(
+            f"CANONICAL_FAILURE_CLASS_CONTRADICTION:"
+            f"{canonical_failure}!={state.get('failure_class')}"
+        )
+    try:
+        retry_count = int(machine["retry_count"])
+    except ValueError as exc:
+        raise ValueError(
+            f"CANONICAL_RETRY_COUNT_INVALID:{machine['retry_count']}"
+        ) from exc
+    if retry_count < 0 or str(retry_count) != machine["retry_count"]:
+        raise ValueError(f"CANONICAL_RETRY_COUNT_INVALID:{machine['retry_count']}")
+
+    enriched = dict(state)
+    enriched["retry_count"] = retry_count
+    enriched["recovery"] = {
+        "incident_signature": _parse_none(machine["recovery_incident_signature"]),
+        "incident_head_sha": _parse_none(machine["recovery_incident_head_sha"]),
+        "window_started_at": _parse_none(machine["retry_window_started_at"]),
+        "retry_target": _parse_none(machine["retry_target"]),
+        "cause_established": _parse_bool(machine["cause_established"], "cause_established"),
+        "executor_status": machine["executor_status"],
+    }
+    return enriched
+
+
+def validate_recovery_state(state: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    failure_class = state.get("failure_class")
+    retry_count = state.get("retry_count")
+    recovery = state.get("recovery")
+
+    if failure_class not in VALID_FAILURE_CLASSES:
+        problems.append("INVALID_FAILURE_CLASS")
+
+    if not isinstance(retry_count, int) or isinstance(retry_count, bool) or retry_count < 0:
+        problems.append("INVALID_RETRY_COUNT")
+
+    if not isinstance(recovery, dict):
+        problems.append("INVALID_RECOVERY_STATE")
+        return problems
+
+    required = {
+        "incident_signature",
+        "incident_head_sha",
+        "window_started_at",
+        "retry_target",
+        "cause_established",
+        "executor_status",
+    }
+    missing = sorted(required - recovery.keys())
+    if missing:
+        problems.append("MISSING_RECOVERY_FIELDS:" + ",".join(missing))
+        return problems
+
+    if not isinstance(recovery.get("cause_established"), bool):
+        problems.append("INVALID_CAUSE_ESTABLISHED")
+
+    if recovery.get("executor_status") not in VALID_EXECUTOR_STATUS:
+        problems.append("INVALID_EXECUTOR_STATUS")
+
+    if failure_class == "NONE":
+        if retry_count != 0:
+            problems.append("RETRY_COUNT_WITHOUT_FAILURE")
+        if any(
+            recovery.get(key) is not None
+            for key in ("incident_signature", "incident_head_sha", "window_started_at", "retry_target")
+        ):
+            problems.append("RECOVERY_METADATA_WITHOUT_FAILURE")
+        if recovery.get("cause_established") is not False:
+            problems.append("CAUSE_ESTABLISHED_WITHOUT_FAILURE")
+        return problems
+
+    signature = recovery.get("incident_signature")
+    incident_head = recovery.get("incident_head_sha")
+    if not isinstance(signature, str) or not signature:
+        problems.append("MISSING_INCIDENT_SIGNATURE")
+    if not isinstance(incident_head, str) or not incident_head:
+        problems.append("MISSING_INCIDENT_HEAD")
+    elif incident_head != state.get("head_sha"):
+        problems.append("STALE_RECOVERY_INCIDENT_HEAD")
+
+    if failure_class in RETRYABLE_FAILURE_CLASSES:
+        target = recovery.get("retry_target")
+        if not _is_specific_retry_target(target):
+            problems.append("BLIND_OR_INVALID_RETRY_TARGET")
+        started_at = recovery.get("window_started_at")
+        if not isinstance(started_at, str) or not started_at:
+            problems.append("MISSING_RETRY_WINDOW_START")
+        else:
+            try:
+                parse_utc(started_at)
+            except ValueError as exc:
+                problems.append(str(exc))
+    elif recovery.get("retry_target") is not None:
+        problems.append("RETRY_TARGET_ON_NON_RETRYABLE_FAILURE")
+
+    return problems
+
+
+def evaluate_recovery(state: dict[str, Any], now: str) -> RecoveryDecision:
+    problems = validate_recovery_state(state)
+    if problems:
+        raise ValueError(";".join(dict.fromkeys(problems)))
+
+    failure_class = state["failure_class"]
+    retry_count = state["retry_count"]
+    recovery = state["recovery"]
+
+    if failure_class == "NONE":
+        return RecoveryDecision(
+            action="NO_ACTION",
+            next_role=None,
+            retry_allowed=False,
+            blocker_reason=None,
+            blocks_independent_wip=False,
+        )
+
+    if failure_class in RETRYABLE_FAILURE_CLASSES:
+        now_dt = parse_utc(now)
+        started_at = parse_utc(recovery["window_started_at"])
+        age = (now_dt - started_at).total_seconds()
+        if age < 0:
+            raise ValueError("RETRY_WINDOW_STARTS_IN_FUTURE")
+        if age > RETRY_WINDOW_SECONDS:
+            return RecoveryDecision(
+                action="BLOCK_RETRY_WINDOW_EXPIRED",
+                next_role="Lab",
+                retry_allowed=False,
+                blocker_reason="RETRY_WINDOW_EXPIRED",
+                blocks_independent_wip=True,
+            )
+        if retry_count >= MAX_RETRIES:
+            return RecoveryDecision(
+                action="BLOCK_RETRY_BUDGET_EXHAUSTED",
+                next_role="Lab",
+                retry_allowed=False,
+                blocker_reason="RETRY_BUDGET_EXHAUSTED",
+                blocks_independent_wip=True,
+            )
+        return RecoveryDecision(
+            action="RETRY_CAUSAL_TARGET",
+            next_role=state.get("expected_role"),
+            retry_allowed=True,
+            blocker_reason=None,
+            blocks_independent_wip=False,
+            retry_target=recovery["retry_target"],
+        )
+
+    if failure_class == "PRODUCT":
+        if recovery["cause_established"]:
+            return RecoveryDecision(
+                action="ROUTE_ENGINEERING",
+                next_role="Engineering",
+                retry_allowed=False,
+                blocker_reason=None,
+                blocks_independent_wip=False,
+            )
+        return RecoveryDecision(
+            action="ROUTE_LAB",
+            next_role="Lab",
+            retry_allowed=False,
+            blocker_reason="PRODUCT_CAUSE_UNCERTAIN",
+            blocks_independent_wip=False,
+        )
+
+    if failure_class == "HUMAN_GATE":
+        return RecoveryDecision(
+            action="WAIT_HUMAN_GATE",
+            next_role=None,
+            retry_allowed=False,
+            blocker_reason=None,
+            blocks_independent_wip=False,
+        )
+
+    if failure_class == "AUTHORITY":
+        return RecoveryDecision(
+            action="BLOCK_AUTHORITY",
+            next_role="Lead",
+            retry_allowed=False,
+            blocker_reason="AUTHORITY_REQUIRED",
+            blocks_independent_wip=True,
+        )
+
+    if failure_class == "PLATFORM":
+        blocker = (
+            "PLATFORM_EXECUTOR_UNAVAILABLE"
+            if recovery["executor_status"] == "UNAVAILABLE"
+            else "PLATFORM_UNAVAILABLE"
+        )
+        return RecoveryDecision(
+            action="BLOCK_PLATFORM",
+            next_role="Lead",
+            retry_allowed=False,
+            blocker_reason=blocker,
+            blocks_independent_wip=True,
+        )
+
+    raise AssertionError(f"unhandled failure class: {failure_class}")
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--canonical-body", required=True)
+    parser.add_argument("--now", required=True)
+    args = parser.parse_args()
+
+    state = load_json(args.state)
+    body = Path(args.canonical_body).read_text(encoding="utf-8")
+    state = apply_canonical_recovery(state, body)
+    decision = evaluate_recovery(state, args.now)
+    print(
+        "GOVERNANCE_RECOVERY_OK "
+        f"failure_class={state.get('failure_class')} "
+        f"retry_count={state.get('retry_count')} "
+        f"action={decision.action} "
+        f"next_role={decision.next_role or 'NONE'} "
+        f"blocker={decision.blocker_reason or 'NONE'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance/recovery_contract.py
+++ b/tools/governance/recovery_contract.py
@@ -4,40 +4,29 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 VALID_FAILURE_CLASSES = {
-    "NONE",
-    "TRANSIENT",
-    "HARNESS_ORACLE",
-    "PRODUCT",
-    "HUMAN_GATE",
-    "AUTHORITY",
-    "PLATFORM",
+    "NONE", "TRANSIENT", "HARNESS_ORACLE", "PRODUCT",
+    "HUMAN_GATE", "AUTHORITY", "PLATFORM",
 }
 RETRYABLE_FAILURE_CLASSES = {"TRANSIENT", "HARNESS_ORACLE"}
-MAX_RETRIES = 2
-RETRY_WINDOW_SECONDS = 6 * 60 * 60
 VALID_EXECUTOR_STATUS = {"AVAILABLE", "UNAVAILABLE", "UNKNOWN"}
 VALID_ROLES = {"Lead", "Lab", "Engineering", "Verification"}
+MAX_RETRIES = 2
+RETRY_WINDOW_SECONDS = 6 * 60 * 60
 CI_JOB_TARGET_RE = re.compile(r"^CI_JOB:(\d+):(\d+)$")
 ROLE_TARGET_RE = re.compile(r"^ROLE:(Lead|Lab|Engineering|Verification)$")
 MACHINE_BLOCK_RE = re.compile(
-    r"## État machine canonique\s*```text\s*(.*?)```",
-    re.DOTALL,
+    r"## État machine canonique\s*```text\s*(.*?)```", re.DOTALL
 )
 CANONICAL_RECOVERY_REQUIRED = {
-    "failure_class",
-    "retry_count",
-    "recovery_incident_signature",
-    "recovery_incident_head_sha",
-    "retry_window_started_at",
-    "retry_target",
-    "cause_established",
-    "executor_status",
+    "failure_class", "retry_count", "recovery_incident_signature",
+    "recovery_incident_head_sha", "retry_window_started_at", "retry_target",
+    "cause_established", "executor_status",
 }
 
 
@@ -49,9 +38,6 @@ class RecoveryDecision:
     blocker_reason: str | None
     blocks_independent_wip: bool
     retry_target: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
 
 
 def load_json(path: str | Path) -> dict[str, Any]:
@@ -68,12 +54,6 @@ def parse_utc(raw: str) -> datetime:
     return value.astimezone(timezone.utc)
 
 
-def _is_specific_retry_target(target: str | None) -> bool:
-    if target is None:
-        return False
-    return bool(CI_JOB_TARGET_RE.fullmatch(target) or ROLE_TARGET_RE.fullmatch(target))
-
-
 def parse_machine_block(body: str) -> dict[str, str]:
     match = MACHINE_BLOCK_RE.search(body)
     if not match:
@@ -81,21 +61,20 @@ def parse_machine_block(body: str) -> dict[str, str]:
     values: dict[str, str] = {}
     for raw_line in match.group(1).splitlines():
         line = raw_line.strip()
-        if not line or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        values[key.strip()] = value.strip()
+        if line and "=" in line:
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip()
     missing = sorted(CANONICAL_RECOVERY_REQUIRED - values.keys())
     if missing:
         raise ValueError("CANONICAL_RECOVERY_FIELDS_MISSING:" + ",".join(missing))
     return values
 
 
-def _parse_none(raw: str) -> str | None:
+def _none(raw: str) -> str | None:
     return None if raw == "NONE" else raw
 
 
-def _parse_bool(raw: str, field: str) -> bool:
+def _bool(raw: str, field: str) -> bool:
     if raw == "true":
         return True
     if raw == "false":
@@ -105,11 +84,10 @@ def _parse_bool(raw: str, field: str) -> bool:
 
 def apply_canonical_recovery(state: dict[str, Any], body: str) -> dict[str, Any]:
     machine = parse_machine_block(body)
-    canonical_failure = machine["failure_class"]
-    if state.get("failure_class") != canonical_failure:
+    if state.get("failure_class") != machine["failure_class"]:
         raise ValueError(
-            f"CANONICAL_FAILURE_CLASS_CONTRADICTION:"
-            f"{canonical_failure}!={state.get('failure_class')}"
+            "CANONICAL_FAILURE_CLASS_CONTRADICTION:"
+            f"{machine['failure_class']}!={state.get('failure_class')}"
         )
     try:
         retry_count = int(machine["retry_count"])
@@ -123,14 +101,21 @@ def apply_canonical_recovery(state: dict[str, Any], body: str) -> dict[str, Any]
     enriched = dict(state)
     enriched["retry_count"] = retry_count
     enriched["recovery"] = {
-        "incident_signature": _parse_none(machine["recovery_incident_signature"]),
-        "incident_head_sha": _parse_none(machine["recovery_incident_head_sha"]),
-        "window_started_at": _parse_none(machine["retry_window_started_at"]),
-        "retry_target": _parse_none(machine["retry_target"]),
-        "cause_established": _parse_bool(machine["cause_established"], "cause_established"),
+        "incident_signature": _none(machine["recovery_incident_signature"]),
+        "incident_head_sha": _none(machine["recovery_incident_head_sha"]),
+        "window_started_at": _none(machine["retry_window_started_at"]),
+        "retry_target": _none(machine["retry_target"]),
+        "cause_established": _bool(machine["cause_established"], "cause_established"),
         "executor_status": machine["executor_status"],
     }
     return enriched
+
+
+def _specific_retry_target(target: str | None) -> bool:
+    return bool(
+        target
+        and (CI_JOB_TARGET_RE.fullmatch(target) or ROLE_TARGET_RE.fullmatch(target))
+    )
 
 
 def validate_recovery_state(state: dict[str, Any]) -> list[str]:
@@ -141,43 +126,43 @@ def validate_recovery_state(state: dict[str, Any]) -> list[str]:
 
     if failure_class not in VALID_FAILURE_CLASSES:
         problems.append("INVALID_FAILURE_CLASS")
-
     if not isinstance(retry_count, int) or isinstance(retry_count, bool) or retry_count < 0:
         problems.append("INVALID_RETRY_COUNT")
-
     if not isinstance(recovery, dict):
         problems.append("INVALID_RECOVERY_STATE")
         return problems
 
     required = {
-        "incident_signature",
-        "incident_head_sha",
-        "window_started_at",
-        "retry_target",
-        "cause_established",
-        "executor_status",
+        "incident_signature", "incident_head_sha", "window_started_at",
+        "retry_target", "cause_established", "executor_status",
     }
     missing = sorted(required - recovery.keys())
     if missing:
         problems.append("MISSING_RECOVERY_FIELDS:" + ",".join(missing))
         return problems
 
-    if not isinstance(recovery.get("cause_established"), bool):
+    cause_established = recovery.get("cause_established")
+    executor_status = recovery.get("executor_status")
+    if not isinstance(cause_established, bool):
         problems.append("INVALID_CAUSE_ESTABLISHED")
-
-    if recovery.get("executor_status") not in VALID_EXECUTOR_STATUS:
+    elif cause_established and failure_class != "PRODUCT":
+        problems.append("CAUSE_ESTABLISHED_ONLY_VALID_FOR_PRODUCT")
+    if executor_status not in VALID_EXECUTOR_STATUS:
         problems.append("INVALID_EXECUTOR_STATUS")
+    elif executor_status == "UNAVAILABLE" and failure_class != "PLATFORM":
+        problems.append("EXECUTOR_UNAVAILABLE_REQUIRES_PLATFORM")
 
     if failure_class == "NONE":
         if retry_count != 0:
             problems.append("RETRY_COUNT_WITHOUT_FAILURE")
         if any(
             recovery.get(key) is not None
-            for key in ("incident_signature", "incident_head_sha", "window_started_at", "retry_target")
+            for key in (
+                "incident_signature", "incident_head_sha",
+                "window_started_at", "retry_target",
+            )
         ):
             problems.append("RECOVERY_METADATA_WITHOUT_FAILURE")
-        if recovery.get("cause_established") is not False:
-            problems.append("CAUSE_ESTABLISHED_WITHOUT_FAILURE")
         return problems
 
     signature = recovery.get("incident_signature")
@@ -191,8 +176,15 @@ def validate_recovery_state(state: dict[str, Any]) -> list[str]:
 
     if failure_class in RETRYABLE_FAILURE_CLASSES:
         target = recovery.get("retry_target")
-        if not _is_specific_retry_target(target):
+        if not _specific_retry_target(target):
             problems.append("BLIND_OR_INVALID_RETRY_TARGET")
+        elif ROLE_TARGET_RE.fullmatch(target):
+            target_role = target.split(":", 1)[1]
+            expected_role = state.get("expected_role")
+            if expected_role not in VALID_ROLES:
+                problems.append("INVALID_RETRY_EXPECTED_ROLE")
+            elif target_role != expected_role:
+                problems.append("ROLE_RETRY_TARGET_MISMATCH")
         started_at = recovery.get("window_started_at")
         if not isinstance(started_at, str) or not started_at:
             problems.append("MISSING_RETRY_WINDOW_START")
@@ -201,8 +193,11 @@ def validate_recovery_state(state: dict[str, Any]) -> list[str]:
                 parse_utc(started_at)
             except ValueError as exc:
                 problems.append(str(exc))
-    elif recovery.get("retry_target") is not None:
-        problems.append("RETRY_TARGET_ON_NON_RETRYABLE_FAILURE")
+    else:
+        if recovery.get("retry_target") is not None:
+            problems.append("RETRY_TARGET_ON_NON_RETRYABLE_FAILURE")
+        if recovery.get("window_started_at") is not None:
+            problems.append("RETRY_WINDOW_ON_NON_RETRYABLE_FAILURE")
 
     return problems
 
@@ -217,94 +212,46 @@ def evaluate_recovery(state: dict[str, Any], now: str) -> RecoveryDecision:
     recovery = state["recovery"]
 
     if failure_class == "NONE":
-        return RecoveryDecision(
-            action="NO_ACTION",
-            next_role=None,
-            retry_allowed=False,
-            blocker_reason=None,
-            blocks_independent_wip=False,
-        )
+        return RecoveryDecision("NO_ACTION", None, False, None, False)
 
     if failure_class in RETRYABLE_FAILURE_CLASSES:
-        now_dt = parse_utc(now)
-        started_at = parse_utc(recovery["window_started_at"])
-        age = (now_dt - started_at).total_seconds()
+        age = (parse_utc(now) - parse_utc(recovery["window_started_at"])).total_seconds()
         if age < 0:
             raise ValueError("RETRY_WINDOW_STARTS_IN_FUTURE")
         if age > RETRY_WINDOW_SECONDS:
             return RecoveryDecision(
-                action="BLOCK_RETRY_WINDOW_EXPIRED",
-                next_role="Lab",
-                retry_allowed=False,
-                blocker_reason="RETRY_WINDOW_EXPIRED",
-                blocks_independent_wip=True,
+                "BLOCK_RETRY_WINDOW_EXPIRED", "Lab", False,
+                "RETRY_WINDOW_EXPIRED", True,
             )
         if retry_count >= MAX_RETRIES:
             return RecoveryDecision(
-                action="BLOCK_RETRY_BUDGET_EXHAUSTED",
-                next_role="Lab",
-                retry_allowed=False,
-                blocker_reason="RETRY_BUDGET_EXHAUSTED",
-                blocks_independent_wip=True,
+                "BLOCK_RETRY_BUDGET_EXHAUSTED", "Lab", False,
+                "RETRY_BUDGET_EXHAUSTED", True,
             )
         return RecoveryDecision(
-            action="RETRY_CAUSAL_TARGET",
-            next_role=state.get("expected_role"),
-            retry_allowed=True,
-            blocker_reason=None,
-            blocks_independent_wip=False,
-            retry_target=recovery["retry_target"],
+            "RETRY_CAUSAL_TARGET", state.get("expected_role"), True,
+            None, False, recovery["retry_target"],
         )
 
     if failure_class == "PRODUCT":
         if recovery["cause_established"]:
-            return RecoveryDecision(
-                action="ROUTE_ENGINEERING",
-                next_role="Engineering",
-                retry_allowed=False,
-                blocker_reason=None,
-                blocks_independent_wip=False,
-            )
+            return RecoveryDecision("ROUTE_ENGINEERING", "Engineering", False, None, False)
         return RecoveryDecision(
-            action="ROUTE_LAB",
-            next_role="Lab",
-            retry_allowed=False,
-            blocker_reason="PRODUCT_CAUSE_UNCERTAIN",
-            blocks_independent_wip=False,
+            "ROUTE_LAB", "Lab", False, "PRODUCT_CAUSE_UNCERTAIN", False
         )
-
     if failure_class == "HUMAN_GATE":
-        return RecoveryDecision(
-            action="WAIT_HUMAN_GATE",
-            next_role=None,
-            retry_allowed=False,
-            blocker_reason=None,
-            blocks_independent_wip=False,
-        )
-
+        return RecoveryDecision("WAIT_HUMAN_GATE", None, False, None, False)
     if failure_class == "AUTHORITY":
         return RecoveryDecision(
-            action="BLOCK_AUTHORITY",
-            next_role="Lead",
-            retry_allowed=False,
-            blocker_reason="AUTHORITY_REQUIRED",
-            blocks_independent_wip=True,
+            "BLOCK_AUTHORITY", "Lead", False, "AUTHORITY_REQUIRED", True
         )
-
     if failure_class == "PLATFORM":
         blocker = (
             "PLATFORM_EXECUTOR_UNAVAILABLE"
             if recovery["executor_status"] == "UNAVAILABLE"
             else "PLATFORM_UNAVAILABLE"
         )
-        return RecoveryDecision(
-            action="BLOCK_PLATFORM",
-            next_role="Lead",
-            retry_allowed=False,
-            blocker_reason=blocker,
-            blocks_independent_wip=True,
-        )
-
+        return RecoveryDecision("BLOCK_PLATFORM", "Lead", False, blocker, True)
     raise AssertionError(f"unhandled failure class: {failure_class}")
 
 
@@ -317,9 +264,10 @@ def main() -> int:
     parser.add_argument("--now", required=True)
     args = parser.parse_args()
 
-    state = load_json(args.state)
-    body = Path(args.canonical_body).read_text(encoding="utf-8")
-    state = apply_canonical_recovery(state, body)
+    state = apply_canonical_recovery(
+        load_json(args.state),
+        Path(args.canonical_body).read_text(encoding="utf-8"),
+    )
     decision = evaluate_recovery(state, args.now)
     print(
         "GOVERNANCE_RECOVERY_OK "

--- a/tools/governance/test_recovery_contract.py
+++ b/tools/governance/test_recovery_contract.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+import copy
+import json
+import unittest
+
+from recovery_contract import (
+    apply_canonical_recovery,
+    evaluate_recovery,
+    validate_recovery_state,
+)
+
+
+def base_state():
+    return {
+        "schema_version": 1,
+        "current_wip": "#84-G3",
+        "stage": "CI_RUNNING",
+        "issue": "#84",
+        "pull_request": "#93",
+        "pr_status": "draft",
+        "head_sha": "head",
+        "expected_role": "Engineering",
+        "required_checks": ["governance-recovery-contract"],
+        "engineering_handoff": {"status": "NONE", "head_sha": None},
+        "verification_verdict": {"status": "PENDING", "head_sha": None},
+        "ci_state": {"status": "PENDING", "summary": "PENDING"},
+        "human_gate": {"status": "NONE", "issue": None},
+        "parallel_human_gates": [],
+        "blocked_reason": None,
+        "failure_class": "NONE",
+        "retry_count": 0,
+        "last_progress_at": "2026-08-27T16:30:00Z",
+        "authority": {"state": "GRANTED", "scope": "#84-G3_ONLY"},
+        "contradictions": [],
+        "recovery": {
+            "incident_signature": None,
+            "incident_head_sha": None,
+            "window_started_at": None,
+            "retry_target": None,
+            "cause_established": False,
+            "executor_status": "AVAILABLE",
+        },
+    }
+
+
+def incident_state(failure_class="TRANSIENT", retry_count=0, **recovery_overrides):
+    state = base_state()
+    state["failure_class"] = failure_class
+    state["retry_count"] = retry_count
+    recovery = {
+        "incident_signature": "sig:example",
+        "incident_head_sha": state["head_sha"],
+        "window_started_at": "2026-08-27T12:00:00Z",
+        "retry_target": "CI_JOB:33087069466:98569506439",
+        "cause_established": False,
+        "executor_status": "AVAILABLE",
+    }
+    recovery.update(recovery_overrides)
+    state["recovery"] = recovery
+    return state
+
+
+def canonical_body(**overrides):
+    values = {
+        "current_wip": "#84-G3",
+        "wip_kind": "GOVERNANCE",
+        "stage": "CI_RUNNING",
+        "failure_class": "NONE",
+        "retry_count": "0",
+        "expected_role": "Engineering",
+        "human_gate": "false",
+        "active_issue": "#84",
+        "active_pr": "#93",
+        "pr_status": "DRAFT",
+        "active_head_sha": "head",
+        "base_branch": "webots-ci",
+        "base_sha": "base",
+        "authority": "EXPLICIT_USER",
+        "authority_scope": "#84-G3_ONLY",
+        "authority_state": "GRANTED",
+        "focused_run": "PENDING",
+        "focused_run_result": "PENDING",
+        "exact_head_ci": "PENDING",
+        "engineering_handoff": "NONE",
+        "verification_verdict": "PENDING",
+        "blocked_reason": "NONE",
+        "recovery_incident_signature": "NONE",
+        "recovery_incident_head_sha": "NONE",
+        "retry_window_started_at": "NONE",
+        "retry_target": "NONE",
+        "cause_established": "false",
+        "executor_status": "AVAILABLE",
+    }
+    values.update(overrides)
+    lines = "\n".join(f"{key}={value}" for key, value in values.items())
+    return f"""# State
+
+## État machine canonique
+
+```text
+{lines}
+```
+"""
+
+
+class RecoveryContractTests(unittest.TestCase):
+    NOW = "2026-08-27T16:00:00Z"
+
+    def test_no_failure_is_no_action_and_clean_recovery_state(self):
+        state = base_state()
+        self.assertEqual(validate_recovery_state(state), [])
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "NO_ACTION")
+        self.assertFalse(decision.retry_allowed)
+        self.assertFalse(decision.blocks_independent_wip)
+
+    def test_unknown_failure_class_fails_closed(self):
+        state = base_state()
+        state["failure_class"] = "MAYBE"
+        with self.assertRaisesRegex(ValueError, "INVALID_FAILURE_CLASS"):
+            evaluate_recovery(state, self.NOW)
+
+    def test_retry_count_must_be_non_negative_integer(self):
+        for value in (-1, True, "1"):
+            state = base_state()
+            state["retry_count"] = value
+            with self.subTest(value=value), self.assertRaisesRegex(ValueError, "INVALID_RETRY_COUNT"):
+                evaluate_recovery(state, self.NOW)
+
+    def test_transient_retries_only_specific_causal_target_within_budget(self):
+        for retry_count in (0, 1):
+            state = incident_state("TRANSIENT", retry_count=retry_count)
+            decision = evaluate_recovery(state, self.NOW)
+            self.assertEqual(decision.action, "RETRY_CAUSAL_TARGET")
+            self.assertTrue(decision.retry_allowed)
+            self.assertEqual(decision.retry_target, "CI_JOB:33087069466:98569506439")
+
+    def test_harness_oracle_can_retry_exact_role_target_within_budget(self):
+        state = incident_state(
+            "HARNESS_ORACLE",
+            retry_count=1,
+            retry_target="ROLE:Engineering",
+        )
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "RETRY_CAUSAL_TARGET")
+        self.assertEqual(decision.retry_target, "ROLE:Engineering")
+
+    def test_blind_ci_retry_target_is_forbidden(self):
+        for target in ("CI_ALL", "CI_JOB", "workflow:all", "", None):
+            state = incident_state("TRANSIENT", retry_target=target)
+            with self.subTest(target=target), self.assertRaisesRegex(
+                ValueError, "BLIND_OR_INVALID_RETRY_TARGET"
+            ):
+                evaluate_recovery(state, self.NOW)
+
+    def test_retry_budget_exhaustion_routes_to_lab_with_explicit_blocker(self):
+        state = incident_state("TRANSIENT", retry_count=2)
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "BLOCK_RETRY_BUDGET_EXHAUSTED")
+        self.assertEqual(decision.next_role, "Lab")
+        self.assertEqual(decision.blocker_reason, "RETRY_BUDGET_EXHAUSTED")
+        self.assertFalse(decision.retry_allowed)
+
+    def test_retry_window_expiry_routes_to_lab_instead_of_resetting_silently(self):
+        state = incident_state(
+            "HARNESS_ORACLE",
+            retry_count=1,
+            window_started_at="2026-08-27T08:00:00Z",
+        )
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "BLOCK_RETRY_WINDOW_EXPIRED")
+        self.assertEqual(decision.next_role, "Lab")
+        self.assertEqual(decision.blocker_reason, "RETRY_WINDOW_EXPIRED")
+
+    def test_stale_incident_head_cannot_be_retried(self):
+        state = incident_state("TRANSIENT", incident_head_sha="old-head")
+        with self.assertRaisesRegex(ValueError, "STALE_RECOVERY_INCIDENT_HEAD"):
+            evaluate_recovery(state, self.NOW)
+
+    def test_product_routes_engineering_only_when_cause_is_established(self):
+        established = incident_state(
+            "PRODUCT",
+            retry_target=None,
+            window_started_at=None,
+            cause_established=True,
+        )
+        uncertain = copy.deepcopy(established)
+        uncertain["recovery"]["cause_established"] = False
+
+        self.assertEqual(evaluate_recovery(established, self.NOW).action, "ROUTE_ENGINEERING")
+        decision = evaluate_recovery(uncertain, self.NOW)
+        self.assertEqual(decision.action, "ROUTE_LAB")
+        self.assertEqual(decision.next_role, "Lab")
+        self.assertEqual(decision.blocker_reason, "PRODUCT_CAUSE_UNCERTAIN")
+
+    def test_human_gate_waits_without_blocking_independent_wip_or_retrying(self):
+        state = incident_state(
+            "HUMAN_GATE",
+            retry_target=None,
+            window_started_at=None,
+        )
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "WAIT_HUMAN_GATE")
+        self.assertIsNone(decision.next_role)
+        self.assertFalse(decision.retry_allowed)
+        self.assertFalse(decision.blocks_independent_wip)
+
+    def test_authority_fails_closed_without_automatic_retry(self):
+        state = incident_state(
+            "AUTHORITY",
+            retry_target=None,
+            window_started_at=None,
+        )
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "BLOCK_AUTHORITY")
+        self.assertEqual(decision.next_role, "Lead")
+        self.assertEqual(decision.blocker_reason, "AUTHORITY_REQUIRED")
+        self.assertFalse(decision.retry_allowed)
+
+    def test_platform_executor_unavailable_models_agent_capacity_failure(self):
+        state = incident_state(
+            "PLATFORM",
+            retry_target=None,
+            window_started_at=None,
+            executor_status="UNAVAILABLE",
+        )
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "BLOCK_PLATFORM")
+        self.assertEqual(decision.next_role, "Lead")
+        self.assertEqual(decision.blocker_reason, "PLATFORM_EXECUTOR_UNAVAILABLE")
+        self.assertFalse(decision.retry_allowed)
+
+    def test_non_retryable_classes_cannot_smuggle_retry_target(self):
+        for failure_class in ("PRODUCT", "HUMAN_GATE", "AUTHORITY", "PLATFORM"):
+            state = incident_state(
+                failure_class,
+                retry_target="CI_JOB:1:2",
+                window_started_at=None,
+            )
+            with self.subTest(failure_class=failure_class), self.assertRaisesRegex(
+                ValueError, "RETRY_TARGET_ON_NON_RETRYABLE_FAILURE"
+            ):
+                evaluate_recovery(state, self.NOW)
+
+    def test_no_failure_cannot_keep_stale_retry_metadata(self):
+        state = base_state()
+        state["retry_count"] = 1
+        state["recovery"]["incident_signature"] = "sig:stale"
+        problems = validate_recovery_state(state)
+        self.assertIn("RETRY_COUNT_WITHOUT_FAILURE", problems)
+        self.assertIn("RECOVERY_METADATA_WITHOUT_FAILURE", problems)
+
+    def test_live_canonical_recovery_fields_are_machine_readable(self):
+        state = apply_canonical_recovery(base_state(), canonical_body())
+        self.assertEqual(state["retry_count"], 0)
+        self.assertEqual(
+            state["recovery"],
+            {
+                "incident_signature": None,
+                "incident_head_sha": None,
+                "window_started_at": None,
+                "retry_target": None,
+                "cause_established": False,
+                "executor_status": "AVAILABLE",
+            },
+        )
+        self.assertEqual(evaluate_recovery(state, self.NOW).action, "NO_ACTION")
+
+    def test_live_platform_incident_is_not_silently_retried(self):
+        raw_state = base_state()
+        raw_state["failure_class"] = "PLATFORM"
+        state = apply_canonical_recovery(
+            raw_state,
+            canonical_body(
+                failure_class="PLATFORM",
+                recovery_incident_signature="agent-capacity-exhausted",
+                recovery_incident_head_sha="head",
+                executor_status="UNAVAILABLE",
+            ),
+        )
+        decision = evaluate_recovery(state, self.NOW)
+        self.assertEqual(decision.action, "BLOCK_PLATFORM")
+        self.assertEqual(decision.blocker_reason, "PLATFORM_EXECUTOR_UNAVAILABLE")
+        self.assertFalse(decision.retry_allowed)
+
+    def test_live_canonical_recovery_fields_are_required(self):
+        body = canonical_body().replace("retry_target=NONE\n", "")
+        with self.assertRaisesRegex(ValueError, "CANONICAL_RECOVERY_FIELDS_MISSING:retry_target"):
+            apply_canonical_recovery(base_state(), body)
+
+    def test_live_failure_class_mismatch_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "CANONICAL_FAILURE_CLASS_CONTRADICTION"):
+            apply_canonical_recovery(
+                base_state(),
+                canonical_body(failure_class="PLATFORM"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/governance/test_recovery_hardening.py
+++ b/tools/governance/test_recovery_hardening.py
@@ -34,6 +34,19 @@ class RecoveryHardeningTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "RETRY_WINDOW_ON_NON_RETRYABLE_FAILURE"):
             evaluate_recovery(state, self.NOW)
 
+    def test_non_retryable_failure_cannot_keep_retry_count(self):
+        for failure_class in ("PRODUCT", "HUMAN_GATE", "AUTHORITY", "PLATFORM"):
+            state = incident_state(
+                failure_class,
+                retry_count=1,
+                retry_target=None,
+                window_started_at=None,
+            )
+            with self.subTest(failure_class=failure_class), self.assertRaisesRegex(
+                ValueError, "RETRY_COUNT_ON_NON_RETRYABLE_FAILURE"
+            ):
+                evaluate_recovery(state, self.NOW)
+
     def test_role_retry_target_must_match_expected_role(self):
         state = incident_state("HARNESS_ORACLE", retry_target="ROLE:Verification")
         state["expected_role"] = "Engineering"

--- a/tools/governance/test_recovery_hardening.py
+++ b/tools/governance/test_recovery_hardening.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import unittest
+
+from recovery_contract import evaluate_recovery
+from test_recovery_contract import base_state, incident_state
+
+
+class RecoveryHardeningTests(unittest.TestCase):
+    NOW = "2026-08-27T16:00:00Z"
+
+    def test_executor_unavailable_requires_platform_classification(self):
+        state = incident_state("TRANSIENT")
+        state["recovery"]["executor_status"] = "UNAVAILABLE"
+        with self.assertRaisesRegex(ValueError, "EXECUTOR_UNAVAILABLE_REQUIRES_PLATFORM"):
+            evaluate_recovery(state, self.NOW)
+
+        healthy = base_state()
+        healthy["recovery"]["executor_status"] = "UNAVAILABLE"
+        with self.assertRaisesRegex(ValueError, "EXECUTOR_UNAVAILABLE_REQUIRES_PLATFORM"):
+            evaluate_recovery(healthy, self.NOW)
+
+    def test_cause_established_cannot_be_stale_outside_product(self):
+        state = incident_state("HARNESS_ORACLE")
+        state["recovery"]["cause_established"] = True
+        with self.assertRaisesRegex(ValueError, "CAUSE_ESTABLISHED_ONLY_VALID_FOR_PRODUCT"):
+            evaluate_recovery(state, self.NOW)
+
+    def test_non_retryable_failure_cannot_keep_retry_window(self):
+        state = incident_state(
+            "AUTHORITY",
+            retry_target=None,
+            window_started_at="2026-08-27T12:00:00Z",
+        )
+        with self.assertRaisesRegex(ValueError, "RETRY_WINDOW_ON_NON_RETRYABLE_FAILURE"):
+            evaluate_recovery(state, self.NOW)
+
+    def test_role_retry_target_must_match_expected_role(self):
+        state = incident_state("HARNESS_ORACLE", retry_target="ROLE:Verification")
+        state["expected_role"] = "Engineering"
+        with self.assertRaisesRegex(ValueError, "ROLE_RETRY_TARGET_MISMATCH"):
+            evaluate_recovery(state, self.NOW)
+
+    def test_role_retry_requires_valid_expected_role(self):
+        state = incident_state("HARNESS_ORACLE", retry_target="ROLE:Engineering")
+        state["expected_role"] = "Unknown"
+        with self.assertRaisesRegex(ValueError, "INVALID_RETRY_EXPECTED_ROLE"):
+            evaluate_recovery(state, self.NOW)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Objective

Implements only **#84-G3** from `webots-ci@ed28249f7e2a86d3ffff84ddc0912d8459b1b86a`.

## Scope

Adds a deterministic, read-only bounded recovery decision layer above the integrated G1/G2 governance contracts.

### Recovery rules
- machine failure classes: `TRANSIENT`, `HARNESS_ORACLE`, `PRODUCT`, `HUMAN_GATE`, `AUTHORITY`, `PLATFORM`;
- agent/executor capacity exhaustion is represented as `PLATFORM`, never as a silent retry;
- at most two retries in six hours for a declared same-head `TRANSIENT`/`HARNESS_ORACLE` incident;
- retries require a specific causal target (`CI_JOB:<run_id>:<job_id>` or `ROLE:<role>`); blind all-CI retries fail closed;
- `ROLE:*` must match the valid expected role;
- exhausted/expired retry budget becomes an explicit blocker and routes to Lab;
- `PRODUCT` routes Engineering only when cause is established, otherwise Lab;
- `HUMAN_GATE` waits without blocking an independent authorized WIP;
- `AUTHORITY`/`PLATFORM` fail closed and route Lead without automatic retry;
- `executor_status=UNAVAILABLE` requires `PLATFORM`; stale retry/cause metadata fails closed;
- non-retryable classes (`PRODUCT`, `HUMAN_GATE`, `AUTHORITY`, `PLATFORM`) require `retry_count=0`.

## Exact-head evidence

Final head: `54afa497ae8bd602b7bbc43995857fc2b13554e8`.

- 26/26 pull-request workflows SUCCESS;
- G1 run `33096700736` SUCCESS;
- G2 run `33096700489` SUCCESS after a targeted same-head rerun caused only by a canonical #22/head race;
- G3 run `33096700814` SUCCESS;
- Webots smoke `33096700637` SUCCESS;
- parametric obstacle run `33096700698` SUCCESS after a targeted same-head rerun caused by external `raw.githubusercontent.com` EXTERNPROTO connection failures;
- G3 gate executes **65 G1+G2+G3 tests**;
- live path validates #22 -> G1 -> G2 -> G3 on this exact head and returns `NO_ACTION` for the clean current state.

## Verification correction

Independent Verification rejected previous head `9053bd5ac19a3c141869df2f0af2d5bae13087f2` because stale `retry_count>0` was still accepted on non-retryable failure classes. This head closes only that defect with `RETRY_COUNT_ON_NON_RETRYABLE_FAILURE` and causal counter-tests across all four non-retryable classes.

## Explicit boundary

G3 validates the current declared recovery state and returns a deterministic decision. It does **not** yet create incident history, observe provider quota/capacity by itself, or execute retries/transitions. That observation/execution wiring belongs to G4 and is intentionally absent here.

## Non-goals

No G4 event-driven execution, no automatic mutation/retry engine, no product code, no new merge authority, no secrets/permissions/rulesets/protections, and no `main` change.

Draft until independent Verification on the exact final head.