### PR TITLE
Lab: diagnose intermittent Zelos repeat tooltip hover

### DIFF
--- a/experiments/runtime-v2-student-ui/diagnostic_probe.py
+++ b/experiments/runtime-v2-student-ui/diagnostic_probe.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Bounded Lab instrumentation for the intermittent Blockly repeat tooltip gate.
+
+This wrapper does not change product code or the gate oracle. It records DOM state
+around the existing CDP hover, then delegates to the unchanged probe.main().
+"""
+import json
+import os
+from pathlib import Path
+
+import probe
+
+_ORIGINAL_HOVER = probe.Cdp.hover
+
+
+def _snapshot(c, rect, phase):
+    expr = """(() => {
+      const r = %s;
+      const x = r.x + r.width / 2, y = r.y + r.height / 2;
+      const el = document.elementFromPoint(x, y);
+      const tips = [...document.querySelectorAll('.blocklyTooltipDiv')].map(node => {
+        const b = node.getBoundingClientRect();
+        const s = getComputedStyle(node);
+        return {
+          className: node.className || '',
+          text: (node.innerText || node.textContent || '').trim(),
+          display: s.display,
+          visibility: s.visibility,
+          opacity: s.opacity,
+          width: b.width,
+          height: b.height,
+          left: b.left,
+          top: b.top,
+          html: node.outerHTML.slice(0, 1200)
+        };
+      });
+      return {
+        phase: %s,
+        point: {x, y},
+        elementAtPoint: el ? {
+          tag: el.tagName,
+          className: el.className && (el.className.baseVal || el.className) || '',
+          text: (el.textContent || '').trim().slice(0, 200),
+          outerHTML: el.outerHTML ? el.outerHTML.slice(0, 1200) : ''
+        } : null,
+        tooltipDivs: tips,
+        activeElement: document.activeElement ? {
+          tag: document.activeElement.tagName,
+          className: document.activeElement.className || '',
+          text: (document.activeElement.textContent || '').trim().slice(0, 200)
+        } : null
+      };
+    })()""" % (json.dumps(rect), json.dumps(phase))
+    return c.eval(expr)
+
+
+def diagnostic_hover(self, rect):
+    out = Path(os.environ.get('WEBEEBLOCKS_CI_ARTIFACT_DIR', '.')) / 'tooltip-hover-diagnostic.json'
+    observations = []
+    try:
+        observations.append(_snapshot(self, rect, 'before_hover'))
+        _ORIGINAL_HOVER(self, rect)
+        observations.append(_snapshot(self, rect, 'immediately_after_hover'))
+    finally:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(observations, ensure_ascii=False, indent=2), encoding='utf-8')
+
+
+probe.Cdp.hover = diagnostic_hover
+
+if __name__ == '__main__':
+    probe.main()

--- a/experiments/runtime-v2-student-ui/run.sh
+++ b/experiments/runtime-v2-student-ui/run.sh
@@ -15,4 +15,15 @@ export WEBEEBLOCKS_CI_ARTIFACT_DIR="$OUT"
 xvfb-run -a webots --stdout --stderr --batch --mode=realtime "$ROOT/worlds/crazyflie_runtime_v2.wbt" > "$OUT/webots.log" 2>&1 &
 wpid=$!
 trap 'kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true' EXIT
+set +e
 python3 "$ROOT/experiments/runtime-v2-student-ui/diagnostic_probe.py" --fixture "$FIXTURE" --expected-ast "$EXPECTED_AST" --output "$OUT/metrics.json" --screenshot "$OUT/workspace-1366x768.png"
+probe_status=$?
+set -e
+if [[ -s "$OUT/tooltip-hover-diagnostic.json" ]]; then
+  echo 'WEBEEBLOCKS_TOOLTIP_DIAGNOSTIC_BEGIN'
+  cat "$OUT/tooltip-hover-diagnostic.json"
+  echo 'WEBEEBLOCKS_TOOLTIP_DIAGNOSTIC_END'
+else
+  echo 'WEBEEBLOCKS_TOOLTIP_DIAGNOSTIC_MISSING'
+fi
+exit "$probe_status"

--- a/experiments/runtime-v2-student-ui/run.sh
+++ b/experiments/runtime-v2-student-ui/run.sh
@@ -15,4 +15,4 @@ export WEBEEBLOCKS_CI_ARTIFACT_DIR="$OUT"
 xvfb-run -a webots --stdout --stderr --batch --mode=realtime "$ROOT/worlds/crazyflie_runtime_v2.wbt" > "$OUT/webots.log" 2>&1 &
 wpid=$!
 trap 'kill "$wpid" 2>/dev/null || true; wait "$wpid" 2>/dev/null || true' EXIT
-python3 "$ROOT/experiments/runtime-v2-student-ui/probe.py" --fixture "$FIXTURE" --expected-ast "$EXPECTED_AST" --output "$OUT/metrics.json" --screenshot "$OUT/workspace-1366x768.png"
+python3 "$ROOT/experiments/runtime-v2-student-ui/diagnostic_probe.py" --fixture "$FIXTURE" --expected-ast "$EXPECTED_AST" --output "$OUT/metrics.json" --screenshot "$OUT/workspace-1366x768.png"


### PR DESCRIPTION
## Purpose

Temporary Lab-only measurement for #84 / PR #95. Base is the active G4-H0 branch, not `webots-ci` or `main`.

## Scope

- preserve the existing `probe.py` oracle unchanged;
- wrap the existing CDP hover to record the DOM element under the target point and every `.blocklyTooltipDiv` immediately before/after hover;
- emit `tooltip-hover-diagnostic.json` into the existing uploaded artifact directory;
- run the existing probe through the diagnostic wrapper.

## Non-goals

No product change, no gate weakening/requalification, no timing tuning, no `webots-ci` integration, no `main` action. This PR is an expendable measurement instrument and must be closed after evidence is collected.

Derived exactly from PR #95 head `1df87a3fd2a28d9c5ff82c56dd1f0d30ee1c7f41`.