### PR TITLE
Add Runtime v2 simulation reset and replay

### DIFF
--- a/.github/workflows/runtime-v2-observability.yml
+++ b/.github/workflows/runtime-v2-observability.yml
@@ -116,7 +116,7 @@ jobs:
           assert not errors, errors[:1]
           names = [e.get('event') for e in events]
           for required in (
-              'TECHNICAL_FAILURE_OK','STEP_TAKEOFF_HELD','STEP_REPEAT_HELD','STEP_RANGE_HELD',
+              'TECHNICAL_FAILURE_OK','TECHNICAL_FAILURE_RESET_OK','STEP_TAKEOFF_HELD','STEP_REPEAT_HELD','STEP_RANGE_HELD',
               'STEP_NUMBER_HELD_AFTER_SENSOR','STEP_COMPARE_HELD','STEP_IF_HELD','SEMANTIC_DECISION_CHAIN_OK',
               'STEP_CONTINUE_DONE','STEP_SCENARIO_DONE'):
               assert required in names, (required, names)
@@ -148,9 +148,10 @@ jobs:
           chain = next(e['detail'] for e in events if e.get('event') == 'SEMANTIC_DECISION_CHAIN_OK')
           assert [p['kind'] for p in chain['pauses']] == ['range','number','compare','if','move'], chain
           assert 'decision' not in chain['pauses'][3], chain
-          assert all(int(p['txCount']) <= 2 for p in [e['detail'] for e in events if e.get('event') == 'DEBUG_PAUSED'][2:7]), pauses
+          step_tx_baseline = int(pauses[0]['txCount'])
+          assert all(int(p['txCount']) - step_tx_baseline <= 2 for p in [e['detail'] for e in events if e.get('event') == 'DEBUG_PAUSED'][2:7]), pauses
           move_pause = pauses[6]
-          assert int(move_pause['txCount']) <= 2, move_pause
+          assert int(move_pause['txCount']) - step_tx_baseline <= 2, move_pause
           trace=[]
           for line in log.splitlines():
               if ' TRACE TAKEOFF ' in line: trace.append('TAKEOFF')

--- a/.github/workflows/runtime-v2-reset-replay.yml
+++ b/.github/workflows/runtime-v2-reset-replay.yml
@@ -1,0 +1,159 @@
+name: Runtime v2 reset and replay
+
+on:
+  pull_request:
+    branches: [webots-ci]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'controllers/crazyflie_runtime_v2/**'
+      - 'worlds/crazyflie_runtime_v2.wbt'
+      - 'plugins/robot_windows/blockly/webeeblocks/wwi_backend.js'
+      - 'plugins/robot_windows/blockly_v2/**'
+      - 'tools/ci/test_runtime_v2_reset.js'
+      - 'tools/ci/prepare_runtime_v2_reset.py'
+      - '.github/workflows/runtime-v2-reset-replay.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  reset-contract-fast:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Validate reset protocol and product sources
+        run: |
+          set -euo pipefail
+          node --check plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
+          node --check plugins/robot_windows/blockly_v2/main.js
+          node --check tools/ci/test_runtime_v2_reset.js
+          python3 -m py_compile tools/ci/prepare_runtime_v2_reset.py
+          node tools/ci/test_runtime_v2_reset.js
+          grep -q 'id="resetSimulation"' plugins/robot_windows/blockly_v2/blockly_v2.html
+          grep -q 'supervisor TRUE' worlds/crazyflie_runtime_v2.wbt
+          grep -q 'REQUEST_RESET' controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+          grep -q 'wb_supervisor_node_reset_physics' controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+
+  reset-replay-webots:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    needs: reset-contract-fast
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare pinned Blockly 13.2.1 browser assets
+        run: ./tools/prepare_runtime_v2.sh
+
+      - name: Build Runtime v2 controller with official Webots R2025a
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-artifacts/runtime-v2-reset
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace/controllers/crazyflie_runtime_v2 \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc 'make clean && make' \
+            2>&1 | tee ci-artifacts/runtime-v2-reset/build.log
+
+      - name: Prepare reset/replay Robot Window harness
+        run: python3 tools/ci/prepare_runtime_v2_reset.py
+
+      - name: Run real Webots reset/replay scenario
+        shell: bash
+        run: |
+          set -o pipefail
+          set +e
+          docker run --rm \
+            -e LIBGL_ALWAYS_SOFTWARE=true \
+            -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            cyberbotics/webots:R2025a-ubuntu22.04 \
+            bash -lc '
+              set -e
+              apt-get update >/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget ca-certificates >/dev/null
+              wget -q -O /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+              DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/google-chrome.deb >/dev/null
+              chmod +x /workspace/tools/ci/webots_runtime_v2_browser.sh
+              mkdir -p /workspace/ci-artifacts/runtime-v2-reset /root/.config/Cyberbotics
+              printf "%s\n" \
+                "[RobotWindow]" \
+                "browser=/workspace/tools/ci/webots_runtime_v2_browser.sh" \
+                "newBrowserWindow=false" \
+                > /root/.config/Cyberbotics/Webots-R2025a.conf
+              python3 /workspace/tools/ci/runtime_wwi_event_server.py \
+                --output /workspace/ci-artifacts/runtime-v2-reset/browser-events.jsonl &
+              server=$!
+              trap "kill $server 2>/dev/null || true" EXIT
+              sleep 0.5
+              timeout -k 5s 150s xvfb-run -a webots --stdout --stderr --batch --mode=realtime /workspace/worlds/crazyflie_runtime_v2.wbt
+            ' \
+            2>&1 | tee ci-artifacts/runtime-v2-reset/webots.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "$code" > ci-artifacts/runtime-v2-reset/exit-code.txt
+          if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then exit "$code"; fi
+
+      - name: Validate workspace preservation, reset pose and replay
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, re
+          from pathlib import Path
+
+          events = [json.loads(line) for line in Path('ci-artifacts/runtime-v2-reset/browser-events.jsonl').read_text().splitlines() if line.strip()]
+          errors = [e for e in events if e.get('event') in ('ERROR', 'WINDOW_ERROR', 'UNHANDLED_REJECTION')]
+          assert not errors, errors[:1]
+          names = [e.get('event') for e in events]
+          assert names.count('RESET_OK') >= 3, names
+          for required in ('NORMAL_FIRST_DONE', 'NORMAL_REPLAY_DONE', 'UNSAFE_FIRST_DONE', 'UNSAFE_REPLAY_DONE'):
+              assert required in names, (required, names)
+          reset_events = [e for e in events if e.get('event') == 'RESET_EVENT']
+          assert len(reset_events) >= 3, reset_events
+          assert all(e.get('detail', {}).get('workspacePreserved') is True for e in reset_events), reset_events
+
+          reset_proofs = [e['detail'] for e in events if e.get('event') == 'RESET_OK']
+          for proof in reset_proofs:
+              snap = proof['snapshot']
+              assert snap['state'] == 'PRÊT', snap
+              assert snap['backendReady'] is True and snap['pending'] == 0, snap
+              assert snap['submitDisabled'] is False, snap
+
+          log = Path('ci-artifacts/runtime-v2-reset/webots.log').read_text(errors='replace')
+          traces = re.findall(
+              r'WEBEEBLOCKS_RUNTIME_V2 TRACE RESET x=([-0-9.]+) y=([-0-9.]+) z=([-0-9.]+) origin_x=([-0-9.]+) origin_y=([-0-9.]+) origin_z=([-0-9.]+)',
+              log)
+          assert len(traces) >= 3, traces
+          for values in traces:
+              x, y, z, ox, oy, oz = map(float, values)
+              assert abs(x - ox) < 0.03, values
+              assert abs(y - oy) < 0.03, values
+              assert abs(z - oz) < 0.05, values
+          assert log.count('ERR UNSAFE_OR_TIMEOUT') >= 2, 'unsafe fail-safe not exercised twice'
+          assert log.count('FATAL unsafe attitude or action timeout') >= 2, 'native fail-safe trace missing'
+          print('PASS: real R2025a reset preserves Blockly program, restores the Crazyflie, and supports replay after TERMINÉ and ARRÊTÉ.')
+          PY
+
+      - name: Upload reset/replay diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-v2-reset-replay-r2025a
+          path: ci-artifacts/runtime-v2-reset/
+          if-no-files-found: error

--- a/.github/workflows/runtime-v2-webots-wwi.yml
+++ b/.github/workflows/runtime-v2-webots-wwi.yml
@@ -43,10 +43,32 @@ jobs:
           python3 -m py_compile tools/ci/prepare_runtime_v2_webots.py
           grep -Fq 'vendor/blockly_compressed.js' plugins/robot_windows/blockly_v2/blockly_v2.html
           grep -Fq 'vendor/blocks_compressed.js' plugins/robot_windows/blockly_v2/blockly_v2.html
-          ! grep -Fq 'google-blockly-31ee4ea/blockly_' plugins/robot_windows/blockly_v2/blockly_v2.html
+          if grep -Fq 'google-blockly-31ee4ea/blockly_' plugins/robot_windows/blockly_v2/blockly_v2.html; then
+            echo '::error::legacy google-blockly asset reference is forbidden'
+            exit 1
+          fi
           grep -Fq 'window "blockly_v2"' worlds/crazyflie_runtime_v2.wbt
-          ! grep -Rq 'wb_supervisor_' controllers/crazyflie_runtime_v2
-          ! grep -Rq 'bridge.py' plugins/robot_windows/blockly_v2 controllers/crazyflie_runtime_v2
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          source = Path('controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c').read_text()
+          used = set(re.findall(r'\b(wb_supervisor_[A-Za-z0-9_]+)\s*\(', source))
+          allowed = {
+              'wb_supervisor_node_get_self',
+              'wb_supervisor_node_get_field',
+              'wb_supervisor_field_get_sf_vec3f',
+              'wb_supervisor_field_get_sf_rotation',
+              'wb_supervisor_field_set_sf_vec3f',
+              'wb_supervisor_field_set_sf_rotation',
+              'wb_supervisor_node_reset_physics',
+          }
+          assert used == allowed, f'unexpected Runtime v2 Supervisor API set: used={sorted(used)} allowed={sorted(allowed)}'
+          PY
+          if grep -Rq 'bridge.py' plugins/robot_windows/blockly_v2 controllers/crazyflie_runtime_v2; then
+            echo '::error::bridge.py dependency is forbidden in Runtime v2'
+            exit 1
+          fi
 
       - name: Re-prove Runtime v2 semantic core
         run: python3 tools/ci/run_runtime_v2_core_harness.py
@@ -120,8 +142,14 @@ jobs:
           grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 CI READY_DELAY_BEGIN' "$LOG"
           grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 CI READY_DELAY_END' "$LOG"
           grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 READY' "$LOG"
-          ! grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 FATAL' "$LOG"
-          ! grep -Fq 'ERROR:' "$LOG"
+          if grep -Fq 'WEBEEBLOCKS_RUNTIME_V2 FATAL' "$LOG"; then
+            echo '::error::Runtime v2 emitted FATAL'
+            exit 1
+          fi
+          if grep -Fq 'ERROR:' "$LOG"; then
+            echo '::error::Webots log contains ERROR:'
+            exit 1
+          fi
           python3 - <<'PY'
           import json, re
           from pathlib import Path

--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -28,6 +28,7 @@
 #define ALT_TOL 0.05
 #define STOP_WINDOW 0.5
 #define RESET_WINDOW 0.25
+#define RESET_TIMEOUT 5.0
 #define ACTION_TIMEOUT 25.0
 
 typedef enum {
@@ -435,6 +436,21 @@ int main(void) {
         (fabs(actual.roll) > 1.2 || fabs(actual.pitch) > 1.2 || now - action_start > ACTION_TIMEOUT)) {
       response_error(active_id, "UNSAFE_OR_TIMEOUT");
       fprintf(stderr, PREFIX " FATAL unsafe attitude or action timeout\n");
+      stop_motors(m1, m2, m3, m4);
+      airborne = 0;
+      failsafe_latched = 1;
+      command = CMD_IDLE;
+      active_id = -1;
+      stable_since = -1.0;
+      previous_time = now;
+      previous_x = x;
+      previous_y = y;
+      previous_z = z;
+      continue;
+    }
+
+    if (command == CMD_RESET && now - action_start > RESET_TIMEOUT) {
+      response_error(active_id, "RESET_TIMEOUT");
       stop_motors(m1, m2, m3, m4);
       airborne = 0;
       failsafe_latched = 1;

--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -10,6 +10,7 @@
 #include <webots/motor.h>
 #include <webots/plugins/robot_window/default.h>
 #include <webots/robot.h>
+#include <webots/supervisor.h>
 
 #include "pid_controller.h"
 
@@ -26,13 +27,15 @@
 #define VZ_TOL 0.15
 #define ALT_TOL 0.05
 #define STOP_WINDOW 0.5
+#define RESET_WINDOW 0.25
 #define ACTION_TIMEOUT 25.0
 
 typedef enum {
   CMD_IDLE,
   CMD_TAKEOFF,
   CMD_MOVE,
-  CMD_LAND
+  CMD_LAND,
+  CMD_RESET
 } command_t;
 
 typedef enum {
@@ -40,7 +43,8 @@ typedef enum {
   REQUEST_TAKEOFF,
   REQUEST_MOVE,
   REQUEST_LAND,
-  REQUEST_RANGE
+  REQUEST_RANGE,
+  REQUEST_RESET
 } request_kind_t;
 
 typedef struct {
@@ -156,6 +160,11 @@ static request_t parse_request(const char *message) {
     request.kind = REQUEST_LAND;
     return request;
   }
+  if (sscanf(message, PREFIX " REQUEST %d RESET %1s", &id, extra) == 1) {
+    request.id = id;
+    request.kind = REQUEST_RESET;
+    return request;
+  }
 
   request.id = extract_id(message);
   return request;
@@ -181,6 +190,12 @@ static void trace_land(void) {
   fflush(stdout);
 }
 
+static void trace_reset(double x, double y, double z, double origin_x, double origin_y, double origin_z) {
+  printf(PREFIX " TRACE RESET x=%.9f y=%.9f z=%.9f origin_x=%.9f origin_y=%.9f origin_z=%.9f\n",
+         x, y, z, origin_x, origin_y, origin_z);
+  fflush(stdout);
+}
+
 int main(void) {
   wb_robot_init();
   const int step = (int)wb_robot_get_basic_time_step();
@@ -200,6 +215,19 @@ int main(void) {
     return 1;
   }
 
+  WbNodeRef self_node = wb_supervisor_node_get_self();
+  WbFieldRef translation_field = self_node ? wb_supervisor_node_get_field(self_node, "translation") : 0;
+  WbFieldRef rotation_field = self_node ? wb_supervisor_node_get_field(self_node, "rotation") : 0;
+  if (!self_node || !translation_field || !rotation_field) {
+    fprintf(stderr, PREFIX " FATAL supervisor reset fields unavailable\n");
+    wb_robot_cleanup();
+    return 1;
+  }
+  const double *initial_translation_ref = wb_supervisor_field_get_sf_vec3f(translation_field);
+  const double *initial_rotation_ref = wb_supervisor_field_get_sf_rotation(rotation_field);
+  double initial_translation[3] = {initial_translation_ref[0], initial_translation_ref[1], initial_translation_ref[2]};
+  double initial_rotation[4] = {initial_rotation_ref[0], initial_rotation_ref[1], initial_rotation_ref[2], initial_rotation_ref[3]};
+
   wb_motor_set_position(m1, INFINITY);
   wb_motor_set_position(m2, INFINITY);
   wb_motor_set_position(m3, INFINITY);
@@ -216,11 +244,16 @@ int main(void) {
 
   const double *position = wb_gps_get_values(gps);
   const double *rpy = wb_inertial_unit_get_roll_pitch_yaw(imu);
+  const double origin_x = position[0];
+  const double origin_y = position[1];
   const double origin_z = position[2];
-  double target_x = position[0];
-  double target_y = position[1];
-  double target_z = position[2];
-  double target_yaw = rpy[2];
+  const double origin_roll = rpy[0];
+  const double origin_pitch = rpy[1];
+  const double origin_yaw = rpy[2];
+  double target_x = origin_x;
+  double target_y = origin_y;
+  double target_z = origin_z;
+  double target_yaw = origin_yaw;
 
   double previous_x = position[0];
   double previous_y = position[1];
@@ -228,6 +261,7 @@ int main(void) {
   double previous_time = wb_robot_get_time();
 
   int airborne = 0;
+  int failsafe_latched = 0;
   command_t command = CMD_IDLE;
   int active_id = -1;
   double active_value = 0.0;
@@ -297,12 +331,36 @@ int main(void) {
       request_t request = parse_request(message);
       if (request.id < 1)
         continue;
+      if (request.kind == REQUEST_INVALID) {
+        response_error(request.id, "INVALID_REQUEST");
+        continue;
+      }
       if (command != CMD_IDLE) {
         response_error(request.id, "BUSY");
         continue;
       }
-      if (request.kind == REQUEST_INVALID) {
-        response_error(request.id, "INVALID_REQUEST");
+      if (request.kind == REQUEST_RESET) {
+        stop_motors(m1, m2, m3, m4);
+        wb_supervisor_field_set_sf_vec3f(translation_field, initial_translation);
+        wb_supervisor_field_set_sf_rotation(rotation_field, initial_rotation);
+        wb_supervisor_node_reset_physics(self_node);
+        init_pid_attitude_fixed_height_controller();
+        airborne = 0;
+        failsafe_latched = 0;
+        target_x = origin_x;
+        target_y = origin_y;
+        target_z = origin_z;
+        target_yaw = origin_yaw;
+        active_id = request.id;
+        active_value = 0.0;
+        active_direction[0] = '\0';
+        command = CMD_RESET;
+        stable_since = -1.0;
+        action_start = now;
+        continue;
+      }
+      if (failsafe_latched) {
+        response_error(request.id, "RESET_REQUIRED");
         continue;
       }
       if (request.kind == REQUEST_RANGE) {
@@ -374,12 +432,48 @@ int main(void) {
       }
     }
 
-    if (command != CMD_IDLE &&
+    if (command != CMD_IDLE && command != CMD_RESET &&
         (fabs(actual.roll) > 1.2 || fabs(actual.pitch) > 1.2 || now - action_start > ACTION_TIMEOUT)) {
       response_error(active_id, "UNSAFE_OR_TIMEOUT");
       fprintf(stderr, PREFIX " FATAL unsafe attitude or action timeout\n");
       stop_motors(m1, m2, m3, m4);
-      break;
+      airborne = 0;
+      failsafe_latched = 1;
+      command = CMD_IDLE;
+      active_id = -1;
+      stable_since = -1.0;
+      previous_time = now;
+      previous_x = x;
+      previous_y = y;
+      previous_z = z;
+      continue;
+    }
+
+    if (command == CMD_RESET) {
+      stop_motors(m1, m2, m3, m4);
+      const int pose_ready = fabs(x - origin_x) < POSITION_TOL && fabs(y - origin_y) < POSITION_TOL &&
+                             fabs(z - origin_z) < ALT_TOL && fabs(rpy[0] - origin_roll) < YAW_TOL &&
+                             fabs(rpy[1] - origin_pitch) < YAW_TOL && fabs(wrap_angle(yaw - origin_yaw)) < YAW_TOL;
+      const int motion_ready = hypot(actual.vx, actual.vy) < SPEED_TOL && fabs(vz) < VZ_TOL &&
+                               fabs(actual.yaw_rate) < YAW_RATE_TOL;
+      if (pose_ready && motion_ready) {
+        if (stable_since < 0.0)
+          stable_since = now;
+        if (now - stable_since >= RESET_WINDOW) {
+          trace_reset(x, y, z, origin_x, origin_y, origin_z);
+          response_ok(active_id);
+          command = CMD_IDLE;
+          active_id = -1;
+          stable_since = -1.0;
+        }
+      } else {
+        stable_since = -1.0;
+      }
+      previous_time = now;
+      previous_x = x;
+      previous_y = y;
+      previous_z = z;
+      continue;
     }
 
     if (command == CMD_TAKEOFF) {

--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -134,6 +134,7 @@ static request_t parse_request(const char *message) {
   int id = -1;
   double value = 0.0;
   char direction[32] = {0};
+  char command[32] = {0};
   char extra[2] = {0};
 
   if (sscanf(message, PREFIX " REQUEST %d TAKEOFF %lf %1s", &id, &value, extra) == 2) {
@@ -155,14 +156,12 @@ static request_t parse_request(const char *message) {
     strncpy(request.direction, direction, sizeof(request.direction) - 1);
     return request;
   }
-  if (sscanf(message, PREFIX " REQUEST %d LAND %1s", &id, extra) == 1) {
+  if (sscanf(message, PREFIX " REQUEST %d %31s %1s", &id, command, extra) == 2) {
     request.id = id;
-    request.kind = REQUEST_LAND;
-    return request;
-  }
-  if (sscanf(message, PREFIX " REQUEST %d RESET %1s", &id, extra) == 1) {
-    request.id = id;
-    request.kind = REQUEST_RESET;
+    if (strcmp(command, "LAND") == 0)
+      request.kind = REQUEST_LAND;
+    else if (strcmp(command, "RESET") == 0)
+      request.kind = REQUEST_RESET;
     return request;
   }
 

--- a/experiments/runtime-v2-student-ui/probe.py
+++ b/experiments/runtime-v2-student-ui/probe.py
@@ -116,12 +116,14 @@ RENDER_LOCALE=r'''(() => {
  if(!logicAnd||!logicOr||!range||!repeat)throw new Error('rendered locale evidence blocks missing');
  const field=range.getField('DIRECTION');
  const fieldRoot=field.getSvgRoot();
+ const repeatRoot=repeat.getSvgRoot();
+ const repeatPath=repeatRoot&&repeatRoot.querySelector('.blocklyPath');
  return {
    logicAndText:logicAnd.toString(),logicAndSvgText:logicAnd.getSvgRoot().textContent,
    logicOrText:logicOr.toString(),logicOrSvgText:logicOr.getSvgRoot().textContent,
    logicRects:[rect(logicAnd.getSvgRoot()),rect(logicOr.getSvgRoot())],directionFieldRect:rect(fieldRoot),directionFieldText:fieldRoot.textContent,
    directionFieldRole:fieldRoot.getAttribute('role'),directionFieldAriaLabel:fieldRoot.getAttribute('aria-label'),
-   repeatRect:rect(repeat.inputList.flatMap(input=>input.fieldRow).find(field=>field.getSvgRoot&&field.getSvgRoot()).getSvgRoot()),
+   repeatRect:rect(repeatPath||repeatRoot),
    workspaceAriaLabel:document.getElementById('blocklyDiv').getAttribute('aria-label')
  };
 })()'''

--- a/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
+++ b/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
@@ -35,6 +35,8 @@
     };
     if (options && options.simulationDebug === true)
       capabilities.simulationDebug = true;
+    if (options && options.simulationReset === true)
+      capabilities.simulationReset = true;
     this.capabilities = Object.freeze(capabilities);
   }
 
@@ -71,6 +73,15 @@
         delete self.pending[id];
         reject(error);
       }
+    });
+  };
+
+  RuntimeV2WwiBackend.prototype._cancelPendingForReset = function() {
+    var pending = this.pending;
+    this.pending = Object.create(null);
+    Object.keys(pending).forEach(function(id) {
+      clearTimeout(pending[id].timer);
+      pending[id].reject(new RuntimeV2BackendError('RESET_CANCELLED'));
     });
   };
 
@@ -113,6 +124,20 @@
   RuntimeV2WwiBackend.prototype.move = function(direction, distanceM) { return this._request(['MOVE', String(direction), Number(distanceM).toPrecision(17)]); };
   RuntimeV2WwiBackend.prototype.land = function() { return this._request(['LAND']); };
   RuntimeV2WwiBackend.prototype.readRange = function(direction) { return this._request(['RANGE', String(direction)]); };
+  RuntimeV2WwiBackend.prototype.resetSimulation = function() {
+    if (!this.capabilities || this.capabilities.simulationReset !== true)
+      return Promise.reject(new Error('Runtime v2 simulation reset unavailable'));
+    this._cancelPendingForReset();
+    this.ready = false;
+    var self = this;
+    return this._request(['RESET']).then(function(value) {
+      self.ready = true;
+      return value;
+    }, function(error) {
+      self.ready = true;
+      throw error;
+    });
+  };
   RuntimeV2WwiBackend.prototype.vertical = function() { return Promise.reject(new Error('Runtime v2 Webots backend vertical capability unavailable')); };
   RuntimeV2WwiBackend.prototype.turn = function() { return Promise.reject(new Error('Runtime v2 Webots backend turn capability unavailable')); };
   RuntimeV2WwiBackend.prototype.wait = function() { return Promise.reject(new Error('Runtime v2 Webots backend wait capability unavailable')); };

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -31,6 +31,7 @@
       <button id="projectOpen" type="button">Ouvrir</button>
       <button id="projectSave" type="button">Enregistrer</button>
       <button id="projectSaveAs" type="button">Enregistrer sous</button>
+      <button id="resetSimulation" type="button" hidden disabled>Réinitialiser</button>
       <button id="submit" disabled>Lancer le vol</button>
     </div>
   </header>

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -4,6 +4,7 @@ var robotWindow = null;
 var runtimeBackend = null;
 var runtimeRunning = false;
 var runtimeTerminal = false;
+var runtimeResetPending = false;
 var runtimeDebug = null;
 
 var WEBEEBLOCKS_WORKSPACE_SCALE = 0.90;
@@ -36,11 +37,24 @@ var WebeeBlocksStudentTheme = Blockly.Theme.defineTheme('webeeblocksStudent', {
   startHats: false
 });
 
+function updateRuntimeActions() {
+  var ready = !!(runtimeBackend && runtimeBackend.ready);
+  var submit = document.getElementById('submit');
+  var reset = document.getElementById('resetSimulation');
+  submit.disabled = !ready || runtimeRunning || runtimeTerminal || runtimeResetPending;
+  if (reset) {
+    var resetSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationReset === true);
+    reset.hidden = !resetSupported;
+    reset.disabled = !resetSupported || !ready || runtimeRunning || runtimeResetPending || !runtimeTerminal;
+  }
+}
+
 function setRuntimeStatus(state, detail) {
   document.getElementById('runtimeState').textContent = state;
   document.getElementById('runtimeDetail').textContent = detail || '';
   document.body.dataset.runtimeState = state;
   window.dispatchEvent(new CustomEvent('webeeblocks-runtime-v2', { detail: {state: state, detail: detail || null} }));
+  updateRuntimeActions();
 }
 
 function setRuntimeFailure(error) {
@@ -122,7 +136,7 @@ function receiveMessage(value) {
 function setDebugControls(paused) {
   document.getElementById('stepNext').disabled = !paused;
   document.getElementById('stepContinue').disabled = !runtimeRunning;
-  document.getElementById('stepMode').disabled = runtimeRunning;
+  document.getElementById('stepMode').disabled = runtimeRunning || runtimeResetPending;
 }
 function studentDirectionLabel(direction) {
   var labels = {front: 'devant', back: 'derrière', left: 'à gauche', right: 'à droite', up: 'au-dessus'};
@@ -175,8 +189,51 @@ function wireDebugControls() {
   document.getElementById('stepContinue').addEventListener('click', function() { runtimeDebug.continueRun(); });
 }
 
+function serializedWorkspace() {
+  if (!workspace || !Blockly.serialization || !Blockly.serialization.workspaces)
+    throw new Error('Blockly workspace serialization unavailable');
+  return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+}
+
+async function resetSimulation() {
+  if (runtimeRunning || runtimeResetPending || !runtimeTerminal || !runtimeBackend || !runtimeBackend.ready)
+    return;
+  if (!runtimeBackend.capabilities || runtimeBackend.capabilities.simulationReset !== true) {
+    setRuntimeFailure(new Error('Simulation reset unavailable'));
+    return;
+  }
+  var before = serializedWorkspace();
+  var profile = runtimeProfile;
+  runtimeResetPending = true;
+  updateRuntimeActions();
+  setDebugControls(false);
+  setRuntimeStatus('RÉINITIALISATION', 'Retour à l’état initial de la simulation');
+  try {
+    await runtimeBackend.resetSimulation();
+    var after = serializedWorkspace();
+    if (after !== before)
+      throw new Error('Simulation reset changed Blockly workspace');
+    if (runtimeProfile !== profile)
+      throw new Error('Simulation reset changed activity profile');
+    runtimeTerminal = false;
+    renderSensorValues({});
+    renderVariables(null);
+    if (runtimeDebug) runtimeDebug.finish();
+    document.getElementById('debugState').textContent = 'Observation inactive';
+    setRuntimeStatus('PRÊT', 'Simulation réinitialisée');
+    window.dispatchEvent(new CustomEvent('webeeblocks-runtime-v2-reset', {detail: {workspacePreserved: true}}));
+  } catch (error) {
+    runtimeTerminal = true;
+    setRuntimeFailure(error);
+  } finally {
+    runtimeResetPending = false;
+    setDebugControls(false);
+    updateRuntimeActions();
+  }
+}
+
 async function runProgram() {
-  if (runtimeRunning || !runtimeBackend || !runtimeBackend.ready) return;
+  if (runtimeRunning || runtimeTerminal || runtimeResetPending || !runtimeBackend || !runtimeBackend.ready) return;
   var submit = document.getElementById('submit');
   var stepMode = document.getElementById('stepMode');
   var debugRequested = stepMode.checked === true;
@@ -202,14 +259,15 @@ async function runProgram() {
   } finally {
     if (runtimeDebug) runtimeDebug.finish();
     stepMode.disabled = false;
-    submit.disabled = !runtimeBackend.ready;
+    updateRuntimeActions();
   }
 }
 
 function onWorkspaceChange(event) {
   if (!event || event.type === Blockly.Events.UI) return;
   try { WebeeBlocksActivityContract.applyFieldBounds(runtimeProfile, workspace); } catch (error) { console.error(error); }
-  if (!runtimeRunning && runtimeTerminal) { runtimeTerminal = false; setRuntimeStatus('PRÊT', 'Programme modifié'); }
+  if (!runtimeRunning && runtimeTerminal)
+    document.getElementById('runtimeDetail').textContent = 'Programme modifié — réinitialisez la simulation avant de relancer';
 }
 function wireWorkspaceControls() {
   document.getElementById('zoomIn').addEventListener('click', function() { workspace.zoomCenter(1); });
@@ -218,6 +276,7 @@ function wireWorkspaceControls() {
   document.getElementById('zoomReset').addEventListener('click', function() {
     workspace.setScale(WEBEEBLOCKS_WORKSPACE_SCALE); if (typeof workspace.scrollCenter === 'function') workspace.scrollCenter();
   });
+  document.getElementById('resetSimulation').addEventListener('click', resetSimulation);
 }
 
 window.onload = async function() {
@@ -237,12 +296,12 @@ window.onload = async function() {
   try {
     var module = await import('https://cyberbotics.com/wwi/R2025a/RobotWindow.js');
     robotWindow = new module.default();
-    runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true});
+    runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true, simulationReset: true});
     robotWindow.receive = receiveMessage;
     setRuntimeStatus('INITIALISATION', 'Attente du Runtime v2');
     await runtimeBackend.waitUntilReady();
-    document.getElementById('submit').disabled = false;
     if (runtimeBackend.capabilities && runtimeBackend.capabilities.simulationDebug === true) document.getElementById('debugPanel').hidden = false;
+    updateRuntimeActions();
     setRuntimeStatus('PRÊT', 'Runtime v2 connecté');
   } catch (error) { setRuntimeFailure(error); }
 };

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -4,6 +4,7 @@
   var manager = null;
   var busy = false;
   var supported = false;
+  var runtimeLocked = false;
 
   function fileState(text, error) {
     var target = document.getElementById('projectFileState');
@@ -31,14 +32,21 @@
     var open = document.getElementById('projectOpen');
     var save = document.getElementById('projectSave');
     var saveAs = document.getElementById('projectSaveAs');
-    var locked = busy || !supported;
+    var locked = busy || !supported || runtimeLocked;
     if (open) open.disabled = locked;
     if (saveAs) saveAs.disabled = locked;
     if (save) save.disabled = locked || !manager || !manager.hasCurrentTarget();
   }
 
+  function setRuntimeLocked(locked) {
+    runtimeLocked = locked === true;
+    var blocklyDiv = document.getElementById('blocklyDiv');
+    if (blocklyDiv) blocklyDiv.inert = runtimeLocked;
+    renderButtons();
+  }
+
   async function operation(name, action) {
-    if (busy || !supported) return null;
+    if (busy || !supported || runtimeLocked) return null;
     busy = true;
     renderButtons();
     try { return await action(); }
@@ -66,6 +74,12 @@
     var base = manager && manager.currentName() ? manager.currentName() : runtimeProfile.id;
     return WebeeBlocksProjectFiles.normalizeName(base);
   }
+
+  window.addEventListener('webeeblocks-runtime-v2', function(event) {
+    var state = event && event.detail ? event.detail.state : null;
+    if (state === 'RÉINITIALISATION') setRuntimeLocked(true);
+    else if (runtimeLocked) setRuntimeLocked(false);
+  });
 
   window.addEventListener('load', function() {
     if (!workspace || !runtimeProfile) {

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -106,9 +106,15 @@
     document.getElementById('projectOpen').addEventListener('click', function() {
       operation('open', async function() {
         var result = await manager.open();
-        runtimeTerminal = false;
         fileState('Projet : ' + result.name, false);
-        if (runtimeBackend && runtimeBackend.ready) setRuntimeStatus('PRÊT', 'Projet ouvert');
+        if (runtimeBackend && runtimeBackend.ready) {
+          if (runtimeTerminal) {
+            document.getElementById('runtimeDetail').textContent = 'Projet ouvert — réinitialisez la simulation avant de relancer';
+            updateRuntimeActions();
+          } else {
+            setRuntimeStatus('PRÊT', 'Projet ouvert');
+          }
+        }
       });
     });
 

--- a/tools/ci/prepare_runtime_v2_observability.py
+++ b/tools/ci/prepare_runtime_v2_observability.py
@@ -119,6 +119,8 @@ __COMMON__
     if (String(Blockly.VERSION || '') !== '13.2.1') throw new Error('unexpected Blockly.VERSION');
     if (!runtimeBackend.capabilities || runtimeBackend.capabilities.simulationDebug !== true)
       throw new Error('simulation-only debug capability not enabled for Webots backend');
+    if (!runtimeBackend.capabilities || runtimeBackend.capabilities.simulationReset !== true)
+      throw new Error('simulation-only reset capability not enabled for Webots backend');
     if (document.getElementById('debugPanel').hidden) throw new Error('simulation debug panel remained hidden');
     if (!document.getElementById('debugVariablesRow').hidden)
       throw new Error('variables shown despite no product variable semantics');
@@ -146,6 +148,22 @@ __COMMON__
     if (!diagnostics.length || diagnostics[diagnostics.length - 1].studentState !== 'ERREUR' || diagnostics[diagnostics.length - 1].machineCode !== null)
       throw new Error('technical diagnostic mismatch: ' + JSON.stringify(diagnostics));
     await report('TECHNICAL_FAILURE_OK', snapshot());
+
+    const resetTxStart = wwiTx.length;
+    const workspaceBeforeReset = JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+    document.getElementById('resetSimulation').click();
+    await waitFor(() => document.getElementById('runtimeState').textContent === 'PRÊT', 'reset after technical failure', 5000);
+    const resetTx = wwiTx.slice(resetTxStart);
+    if (resetTx.length !== 1 || !resetTx[0].includes(' RESET'))
+      throw new Error('technical failure reset did not emit exactly one RESET request: ' + JSON.stringify(resetTx));
+    if (runtimeBackend.pending && Object.keys(runtimeBackend.pending).length !== 0)
+      throw new Error('technical failure reset left pending backend requests: ' + JSON.stringify(snapshot()));
+    const workspaceAfterReset = JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+    if (workspaceAfterReset !== workspaceBeforeReset)
+      throw new Error('technical failure reset changed workspace');
+    if (JSON.stringify(WebeeBlocksSemanticAst.compileWorkspace(workspace)) !== JSON.stringify(baselineAst))
+      throw new Error('technical failure reset changed AST');
+    await report('TECHNICAL_FAILURE_RESET_OK', snapshot());
 
     loadXml(__REACTIVE__);
     const stepAst = WebeeBlocksSemanticAst.compileWorkspace(workspace);
@@ -182,7 +200,7 @@ __COMMON__
       throw new Error('number semantic boundary mismatch: ' + JSON.stringify(paused[3]));
     if (wwiTx.length !== txStart + 2 || !wwiTx[txStart + 1].includes(' RANGE front'))
       throw new Error('range step did not release exactly one RANGE request');
-    if (wwiTx.some(text => text.includes(' MOVE '))) throw new Error('branch action started while evaluating condition');
+    if (wwiTx.slice(txStart).some(text => text.includes(' MOVE '))) throw new Error('branch action started while evaluating condition');
     const sensorText = document.getElementById('debugSensors').textContent;
     if (!sensorText.includes(String(sensors[0].sensorValue)))
       throw new Error('raw sensor value not displayed verbatim: ' + sensorText);

--- a/tools/ci/prepare_runtime_v2_reset.py
+++ b/tools/ci/prepare_runtime_v2_reset.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HTML = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
+MARKER = '<!-- WEBEEBLOCKS_RESET_REPLAY_CI -->'
+
+NORMAL = '''<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="webeeblocks_v2_takeoff" id="reset_normal_takeoff" x="40" y="40">
+    <field name="HEIGHT">0.5</field>
+    <next>
+      <block type="webeeblocks_v2_move" id="reset_normal_move">
+        <field name="DIRECTION">forward</field>
+        <field name="DISTANCE">0.2</field>
+        <next><block type="webeeblocks_v2_land" id="reset_normal_land"></block></next>
+      </block>
+    </next>
+  </block>
+</xml>'''
+
+BLOCKED = '''<xml xmlns="https://developers.google.com/blockly/xml">
+  <block type="webeeblocks_v2_takeoff" id="reset_blocked_takeoff" x="40" y="40">
+    <field name="HEIGHT">0.5</field>
+    <next>
+      <block type="webeeblocks_v2_move" id="reset_blocked_move">
+        <field name="DIRECTION">forward</field>
+        <field name="DISTANCE">2</field>
+        <next><block type="webeeblocks_v2_land" id="reset_blocked_land"></block></next>
+      </block>
+    </next>
+  </block>
+</xml>'''
+
+SCRIPT = r'''
+<script>
+(async function() {
+  function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+  let seq = 0;
+  let chain = Promise.resolve();
+  function report(event, detail) {
+    const payload = {seq: seq++, event, detail: detail === undefined ? null : detail, wall_ms: Date.now()};
+    chain = chain.then(() => fetch('http://127.0.0.1:8765/event', {
+      method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload)
+    }));
+    return chain;
+  }
+  function snapshot() {
+    return {
+      state: document.getElementById('runtimeState') && document.getElementById('runtimeState').textContent,
+      detail: document.getElementById('runtimeDetail') && document.getElementById('runtimeDetail').textContent,
+      submitDisabled: document.getElementById('submit') && document.getElementById('submit').disabled,
+      resetHidden: document.getElementById('resetSimulation') && document.getElementById('resetSimulation').hidden,
+      resetDisabled: document.getElementById('resetSimulation') && document.getElementById('resetSimulation').disabled,
+      backendReady: window.runtimeBackend && runtimeBackend.ready,
+      pending: window.runtimeBackend ? Object.keys(runtimeBackend.pending || {}).length : null,
+      runtimeRunning: !!window.runtimeRunning,
+      runtimeTerminal: !!window.runtimeTerminal,
+      runtimeResetPending: !!window.runtimeResetPending
+    };
+  }
+  async function waitFor(predicate, label, timeoutMs) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (predicate()) return;
+      await sleep(25);
+    }
+    throw new Error('timeout waiting for ' + label + ': ' + JSON.stringify(snapshot()));
+  }
+  function loadXml(xml) {
+    workspace.clear();
+    const dom = Blockly.utils.xml.textToDom(xml);
+    Blockly.Xml.domToWorkspace(dom, workspace);
+  }
+  function workspaceState() {
+    return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+  }
+  function astState() {
+    return JSON.stringify(WebeeBlocksSemanticAst.compileWorkspace(workspace));
+  }
+  async function clickResetAndProve(label, expectedWorkspace, expectedAst) {
+    const button = document.getElementById('resetSimulation');
+    if (button.hidden || button.disabled) throw new Error(label + ' reset action unavailable: ' + JSON.stringify(snapshot()));
+    button.click();
+    if (!button.disabled) throw new Error(label + ' reset action not gated while pending');
+    await waitFor(() => document.getElementById('runtimeState').textContent === 'PRÊT', label + ' reset ready', 12000);
+    if (!runtimeBackend.ready || Object.keys(runtimeBackend.pending || {}).length !== 0)
+      throw new Error(label + ' backend not genuinely ready: ' + JSON.stringify(snapshot()));
+    if (workspaceState() !== expectedWorkspace) throw new Error(label + ' workspace changed across reset');
+    if (astState() !== expectedAst) throw new Error(label + ' AST changed across reset');
+    if (runtimeProfile.id !== 'reactive-obstacle-v2') throw new Error(label + ' activity profile changed');
+    if (document.getElementById('submit').disabled) throw new Error(label + ' run did not become available after reset');
+    await report('RESET_OK', {label, workspace: expectedWorkspace, ast: JSON.parse(expectedAst), snapshot: snapshot()});
+  }
+
+  window.addEventListener('error', event => report('WINDOW_ERROR', {
+    message: event.message, filename: event.filename, lineno: event.lineno, colno: event.colno
+  }));
+  window.addEventListener('unhandledrejection', event => report('UNHANDLED_REJECTION', String(event.reason)));
+  window.addEventListener('webeeblocks-runtime-v2', event => report('STATE', event.detail));
+  window.addEventListener('webeeblocks-runtime-v2-reset', event => report('RESET_EVENT', event.detail));
+
+  try {
+    await waitFor(() => window.workspace && window.runtimeBackend && runtimeBackend.ready === true,
+      'Runtime v2 READY', 20000);
+    if (!runtimeBackend.capabilities || runtimeBackend.capabilities.simulationReset !== true)
+      throw new Error('simulation-only reset capability missing');
+    if (document.getElementById('resetSimulation').hidden)
+      throw new Error('Réinitialiser remained hidden in Webots simulation');
+    await report('READY', snapshot());
+
+    loadXml(__NORMAL__);
+    const normalWorkspace = workspaceState();
+    const normalAst = astState();
+    document.getElementById('submit').click();
+    await waitFor(() => document.getElementById('runtimeState').textContent === 'TERMINÉ', 'first normal completion', 45000);
+    if (!document.getElementById('submit').disabled) throw new Error('rerun allowed without reset after TERMINÉ');
+    await report('NORMAL_FIRST_DONE', {workspace: normalWorkspace, ast: JSON.parse(normalAst), snapshot: snapshot()});
+    await clickResetAndProve('after-terminated', normalWorkspace, normalAst);
+
+    document.getElementById('submit').click();
+    await waitFor(() => document.getElementById('runtimeState').textContent === 'TERMINÉ', 'second normal completion', 45000);
+    if (workspaceState() !== normalWorkspace || astState() !== normalAst)
+      throw new Error('normal replay changed workspace or AST');
+    await report('NORMAL_REPLAY_DONE', {workspace: normalWorkspace, ast: JSON.parse(normalAst), snapshot: snapshot()});
+    await clickResetAndProve('before-unsafe', normalWorkspace, normalAst);
+
+    loadXml(__BLOCKED__);
+    const blockedWorkspace = workspaceState();
+    const blockedAst = astState();
+    document.getElementById('submit').click();
+    await waitFor(() => document.getElementById('runtimeState').textContent === 'ARRÊTÉ', 'first unsafe stop', 45000);
+    await report('UNSAFE_FIRST_DONE', {workspace: blockedWorkspace, ast: JSON.parse(blockedAst), snapshot: snapshot()});
+    await clickResetAndProve('after-stopped', blockedWorkspace, blockedAst);
+
+    document.getElementById('submit').click();
+    await waitFor(() => document.getElementById('runtimeState').textContent === 'ARRÊTÉ', 'second unsafe stop', 45000);
+    if (workspaceState() !== blockedWorkspace || astState() !== blockedAst)
+      throw new Error('unsafe replay changed workspace or AST');
+    await report('UNSAFE_REPLAY_DONE', {workspace: blockedWorkspace, ast: JSON.parse(blockedAst), snapshot: snapshot()});
+    await chain;
+    console.log('WEBEEBLOCKS_CI_RESET_REPLAY_DONE');
+  } catch (error) {
+    await report('ERROR', error && error.stack ? error.stack : String(error));
+    await report('FINAL_DIAG', snapshot());
+    await chain;
+    console.error('WEBEEBLOCKS_CI_RESET_REPLAY_ERROR=' + (error && error.stack ? error.stack : String(error)));
+  }
+})();
+</script>
+'''
+
+base = HTML.read_text(encoding='utf-8').split(MARKER, 1)[0].rstrip()
+script = SCRIPT.replace('__NORMAL__', json.dumps(NORMAL)).replace('__BLOCKED__', json.dumps(BLOCKED))
+if '</body>' not in base:
+    raise SystemExit('blockly_v2.html missing </body>')
+HTML.write_text(base.replace('</body>', f'{MARKER}\n{script}\n</body>') + '\n', encoding='utf-8')
+print('PREPARED_RUNTIME_V2_RESET_REPLAY')

--- a/tools/ci/test_runtime_v2_reset.js
+++ b/tools/ci/test_runtime_v2_reset.js
@@ -1,8 +1,11 @@
 'use strict';
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
 const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_backend.js');
 
-(async () => {
+async function testBackendResetContract() {
   const sent = [];
   const backend = new WwiBackend({send: message => sent.push(String(message))}, {
     timeoutMs: 1000,
@@ -38,11 +41,123 @@ const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_
   assert.strictEqual(backend.ready, true);
   assert.strictEqual(Object.keys(backend.pending).length, 0);
 
+  // A bounded native reset failure must leave the browser backend retryable.
+  const timedOutReset = backend.resetSimulation().then(
+    () => { throw new Error('timed-out reset unexpectedly resolved'); },
+    error => error
+  );
+  assert.match(sent[2], / REQUEST 3 RESET$/);
+  backend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 3 ERR RESET_TIMEOUT');
+  const resetError = await timedOutReset;
+  assert.strictEqual(resetError.code, 'RESET_TIMEOUT');
+  assert.strictEqual(backend.ready, true);
+  assert.strictEqual(Object.keys(backend.pending).length, 0);
+
+  const retryReset = backend.resetSimulation();
+  assert.match(sent[3], / REQUEST 4 RESET$/);
+  backend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 4 OK');
+  await retryReset;
+  assert.strictEqual(backend.ready, true);
+  assert.strictEqual(Object.keys(backend.pending).length, 0);
+
   const physical = new WwiBackend({send: () => {}}, {timeoutMs: 1000});
   assert.notStrictEqual(physical.capabilities.simulationReset, true);
   await assert.rejects(() => physical.resetSimulation(), /simulation reset unavailable/);
+}
 
-  console.log('PASS: simulation reset is explicit, cancels pending requests, ignores stale replies, and is unavailable without the simulation capability.');
+async function testProjectOpenKeepsResetRequirement() {
+  const source = fs.readFileSync(path.join(__dirname, '../../plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
+  let loadHandler = null;
+  let openHandler = null;
+  let statusCalls = 0;
+  let actionUpdates = 0;
+
+  function button(id) {
+    return {
+      id,
+      disabled: false,
+      addEventListener(type, handler) {
+        if (id === 'projectOpen' && type === 'click') openHandler = handler;
+      }
+    };
+  }
+
+  const elements = {
+    projectOpen: button('projectOpen'),
+    projectSave: button('projectSave'),
+    projectSaveAs: button('projectSaveAs'),
+    projectFileState: {textContent: '', dataset: {}},
+    activityTitle: {textContent: ''},
+    activityGoal: {textContent: ''},
+    runtimeDetail: {textContent: ''}
+  };
+  const manager = {
+    nativeFileSystemAccess: true,
+    hasCurrentTarget: () => false,
+    currentName: () => null,
+    open: async () => ({name: 'opened.wbb'}),
+    saveAs: async () => ({name: 'saved.wbb'}),
+    save: async () => ({name: 'saved.wbb'})
+  };
+  const context = {
+    console,
+    setTimeout,
+    clearTimeout,
+    CustomEvent: function CustomEvent(type, options) { this.type = type; this.detail = options && options.detail; },
+    window: {
+      addEventListener(type, handler) { if (type === 'load') loadHandler = handler; },
+      dispatchEvent() {}
+    },
+    document: {
+      body: {dataset: {}},
+      getElementById(id) { return elements[id]; }
+    },
+    workspace: {updateToolbox() {}},
+    runtimeProfile: {id: 'reactive-obstacle-v2', brief: {visible: false}},
+    runtimeTerminal: true,
+    runtimeBackend: {ready: true},
+    Blockly: {},
+    WebeeBlocksActivityProfiles: {},
+    WebeeBlocksActivities: {DOCUMENT: {}, BLOCK_CATALOG: {}},
+    WebeeBlocksSemanticAst: {},
+    WebeeBlocksActivityContract: {applyFieldBounds() {}},
+    WebeeBlocksProjectFiles: {
+      createBrowserTransport: () => ({}),
+      createManager: () => manager,
+      normalizeName: name => name
+    },
+    buildToolbox: () => ({}),
+    setRuntimeStatus() { statusCalls += 1; },
+    updateRuntimeActions() { actionUpdates += 1; }
+  };
+  context.window.window = context.window;
+
+  vm.runInNewContext(source, context, {filename: 'project_ui.js'});
+  assert.strictEqual(typeof loadHandler, 'function');
+  loadHandler();
+  assert.strictEqual(typeof openHandler, 'function');
+  openHandler();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.strictEqual(context.runtimeTerminal, true, 'opening a project must not clear terminal/reset-required state');
+  assert.strictEqual(statusCalls, 0, 'opening while terminal must not publish PRÊT');
+  assert.ok(actionUpdates >= 1, 'opening while terminal must refresh action gating');
+  assert.match(elements.runtimeDetail.textContent, /réinitialisez la simulation/);
+}
+
+function testNativeResetTimeoutSourceContract() {
+  const source = fs.readFileSync(path.join(__dirname, '../../controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c'), 'utf8');
+  assert.match(source, /#define RESET_TIMEOUT [0-9.]+/);
+  assert.match(source, /command == CMD_RESET && now - action_start > RESET_TIMEOUT/);
+  assert.match(source, /response_error\(active_id, "RESET_TIMEOUT"\)/);
+  assert.match(source, /failsafe_latched = 1;/);
+}
+
+(async () => {
+  await testBackendResetContract();
+  await testProjectOpenKeepsResetRequirement();
+  testNativeResetTimeoutSourceContract();
+  console.log('PASS: reset cancels stale requests, remains retryable after timeout, project open preserves reset gating, and physical backend reset stays unavailable.');
 })().catch(error => {
   console.error(error.stack || error);
   process.exit(1);

--- a/tools/ci/test_runtime_v2_reset.js
+++ b/tools/ci/test_runtime_v2_reset.js
@@ -1,0 +1,49 @@
+'use strict';
+const assert = require('assert');
+const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_backend.js');
+
+(async () => {
+  const sent = [];
+  const backend = new WwiBackend({send: message => sent.push(String(message))}, {
+    timeoutMs: 1000,
+    simulationDebug: true,
+    simulationReset: true
+  });
+
+  backend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 READY');
+  assert.strictEqual(backend.ready, true);
+  assert.strictEqual(backend.capabilities.simulationReset, true);
+
+  const oldRequest = backend.move('forward', 0.2).then(
+    () => { throw new Error('old request unexpectedly resolved'); },
+    error => error
+  );
+  assert.match(sent[0], / REQUEST 1 MOVE forward /);
+  assert.strictEqual(Object.keys(backend.pending).length, 1);
+
+  const reset = backend.resetSimulation();
+  const cancelled = await oldRequest;
+  assert.strictEqual(cancelled.code, 'RESET_CANCELLED');
+  assert.strictEqual(backend.ready, false);
+  assert.strictEqual(Object.keys(backend.pending).length, 1);
+  assert.match(sent[1], / REQUEST 2 RESET$/);
+
+  // A response from the pre-reset generation must be harmless.
+  backend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 OK');
+  assert.strictEqual(Object.keys(backend.pending).length, 1);
+  assert.strictEqual(backend.ready, false);
+
+  backend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 2 OK');
+  await reset;
+  assert.strictEqual(backend.ready, true);
+  assert.strictEqual(Object.keys(backend.pending).length, 0);
+
+  const physical = new WwiBackend({send: () => {}}, {timeoutMs: 1000});
+  assert.notStrictEqual(physical.capabilities.simulationReset, true);
+  await assert.rejects(() => physical.resetSimulation(), /simulation reset unavailable/);
+
+  console.log('PASS: simulation reset is explicit, cancels pending requests, ignores stale replies, and is unavailable without the simulation capability.');
+})().catch(error => {
+  console.error(error.stack || error);
+  process.exit(1);
+});

--- a/tools/ci/test_runtime_v2_reset.js
+++ b/tools/ci/test_runtime_v2_reset.js
@@ -65,12 +65,14 @@ async function testBackendResetContract() {
   await assert.rejects(() => physical.resetSimulation(), /simulation reset unavailable/);
 }
 
-async function testProjectOpenKeepsResetRequirement() {
+async function testProjectOpenKeepsResetRequirementAndLocksDuringReset() {
   const source = fs.readFileSync(path.join(__dirname, '../../plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
   let loadHandler = null;
+  let runtimeStatusHandler = null;
   let openHandler = null;
   let statusCalls = 0;
   let actionUpdates = 0;
+  let openCalls = 0;
 
   function button(id) {
     return {
@@ -89,13 +91,14 @@ async function testProjectOpenKeepsResetRequirement() {
     projectFileState: {textContent: '', dataset: {}},
     activityTitle: {textContent: ''},
     activityGoal: {textContent: ''},
-    runtimeDetail: {textContent: ''}
+    runtimeDetail: {textContent: ''},
+    blocklyDiv: {inert: false}
   };
   const manager = {
     nativeFileSystemAccess: true,
     hasCurrentTarget: () => false,
     currentName: () => null,
-    open: async () => ({name: 'opened.wbb'}),
+    open: async () => { openCalls += 1; return {name: 'opened.wbb'}; },
     saveAs: async () => ({name: 'saved.wbb'}),
     save: async () => ({name: 'saved.wbb'})
   };
@@ -105,7 +108,10 @@ async function testProjectOpenKeepsResetRequirement() {
     clearTimeout,
     CustomEvent: function CustomEvent(type, options) { this.type = type; this.detail = options && options.detail; },
     window: {
-      addEventListener(type, handler) { if (type === 'load') loadHandler = handler; },
+      addEventListener(type, handler) {
+        if (type === 'load') loadHandler = handler;
+        if (type === 'webeeblocks-runtime-v2') runtimeStatusHandler = handler;
+      },
       dispatchEvent() {}
     },
     document: {
@@ -134,11 +140,24 @@ async function testProjectOpenKeepsResetRequirement() {
 
   vm.runInNewContext(source, context, {filename: 'project_ui.js'});
   assert.strictEqual(typeof loadHandler, 'function');
+  assert.strictEqual(typeof runtimeStatusHandler, 'function');
   loadHandler();
   assert.strictEqual(typeof openHandler, 'function');
+
+  runtimeStatusHandler({detail: {state: 'RÉINITIALISATION'}});
+  assert.strictEqual(elements.blocklyDiv.inert, true, 'Blockly surface must be inert while reset stabilizes');
+  assert.strictEqual(elements.projectOpen.disabled, true, 'Open must be disabled while reset stabilizes');
   openHandler();
   await new Promise(resolve => setTimeout(resolve, 0));
+  assert.strictEqual(openCalls, 0, 'late Open event must be rejected while reset is locked');
 
+  runtimeStatusHandler({detail: {state: 'PRÊT'}});
+  assert.strictEqual(elements.blocklyDiv.inert, false, 'Blockly surface must unlock after reset leaves pending state');
+  assert.strictEqual(elements.projectOpen.disabled, false, 'Open must unlock after reset leaves pending state');
+
+  openHandler();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.strictEqual(openCalls, 1, 'Open must work again after reset lock is released');
   assert.strictEqual(context.runtimeTerminal, true, 'opening a project must not clear terminal/reset-required state');
   assert.strictEqual(statusCalls, 0, 'opening while terminal must not publish PRÊT');
   assert.ok(actionUpdates >= 1, 'opening while terminal must refresh action gating');
@@ -155,9 +174,9 @@ function testNativeResetTimeoutSourceContract() {
 
 (async () => {
   await testBackendResetContract();
-  await testProjectOpenKeepsResetRequirement();
+  await testProjectOpenKeepsResetRequirementAndLocksDuringReset();
   testNativeResetTimeoutSourceContract();
-  console.log('PASS: reset cancels stale requests, remains retryable after timeout, project open preserves reset gating, and physical backend reset stays unavailable.');
+  console.log('PASS: reset cancels stale requests, stays retryable, locks Blockly/Open while pending, preserves project reset gating, and remains simulation-only.');
 })().catch(error => {
   console.error(error.stack || error);
   process.exit(1);

--- a/worlds/crazyflie_runtime_v2.wbt
+++ b/worlds/crazyflie_runtime_v2.wbt
@@ -45,5 +45,6 @@ Crazyflie {
   name "Crazyflie Runtime v2"
   controller "crazyflie_runtime_v2"
   window "blockly_v2"
+  supervisor TRUE
   synchronization TRUE
 }


### PR DESCRIPTION
## Objective

Closes #78 by adding a student-facing **Réinitialiser** action for Runtime v2 simulation so the same Blockly program can be replayed from the initial Crazyflie/world state after `TERMINÉ`, `ARRÊTÉ` or another terminal failure.

## Causal contract

**Problem:** Runtime v2 had no reset primitive, and the native controller exited after `UNSAFE_OR_TIMEOUT`, so replay from the initial simulation state was impossible without reloading the world.

**Bounded change:** keep the simulation controller alive in a latched safe state, add an explicit WWI `RESET` backed by the Webots Supervisor API, reset physics/PID/runtime request state, and expose a simulation-only `Réinitialiser` action that preserves the Blockly workspace and activity profile.

**Observable acceptance oracle:** in the real Webots R2025a Robot Window, a non-trivial program must run, reset to the initial pose with the exact workspace/AST unchanged, and run again; the same must hold after `ARRÊTÉ`. `PRÊT` appears only after a successful reset response and an empty pending-request set.

## Scope

- native Runtime v2 controller reset/recovery;
- simulation-only Supervisor pose/physics restoration;
- WWI pending-request cancellation and stale-response isolation;
- student-facing reset gating while preserving workspace/profile;
- focused reset/replay proof and causal regression-harness repairs;
- repairs from `NO_GO dc196071a1cf0f320470ffb1d0fc4b134747e0c5`;
- repair of the Runtime v2 full-suite false-positive oracle found on `4d2e94ae17fb9fe4772fc588fd8b5a932f1c1fc5`;
- repair of `NO_GO 9e1e302ec26fb1e1a211a8cb58892c5e2b51ebcd` for concurrent workspace mutation during reset stabilization.

## Non-goals

- no physical-Crazyflie reset or flight;
- no AST/interpreter semantic change;
- no weakening of `UNSAFE_OR_TIMEOUT`, workspace-preservation, observability, transaction-budget, tooltip or anti-tutoring oracles;
- no autosave/history/progress tracking;
- no new activity/profile and no #66/#71/#80/#87 expansion;
- no `main` change.

## Evidence

- `VERIFIED_BY_PRIMARY_SOURCE`: official Webots R2025a Crazyflie PROTO exposes `supervisor`, mapped to `Robot.supervisor`.
- `NO_GO dc196071a1cf0f320470ffb1d0fc4b134747e0c5` repaired: project open preserves terminal/reset gating and native reset has a bounded 5 s `RESET_TIMEOUT`, fails safe and remains retryable.
- `PROVEN_BY_TEST`: `tools/ci/test_runtime_v2_reset.js` proves stale-request cancellation, retryability after `RESET_TIMEOUT`, project-open terminal gating, reset-time Blockly/Open locking, and physical-backend reset unavailability.
- `UNPROVEN 4d2e94ae17fb9fe4772fc588fd8b5a932f1c1fc5` repaired: Runtime v2 negative shell guards are fail-closed and Supervisor use is constrained to the exact seven APIs needed by simulation reset.
- `NO_GO 9e1e302ec26fb1e1a211a8cb58892c5e2b51ebcd` repaired: project-file operations are locked and Blockly is inert while reset stabilizes; a late Open event is rejected.
- `VERIFIED_BY_CI` on final head `64795437e019ac4ed7236bd3fb59c254fae40909`: the complete Ready suite is green, including the real R2025a reset/replay scenario, Runtime v2 Webots WWI, observability, Zelos and all historical gates. Transient infrastructure failures in Gyro/Encoders/Smoke and one observability startup timeout were resolved by bounded targeted retries without code changes.
- All four inline review threads are resolved.
- `VERIFIED_BY_CODE_INSPECTION`: current Runtime v2 world is static apart from the Crazyflie, so the current activity has no additional mutable activity-world state requiring restoration.

## Final verdict and integration

`GO 64795437e019ac4ed7236bd3fb59c254fae40909` recorded by an independent Reviewer-Integrator.

Merged unchanged into `webots-ci` as `6f040e62c12eed1bf625d1827f6ed4eb887fc808`.

No local execution is claimed; exact-head GitHub CI, the real Webots R2025a harness and code inspection are the evidence.

`main` was not modified.