### PR TITLE
Simplify controller handoffs and add Android notification transport

### DIFF
--- a/.controller/NOTICE
+++ b/.controller/NOTICE
@@ -1,0 +1,1 @@
+The live `.controller/handoff.json` payload belongs only on the dedicated `controller-signal` branch. Do not merge transport payload updates into `webots-ci` or `main`.

--- a/.controller/README.md
+++ b/.controller/README.md
@@ -1,0 +1,7 @@
+# Controller notification transport
+
+This directory contains only data used by the controller notification transport.
+
+`handoff.example.json` documents the payload schema integrated with `webots-ci`.
+
+The live payload is written only on the dedicated `controller-signal` branch as `.controller/handoff.json`. That transport branch is never merged into `webots-ci` or `main`.

--- a/.controller/SCHEMA.md
+++ b/.controller/SCHEMA.md
@@ -1,0 +1,5 @@
+# Handoff payload schema
+
+The live transport payload on `controller-signal` is `.controller/handoff.json` with `version: 1`, a `signal` in `READY_FOR_CONTROLLER | HUMAN_REQUIRED | DONE`, a short `message`, optional `copy_text`, and a WebeeBlocks GitHub `url`.
+
+`WAITING_EXTERNAL` is never transported to ntfy.

--- a/.controller/WHY.md
+++ b/.controller/WHY.md
@@ -1,0 +1,1 @@
+`issue_comment` workflows require the workflow file on the repository default branch. Because WebeeBlocks keeps `main` human-controlled, terminal notification delivery uses a dedicated push-triggered `controller-signal` branch instead.

--- a/.controller/handoff.example.json
+++ b/.controller/handoff.example.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "signal": "READY_FOR_CONTROLLER",
+  "message": "PR stabilisée : une nouvelle impulsion du Contrôleur est utile.",
+  "copy_text": "Nouvelle impulsion. Reprends ton contrat de Contrôleur WebeeBlocks, reconstruis l'état réel depuis GitHub et poursuis jusqu'à la prochaine frontière terminale réelle.",
+  "url": "https://github.com/djibian/webeeblocks/issues/100"
+}

--- a/.github/workflows/controller-android-notification.yml
+++ b/.github/workflows/controller-android-notification.yml
@@ -1,0 +1,283 @@
+name: Controller Android notification
+
+on:
+  pull_request:
+    branches: [webots-ci]
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    branches: [controller-signal]
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  notify-signal:
+    name: Controller signal notification
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish trusted transport payload to ntfy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SIGNAL_SHA: ${{ github.sha }}
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          NTFY_SERVER: ${{ secrets.NTFY_SERVER }}
+        run: |
+          python3 - <<'PY'
+          import base64
+          import json
+          import os
+          import urllib.request
+
+          topic = os.environ.get('NTFY_TOPIC', '').strip()
+          if not topic:
+              print('NTFY_TOPIC is not configured; GitHub @mention remains the fallback.')
+              raise SystemExit(0)
+
+          token = os.environ['GH_TOKEN']
+          repo = os.environ['REPOSITORY']
+          sha = os.environ['SIGNAL_SHA']
+          server = os.environ.get('NTFY_SERVER', '').strip() or 'https://ntfy.sh'
+
+          request = urllib.request.Request(
+              f'https://api.github.com/repos/{repo}/contents/.controller/handoff.json?ref={sha}',
+              headers={
+                  'Authorization': f'Bearer {token}',
+                  'Accept': 'application/vnd.github+json',
+                  'X-GitHub-Api-Version': '2022-11-28',
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              envelope = json.load(response)
+
+          payload = json.loads(base64.b64decode(envelope['content']).decode('utf-8'))
+          if payload.get('version') != 1:
+              raise SystemExit('Unsupported handoff payload version')
+
+          signal = str(payload.get('signal', '')).strip()
+          if signal not in {'READY_FOR_CONTROLLER', 'HUMAN_REQUIRED', 'DONE'}:
+              raise SystemExit(f'Unsupported notification signal: {signal!r}')
+
+          message = str(payload.get('message', '')).strip() or signal
+          copy_text = str(payload.get('copy_text', '')).strip()
+          url = str(payload.get('url', '')).strip() or 'https://github.com/djibian/webeeblocks/issues/100'
+          if not url.startswith('https://github.com/djibian/webeeblocks/'):
+              raise SystemExit('Notification URL must remain inside djibian/webeeblocks')
+
+          if signal == 'READY_FOR_CONTROLLER':
+              title = 'WebeeBlocks — READY'
+              priority = 3
+              tags = ['white_check_mark', 'robot']
+          elif signal == 'HUMAN_REQUIRED':
+              title = 'WebeeBlocks — ACTION HUMAINE'
+              priority = 5
+              tags = ['warning', 'robot']
+          else:
+              title = 'WebeeBlocks — TERMINÉ'
+              priority = 2
+              tags = ['checkered_flag', 'robot']
+
+          actions = []
+          if copy_text:
+              actions.append({'action': 'copy', 'label': 'Copier', 'value': copy_text})
+          actions.append({'action': 'view', 'label': 'Ouvrir GitHub', 'url': url})
+          if signal in {'READY_FOR_CONTROLLER', 'HUMAN_REQUIRED'}:
+              actions.append({'action': 'view', 'label': 'Ouvrir ChatGPT', 'url': 'https://chatgpt.com/'})
+
+          ntfy_payload = {
+              'topic': topic,
+              'title': title,
+              'message': message[:3500],
+              'priority': priority,
+              'tags': tags,
+              'click': url,
+              'actions': actions[:3],
+          }
+          publish = urllib.request.Request(
+              server.rstrip('/') + '/',
+              data=json.dumps(ntfy_payload).encode('utf-8'),
+              headers={'Content-Type': 'application/json'},
+              method='POST',
+          )
+          with urllib.request.urlopen(publish, timeout=20) as response:
+              print(f'ntfy status: {response.status}')
+          PY
+
+  wait-for-pr-stability:
+    name: Controller readiness watcher
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for exact-head checks, publish READY, and notify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          NTFY_SERVER: ${{ secrets.NTFY_SERVER }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repo = os.environ['REPOSITORY']
+          pr_number = int(os.environ['PR_NUMBER'])
+          head_sha = os.environ['HEAD_SHA']
+          topic = os.environ.get('NTFY_TOPIC', '').strip()
+          server = os.environ.get('NTFY_SERVER', '').strip() or 'https://ntfy.sh'
+          api = 'https://api.github.com'
+          own_check_name = 'Controller readiness watcher'
+          restart_text = (
+              "Nouvelle impulsion. Reprends ton contrat de Contrôleur WebeeBlocks, "
+              "reconstruis l'état réel depuis GitHub et poursuis jusqu'à la prochaine "
+              "frontière terminale réelle."
+          )
+
+          def github_request(path, method='GET', payload=None):
+              data = None if payload is None else json.dumps(payload).encode('utf-8')
+              request = urllib.request.Request(
+                  api + path,
+                  data=data,
+                  method=method,
+                  headers={
+                      'Authorization': f'Bearer {token}',
+                      'Accept': 'application/vnd.github+json',
+                      'X-GitHub-Api-Version': '2022-11-28',
+                      'Content-Type': 'application/json',
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  body = response.read().decode('utf-8')
+                  return json.loads(body) if body else None
+
+          def current_pr():
+              pr = github_request(f'/repos/{repo}/pulls/{pr_number}')
+              if pr['state'] != 'open' or pr['draft'] or pr['head']['sha'] != head_sha:
+                  print('PR changed, closed, or became Draft; stale watcher stops.')
+                  raise SystemExit(0)
+              return pr
+
+          # Allow all workflows triggered by the same PR event to register first.
+          time.sleep(30)
+          started = time.monotonic()
+          observed_external_checks = False
+          stable_since = None
+          stable_fingerprint = None
+          checks = []
+
+          while time.monotonic() - started < 2700:  # 45 minute safety horizon
+              current_pr()
+              result = github_request(f'/repos/{repo}/commits/{head_sha}/check-runs?per_page=100')
+              checks = [
+                  check for check in result.get('check_runs', [])
+                  if check.get('name') != own_check_name
+              ]
+              if checks:
+                  observed_external_checks = True
+
+              pending = [check for check in checks if check.get('status') != 'completed']
+              fingerprint = tuple(sorted(
+                  (check.get('name'), check.get('status'), check.get('conclusion'), check.get('id'))
+                  for check in checks
+              ))
+
+              if pending:
+                  stable_since = None
+                  stable_fingerprint = None
+              elif observed_external_checks:
+                  now = time.monotonic()
+                  if fingerprint != stable_fingerprint:
+                      stable_fingerprint = fingerprint
+                      stable_since = now
+                  elif stable_since is not None and now - stable_since >= 60:
+                      break
+              elif time.monotonic() - started >= 120:
+                  # Missing checks are themselves actionable evidence for a fresh Controller.
+                  break
+
+              print(f'Waiting: {len(pending)} exact-head checks active; {len(checks)} observed.')
+              time.sleep(20)
+          else:
+              print('Checks did not stabilize within watcher horizon; no READY emitted.')
+              raise SystemExit(0)
+
+          pr = current_pr()
+          conclusions = {}
+          for check in checks:
+              conclusion = check.get('conclusion') or 'unknown'
+              conclusions[conclusion] = conclusions.get(conclusion, 0) + 1
+          check_summary = ', '.join(f'{key}={value}' for key, value in sorted(conclusions.items()))
+          if not check_summary:
+              check_summary = 'aucun check exact-head enregistré après la période de grâce'
+
+          # Deduplicate only against the latest handoff situation, so a later WAITING_EXTERNAL
+          # for the same head can still be followed by a new READY after stabilization.
+          comments = github_request(f'/repos/{repo}/issues/100/comments?per_page=100')
+          marker = f'HEAD_SHA: {head_sha}'
+          for comment in reversed(comments):
+              body = comment.get('body') or ''
+              if not body.startswith('WEBEEBLOCKS_SIGNAL:'):
+                  continue
+              if body.startswith('WEBEEBLOCKS_SIGNAL: READY_FOR_CONTROLLER') and marker in body:
+                  print('Equivalent latest READY handoff already exists for this head.')
+                  raise SystemExit(0)
+              break
+
+          pr_url = pr['html_url']
+          comment_body = (
+              'WEBEEBLOCKS_SIGNAL: READY_FOR_CONTROLLER\n\n'
+              '@djibian\n\n'
+              f'HEAD_SHA: {head_sha}\n\n'
+              f'La PR #{pr_number} a atteint un état exact-head stabilisé. '
+              f'Checks observés: {check_summary}.\n\n'
+              'Une nouvelle impulsion du Contrôleur est maintenant utile pour dériver '
+              'le mode depuis les résultats exacts et poursuivre.\n\n'
+              f'COPY_TEXT: {restart_text}\n\n'
+              f'Preuve: {pr_url}'
+          )
+          github_request(
+              f'/repos/{repo}/issues/100/comments',
+              method='POST',
+              payload={'body': comment_body},
+          )
+          print('READY handoff posted to issue #100.')
+
+          if not topic:
+              print('NTFY_TOPIC not configured; GitHub @mention is the notification fallback.')
+              raise SystemExit(0)
+
+          ntfy_payload = {
+              'topic': topic,
+              'title': 'WebeeBlocks — READY',
+              'message': (
+                  f'PR #{pr_number} stabilisée sur {head_sha[:12]}. '
+                  f'Checks: {check_summary}. Nouvelle impulsion utile.'
+              ),
+              'priority': 3,
+              'tags': ['white_check_mark', 'robot'],
+              'click': pr_url,
+              'actions': [
+                  {'action': 'copy', 'label': 'Copier relance', 'value': restart_text},
+                  {'action': 'view', 'label': 'Ouvrir GitHub', 'url': pr_url},
+                  {'action': 'view', 'label': 'Ouvrir ChatGPT', 'url': 'https://chatgpt.com/'},
+              ],
+          }
+          publish = urllib.request.Request(
+              server.rstrip('/') + '/',
+              data=json.dumps(ntfy_payload).encode('utf-8'),
+              headers={'Content-Type': 'application/json'},
+              method='POST',
+          )
+          with urllib.request.urlopen(publish, timeout=20) as response:
+              print(f'ntfy status: {response.status}')
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,56 +26,61 @@ Surface any conflict with the product contract instead of silently optimizing ar
 - Never weaken a safety guard, oracle or acceptance criterion to obtain a green result.
 - GitHub facts outrank chat memory. Read the current branches, issues, pull requests, review state and exact-head checks before deciding what to do.
 - Issue #22 is a human-readable roadmap only. It must not be used as a machine lock, role token, queue or state database.
+- Issue #100 is only the human handoff/notification log. It must never override repository facts or become a work queue.
+- `controller-signal` is a transport branch only. It is never merged into `webots-ci` or `main` and may contain only the notification workflow inherited from `webots-ci` plus `.controller/handoff.json` updates used to trigger Android notification delivery.
 
 ## One controller, two modes
 
-Every launch derives its mode from GitHub. Do not persist a parallel controller state.
+Every launch derives exactly one mode from current GitHub evidence. Draft/Ready is not a role lock and is never an authorization boundary.
 
 | Observed state | Mode and action |
 | --- | --- |
 | No active controller pull request | **Worker**: select and deliver one bounded increment |
-| Active pull request is Draft | **Worker**: continue the same causal contract |
-| Ready pull request has missing or failing exact-head evidence | **Worker**: return it to Draft before changing code, then repair |
-| Ready pull request is green and has no exact-head verdict | **Reviewer-Integrator**: independently verify it |
-| Exact-head `NO_GO` verdict | **Worker**: return to Draft if needed and repair only the reported contradiction |
-| Exact-head `GO` verdict | **Reviewer-Integrator**: recheck the head and merge to `webots-ci` in the same launch |
-| A human decision is explicitly required | Wait and report the exact decision; do not simulate consent |
-| Multiple active controller pull requests or unauthorized `main` activity | Reconcile conservatively before starting new work |
+| Active PR has a current exact-head `GO` | **Reviewer-Integrator**: recheck the unchanged head and merge if still valid |
+| Active PR has exact-head `NO_GO` or `UNPROVEN` | **Worker**: repair only the reported contradiction on the same PR |
+| Active PR has missing, pending or failing exact-head evidence | **Worker**: continue diagnosis/repair on the same causal contract |
+| Active PR is exact-head green and has no current exact-head verdict | **Reviewer-Integrator**: independently falsify and judge it |
+| A precise human decision, permission or physical test is indispensable | stop at `HUMAN_REQUIRED`; do not simulate consent |
+| Multiple active controller PRs or unauthorized `main` activity | reconcile conservatively before starting new work |
 
-An exact-head verdict must identify the full commit SHA. A verdict for an older head is stale.
+An exact-head verdict identifies the full commit SHA. Any code change makes every verdict for the previous head stale.
+
+A launch has exactly one mode, but within that mode it continues through every immediately actionable step of the same causal contract. Completing one tool call, commit, test, comment or publication is never by itself a reason to stop.
 
 ## Worker mode
 
 Worker combines product scoping, experiment design and implementation. Its unit of work is one causal contract: one observable problem, one bounded change and one falsifiable acceptance oracle.
 
-1. Read `AGENTS.md`, `docs/PRODUCT_VISION.md`, the active pull request or the smallest actionable product issue, relevant code and current CI evidence.
+1. Read `AGENTS.md`, `docs/PRODUCT_VISION.md`, the active pull request or smallest actionable issue, relevant code and current CI evidence.
 2. State the objective, causal contract, scope and non-goals in the pull request.
 3. When causality is uncertain, run the smallest discriminating experiment before broadening production code.
 4. Implement a complete reviewable increment. Prefer causal fixes, reversible changes and the smallest test that would have failed before the fix.
 5. Separate product behavior, test harness and instrumentation. Evidence from one layer does not prove another.
-6. Run the cheapest relevant checks locally, then push the final intended head once. Do not create no-op commits or use pushes to refresh CI.
-7. Keep the pull request Draft while code is changing. Mark it Ready only after the final head is stable and fast checks pass. This transition requests the full CI suite.
-8. Stop after publishing the evidence. Review and merge belong to a fresh Reviewer-Integrator launch.
+6. When there is no active PR, work on the short-lived branch until the intended head is stable, then normally open the PR directly **Ready for review** so the full suite runs once. Draft is allowed only for a genuinely incomplete legacy/exceptional PR; do not use Draft as a machine-state lock.
+7. If a Ready PR later fails CI or receives `NO_GO`/`UNPROVEN`, repair it **without converting it back to Draft**. Push the causal repair to the same PR; the new SHA invalidates the old verdict and `synchronize` requests fresh exact-head CI automatically.
+8. After every meaningful result, ask only: **does another safe, causal, immediately actionable Worker step remain in this same contract?** If yes, perform it now. This includes diagnosis, implementation, discriminating tests, correction from already observed evidence, complete diff inspection, evidence reconciliation and publication.
+9. Do not switch to Reviewer-Integrator in the same launch. When exact-head evidence becomes fully green and the next useful action is independent review, that role boundary is a legitimate terminal frontier.
 
 If the causal question changes materially, stop expanding the pull request and create a separate issue. Do not split work merely to satisfy arbitrary size or commit limits.
 
 ## Reviewer-Integrator mode
 
-Reviewer-Integrator is read-only with respect to product code. It must not repair the change it reviews.
+Reviewer-Integrator is read-only with respect to the code it reviews. It must not repair the change it judges.
 
-1. Resolve the exact pull-request head SHA and confirm the base is `webots-ci`.
+1. Resolve the exact PR head SHA and confirm the base is `webots-ci`.
 2. Inspect the complete diff, causal contract, product constraints, tests and all required checks for that exact head.
-3. Try to falsify the claim: look for hidden skips, false-positive oracles, weakened guards, proxy evidence presented as product behavior, scope creep and unexplained regressions.
+3. Try to falsify the claim: look for hidden skips, false-positive oracles, weakened guards, proxy evidence presented as product behavior, scope creep, concurrency gaps and unexplained regressions.
 4. Record exactly one exact-head verdict in the pull request:
    - `GO <full_sha>` only when the scoped claim is supported and all required exact-head evidence is green;
    - `NO_GO <full_sha>` with concrete blocking contradictions and the smallest useful repair boundary;
    - `UNPROVEN <full_sha>` when the environment cannot exercise the claim or the evidence is inconclusive.
-5. On `NO_GO` or `UNPROVEN`, return the pull request to Draft and stop. Do not modify code.
-6. On `GO`, re-read the head immediately. If the SHA and checks are unchanged, merge to `webots-ci` in the same launch, close the completed issue and update the human roadmap. If anything changed, the verdict is stale: do not merge.
+5. On `NO_GO` or `UNPROVEN`, do not modify code and do not convert the PR to Draft. Complete the review evidence/handoff and stop; a fresh Worker launch repairs the same Ready PR.
+6. On `GO`, immediately re-read the PR head and checks. If the SHA and evidence are unchanged, merge to `webots-ci` in the same launch, close the completed issue, reconcile the human roadmap when materially necessary and verify the resulting integration state. If anything changed, the verdict is stale and must not be consumed.
+7. A successful merge is not automatically the end of useful Reviewer-Integrator work: complete deterministic post-merge checks, issue closure and handoff bookkeeping that are immediately available before stopping.
 
 ## Pull-request evidence contract
 
-Every controller pull request must state:
+Every controller pull request states:
 
 - objective and linked issue;
 - causal contract and observable acceptance oracle;
@@ -90,14 +95,104 @@ A green job proves only what its oracle exercises. A skipped test is not a pass.
 
 ## Efficient CI contract
 
-- Draft pushes execute only fast, path-relevant checks; full-suite jobs stay skipped.
-- The normal Draft-to-Ready transition runs the full pull-request suite once for the stable head. Opening a pull request directly as Ready is also supported.
-- Any code change after Ready requires returning to Draft, then marking Ready again after repair.
+- New controller PRs normally open directly Ready after branch-side preparation, which requests the full suite once for the first reviewable head.
+- A later repair is pushed directly to the same Ready PR. The `synchronize` event requests fresh exact-head CI; no Ready→Draft→Ready round-trip is required.
+- Draft remains supported for exceptional incomplete work but carries no review authority and is not part of normal role derivation.
 - Concurrency cancellation may discard superseded runs; only completed checks for the exact final head count.
-- One targeted rerun is allowed for a demonstrably transient infrastructure failure. Repeated or unexplained failure is product evidence, not a rerun strategy.
+- A targeted rerun is allowed only for a demonstrably transient infrastructure failure. Repeated or unexplained failure is product evidence, not a rerun strategy.
+- Do not poll merely to consume time. Re-observe an external check only after useful work, a reasonable stabilization boundary or a concrete event makes the new observation informative.
 
-## Bounded recovery and completion
+## Saturation, recovery and terminal frontiers
 
-Never loop on CI, reviews or GitHub state. In one launch, use at most one implementation push, one Ready transition, one targeted transient rerun and one merge attempt. If the work cannot advance safely within those bounds, record the blocker and stop.
+The controller optimizes for maximum useful progress per manual launch, not number of actions or elapsed time.
 
-Work is complete only when the objective is met, the intended behavior is actually exercised, exact-head CI has no unexplained failure, Reviewer-Integrator recorded `GO`, the same head was merged to `webots-ci`, and remaining uncertainty is explicit.
+After each completed action, continue in the same launch whenever another action is simultaneously:
+
+1. within the current mode;
+2. inside the same causal contract;
+3. authorized by current GitHub facts;
+4. safe and reversible where relevant;
+5. immediately actionable without pretending an external event has completed.
+
+There is no arbitrary per-launch limit on meaningful commits, pushes, tests, comments or inspections. Repetition is forbidden, but new evidence may justify another correction cycle in the same Worker launch when that evidence is already available.
+
+A launch may terminate only at a real frontier:
+
+- the next useful action belongs to the other controller mode;
+- exact-head CI or another external event is genuinely still running and no useful same-mode work remains;
+- a precise human decision, permission, physical test or new external authority is indispensable;
+- the causal contract is complete and immediate bookkeeping is reconciled;
+- no further authorized work is currently actionable;
+- a platform/tool failure genuinely prevents the next required operation.
+
+Do not manufacture work to avoid a frontier. Do not wait or poll repetitively when the frontier is external.
+
+## Handoff and Android notification protocol
+
+At every terminal frontier, publish exactly one concise handoff comment in issue #100. Repository facts remain authoritative.
+
+The first line is exactly one of:
+
+- `WEBEEBLOCKS_SIGNAL: READY_FOR_CONTROLLER`
+- `WEBEEBLOCKS_SIGNAL: WAITING_EXTERNAL`
+- `WEBEEBLOCKS_SIGNAL: HUMAN_REQUIRED`
+- `WEBEEBLOCKS_SIGNAL: DONE`
+
+Always mention `@djibian`, which remains the zero-configuration GitHub Mobile fallback.
+
+### READY_FOR_CONTROLLER
+
+Use only when another manual Controller launch can usefully act immediately. Include the completed result, why the next launch is actionable, the expected next action and exactly:
+
+`COPY_TEXT: Nouvelle impulsion. Reprends ton contrat de Contrôleur WebeeBlocks, reconstruis l'état réel depuis GitHub et poursuis jusqu'à la prochaine frontière terminale réelle.`
+
+Do not emit READY merely because the current launch ended.
+
+### WAITING_EXTERNAL
+
+Use when the only remaining frontier is an external CI/check/event that is genuinely still running. State what is pending and the exact head. Do **not** ask Emmanuel to relaunch and do not include `COPY_TEXT`.
+
+The GitHub notification workflow watches active Ready PRs and emits a later deduplicated `READY_FOR_CONTROLLER` when that exact head stabilizes. Therefore a Controller launch must not poll CI merely to discover that the same wait still exists.
+
+### HUMAN_REQUIRED
+
+Use only when human authority or a non-simulable human/physical action is indispensable. Include:
+
+- `Décision requise:` one concrete question;
+- `Options:` only genuine choices;
+- `Recommandation:` one recommended choice with concise rationale;
+- `COPY_TEXT:` a short recommended response that can be pasted unchanged;
+- relevant evidence links.
+
+### DONE
+
+Use only when no further authorized work is currently available **and no known external event is expected to make it immediately actionable**. Explain why. Do not use DONE as a synonym for waiting on CI.
+
+Avoid duplicate handoff comments for an unchanged frontier.
+
+### Android transport branch
+
+After writing the #100 handoff, mirror notification-worthy signals to the dedicated `controller-signal` branch when that branch exists:
+
+- mirror `READY_FOR_CONTROLLER`, `HUMAN_REQUIRED` and `DONE`;
+- do **not** mirror `WAITING_EXTERNAL`;
+- update only `.controller/handoff.json`; never modify any other file on `controller-signal`;
+- never merge `controller-signal` into another branch.
+
+The JSON payload is:
+
+```json
+{
+  "version": 1,
+  "signal": "READY_FOR_CONTROLLER | HUMAN_REQUIRED | DONE",
+  "message": "short human-readable summary",
+  "copy_text": "optional COPY_TEXT payload",
+  "url": "https://github.com/djibian/webeeblocks/issues/100"
+}
+```
+
+Updating this file is a meaningful notification transport action, not a no-op CI refresh. If the transport branch or ntfy configuration is unavailable, the #100 mention remains authoritative fallback and product/review state must not be changed merely to repair notification delivery.
+
+## Completion
+
+Work is complete only when the objective is met, intended behavior is actually exercised, exact-head CI has no unexplained failure, Reviewer-Integrator recorded `GO`, the same head was merged to `webots-ci`, and remaining uncertainty is explicit.

--- a/docs/CONTROLLER_ARCHITECTURE_CHANGELOG.md
+++ b/docs/CONTROLLER_ARCHITECTURE_CHANGELOG.md
@@ -1,0 +1,18 @@
+# Controller architecture simplification — 2026-08-29
+
+The #78 / PR #99 cycle exposed three orchestration costs that were unrelated to product correctness:
+
+1. repeated Ready→Draft→Ready transitions were required only because role derivation used PR Draft state as a lock;
+2. Controller runs stopped while CI was still active, but `DONE` did not distinguish temporary waiting from real completion;
+3. the user had to inspect GitHub manually to discover when the exact head had stabilized.
+
+This change removes those costs while preserving independent review:
+
+- role derivation now uses exact-head CI and exact-head verdicts, not Draft/Ready;
+- Worker repairs a failing or rejected Ready PR directly, with the new SHA invalidating stale verdicts;
+- new PRs normally open directly Ready after branch-side preparation;
+- `WAITING_EXTERNAL` represents a real asynchronous wait and never asks for a useless Controller relaunch;
+- a GitHub-native PR watcher emits `READY_FOR_CONTROLLER` after exact-head stabilization;
+- a dedicated `controller-signal` branch can deliver non-CI terminal signals to ntfy without modifying `main`.
+
+Independent Reviewer-Integrator review remains mandatory before merge to `webots-ci`, and `main` remains human-controlled.

--- a/docs/CONTROLLER_HANDOFF_STATES.md
+++ b/docs/CONTROLLER_HANDOFF_STATES.md
@@ -1,0 +1,6 @@
+# Controller handoff states
+
+- `READY_FOR_CONTROLLER`: a new manual impulse is useful now.
+- `WAITING_EXTERNAL`: external CI/event is still running; no manual relaunch is useful.
+- `HUMAN_REQUIRED`: a human decision, permission or physical action is indispensable.
+- `DONE`: no work is actionable and no known external event is expected to reopen it immediately.

--- a/docs/CONTROLLER_LIFECYCLE.md
+++ b/docs/CONTROLLER_LIFECYCLE.md
@@ -1,0 +1,9 @@
+# Simplified controller lifecycle
+
+`Worker -> Ready PR -> exact-head CI -> Reviewer-Integrator -> GO -> merge`
+
+If CI or review rejects the head:
+
+`Ready PR -> Worker repair on same PR -> new SHA -> fresh CI -> Reviewer-Integrator`
+
+No Ready→Draft→Ready loop is required. Every code change invalidates older verdicts by changing the exact head SHA.

--- a/docs/CONTROLLER_NOTES.md
+++ b/docs/CONTROLLER_NOTES.md
@@ -1,0 +1,1 @@
+This infrastructure change is intentionally completed before resuming product issue #80 so subsequent product cycles benefit from the simplified handoff/notification architecture.

--- a/docs/CONTROLLER_NOTIFICATIONS.md
+++ b/docs/CONTROLLER_NOTIFICATIONS.md
@@ -1,0 +1,109 @@
+# Controller handoff and Android notifications
+
+WebeeBlocks uses issue #100 as the durable human handoff log. Repository facts remain authoritative; #100 is not a queue, lock or machine-state database.
+
+## Signals
+
+The Controller records exactly one terminal signal:
+
+- `READY_FOR_CONTROLLER`: a fresh manual Controller impulse is immediately useful;
+- `WAITING_EXTERNAL`: CI/checks or another external event are still running, so no user action is useful yet;
+- `HUMAN_REQUIRED`: a concrete human decision, permission or physical action is indispensable;
+- `DONE`: nothing further is currently actionable and no known external event is expected to make it immediately actionable.
+
+Every signal mentions `@djibian`, so GitHub Mobile remains the zero-configuration fallback.
+
+## Why WAITING_EXTERNAL exists
+
+Before this contract, a Controller run waiting for CI used `DONE`, and Emmanuel then had to inspect GitHub manually to discover when another launch became useful. `WAITING_EXTERNAL` separates a temporary asynchronous wait from real completion.
+
+A Ready PR is watched by GitHub Actions. Once its exact head stabilizes, the watcher posts a deduplicated `READY_FOR_CONTROLLER` in #100 and can send the Android notification automatically. ChatGPT therefore does not poll CI.
+
+## Simplified PR lifecycle
+
+Draft/Ready is no longer a Worker/Reviewer lock.
+
+Normal lifecycle:
+
+1. Worker prepares a stable head on a short-lived branch.
+2. Worker opens the PR directly Ready for review.
+3. Full exact-head CI runs.
+4. If CI fails or independent review returns `NO_GO`/`UNPROVEN`, a fresh Worker repairs the same Ready PR directly.
+5. The repair push changes the SHA, invalidates stale verdicts and triggers fresh CI through `synchronize`.
+6. When exact-head CI stabilizes, the watcher notifies Emmanuel.
+7. A fresh Reviewer-Integrator either rejects the head or records `GO` and merges it unchanged to `webots-ci`.
+
+The old Ready→Draft→Ready round-trip is not required. Draft remains available only for genuinely incomplete exceptional work.
+
+## Automatic PR-stability watcher
+
+`.github/workflows/controller-android-notification.yml` watches non-Draft pull requests targeting `webots-ci` on `opened`, `reopened`, `synchronize` and `ready_for_review`.
+
+The watcher:
+
+- never checks out or executes candidate PR code;
+- binds itself to the exact PR head SHA;
+- aborts if the PR closes, becomes Draft or changes head;
+- waits until external exact-head checks are complete and remain unchanged for a stabilization window;
+- treats a stabilized failing head as actionable, because Worker can diagnose it;
+- posts one deduplicated `READY_FOR_CONTROLLER` handoff in #100;
+- optionally sends the same event through ntfy.
+
+## Why issue_comment is not the ntfy trigger
+
+GitHub documents that `issue_comment` workflows run only when the workflow file exists on the repository default branch. WebeeBlocks deliberately keeps `main` human-controlled and does not install controller infrastructure there. Therefore #100 comments cannot directly trigger ntfy without violating that branch boundary.
+
+Instead, non-CI terminal notifications use a dedicated transport branch.
+
+## `controller-signal` transport branch
+
+After this infrastructure is integrated, create `controller-signal` from the integrated `webots-ci` head. It is permanent transport infrastructure, not a product WIP and never merges anywhere.
+
+For `READY_FOR_CONTROLLER`, `HUMAN_REQUIRED` and `DONE`, the Controller first writes the authoritative #100 comment, then updates only:
+
+`.controller/handoff.json`
+
+on `controller-signal`.
+
+`WAITING_EXTERNAL` is intentionally not mirrored, because the user should not be disturbed while CI is still running.
+
+Expected payload:
+
+```json
+{
+  "version": 1,
+  "signal": "HUMAN_REQUIRED",
+  "message": "Short human-readable summary",
+  "copy_text": "Recommended response ready to copy",
+  "url": "https://github.com/djibian/webeeblocks/issues/100"
+}
+```
+
+A `push` workflow on that branch reads the JSON strictly as data and publishes the Android notification. It does not execute repository code from the payload.
+
+## ntfy one-time setup
+
+1. Install the official ntfy Android application.
+2. Choose a long, random, unguessable topic and subscribe to it.
+3. In GitHub repository **Settings → Secrets and variables → Actions**, create `NTFY_TOPIC` with that topic.
+4. Optional: add `NTFY_SERVER` for a self-hosted ntfy server; otherwise `https://ntfy.sh` is used.
+
+Do not commit the topic. Treat it as a low-value notification credential: if it is ever exposed or spammed, rotate it.
+
+If `NTFY_TOPIC` is absent, all workflows exit cleanly and GitHub `@djibian` mentions remain the fallback.
+
+## Android actions
+
+Notifications can contain up to three actions:
+
+- **Copier** / **Copier relance**: copies the `COPY_TEXT` payload;
+- **Ouvrir GitHub**: opens the relevant PR or #100;
+- **Ouvrir ChatGPT**: opens ChatGPT.
+
+`HUMAN_REQUIRED` uses high priority; `READY_FOR_CONTROLLER` uses normal priority; `DONE` uses low priority.
+
+## Security boundary
+
+The ntfy topic is the only secret required by this workflow. Never add product credentials, deployment secrets or privileged external authority to this notification mechanism.
+
+The PR watcher reads GitHub API metadata/checks only and never executes PR code. The signal transport reads only the fixed JSON path from the trusted transport branch. `main` is not modified by this architecture.

--- a/docs/CONTROLLER_NOTIFICATION_SECURITY.md
+++ b/docs/CONTROLLER_NOTIFICATION_SECURITY.md
@@ -1,0 +1,7 @@
+# Controller notification security boundary
+
+The notification workflow handles only GitHub metadata and a low-value ntfy topic secret. It never checks out or executes candidate PR code.
+
+The ntfy topic is not a product credential or deployment authority. Rotate it if exposed. Do not add higher-value secrets to this workflow.
+
+`main` remains outside the notification architecture.

--- a/docs/CONTROLLER_PR_RULES.md
+++ b/docs/CONTROLLER_PR_RULES.md
@@ -1,0 +1,3 @@
+# Controller PR state rules
+
+Draft/Ready is not a role lock. New controller PRs normally open Ready after branch-side preparation. A failing or rejected Ready PR is repaired directly on the same PR; the new SHA invalidates stale verdicts and triggers fresh CI.


### PR DESCRIPTION
## Objective

Complete the controller-infrastructure step deliberately scheduled after #78/#99 and before resuming #80.

## Causal contract

**Observed problem from #99:** role derivation used Draft/Ready as a lock, forcing repeated Ready→Draft→Ready transitions; `DONE` conflated temporary CI waiting with real completion; Emmanuel had to inspect GitHub manually to know when an exact head became actionable again.

**Bounded change:** derive Worker/Reviewer from exact-head CI + exact-head verdict instead of Draft/Ready, add `WAITING_EXTERNAL`, add a GitHub-native exact-head PR stability watcher, and add optional ntfy delivery without modifying `main`.

**Acceptance oracle:** a non-Draft PR targeting `webots-ci` is watched without executing PR code; once its unchanged exact head stabilizes, #100 receives one deduplicated `READY_FOR_CONTROLLER`. A failing stabilized head is also actionable. Non-CI terminal signals can be mirrored through the dedicated `controller-signal` transport branch after integration. Missing `NTFY_TOPIC` must fail open to GitHub mentions, not block development.

## Important design correction

The previously staged design used `issue_comment` as the ntfy trigger. GitHub documents that `issue_comment` workflows require the workflow file on the repository default branch. Because default `main` remains human-controlled and out of scope, this PR does **not** use `issue_comment`. It uses normal `pull_request` events for CI stabilization and a dedicated push-triggered `controller-signal` branch for terminal signal delivery.

## Scope

- `AGENTS.md`: exact-head role derivation; no Ready→Draft repair loop; `WAITING_EXTERNAL`; notification transport contract.
- `.github/workflows/controller-android-notification.yml`: exact-head PR stability watcher + optional ntfy signal transport; no checkout or execution of PR code.
- controller notification/lifecycle/security documentation and payload schema examples.

## Non-goals

- no product feature work (#80 remains deferred until this infrastructure closes);
- no change to `main`;
- no change to product safety or acceptance oracles;
- no secret creation through repository code;
- no background ChatGPT/browser automation;
- no removal of independent Reviewer-Integrator review.

## Security boundary

The notification workflow uses only GitHub metadata and the low-value optional `NTFY_TOPIC`. Candidate PR code is never checked out or executed by the watcher. No product/deployment credential is introduced.

## Post-merge setup

After independent `GO` and merge to `webots-ci`:
1. create `controller-signal` from the integrated head;
2. create the initial `.controller/handoff.json` there;
3. update #100 protocol and the paused Controller task prompt to the integrated contract;
4. Emmanuel performs the one-time `NTFY_TOPIC` secret + Android subscription setup.

Relates to #100. Does not close #100 because it remains the durable handoff channel.