### PR TITLE
Make Historical Light Sensor gate offline-deterministic

### DIFF
--- a/.github/workflows/historical-light-sensor-ci.yml
+++ b/.github/workflows/historical-light-sensor-ci.yml
@@ -58,13 +58,44 @@ jobs:
               make
             ' 2>&1 | tee ci-artifacts/light-sensor-build.log
 
-      - name: Execute historical light sensor program
+      - name: Prepare offline historical world
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          source = Path('worlds/lightSensorBoxChallenge.wbt')
+          target = Path('worlds/.ci-lightSensorBoxChallenge-local.wbt')
+          remote_prefix = 'https://raw.githubusercontent.com/cyberbotics/webots/R2025a/'
+          local_prefix = 'webots://'
+
+          original = source.read_text(encoding='utf-8')
+          if 'webots://' in original:
+              raise SystemExit('Unexpected pre-existing webots:// reference in historical source world.')
+
+          replacements = original.count(remote_prefix)
+          if replacements != 7:
+              raise SystemExit(f'Expected exactly 7 Cyberbotics R2025a remote EXTERNPROTO references, found {replacements}.')
+
+          localized = original.replace(remote_prefix, local_prefix)
+          if 'raw.githubusercontent.com/cyberbotics/webots/' in localized:
+              raise SystemExit('A Cyberbotics raw.githubusercontent.com dependency remains after localization.')
+
+          if localized.replace(local_prefix, remote_prefix) != original:
+              raise SystemExit('Offline world differs from the historical world by more than the allowed URL-prefix localization.')
+
+          target.write_text(localized, encoding='utf-8')
+          print(f'PASS: localized exactly {replacements} Webots R2025a EXTERNPROTO references without changing world semantics.')
+          PY
+
+      - name: Execute historical light sensor program offline
         shell: bash
         run: |
           set +e
           set -o pipefail
 
           docker run --rm \
+            --network none \
             -e LIBGL_ALWAYS_SOFTWARE=true \
             -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
             -v "${{ github.workspace }}:/workspace" \
@@ -75,7 +106,7 @@ jobs:
               --stderr \
               --batch \
               --mode=fast \
-              /workspace/worlds/lightSensorBoxChallenge.wbt' \
+              /workspace/worlds/.ci-lightSensorBoxChallenge-local.wbt' \
             2>&1 | tee ci-artifacts/webots-light-sensor.log
 
           code=${PIPESTATUS[0]}
@@ -94,6 +125,7 @@ jobs:
           if [ -f controllers/my_controller/.ci-light-sensor-backup.py ]; then
             mv controllers/my_controller/.ci-light-sensor-backup.py controllers/my_controller/my_controller.py
           fi
+          rm -f worlds/.ci-lightSensorBoxChallenge-local.wbt
 
       - name: Validate historical light sensor behavior
         shell: bash
@@ -122,7 +154,7 @@ jobs:
             exit 1
           fi
 
-          echo 'PASS: exact historical BoxWithLightSensor Blockly Python reached observable behavior under Webots R2025a.'
+          echo 'PASS: exact historical BoxWithLightSensor Blockly Python reached observable behavior under Webots R2025a with runtime networking disabled.'
 
       - name: Upload diagnostics
         if: always()

--- a/.github/workflows/historical-light-sensor-ci.yml
+++ b/.github/workflows/historical-light-sensor-ci.yml
@@ -24,6 +24,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout pinned Webots R2025a projects
+        uses: actions/checkout@v4
+        with:
+          repository: cyberbotics/webots
+          ref: R2025a
+          path: .ci-webots-r2025a
+          sparse-checkout: projects
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+
       - name: Prepare diagnostics
         run: mkdir -p ci-artifacts
 
@@ -84,8 +94,23 @@ jobs:
           if localized.replace(local_prefix, remote_prefix) != original:
               raise SystemExit('Offline world differs from the historical world by more than the allowed URL-prefix localization.')
 
+          projects = Path('.ci-webots-r2025a/projects')
+          required = [
+              'objects/backgrounds/protos/TexturedBackground.proto',
+              'objects/backgrounds/protos/TexturedBackgroundLight.proto',
+              'objects/floors/protos/RectangleArena.proto',
+              'objects/floors/protos/Floor.proto',
+              'appearances/protos/Parquetry.proto',
+              'objects/apartment_structure/protos/Wall.proto',
+              'robots/adept/pioneer3/protos/Pioneer3dx.proto',
+          ]
+          missing = [path for path in required if not (projects / path).is_file()]
+          if missing:
+              raise SystemExit('Pinned Webots R2025a checkout is missing required PROTOs: ' + ', '.join(missing))
+
           target.write_text(localized, encoding='utf-8')
           print(f'PASS: localized exactly {replacements} Webots R2025a EXTERNPROTO references without changing world semantics.')
+          print('PASS: all seven required PROTOs exist in the pinned Cyberbotics R2025a checkout.')
           PY
 
       - name: Execute historical light sensor program offline
@@ -99,6 +124,7 @@ jobs:
             -e LIBGL_ALWAYS_SOFTWARE=true \
             -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
             -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/.ci-webots-r2025a/projects:/usr/local/webots/projects:ro" \
             -w /workspace \
             cyberbotics/webots:R2025a-ubuntu22.04 \
             bash -lc 'timeout -k 5s 30s xvfb-run -a webots \


### PR DESCRIPTION
## Objective

Resolve #103 without weakening the Historical Light Sensor R2025a behavior oracle.

## Causal contract

**Observed problem:** the exact-head Historical Light Sensor gate repeatedly times out before `my_controller` starts because Webots tries to download Cyberbotics R2025a resources from `raw.githubusercontent.com`.

**Bounded change:** modify only `.github/workflows/historical-light-sensor-ci.yml`. The workflow creates a temporary CI-only copy of `worlds/lightSensorBoxChallenge.wbt`, replaces exactly the seven pinned Cyberbotics R2025a URL prefixes with Webots' local `webots://` resource scheme, verifies that this is the only world transformation, checks out the official `cyberbotics/webots@R2025a` `projects/` tree sparsely, mounts those pinned assets read-only at `/usr/local/webots/projects`, and runs Webots with Docker networking disabled.

**Acceptance oracle:** the unchanged exact historical `BoxWithLightSensor.xml` generated controller must start under the official `cyberbotics/webots:R2025a-ubuntu22.04` image and emit `WEBEEBLOCKS_CI_BOX_LIGHT_SENSOR_BEHAVIOR_EXECUTED` while the Webots execution container has `--network none`.

## Scope / non-goals

- no change to `worlds/lightSensorBoxChallenge.wbt`;
- no change to historical Blockly source or generated-controller SHA oracle;
- no skip, retry loop, timeout inflation, or weakened behavior assertion;
- no product/runtime change;
- no `main` change.

## Evidence history

Head `36b6552645162c892dbae5b9aa5d50055fc07625` proved the seven URL-prefix localization itself but failed because the official Docker image does not ship the referenced `projects/` tree under `/usr/local/webots/projects`; Webots failed closed on missing PROTOs.

Current head `7bc78503665ab5e4a41d31a94c0ea7889b94e5af` adds a sparse checkout of the pinned official Cyberbotics `R2025a` `projects/` assets and mounts it read-only at the exact `webots://` resolution location. The workflow also fails if any of the seven required PROTO files is missing before execution.

The unrelated `Historical Gyro GPS R2025a` failure on the previous head reproduced the known HTTP/2/raw.githubusercontent.com infrastructure incident; its single targeted retry was requested independently and is not folded into this causal contract.

## Evidence built into the gate

- fail unless the source world contains exactly seven expected Cyberbotics R2025a remote prefixes;
- fail if any Cyberbotics raw GitHub dependency remains in the localized top-level world;
- fail unless reversing only the URL-prefix substitution reproduces the source world byte-for-byte;
- fail unless all seven required PROTOs exist in the pinned `cyberbotics/webots@R2025a` checkout;
- mount those assets read-only into the official Webots image;
- execute Webots with `--network none`;
- preserve the existing controller-start and behavior-marker assertions.

## Current exact head

`7bc78503665ab5e4a41d31a94c0ea7889b94e5af`

## Remaining uncertainty

Fresh exact-head CI has not yet been requested because the connector failed to convert this repaired Ready PR back to Draft (`Repository.fullDatabaseId`). Under the currently integrated `AGENTS.md`, a human Draft transition is required before the next Ready transition can request the full suite.

Closes #103.