### PR TITLE
Recover project file UI from stale Robot Window cache

### DIFF
--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -59,5 +59,10 @@
   </main>
   <script src="main.js"></script>
   <script src="project_ui.js"></script>
+  <script>
+    if (window.WebeeBlocksProjectUiLoaded !== true) {
+      document.write('<script src="project_ui.js?nocache=' + Date.now() + '"><\\/script>');
+    }
+  </script>
 </body>
 </html>

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -58,11 +58,6 @@
     </nav>
   </main>
   <script src="main.js"></script>
-  <script src="project_ui.js"></script>
-  <script>
-    if (window.WebeeBlocksProjectUiLoaded !== true) {
-      document.write('<script src="project_ui.js?nocache=' + Date.now() + '"><\/script>');
-    }
-  </script>
+  <script src="project_ui.js?rev=20260830-1"></script>
 </body>
 </html>

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -61,7 +61,7 @@
   <script src="project_ui.js"></script>
   <script>
     if (window.WebeeBlocksProjectUiLoaded !== true) {
-      document.write('<script src="project_ui.js?nocache=' + Date.now() + '"><\\/script>');
+      document.write('<script src="project_ui.js?nocache=' + Date.now() + '"><\/script>');
     }
   </script>
 </body>

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -1,6 +1,8 @@
 (function() {
   'use strict';
 
+  window.WebeeBlocksProjectUiLoaded = true;
+
   var manager = null;
   var busy = false;
   var supported = false;

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -1,8 +1,6 @@
 (function() {
   'use strict';
 
-  window.WebeeBlocksProjectUiLoaded = true;
-
   var manager = null;
   var busy = false;
   var supported = false;

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import json
+import re
 
 ROOT = Path(__file__).resolve().parents[2]
 html_path = ROOT / 'plugins/robot_windows/blockly_v2/blockly_v2.html'
@@ -13,9 +14,10 @@ simple_run = '''<xml xmlns="https://developers.google.com/blockly/xml">
 </xml>'''
 html = html_path.read_text(encoding='utf-8')
 
-seam = '  <script src="project_ui.js"></script>\n'
-if seam not in html:
+seam_match = re.search(r'  <script src="project_ui\.js(?:\?[^\"]+)?"></script>\n', html)
+if not seam_match:
     raise SystemExit('project_ui.js seam not found')
+seam = seam_match.group(0)
 
 fake_api = r'''
   <script>


### PR DESCRIPTION
## Objective

Reliably recover the Runtime v2 project-file UI when the Webots/Robot Window HTTP cache serves stale or mis-associated bytes for `project_ui.js`, as observed during the Windows #80 benchmark.

Relates to #80 and #81.

## Causal contract

**Observed problem:** on the weak Windows target, Chrome reached `PRÊT` and the runtime was fluid, but Open / Save / Save As were inert because the normal `/robot_windows/blockly_v2/project_ui.js` request returned cached `interpreter.js` bytes. A request using a distinct query string returned the correct `project_ui.js`.

**Bounded change:** load `project_ui.js` exactly once through a versioned local URL (`project_ui.js?rev=20260830-1`). The historical unversioned URL is no longer executed, so a stale valid `project_ui.js` cannot register handlers and then be followed by a second initializer. No runtime logic in `project_ui.js` changes. The project-file CI harness accepts the same local script URL with an optional query so it continues to exercise the real Robot Window path.

**Acceptance oracle:**
1. exact-head Runtime v2 project-file/Robot Window CI remains green with no regression in Save As / Open / Save / debug/reset behavior;
2. on the Windows reproduction, the versioned local request returns the current `project_ui.js`, results in `window.WebeeBlocksProjectManager` being defined, with Open/Save As active and Save disabled until a file target exists;
3. only one project-file UI initializer is loaded.

## Scope

- `plugins/robot_windows/blockly_v2/blockly_v2.html`: replace the unversioned `project_ui.js` URL with one versioned local URL;
- `tools/ci/prepare_runtime_v2_project_files.py`: allow that versioned URL as the existing harness seam.

## Non-goals

- no unified browser/3D shell (option B remains rejected by the #80 benchmark);
- no AST, interpreter, backend, activity or Webots-world change;
- no Firefox/Edge support claim;
- no Windows packaging/toolchain work;
- no `main` change.

## Evidence

- `VERIFIED_BY_HUMAN_TEST`: #80 benchmark on Windows 10 / i3-3110M / 3.8 GB RAM validated option A and reproduced the stale cache mismatch.
- `VERIFIED_BY_HUMAN_TEST`: exact head `d9289f550f31f9c0aa4549c5d2edb83e4a01820b` was rerun on the same weak Windows PC without clearing Chrome cache; Chrome reached `PRÊT`, `project_ui.js?rev=20260830-1` was the loaded project UI script, `WebeeBlocksProjectManager` was defined, Open and Save As were active, and Save remained disabled before a file target existed. Human result recorded in issue #100 comment `5474753014`.
- `VERIFIED_BY_CODE_INSPECTION`: product diff is one URL substitution; `project_ui.js` is unchanged from `webots-ci`, and no fallback/double initializer remains.
- `VERIFIED_BY_CI`: Runtime v2 manual project files, Runtime v2 Webots WWI, simulation observability, reset/replay, packaging, Robot Window and the other exact-head checks are green. The sole prior exact-head failure, Historical Encoders, was diagnosed as a transient `raw.githubusercontent.com` asset-download failure before the historical controller started; one targeted rerun has been requested under the infrastructure-retry rule.
- `UNPROVEN`: completion of that single Historical Encoders targeted rerun.

## Exact head

`d9289f550f31f9c0aa4549c5d2edb83e4a01820b`
