### PR TITLE
Verify project-file core on Windows

### DIFF
--- a/.github/workflows/runtime-v2-project-files.yml
+++ b/.github/workflows/runtime-v2-project-files.yml
@@ -155,6 +155,10 @@ jobs:
         shell: pwsh
         run: |
           node --check plugins/robot_windows/blockly/webeeblocks/project_files.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           node --check plugins/robot_windows/blockly_v2/project_ui.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           node --check tools/ci/test_runtime_v2_project_files.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           node tools/ci/test_runtime_v2_project_files.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/runtime-v2-project-files.yml
+++ b/.github/workflows/runtime-v2-project-files.yml
@@ -10,6 +10,7 @@ on:
       - 'plugins/robot_windows/blockly_v2/project_files.css'
       - 'tools/ci/test_runtime_v2_project_files.js'
       - 'tools/ci/prepare_runtime_v2_project_files.py'
+      - 'tools/prepare_runtime_v2.ps1'
       - '.github/workflows/runtime-v2-project-files.yml'
   workflow_dispatch:
 
@@ -136,3 +137,24 @@ jobs:
           name: runtime-v2-project-files-r2025a
           path: ci-artifacts/runtime-v2-project-files/
           if-no-files-found: error
+
+  runtime-v2-project-files-windows-core:
+    runs-on: windows-2022
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare pinned Blockly 13.2.1 assets without Bash
+        shell: pwsh
+        run: ./tools/prepare_runtime_v2.ps1
+
+      - name: Validate project-file core and AST round-trip on Windows
+        shell: pwsh
+        run: |
+          node --check plugins/robot_windows/blockly/webeeblocks/project_files.js
+          node --check plugins/robot_windows/blockly_v2/project_ui.js
+          node --check tools/ci/test_runtime_v2_project_files.js
+          node tools/ci/test_runtime_v2_project_files.js


### PR DESCRIPTION
## Objective

Advance #81 with the next smallest Windows-native automated gate: prove that the existing Runtime v2 project-file core contract executes on Windows and round-trips the same backend-neutral AST without Bash.

## Causal contract

**Observed gap:** #107 proved Windows-native Blockly asset preparation and core/preflight checks, but the project-file contract remained exercised only by the Linux/Webots workflow. #81 explicitly requires Runtime v2 project-file tests on Windows and Linux↔Windows portability evidence.

**Bounded change:** extend the existing `Runtime v2 manual project files` workflow with one `windows-2022` core job. It uses the already-integrated `tools/prepare_runtime_v2.ps1`, runs the existing project-file syntax checks, and executes the existing `test_runtime_v2_project_files.js` oracle unchanged.

**Acceptance oracle:** on the exact PR head, the Windows job must prepare Blockly 13.2.1 without Bash and the existing project-file test must pass, including explicit Save/Save As semantics, fail-closed malformed inputs, no autosave/history behavior and full AST round-trip. Every native Node command in the Windows validation step must independently fail the job on non-zero exit. The existing Linux real Robot Window gate must remain green.

## Scope

- add `tools/prepare_runtime_v2.ps1` to the project-files workflow path triggers;
- add one Windows 2022 project-file core/AST round-trip job;
- make each native Node invocation in that Windows job fail closed via immediate `$LASTEXITCODE` checks;
- no product JavaScript changes.

## Non-goals

- no claim that hosted Windows CI validates Webots GUI/Robot Window behavior;
- no browser support claim beyond existing human Chrome evidence;
- no Windows Webots C-controller build yet;
- no release artifact yet;
- no student Node/npm dependency;
- no AST/runtime semantics change;
- no `main` change.

## Evidence

- `VERIFIED_BY_CODE_INSPECTION`: the Windows job invokes the same unchanged `tools/ci/test_runtime_v2_project_files.js` oracle as Linux after native PowerShell preparation.
- `VERIFIED_BY_CODE_INSPECTION`: the existing test explicitly round-trips serialized workspace state back to the same full AST and exercises fail-closed malformed project files.
- `REFUTED` on prior head `1c1115882647f65f0b8b9022f61ce3b9657405ef`: sequential native PowerShell commands could mask an intermediate non-zero exit and yield a false-green job.
- `VERIFIED_BY_CODE_INSPECTION` on current head: every native Node command is followed immediately by `if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`, preserving the oracle while making the step fail closed.
- `VERIFIED_BY_CI`: pending current exact-head Windows and existing Linux project-file evidence.

## Remaining uncertainty

#81 still requires the official Webots R2025a Windows controller build, prepared classroom release artifact/offline boundary, and final real Windows acceptance. Hosted CI does not replace those physical/GUI checks.

## Exact head

`c83b63d354a6a780d2435484c5858018fbc2cd28`

Relates to #81.