### PR TITLE
Ignore stale CI Gate completion notifications

### DIFF
--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -54,8 +54,19 @@ jobs:
           conclusion = run.get('conclusion') or 'unknown'
           if len(head) != 40 or any(character not in '0123456789abcdef' for character in head):
               raise SystemExit('Invalid head SHA')
-          if pull_request['head']['sha'] != head:
-              print('PR head no longer matches this completed run; stale event ignored.')
+          current_request = urllib.request.Request(
+              f"https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
+              headers={
+                  'Accept': 'application/vnd.github+json',
+                  'User-Agent': 'webeeblocks-ci-gate-ntfy',
+              },
+          )
+          with urllib.request.urlopen(current_request, timeout=20) as response:
+              current_pull_request = json.load(response)
+          current_head = (current_pull_request.get('head') or {}).get('sha')
+          current_base = (current_pull_request.get('base') or {}).get('ref')
+          if current_head != head or current_base != 'develop':
+              print('PR no longer matches this completed run; stale event ignored.')
               raise SystemExit(0)
 
           topic = os.environ.get('NTFY_TOPIC', '').strip()

--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -17,6 +17,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0].base.ref == 'develop' &&
+      github.event.workflow_run.pull_requests[0].head.sha == github.event.workflow_run.head_sha &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +54,9 @@ jobs:
           conclusion = run.get('conclusion') or 'unknown'
           if len(head) != 40 or any(character not in '0123456789abcdef' for character in head):
               raise SystemExit('Invalid head SHA')
+          if pull_request['head']['sha'] != head:
+              print('PR head no longer matches this completed run; stale event ignored.')
+              raise SystemExit(0)
 
           topic = os.environ.get('NTFY_TOPIC', '').strip()
           if not topic:


### PR DESCRIPTION
## But

Empêcher le relais ntfy trusted de notifier les exécutions `CI Gate` devenues obsolètes après un nouveau push sur la même PR.

## Périmètre

- un seul fichier : `.github/workflows/controller-handoff-ntfy.yml` ;
- comparaison du SHA embarqué dans la PR avec `workflow_run.head_sha` dans le filtre du job ;
- même comparaison révalidée dans le script avant tout accès au secret et tout envoi ntfy ;
- aucun checkout, aucune exécution de code candidat, aucune permission GitHub, aucune écriture GitHub.

Le contenu est exactement celui déjà validé et intégré sur `develop`. Cette PR termine le bootstrap ntfy autorisé vers `main`.