### PR TITLE
Reconcile trusted relay and main ancestry

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1478,8 +1478,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout pinned Webots R2025a projects
+        uses: actions/checkout@v4
+        with:
+          repository: cyberbotics/webots
+          ref: c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b
+          path: .ci-webots-r2025a
+          sparse-checkout: projects
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+
       - name: Prepare diagnostics
         run: mkdir -p ci-artifacts
+
+      - name: Prepare offline historical encoder world
+        run: |
+          python3 tools/ci/localize_webots_world.py \
+            worlds/boxChallenge.wbt worlds/.ci-boxChallenge-encoders-local.wbt --expected 5
 
       - name: Export exact historical BoxWithEncoders controller
         shell: bash
@@ -1519,9 +1534,11 @@ jobs:
           set -o pipefail
 
           docker run --rm \
+            --network none \
             -e LIBGL_ALWAYS_SOFTWARE=true \
             -e WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
             -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/.ci-webots-r2025a/projects:/usr/local/webots/projects:ro" \
             -w /workspace \
             cyberbotics/webots:R2025a-ubuntu22.04 \
             bash -lc 'timeout -k 5s 30s xvfb-run -a webots \
@@ -1529,7 +1546,7 @@ jobs:
               --stderr \
               --batch \
               --mode=fast \
-              /workspace/worlds/boxChallenge.wbt' \
+              /workspace/worlds/.ci-boxChallenge-encoders-local.wbt' \
             2>&1 | tee ci-artifacts/webots-box-encoders.log
 
           code=${PIPESTATUS[0]}

--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -17,6 +17,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0].base.ref == 'develop' &&
+      github.event.workflow_run.pull_requests[0].head.sha == github.event.workflow_run.head_sha &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +54,20 @@ jobs:
           conclusion = run.get('conclusion') or 'unknown'
           if len(head) != 40 or any(character not in '0123456789abcdef' for character in head):
               raise SystemExit('Invalid head SHA')
+          current_request = urllib.request.Request(
+              f"https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
+              headers={
+                  'Accept': 'application/vnd.github+json',
+                  'User-Agent': 'webeeblocks-ci-gate-ntfy',
+              },
+          )
+          with urllib.request.urlopen(current_request, timeout=20) as response:
+              current_pull_request = json.load(response)
+          current_head = (current_pull_request.get('head') or {}).get('sha')
+          current_base = (current_pull_request.get('base') or {}).get('ref')
+          if current_head != head or current_base != 'develop':
+              print('PR no longer matches this completed run; stale event ignored.')
+              raise SystemExit(0)
 
           topic = os.environ.get('NTFY_TOPIC', '').strip()
           if not topic:

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -69,6 +69,18 @@ class WorkflowContractTests(unittest.TestCase):
             "pull_requests[0].head.sha == github.event.workflow_run.head_sha",
             transport,
         )
+        self.assertIn(
+            "https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
+            transport,
+        )
+        self.assertIn(
+            "current_head != head or current_base != 'develop'",
+            transport,
+        )
+        self.assertLess(
+            transport.index("current_request = urllib.request.Request("),
+            transport.index("topic = os.environ.get('NTFY_TOPIC'"),
+        )
         self.assertIn("permissions: {}", transport)
         self.assertNotIn("  pull_request:\n", transport)
         self.assertNotIn("actions/checkout", transport)
@@ -104,8 +116,21 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("ref: R2025a", suite)
         self.assertEqual(
             suite.count("ref: c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b"),
-            3,
+            4,
         )
+
+    def test_encoders_historical_runtime_is_offline(self) -> None:
+        suite = (WORKFLOWS / "ci-webots.yml").read_text(encoding="utf-8")
+        encoders = suite.split("\n  encoders-historical:\n", 1)[1].split(
+            "\n  gyro-gps-historical:\n", 1
+        )[0]
+        self.assertIn("Prepare offline historical encoder world", encoders)
+        self.assertIn(
+            "/workspace/worlds/.ci-boxChallenge-encoders-local.wbt",
+            encoders,
+        )
+        self.assertIn("--network none", encoders)
+        self.assertIn("/usr/local/webots/projects:ro", encoders)
 
     def test_gyro_gps_historical_runtime_is_offline(self) -> None:
         suite = (WORKFLOWS / "ci-webots.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Résultat

Réconcilier immédiatement le bootstrap trusted de `main` dans `develop` et conserver `main` comme ancêtre de la branche d’intégration.

## Changement de contenu

Un seul fichier : le relais ntfy vérifie désormais le HEAD courant de la PR via l’API GitHub publique en lecture seule avant de lire `NTFY_TOPIC` ou de notifier.

## Histoire

Le commit de tête a deux parents : `develop@796ec577…` et `main@855a5ab0…`. Aucun historique n’est réécrit.

## Sûreté

- `permissions: {}` ;
- aucun jeton GitHub ;
- aucun checkout ni code candidat ;
- aucune écriture GitHub ;
- événement périmé supprimé avant accès au secret ;
- le changement de workflow déclenche volontairement la suite complète du nouveau `CI Gate`.