### PR TITLE
Deliver the Windows classroom release path

### DIFF
--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -2,6 +2,12 @@ name: CI Runtime Suite
 
 on:
   workflow_call:
+    inputs:
+      full:
+        description: Build the complete Windows classroom release.
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
 
 permissions:
@@ -61,6 +67,18 @@ jobs:
       - name: Reject malformed AST before backend actions on Windows
         shell: pwsh
         run: node tools/ci/test_runtime_v2_preflight.js
+
+      - name: Validate project-file core and AST round-trip on Windows
+        shell: pwsh
+        run: |
+          node --check plugins/robot_windows/blockly/webeeblocks/project_files.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check plugins/robot_windows/blockly_v2/project_ui.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node --check tools/ci/test_runtime_v2_project_files.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          node tools/ci/test_runtime_v2_project_files.js
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
   clean-checkout-runtime-v2:
     if: github.event_name != 'pull_request' || github.event.action == 'ready_for_review' || github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
@@ -994,4 +1012,92 @@ jobs:
         with:
           name: experimental-runtime-v2-student-ui
           path: ci-artifacts/runtime-v2-student-ui/
+          if-no-files-found: error
+
+  runtime-v2-windows-release:
+    needs: runtime-v2-windows-assets
+    if: ${{ needs.runtime-v2-windows-assets.result == 'success' && (github.event_name != 'pull_request' || inputs.full) }}
+    runs-on: windows-2022
+    timeout-minutes: 40
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout pinned Webots R2025a release assets
+        uses: actions/checkout@v4
+        with:
+          repository: cyberbotics/webots
+          ref: c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b
+          path: .ci-webots-r2025a
+          sparse-checkout: |
+            /projects/robots/bitcraze/crazyflie/protos/
+            /projects/default/protos/textures/fast_helix.png
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache official Webots R2025a installer
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\webots-R2025a_setup.exe
+          key: webots-R2025a-windows-9e326a54c104fc5
+
+      - name: Install verified Webots R2025a
+        shell: pwsh
+        run: |
+          $installer = Join-Path $env:RUNNER_TEMP 'webots-R2025a_setup.exe'
+          $expected = '9e326a54c104fc5fc88121e26014a409d1e35f0bbf30e23f3a712e7f842b08e7'
+          if (-not (Test-Path -LiteralPath $installer -PathType Leaf)) {
+            Invoke-WebRequest `
+              -Uri 'https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a_setup.exe' `
+              -OutFile $installer
+          }
+          $actual = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            Remove-Item -LiteralPath $installer -Force
+            throw "Webots installer checksum mismatch: $actual"
+          }
+          $webotsHome = Join-Path $env:ProgramFiles 'Webots'
+          $webotsExe = Join-Path $webotsHome 'msys64\mingw64\bin\webots.exe'
+          if (-not (Test-Path -LiteralPath $webotsExe -PathType Leaf)) {
+            $process = Start-Process `
+              -FilePath $installer `
+              -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-') `
+              -Wait `
+              -PassThru
+            if ($process.ExitCode -ne 0) { throw "Webots installer exited with $($process.ExitCode)." }
+          }
+          if (-not (Test-Path -LiteralPath $webotsExe -PathType Leaf)) {
+            throw 'Verified Webots R2025a installation is missing webots.exe.'
+          }
+          $version = (& $webotsExe --version | Out-String).Trim()
+          if ($LASTEXITCODE -ne 0 -or $version -notmatch 'R2025a') {
+            throw "Unexpected Webots version: $version"
+          }
+          "WEBOTS_HOME=$webotsHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "WEBEEBLOCKS_WEBOTS_VERSION=$version"
+
+      - name: Build self-contained Windows classroom release
+        shell: pwsh
+        run: |
+          ./tools/build_windows_classroom_release.ps1 `
+            -WebotsHome $env:WEBOTS_HOME `
+            -WebotsProjectsPath '.ci-webots-r2025a\projects' `
+            -OutputDirectory 'ci-artifacts\windows-release'
+
+      - name: Validate archive from a path containing spaces
+        shell: pwsh
+        run: |
+          ./tools/ci/test_windows_classroom_release.ps1 `
+            -ArchivePath 'ci-artifacts\windows-release\WebeeBlocks-Windows-R2025a.zip' `
+            -WebotsHome $env:WEBOTS_HOME
+
+      - name: Upload Windows classroom release
+        uses: actions/upload-artifact@v4
+        with:
+          name: WebeeBlocks-Windows-R2025a
+          path: ci-artifacts/windows-release/WebeeBlocks-Windows-R2025a.zip
           if-no-files-found: error

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -387,9 +387,13 @@ jobs:
               assert panel['state'] == 'TERMINÉ', terminal_detail
               assert panel['result'] == expected, terminal_detail
               assert panel['time'].endswith(' s') and panel['time'] != '—', terminal_detail
-              assert terminal_detail['runtimeState'] == 'WAITING', terminal_detail
+              assert terminal_detail['runtimeStateAtTerminal'] == 'RECOVERING', terminal_detail
+              assert terminal_detail['runtimeStateAfterFreeze'] in ('RECOVERING', 'WAITING'), terminal_detail
           initial = [e for e in events if e['event'] == 'INITIAL'][-1]
           assert json.loads(initial['detail'])['state'] == 'PRÊT'
+          final_ready = [e for e in events if e['event'] == 'FINAL_RUNTIME_READY']
+          assert final_ready, events
+          assert json.loads(final_ready[-1]['detail'])['runtimeState'] == 'WAITING', final_ready[-1]
           assert any(e['event'] == 'CHALLENGE_TEST_COMPLETE' for e in events), events
 
           challenge = [json.loads(e['detail']) for e in events if e['event'] == 'CHALLENGE']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           python3 tools/ci/test_workflow_contract.py
           python3 tools/ci/test_localize_webots_world.py
           python3 tools/ci/test_repository_hygiene.py
+          python3 tools/ci/test_windows_release_contract.py
 
       - name: Select required suites
         id: scope
@@ -53,6 +54,8 @@ jobs:
     needs: select
     if: ${{ needs.select.outputs.runtime == 'true' }}
     uses: ./.github/workflows/ci-runtime.yml
+    with:
+      full: ${{ needs.select.outputs.full == 'true' }}
 
   webots:
     name: Webots suite

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Windows PowerShell:
 ./tools/prepare_runtime_v2.ps1
 ```
 
-The command prepares the pinned Blockly browser distribution used by the Robot
-Window. Students do not run Node.js or npm; prepared classroom releases contain
-the required assets.
+These developer commands prepare the pinned Blockly browser distribution used
+by the Robot Window. Students do not run Node.js or npm. The Windows classroom
+artifact additionally contains the compiled controller, local R2025a Robot
+Window bridge, offline Crazyflie assets, one-click launcher and integrity
+manifest. See [`docs/WINDOWS_DEPLOYMENT.md`](docs/WINDOWS_DEPLOYMENT.md).
 
 ## Development
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -84,3 +84,6 @@ authority; it is not required for the current manual-release model.
 - two permanent development branches and automatic feature-branch deletion;
 - full regression nightly and before human promotion.
 
+The full gate also builds the Windows classroom ZIP with the official Webots
+R2025a toolchain. Runtime-only PRs retain the fast Windows AST and project-file
+contract; nightly runs and promotions rebuild the complete offline artifact.

--- a/docs/WINDOWS_DEPLOYMENT.md
+++ b/docs/WINDOWS_DEPLOYMENT.md
@@ -1,0 +1,52 @@
+# Windows classroom deployment
+
+## Supported target
+
+The release target is Windows 10 or 11 64-bit with Webots R2025a and a supported
+system browser. Edge or Chrome is recommended for native Open/Save/Save As.
+Firefox keeps the explicit fallback download path; it must clearly produce a
+new copy rather than pretending to update the selected file.
+
+The student machine does not need Git, Node.js, npm, Bash, Python or a compiler.
+Those tools exist only on the release builder.
+
+## Build boundary
+
+The complete gate runs `tools/build_windows_classroom_release.ps1` on a
+`windows-2022` runner after:
+
+1. verifying the official `webots-R2025a_setup.exe` SHA-256;
+2. installing Webots R2025a and using its bundled MSYS2/MinGW toolchain to build
+   `crazyflie_runtime_v2.exe`;
+3. preparing Blockly 13.2.1 through the exact npm lock file;
+4. copying the pinned local Robot Window bridge;
+5. replacing the four remote world dependencies with a local Crazyflie PROTO,
+   two meshes, one texture and built-in floor/background nodes;
+6. emitting a ZIP plus `MANIFEST.sha256`.
+
+The archive validator expands the ZIP under a path containing spaces, verifies
+every checksum, rejects development-only files and runtime URLs, checks every
+JavaScript file, confirms a Windows PE controller and exercises the launcher in
+validation mode.
+
+The Webots installer is cached to avoid repeated large downloads. The complete
+Windows build runs for full gates, nightly validation and promotion to `main`;
+the lightweight Windows Blockly/AST/project-file contract remains on every
+Runtime change.
+
+## Teacher and student path
+
+The teacher installs Webots R2025a, extracts
+`WebeeBlocks-Windows-R2025a.zip` into a writable folder and may disconnect the
+network. The student then double-clicks `Launch-WebeeBlocks.cmd`. The launcher
+finds Webots through `WEBOTS_HOME`, the standard Program Files location or
+`PATH`, opens the packaged world paused and lets Webots open the Robot Window in
+the configured browser.
+
+## Human acceptance boundary
+
+Hosted CI proves build, contents, paths, core semantics and launch resolution.
+It does not prove a visible Windows/Webots/browser classroom session. Before a
+Windows-support claim, copy and complete `WINDOWS-ACCEPTANCE.md` from the
+archive on the least powerful target PC, including the 30-minute offline
+stability and Chrome/Edge plus Firefox file paths required by #81.

--- a/packaging/windows/Launch-WebeeBlocks.cmd
+++ b/packaging/windows/Launch-WebeeBlocks.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0Launch-WebeeBlocks.ps1"
+if errorlevel 1 (
+  echo.
+  echo WebeeBlocks n'a pas pu demarrer. Consultez README-WINDOWS.md.
+  pause
+)

--- a/packaging/windows/Launch-WebeeBlocks.ps1
+++ b/packaging/windows/Launch-WebeeBlocks.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding()]
+param(
+  [string]$WebotsHome = $env:WEBOTS_HOME,
+  [switch]$ValidateOnly
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$world = Join-Path $PSScriptRoot 'worlds\crazyflie_runtime_v2.wbt'
+if (-not (Test-Path -LiteralPath $world -PathType Leaf)) {
+  throw "Monde WebeeBlocks introuvable : $world"
+}
+
+$worldText = Get-Content -LiteralPath $world -Raw
+if ($worldText -match '"(?:https?|webots)://') {
+  throw 'Le monde de classe contient encore une ressource distante.'
+}
+
+$candidates = [System.Collections.Generic.List[string]]::new()
+foreach ($home in @($WebotsHome, (Join-Path $env:ProgramFiles 'Webots'))) {
+  if ([string]::IsNullOrWhiteSpace($home)) { continue }
+  $candidates.Add((Join-Path $home 'msys64\mingw64\bin\webotsw.exe'))
+  $candidates.Add((Join-Path $home 'msys64\mingw64\bin\webots.exe'))
+}
+foreach ($commandName in @('webotsw.exe', 'webots.exe')) {
+  $command = Get-Command $commandName -ErrorAction SilentlyContinue
+  if ($null -ne $command) { $candidates.Add($command.Source) }
+}
+
+$webots = $candidates | Where-Object {
+  -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -LiteralPath $_ -PathType Leaf)
+} | Select-Object -First 1
+if ([string]::IsNullOrWhiteSpace($webots)) {
+  throw 'Webots R2025a est introuvable. Installez-le dans C:\Program Files\Webots ou definissez WEBOTS_HOME.'
+}
+
+if ($ValidateOnly) {
+  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world"
+  exit 0
+}
+
+if ($world.Contains('"')) { throw 'Le chemin du monde contient un guillemet non pris en charge.' }
+$worldArgument = '"' + $world + '"'
+Start-Process -FilePath $webots -ArgumentList @('--mode=pause', $worldArgument) -WorkingDirectory $PSScriptRoot
+Write-Host 'WebeeBlocks demarre. La fenetre Blockly va s’ouvrir dans le navigateur configure par Webots.'

--- a/packaging/windows/Launch-WebeeBlocks.ps1
+++ b/packaging/windows/Launch-WebeeBlocks.ps1
@@ -56,4 +56,4 @@ if ($ValidateOnly) {
 if ($world.Contains('"')) { throw 'Le chemin du monde contient un guillemet non pris en charge.' }
 $worldArgument = '"' + $world + '"'
 Start-Process -FilePath $webots -ArgumentList @('--mode=pause', $worldArgument) -WorkingDirectory $PSScriptRoot
-Write-Host 'WebeeBlocks demarre. La fenetre Blockly va s’ouvrir dans le navigateur configure par Webots.'
+Write-Host "WebeeBlocks demarre. La fenetre Blockly va s'ouvrir dans le navigateur configure par Webots."

--- a/packaging/windows/Launch-WebeeBlocks.ps1
+++ b/packaging/windows/Launch-WebeeBlocks.ps1
@@ -28,15 +28,28 @@ foreach ($commandName in @('webotsw.exe', 'webots.exe')) {
   if ($null -ne $command) { $candidates.Add($command.Source) }
 }
 
-$webots = $candidates | Where-Object {
-  -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -LiteralPath $_ -PathType Leaf)
-} | Select-Object -First 1
+function Test-WebotsR2025a {
+  param([string]$Executable)
+  if ([string]::IsNullOrWhiteSpace($Executable) -or -not (Test-Path -LiteralPath $Executable -PathType Leaf)) {
+    return $false
+  }
+  $versionExecutable = $Executable
+  if ([System.IO.Path]::GetFileName($Executable).Equals('webotsw.exe', [System.StringComparison]::OrdinalIgnoreCase)) {
+    $consoleExecutable = Join-Path (Split-Path $Executable -Parent) 'webots.exe'
+    if (-not (Test-Path -LiteralPath $consoleExecutable -PathType Leaf)) { return $false }
+    $versionExecutable = $consoleExecutable
+  }
+  $version = (& $versionExecutable --version 2>&1 | Out-String).Trim()
+  return ($LASTEXITCODE -eq 0 -and $version -match 'R2025a')
+}
+
+$webots = $candidates | Where-Object { Test-WebotsR2025a -Executable $_ } | Select-Object -First 1
 if ([string]::IsNullOrWhiteSpace($webots)) {
-  throw 'Webots R2025a est introuvable. Installez-le dans C:\Program Files\Webots ou definissez WEBOTS_HOME.'
+  throw 'Webots R2025a est introuvable. Installez exactement R2025a dans C:\Program Files\Webots ou definissez WEBOTS_HOME.'
 }
 
 if ($ValidateOnly) {
-  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world"
+  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world version=R2025a"
   exit 0
 }
 

--- a/packaging/windows/Launch-WebeeBlocks.ps1
+++ b/packaging/windows/Launch-WebeeBlocks.ps1
@@ -18,10 +18,10 @@ if ($worldText -match '"(?:https?|webots)://') {
 }
 
 $candidates = [System.Collections.Generic.List[string]]::new()
-foreach ($home in @($WebotsHome, (Join-Path $env:ProgramFiles 'Webots'))) {
-  if ([string]::IsNullOrWhiteSpace($home)) { continue }
-  $candidates.Add((Join-Path $home 'msys64\mingw64\bin\webotsw.exe'))
-  $candidates.Add((Join-Path $home 'msys64\mingw64\bin\webots.exe'))
+foreach ($candidateHome in @($WebotsHome, (Join-Path $env:ProgramFiles 'Webots'))) {
+  if ([string]::IsNullOrWhiteSpace($candidateHome)) { continue }
+  $candidates.Add((Join-Path $candidateHome 'msys64\mingw64\bin\webotsw.exe'))
+  $candidates.Add((Join-Path $candidateHome 'msys64\mingw64\bin\webots.exe'))
 }
 foreach ($commandName in @('webotsw.exe', 'webots.exe')) {
   $command = Get-Command $commandName -ErrorAction SilentlyContinue

--- a/packaging/windows/README-WINDOWS.md
+++ b/packaging/windows/README-WINDOWS.md
@@ -1,0 +1,36 @@
+# WebeeBlocks — classe Windows
+
+Cette archive est prête à l’emploi après installation de Webots R2025a. Elle
+contient le contrôleur Windows compilé, Blockly 13.2.1, le pont Robot Window et
+les actifs Crazyflie nécessaires au fonctionnement hors ligne.
+
+## Prérequis enseignant
+
+- Windows 10 ou 11 64 bits ;
+- Webots R2025a installé dans `C:\Program Files\Webots` (ou `WEBOTS_HOME`
+  défini) ;
+- Microsoft Edge ou Google Chrome recommandé. Firefox utilise le parcours de
+  sauvegarde de secours et peut créer une nouvelle copie à chaque sauvegarde.
+
+Ni Git, ni Node.js, ni npm, ni compilateur ne sont requis sur le poste élève.
+
+## Installation et lancement
+
+1. décompresser l’archive dans un dossier accessible en écriture, y compris un
+   chemin contenant des espaces ;
+2. double-cliquer sur `Launch-WebeeBlocks.cmd` ;
+3. attendre l’état `PRÊT` dans la fenêtre Blockly ;
+4. démarrer la simulation avec les contrôles Webots puis utiliser **Lancer le
+   vol**.
+
+Après préparation de Webots et extraction de cette archive, couper le réseau ne
+doit pas empêcher le lancement, Blockly, l’exécution, le pas à pas, la remise à
+zéro ou les fichiers `.wbb`.
+
+En cas d’échec, vérifier que
+`C:\Program Files\Webots\msys64\mingw64\bin\webotsw.exe` existe. Le fichier
+`MANIFEST.sha256` permet de contrôler l’intégrité de chaque fichier livré.
+
+Le support Windows reste **à valider humainement** tant que la fiche
+`WINDOWS-ACCEPTANCE.md` n’a pas été remplie sur le poste de classe le moins
+puissant.

--- a/packaging/windows/THIRD_PARTY_NOTICES.md
+++ b/packaging/windows/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,13 @@
+# Third-party notices
+
+The classroom archive contains the following pinned third-party material:
+
+- Blockly 13.2.1, Apache-2.0, prepared from the exact npm lock file;
+- `RobotWindow.js` and `request_methods.js` from Webots R2025a commit
+  `c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b`, Apache-2.0;
+- `Crazyflie.proto`, its two COLLADA meshes and `fast_helix.png` from the same
+  Webots commit. The PROTO retains Cyberbotics’ Webots asset-license header and
+  is distributed only for use with Webots.
+
+Webots is an explicit prerequisite and is not redistributed in this archive.
+The project’s `LICENSE` and upstream notices remain authoritative.

--- a/packaging/windows/WINDOWS-ACCEPTANCE.md
+++ b/packaging/windows/WINDOWS-ACCEPTANCE.md
@@ -1,0 +1,55 @@
+# Acceptation Windows WebeeBlocks
+
+Statut : **NON VALIDÉ**
+
+Cette fiche doit être remplie sur le poste de classe le moins puissant avant de
+revendiquer le support Windows.
+
+## Configuration mesurée
+
+| Élément | Valeur |
+| --- | --- |
+| Date | |
+| Windows (édition/version) | |
+| CPU | |
+| RAM installée | |
+| GPU et pilote | |
+| Webots | R2025a |
+| Navigateur principal | |
+| Navigateur Firefox testé | |
+
+## Parcours obligatoire hors ligne
+
+- [ ] extraction dans un chemin contenant des espaces ;
+- [ ] double-clic sur `Launch-WebeeBlocks.cmd` ;
+- [ ] Robot Window Blockly en français et état `PRÊT` ;
+- [ ] exécution normale puis STOP neutre ;
+- [ ] mode pas à pas, surlignage, valeur brute capteur et Continuer ;
+- [ ] réinitialisation et replay ;
+- [ ] Ouvrir, Enregistrer sous, puis Enregistrer avec Edge/Chrome ;
+- [ ] Ouvrir et sauvegarde de secours explicitée avec Firefox ;
+- [ ] fichier `.wbb` créé sous Windows rouvert sous Linux avec le même AST ;
+- [ ] réseau coupé pendant tout le parcours après installation.
+
+## Mesures du poste le plus faible
+
+| Mesure | Résultat | Critère |
+| --- | --- | --- |
+| Double-clic → `PRÊT` | | consigner la durée |
+| Facteur temps réel Webots | | utilisable pour la classe |
+| CPU Webots + navigateur | | sans saturation durable |
+| Mémoire Webots + navigateur | | sans swap |
+| Glisser-déposer Blockly | | fluide pendant la simulation |
+| Grand programme représentatif | | interaction fluide |
+| 30 min run/reset/open/save | | aucune croissance ou panne progressive |
+
+## Verdict humain
+
+- [ ] **ACCEPTÉ** — aucun défaut bloquant observé ;
+- [ ] **REFUSÉ** — joindre les symptômes, journaux, captures et étapes exactes.
+
+Validé par :
+
+Date :
+
+Version ou SHA de l’archive :

--- a/plugins/robot_windows/blockly_v2/README.md
+++ b/plugins/robot_windows/blockly_v2/README.md
@@ -14,6 +14,13 @@ Requirements:
 - npm;
 - network access during this preparation step to install the pinned npm dependency.
 
-The resulting Robot Window is self-contained at runtime: Blockly browser assets are served from the local `vendor/` directory and no external Blockly resource is required while Webots is running.
+The resulting Robot Window is self-contained at runtime: Blockly browser assets
+are served from the local `vendor/` directory and the pinned Webots R2025a
+bridge is served from `webots/`. No external browser resource is required while
+Webots is running.
 
-`tools/prepare_runtime_v2.sh` is the supported product preparation path. CI must exercise this same command from a checkout where `vendor/` does not already exist; a workflow-only npm preparation is not considered product packaging evidence.
+`tools/prepare_runtime_v2.sh` and `tools/prepare_runtime_v2.ps1` are developer
+preparation paths. CI must exercise them from a checkout where `vendor/` does
+not already exist; a workflow-only npm preparation is not product packaging
+evidence. Student Windows machines use the prepared classroom archive and need
+neither Node.js nor npm.

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -294,7 +294,7 @@ window.onload = async function() {
   window.addEventListener('resize', function() { Blockly.svgResize(workspace); });
   window.dispatchEvent(new CustomEvent('webeeblocks-ui-ready', {detail: {blocklyVersion: Blockly.VERSION, renderer: 'zelos', theme: 'webeeblocksStudent'}}));
   try {
-    var module = await import('https://cyberbotics.com/wwi/R2025a/RobotWindow.js');
+    var module = await import('./webots/RobotWindow.js');
     robotWindow = new module.default();
     runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true, simulationReset: true});
     robotWindow.receive = receiveMessage;

--- a/plugins/robot_windows/blockly_v2/package-lock.json
+++ b/plugins/robot_windows/blockly_v2/package-lock.json
@@ -1,0 +1,572 @@
+{
+  "name": "webeeblocks-runtime-v2-blockly",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webeeblocks-runtime-v2-blockly",
+      "version": "0.0.0",
+      "dependencies": {
+        "blockly": "13.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/blockly": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-13.2.1.tgz",
+      "integrity": "sha512-iOa37H0ks5Zup2G1zZyviLX9E5WzWh3h0Zs8Nta2cPKmnAGHjZ6wrp3VqLTaquTJReJKPwaJZ39K7AD24rT4lg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "jsdom": ">=27.4.0 <30.0.0"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT",
+      "peer": true
+    }
+  }
+}

--- a/plugins/robot_windows/blockly_v2/webots/RobotWindow.js
+++ b/plugins/robot_windows/blockly_v2/webots/RobotWindow.js
@@ -1,0 +1,70 @@
+// Vendored from Webots R2025a commit c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b.
+// Source: resources/web/wwi/RobotWindow.js (Apache-2.0).
+import {getGETQueryValue} from './request_methods.js';
+
+export default class RobotWindow {
+  constructor() {
+    this.name = decodeURI(getGETQueryValue('name', 'undefined'));
+    if (window.location.href.includes('/~WEBOTS_HOME/'))
+      this.wsServer = window.location.href.substring(0, window.location.href.indexOf('/~WEBOTS_HOME/') + 1);
+    else
+      this.wsServer = window.location.href.substring(0, window.location.href.indexOf('/robot_windows/') + 1);
+    this.wsServer = this.wsServer.replace('https://', 'wss://').replace('http://', 'ws://');
+    this.socket = new WebSocket(this.wsServer);
+    this.pendingMsgs = [];
+    this.connect();
+  };
+
+  send(message) {
+    if (this.socket.readyState !== 1)
+      this.pendingMsgs.push(message);
+    else
+      this.socket.send('robot:' + this.name + ':' + message);
+  }
+
+  receive(message, robot) { // to be overridden
+    console.log("Robot window received message from Robot '" + robot + "': " + message);
+  }
+
+  setTitle(title) {
+    document.title = title;
+  }
+
+  connect() {
+    this.socket.onopen = (event) => { this.#onSocketOpen(event); };
+    this.socket.onmessage = (event) => { this.#onSocketMessage(event); };
+    this.socket.onclose = (event) => { this.#onSocketClose(event); };
+    this.socket.onerror = (event) => { };
+    this.send('init robot window');
+  }
+
+  #onSocketOpen(event) {
+    while (this.pendingMsgs.length > 0)
+      this.send(this.pendingMsgs.shift());
+  }
+
+  #onSocketMessage(event) {
+    const socketData = event.data.split(/\r?\n/);
+    for (let i = 0, len = socketData.length; i < len; i++) {
+      const data = socketData[i];
+      const ignoreData = ['application/json:', 'stdout:', 'stderr:'].some(sw => data.startsWith(sw));
+      if (data.startsWith('robot:')) {
+        let message = data.match('"message":"(.*)","name"')[1];
+        const robot = data.match(',"name":"(.*)"}')[1];
+        message = message.replace(/\\/g, '');
+        if (this.name === robot) // receive only the messages of our robot.
+          this.receive(message, robot);
+      } else if (!ignoreData)
+        console.log('WebSocket error: Unknown message received: "' + data + '"');
+    }
+  }
+
+  #onSocketClose(event) {
+    // https://tools.ietf.org/html/rfc6455#section-7.4.1
+    if ((event.code > 1001 && event.code < 1016) || (event.code === 1001)) {
+      if (this.socket)
+        this.socket.close();
+      window.close();
+    }
+  }
+};

--- a/plugins/robot_windows/blockly_v2/webots/RobotWindow.js
+++ b/plugins/robot_windows/blockly_v2/webots/RobotWindow.js
@@ -1,5 +1,6 @@
 // Vendored from Webots R2025a commit c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b.
 // Source: resources/web/wwi/RobotWindow.js (Apache-2.0).
+// Local hardening: malformed robot payloads are logged and ignored instead of throwing.
 import {getGETQueryValue} from './request_methods.js';
 
 export default class RobotWindow {
@@ -49,8 +50,14 @@ export default class RobotWindow {
       const data = socketData[i];
       const ignoreData = ['application/json:', 'stdout:', 'stderr:'].some(sw => data.startsWith(sw));
       if (data.startsWith('robot:')) {
-        let message = data.match('"message":"(.*)","name"')[1];
-        const robot = data.match(',"name":"(.*)"}')[1];
+        const messageMatch = data.match('"message":"(.*)","name"');
+        const robotMatch = data.match(',"name":"(.*)"}');
+        if (!messageMatch || !robotMatch) {
+          console.log('WebSocket error: Malformed robot message ignored: "' + data + '"');
+          continue;
+        }
+        let message = messageMatch[1];
+        const robot = robotMatch[1];
         message = message.replace(/\\/g, '');
         if (this.name === robot) // receive only the messages of our robot.
           this.receive(message, robot);

--- a/plugins/robot_windows/blockly_v2/webots/request_methods.js
+++ b/plugins/robot_windows/blockly_v2/webots/request_methods.js
@@ -1,5 +1,6 @@
 // Vendored from Webots R2025a commit c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b.
 // Source: resources/web/wwi/request_methods.js (Apache-2.0).
+// Local hardening: flag-style and empty query values remain valid inputs.
 
 // Retrieve the given GET value defined by its "variableName"
 // if not found, assign it "defaultValue" instead
@@ -7,9 +8,10 @@ function getGETQueryValue(variableName, defaultValue) {
   const query = window.location.search.substring(1);
   const vars = query.split('&');
   for (let i = 0; i < vars.length; i++) {
-    var pair = vars[i].split('=');
-    if (pair[0] === variableName)
-      return pair[1];
+    const separator = vars[i].indexOf('=');
+    const key = separator === -1 ? vars[i] : vars[i].substring(0, separator);
+    if (key === variableName)
+      return separator === -1 ? '' : vars[i].substring(separator + 1);
   }
   return defaultValue;
 }
@@ -22,9 +24,11 @@ function getGETQueriesMatchingRegularExpression(pattern) {
   const vars = query.split('&');
   const regex = new RegExp(pattern);
   for (let i = 0; i < vars.length; i++) {
-    var pair = vars[i].split('=');
-    if (regex.test(pair[0]))
-      values[pair[0].toLowerCase()] = pair[1].toLowerCase();
+    const separator = vars[i].indexOf('=');
+    const key = separator === -1 ? vars[i] : vars[i].substring(0, separator);
+    const value = separator === -1 ? '' : vars[i].substring(separator + 1);
+    if (regex.test(key))
+      values[key.toLowerCase()] = value.toLowerCase();
   }
   return values;
 }

--- a/plugins/robot_windows/blockly_v2/webots/request_methods.js
+++ b/plugins/robot_windows/blockly_v2/webots/request_methods.js
@@ -1,0 +1,32 @@
+// Vendored from Webots R2025a commit c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b.
+// Source: resources/web/wwi/request_methods.js (Apache-2.0).
+
+// Retrieve the given GET value defined by its "variableName"
+// if not found, assign it "defaultValue" instead
+function getGETQueryValue(variableName, defaultValue) {
+  const query = window.location.search.substring(1);
+  const vars = query.split('&');
+  for (let i = 0; i < vars.length; i++) {
+    var pair = vars[i].split('=');
+    if (pair[0] === variableName)
+      return pair[1];
+  }
+  return defaultValue;
+}
+
+function getGETQueriesMatchingRegularExpression(pattern) {
+  const values = {};
+  const query = window.location.search.substring(1);
+  if (query === '')
+    return values;
+  const vars = query.split('&');
+  const regex = new RegExp(pattern);
+  for (let i = 0; i < vars.length; i++) {
+    var pair = vars[i].split('=');
+    if (regex.test(pair[0]))
+      values[pair[0].toLowerCase()] = pair[1].toLowerCase();
+  }
+  return values;
+}
+
+export {getGETQueryValue, getGETQueriesMatchingRegularExpression};

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -46,25 +46,13 @@ function Write-Utf8NoBom {
   [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
 }
 
-function Convert-ToMsysPath {
-  param([string]$Path)
-  $fullPath = [System.IO.Path]::GetFullPath($Path)
-  if ($fullPath -notmatch '^([A-Za-z]):\\(.*)$') {
-    throw "Only local Windows drive paths are supported by the Webots MSYS2 build: $Path"
-  }
-  $drive = $Matches[1].ToLowerInvariant()
-  $tail = $Matches[2].Replace('\', '/')
-  return "/$drive/$tail"
-}
-
 if ([string]::IsNullOrWhiteSpace($WebotsHome)) {
   throw 'WebotsHome is required to compile the Windows controller.'
 }
 $webotsRoot = (Resolve-Path -LiteralPath $WebotsHome).Path
-$bash = Join-Path $webotsRoot 'msys64\usr\bin\bash.exe'
 $make = Join-Path $webotsRoot 'msys64\usr\bin\make.exe'
 $gcc = Join-Path $webotsRoot 'msys64\mingw64\bin\gcc.exe'
-foreach ($requiredTool in @($bash, $make, $gcc)) {
+foreach ($requiredTool in @($make, $gcc)) {
   if (-not (Test-Path -LiteralPath $requiredTool -PathType Leaf)) {
     throw "Webots R2025a MSYS2 tool is missing: $requiredTool"
   }
@@ -74,16 +62,23 @@ foreach ($requiredTool in @($bash, $make, $gcc)) {
 if ($LASTEXITCODE -ne 0) { throw 'Runtime v2 asset preparation failed.' }
 
 $controllerDir = Join-Path $repoRoot 'controllers\crazyflie_runtime_v2'
-foreach ($path in @($webotsRoot, $controllerDir)) {
-  if ($path.Contains("'")) { throw "Apostrophes are not supported in the build path: $path" }
+$oldWebotsHome = $env:WEBOTS_HOME
+$oldPath = $env:PATH
+try {
+  $env:WEBOTS_HOME = $webotsRoot
+  $env:PATH = ((Join-Path $webotsRoot 'msys64\mingw64\bin'), (Join-Path $webotsRoot 'msys64\usr\bin'), $oldPath) -join ';'
+  & $make -C $controllerDir clean
+  if ($LASTEXITCODE -ne 0) {
+    throw "Webots R2025a controller clean failed with exit code $LASTEXITCODE."
+  }
+  & $make -C $controllerDir
+  if ($LASTEXITCODE -ne 0) {
+    throw "Webots R2025a controller build failed with exit code $LASTEXITCODE."
+  }
 }
-$webotsMsys = Convert-ToMsysPath -Path $webotsRoot
-$controllerMsys = Convert-ToMsysPath -Path $controllerDir
-$env:MSYSTEM = 'MINGW64'
-$buildCommand = "set -euo pipefail; export WEBOTS_HOME='$webotsMsys'; export PATH='$webotsMsys/msys64/mingw64/bin:$webotsMsys/msys64/usr/bin':`$PATH; make -C '$controllerMsys' clean; make -C '$controllerMsys'"
-& $bash -lc $buildCommand
-if ($LASTEXITCODE -ne 0) {
-  throw "Webots R2025a controller build failed with exit code $LASTEXITCODE."
+finally {
+  $env:WEBOTS_HOME = $oldWebotsHome
+  $env:PATH = $oldPath
 }
 $controllerBinary = Join-Path $controllerDir 'crazyflie_runtime_v2.exe'
 if (-not (Test-Path -LiteralPath $controllerBinary -PathType Leaf) -or (Get-Item $controllerBinary).Length -le 0) {

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -99,7 +99,6 @@ foreach ($name in @('Launch-WebeeBlocks.cmd', 'Launch-WebeeBlocks.ps1', 'README-
     (Join-Path $repoRoot "packaging\windows\$name") `
     (Join-Path $packageDir $name)
 }
-Copy-RequiredFile (Join-Path $repoRoot 'LICENSE') (Join-Path $packageDir 'LICENSE')
 
 $blocklySource = Join-Path $repoRoot 'plugins\robot_windows\blockly_v2'
 $blocklyTarget = Join-Path $packageDir 'plugins\robot_windows\blockly_v2'

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -47,12 +47,14 @@ function Write-Utf8NoBom {
 }
 
 function Convert-ToMsysPath {
-  param([string]$Path, [string]$Cygpath)
-  $converted = (& $Cygpath -u $Path).Trim()
-  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($converted)) {
-    throw "Unable to convert Windows path for MSYS2: $Path"
+  param([string]$Path)
+  $fullPath = [System.IO.Path]::GetFullPath($Path)
+  if ($fullPath -notmatch '^([A-Za-z]):\\(.*)$') {
+    throw "Only local Windows drive paths are supported by the Webots MSYS2 build: $Path"
   }
-  return $converted
+  $drive = $Matches[1].ToLowerInvariant()
+  $tail = $Matches[2].Replace('\', '/')
+  return "/$drive/$tail"
 }
 
 if ([string]::IsNullOrWhiteSpace($WebotsHome)) {
@@ -60,8 +62,9 @@ if ([string]::IsNullOrWhiteSpace($WebotsHome)) {
 }
 $webotsRoot = (Resolve-Path -LiteralPath $WebotsHome).Path
 $bash = Join-Path $webotsRoot 'msys64\usr\bin\bash.exe'
-$cygpath = Join-Path $webotsRoot 'msys64\usr\bin\cygpath.exe'
-foreach ($requiredTool in @($bash, $cygpath)) {
+$make = Join-Path $webotsRoot 'msys64\usr\bin\make.exe'
+$gcc = Join-Path $webotsRoot 'msys64\mingw64\bin\gcc.exe'
+foreach ($requiredTool in @($bash, $make, $gcc)) {
   if (-not (Test-Path -LiteralPath $requiredTool -PathType Leaf)) {
     throw "Webots R2025a MSYS2 tool is missing: $requiredTool"
   }
@@ -74,10 +77,10 @@ $controllerDir = Join-Path $repoRoot 'controllers\crazyflie_runtime_v2'
 foreach ($path in @($webotsRoot, $controllerDir)) {
   if ($path.Contains("'")) { throw "Apostrophes are not supported in the build path: $path" }
 }
-$webotsMsys = Convert-ToMsysPath -Path $webotsRoot -Cygpath $cygpath
-$controllerMsys = Convert-ToMsysPath -Path $controllerDir -Cygpath $cygpath
+$webotsMsys = Convert-ToMsysPath -Path $webotsRoot
+$controllerMsys = Convert-ToMsysPath -Path $controllerDir
 $env:MSYSTEM = 'MINGW64'
-$buildCommand = "set -euo pipefail; export WEBOTS_HOME='$webotsMsys'; export PATH='$webotsMsys/msys64/mingw64/bin':`$PATH; make -C '$controllerMsys' clean; make -C '$controllerMsys'"
+$buildCommand = "set -euo pipefail; export WEBOTS_HOME='$webotsMsys'; export PATH='$webotsMsys/msys64/mingw64/bin:$webotsMsys/msys64/usr/bin':`$PATH; make -C '$controllerMsys' clean; make -C '$controllerMsys'"
 & $bash -lc $buildCommand
 if ($LASTEXITCODE -ne 0) {
   throw "Webots R2025a controller build failed with exit code $LASTEXITCODE."

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -1,0 +1,211 @@
+[CmdletBinding()]
+param(
+  [string]$OutputDirectory = 'dist',
+  [Parameter(Mandatory = $true)]
+  [string]$WebotsProjectsPath,
+  [string]$WebotsHome = $env:WEBOTS_HOME
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$projectsRoot = (Resolve-Path -LiteralPath $WebotsProjectsPath).Path
+$packageName = 'WebeeBlocks-Windows-R2025a'
+
+if ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+  $outputRoot = [System.IO.Path]::GetFullPath($OutputDirectory)
+}
+else {
+  $outputRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+}
+$packageDir = Join-Path $outputRoot $packageName
+$archivePath = Join-Path $outputRoot "$packageName.zip"
+if ((Split-Path $packageDir -Leaf) -ne $packageName) {
+  throw 'Unsafe package output target.'
+}
+
+function Copy-RequiredFile {
+  param([string]$Source, [string]$Destination)
+  if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+    throw "Required release file is missing: $Source"
+  }
+  $parent = Split-Path $Destination -Parent
+  if (-not (Test-Path -LiteralPath $parent)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Copy-Item -LiteralPath $Source -Destination $Destination -Force
+}
+
+function Write-Utf8NoBom {
+  param([string]$Path, [string]$Content)
+  $parent = Split-Path $Path -Parent
+  if (-not (Test-Path -LiteralPath $parent)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Convert-ToMsysPath {
+  param([string]$Path, [string]$Cygpath)
+  $converted = (& $Cygpath -u $Path).Trim()
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($converted)) {
+    throw "Unable to convert Windows path for MSYS2: $Path"
+  }
+  return $converted
+}
+
+if ([string]::IsNullOrWhiteSpace($WebotsHome)) {
+  throw 'WebotsHome is required to compile the Windows controller.'
+}
+$webotsRoot = (Resolve-Path -LiteralPath $WebotsHome).Path
+$bash = Join-Path $webotsRoot 'msys64\usr\bin\bash.exe'
+$cygpath = Join-Path $webotsRoot 'msys64\usr\bin\cygpath.exe'
+foreach ($requiredTool in @($bash, $cygpath)) {
+  if (-not (Test-Path -LiteralPath $requiredTool -PathType Leaf)) {
+    throw "Webots R2025a MSYS2 tool is missing: $requiredTool"
+  }
+}
+
+& (Join-Path $PSScriptRoot 'prepare_runtime_v2.ps1')
+if ($LASTEXITCODE -ne 0) { throw 'Runtime v2 asset preparation failed.' }
+
+$controllerDir = Join-Path $repoRoot 'controllers\crazyflie_runtime_v2'
+foreach ($path in @($webotsRoot, $controllerDir)) {
+  if ($path.Contains("'")) { throw "Apostrophes are not supported in the build path: $path" }
+}
+$webotsMsys = Convert-ToMsysPath -Path $webotsRoot -Cygpath $cygpath
+$controllerMsys = Convert-ToMsysPath -Path $controllerDir -Cygpath $cygpath
+$env:MSYSTEM = 'MINGW64'
+$buildCommand = "set -euo pipefail; export WEBOTS_HOME='$webotsMsys'; export PATH='$webotsMsys/msys64/mingw64/bin':`$PATH; make -C '$controllerMsys' clean; make -C '$controllerMsys'"
+& $bash -lc $buildCommand
+if ($LASTEXITCODE -ne 0) {
+  throw "Webots R2025a controller build failed with exit code $LASTEXITCODE."
+}
+$controllerBinary = Join-Path $controllerDir 'crazyflie_runtime_v2.exe'
+if (-not (Test-Path -LiteralPath $controllerBinary -PathType Leaf) -or (Get-Item $controllerBinary).Length -le 0) {
+  throw 'The official Webots Windows build produced no controller executable.'
+}
+
+New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
+if (Test-Path -LiteralPath $packageDir) {
+  Remove-Item -LiteralPath $packageDir -Recurse -Force
+}
+if (Test-Path -LiteralPath $archivePath) {
+  Remove-Item -LiteralPath $archivePath -Force
+}
+New-Item -ItemType Directory -Path $packageDir | Out-Null
+
+foreach ($name in @('Launch-WebeeBlocks.cmd', 'Launch-WebeeBlocks.ps1', 'README-WINDOWS.md', 'WINDOWS-ACCEPTANCE.md', 'THIRD_PARTY_NOTICES.md')) {
+  Copy-RequiredFile `
+    (Join-Path $repoRoot "packaging\windows\$name") `
+    (Join-Path $packageDir $name)
+}
+Copy-RequiredFile (Join-Path $repoRoot 'LICENSE') (Join-Path $packageDir 'LICENSE')
+
+$blocklySource = Join-Path $repoRoot 'plugins\robot_windows\blockly_v2'
+$blocklyTarget = Join-Path $packageDir 'plugins\robot_windows\blockly_v2'
+foreach ($name in @('blockly_v2.html', 'execution_observer.css', 'main.css', 'main.js', 'project_files.css', 'project_ui.js')) {
+  Copy-RequiredFile (Join-Path $blocklySource $name) (Join-Path $blocklyTarget $name)
+}
+foreach ($directory in @('vendor', 'webots')) {
+  $source = Join-Path $blocklySource $directory
+  $target = Join-Path $blocklyTarget $directory
+  if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+    throw "Required Runtime v2 directory is missing: $source"
+  }
+  New-Item -ItemType Directory -Path $target -Force | Out-Null
+  Copy-Item -Path (Join-Path $source '*') -Destination $target -Recurse -Force
+}
+
+$contractsSource = Join-Path $repoRoot 'plugins\robot_windows\blockly\webeeblocks'
+$contractsTarget = Join-Path $packageDir 'plugins\robot_windows\blockly\webeeblocks'
+New-Item -ItemType Directory -Path $contractsTarget -Force | Out-Null
+Get-ChildItem -LiteralPath $contractsSource -File -Filter '*.js' | ForEach-Object {
+  Copy-RequiredFile $_.FullName (Join-Path $contractsTarget $_.Name)
+}
+Copy-RequiredFile `
+  (Join-Path $repoRoot 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js') `
+  (Join-Path $packageDir 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js')
+Copy-RequiredFile $controllerBinary (Join-Path $packageDir 'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe')
+
+$crazyflieRoot = Join-Path $projectsRoot 'robots\bitcraze\crazyflie\protos'
+$protoSource = Join-Path $crazyflieRoot 'Crazyflie.proto'
+$protoText = Get-Content -LiteralPath $protoSource -Raw
+$remoteTexture = 'webots://projects/default/protos/textures/fast_helix.png'
+if (($protoText.Split($remoteTexture).Count - 1) -ne 1) {
+  throw 'Unexpected Crazyflie.proto fast-helix dependency count.'
+}
+$protoText = $protoText.Replace($remoteTexture, 'textures/fast_helix.png')
+if ($protoText -match '"(?:https?|webots)://') {
+  throw 'Crazyflie.proto still contains a remote runtime asset.'
+}
+Write-Utf8NoBom (Join-Path $packageDir 'protos\Crazyflie.proto') $protoText
+foreach ($mesh in @('cf2_assembly.dae', 'ccw_prop.dae')) {
+  Copy-RequiredFile `
+    (Join-Path $crazyflieRoot "meshes\$mesh") `
+    (Join-Path $packageDir "protos\meshes\$mesh")
+}
+Copy-RequiredFile `
+  (Join-Path $projectsRoot 'default\protos\textures\fast_helix.png') `
+  (Join-Path $packageDir 'protos\textures\fast_helix.png')
+
+$worldSource = Join-Path $repoRoot 'worlds\crazyflie_runtime_v2.wbt'
+$worldText = Get-Content -LiteralPath $worldSource -Raw
+$remotePrefix = 'https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/'
+if (($worldText.Split($remotePrefix).Count - 1) -ne 4) {
+  throw 'Expected exactly four pinned remote references in the source Runtime v2 world.'
+}
+$worldText = $worldText.Replace(
+  'EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto"',
+  'EXTERNPROTO "../protos/Crazyflie.proto"'
+)
+foreach ($line in @(
+  'EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackground.proto"',
+  'EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"',
+  'EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2025a/projects/objects/floors/protos/Floor.proto"'
+)) {
+  $worldText = $worldText.Replace("$line`r`n", '').Replace("$line`n", '')
+}
+$worldText = $worldText.Replace('TexturedBackground { }', 'Background { skyColor [ 0.75 0.83 0.92 ] }')
+$worldText = $worldText.Replace('TexturedBackgroundLight { }', 'DirectionalLight { direction -0.4 -0.5 -1 intensity 1.5 }')
+$floor = @'
+Solid {
+  translation 0 0 -0.025
+  children [
+    Shape {
+      appearance PBRAppearance { baseColor 0.65 0.68 0.72 roughness 0.8 }
+      geometry Box { size 4 4 0.05 }
+    }
+  ]
+  boundingObject Box { size 4 4 0.05 }
+}
+'@
+$worldText = $worldText.Replace('Floor { size 4 4 }', $floor.TrimEnd())
+if ($worldText -match '"(?:https?|webots)://') {
+  throw 'The classroom world still contains a remote runtime asset.'
+}
+Write-Utf8NoBom (Join-Path $packageDir 'worlds\crazyflie_runtime_v2.wbt') $worldText
+Copy-RequiredFile `
+  (Join-Path $repoRoot 'worlds\.crazyflie_runtime_v2.wbproj') `
+  (Join-Path $packageDir 'worlds\.crazyflie_runtime_v2.wbproj')
+
+$manifestLines = Get-ChildItem -LiteralPath $packageDir -File -Recurse | Sort-Object FullName | ForEach-Object {
+  $relative = [System.IO.Path]::GetRelativePath($packageDir, $_.FullName).Replace('\', '/')
+  $hash = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+  "$hash  $relative"
+}
+Write-Utf8NoBom (Join-Path $packageDir 'MANIFEST.sha256') (($manifestLines -join "`n") + "`n")
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::CreateFromDirectory(
+  $packageDir,
+  $archivePath,
+  [System.IO.Compression.CompressionLevel]::Optimal,
+  $false
+)
+if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf) -or (Get-Item $archivePath).Length -le 0) {
+  throw 'Windows classroom archive was not created.'
+}
+
+Write-Host "WEBEEBLOCKS_WINDOWS_RELEASE=$archivePath"

--- a/tools/ci/prepare_crazyflie_challenge_ux.py
+++ b/tools/ci/prepare_crazyflie_challenge_ux.py
@@ -151,6 +151,7 @@ script = r'''
     await waitFor(() => challengeEvents.slice(beforeChallenge).some(e => e.state === 'FINISHED' && e.result === expectedResult), name + ' result ' + expectedResult, 70000);
     await waitFor(() => responses.slice(beforeResponses).indexOf('WEBEEBLOCKS_MISSION_V1 DONE') !== -1, name + ' DONE', 5000);
     await waitFor(() => crazyflieRuntimeState === 'RECOVERING', name + ' transport RECOVERING', 1000);
+    const runtimeStateAtTerminal = crazyflieRuntimeState;
     const frozen = panel();
     if (frozen.state !== 'TERMINÉ' || frozen.result !== expectedResult || !/^[0-9]+\.[0-9]{2} s$/.test(frozen.time))
       throw new Error(name + ' terminal panel invalid: ' + JSON.stringify(frozen));
@@ -158,7 +159,11 @@ script = r'''
     await sleep(350);
     if (panel().time !== frozenTime)
       throw new Error(name + ' timer did not remain frozen');
-    await report(name + '_TERMINAL', JSON.stringify({panel: panel(), runtimeState: crazyflieRuntimeState}));
+    await report(name + '_TERMINAL', JSON.stringify({
+      panel: panel(),
+      runtimeStateAtTerminal: runtimeStateAtTerminal,
+      runtimeStateAfterFreeze: crazyflieRuntimeState,
+    }));
     return {responseStart: beforeResponses};
   }
 

--- a/tools/ci/select_ci.py
+++ b/tools/ci/select_ci.py
@@ -27,6 +27,13 @@ FORCE_FULL = (
     "tools/ci/test_ci_gate.py",
     "tools/ci/test_workflow_contract.py",
     "tools/ci/test_repository_hygiene.py",
+    "tools/ci/test_windows_release_contract.py",
+    "tools/build_windows_classroom_release.ps1",
+    "packaging/windows/**",
+    "plugins/robot_windows/blockly_v2/webots/**",
+    "tools/prepare_runtime_v2.*",
+    "controllers/crazyflie_runtime_v2/**",
+    "worlds/crazyflie_runtime_v2*",
 )
 
 RUNTIME = (
@@ -79,7 +86,7 @@ def select(paths: Iterable[str], *, force_full: bool = False) -> Selection:
     if not changed:
         return Selection(True, True, True, "empty or indeterminate diff", changed)
     if any(matches(path, FORCE_FULL) for path in changed):
-        return Selection(True, True, True, "CI control plane changed", changed)
+        return Selection(True, True, True, "full-gate path changed", changed)
 
     runtime = False
     webots = False

--- a/tools/ci/test_select_ci.py
+++ b/tools/ci/test_select_ci.py
@@ -23,6 +23,13 @@ class SelectCiTests(unittest.TestCase):
         result = select(["controllers/crazyflie_runtime_v2/controller.c"])
         self.assertTrue(result.runtime)
         self.assertTrue(result.webots)
+        self.assertTrue(result.full)
+
+    def test_windows_packaging_change_is_full(self) -> None:
+        result = select(["packaging/windows/Launch-WebeeBlocks.ps1"])
+        self.assertTrue(result.runtime)
+        self.assertTrue(result.webots)
+        self.assertTrue(result.full)
 
     def test_legacy_webots_only(self) -> None:
         result = select(["controllers/crazyflie_square/pid_controller.c"])
@@ -37,6 +44,12 @@ class SelectCiTests(unittest.TestCase):
 
     def test_repository_hygiene_contract_change_is_full(self) -> None:
         result = select(["tools/ci/test_repository_hygiene.py"])
+        self.assertTrue(result.runtime)
+        self.assertTrue(result.webots)
+        self.assertTrue(result.full)
+
+    def test_windows_release_contract_change_is_full(self) -> None:
+        result = select(["tools/ci/test_windows_release_contract.py"])
         self.assertTrue(result.runtime)
         self.assertTrue(result.webots)
         self.assertTrue(result.full)

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -72,7 +72,8 @@ $forbidden = @(Get-ChildItem -LiteralPath $testRoot -Recurse -Force | Where-Obje
   $_.Name -in @('node_modules', 'package.json', 'package-lock.json', 'Makefile') -or
   $_.Extension -in @('.c', '.o', '.a')
 })
-Assert-Release ($forbidden.Count -eq 0) ("Development-only release paths: " + (($forbidden.FullName) -join ', '))
+$forbiddenPaths = @($forbidden | ForEach-Object { $_.FullName })
+Assert-Release ($forbidden.Count -eq 0) ("Development-only release paths: " + ($forbiddenPaths -join ', '))
 
 $runtimeText = Get-ChildItem -LiteralPath $testRoot -Recurse -File | Where-Object {
   $_.Extension -in @('.wbt', '.proto', '.html', '.css') -or $_.Name -in @('main.js', 'project_ui.js')

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ArchivePath,
+  [Parameter(Mandatory = $true)]
+  [string]$WebotsHome
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-Release {
+  param([bool]$Condition, [string]$Message)
+  if (-not $Condition) { throw $Message }
+}
+
+$archive = (Resolve-Path -LiteralPath $ArchivePath).Path
+$testRoot = Join-Path $env:RUNNER_TEMP 'WebeeBlocks release check with spaces'
+if ((Split-Path $testRoot -Leaf) -ne 'WebeeBlocks release check with spaces') {
+  throw 'Unsafe release-test extraction target.'
+}
+if (Test-Path -LiteralPath $testRoot) {
+  Remove-Item -LiteralPath $testRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path $testRoot | Out-Null
+Expand-Archive -LiteralPath $archive -DestinationPath $testRoot
+
+$manifestPath = Join-Path $testRoot 'MANIFEST.sha256'
+Assert-Release (Test-Path -LiteralPath $manifestPath -PathType Leaf) 'Missing release manifest.'
+$manifestEntries = @(Get-Content -LiteralPath $manifestPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+Assert-Release ($manifestEntries.Count -ge 20) 'Release manifest is unexpectedly small.'
+$rootPrefix = [System.IO.Path]::GetFullPath($testRoot) + [System.IO.Path]::DirectorySeparatorChar
+foreach ($line in $manifestEntries) {
+  Assert-Release ($line -match '^([0-9a-f]{64})  (.+)$') "Malformed manifest line: $line"
+  $expected = $Matches[1]
+  $relative = $Matches[2]
+  Assert-Release (-not [System.IO.Path]::IsPathRooted($relative)) "Absolute path in manifest: $relative"
+  $target = [System.IO.Path]::GetFullPath((Join-Path $testRoot ($relative.Replace('/', '\'))))
+  Assert-Release ($target.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) "Path traversal in manifest: $relative"
+  Assert-Release (Test-Path -LiteralPath $target -PathType Leaf) "Missing manifest file: $relative"
+  $actual = (Get-FileHash -LiteralPath $target -Algorithm SHA256).Hash.ToLowerInvariant()
+  Assert-Release ($actual -eq $expected) "Checksum mismatch: $relative"
+}
+
+$required = @(
+  'Launch-WebeeBlocks.cmd',
+  'Launch-WebeeBlocks.ps1',
+  'README-WINDOWS.md',
+  'WINDOWS-ACCEPTANCE.md',
+  'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe',
+  'plugins\robot_windows\blockly_v2\blockly_v2.html',
+  'plugins\robot_windows\blockly_v2\vendor\VERSION',
+  'plugins\robot_windows\blockly_v2\vendor\blockly_compressed.js',
+  'plugins\robot_windows\blockly_v2\webots\RobotWindow.js',
+  'plugins\robot_windows\blockly\webeeblocks\semantic_ast.js',
+  'plugins\robot_windows\blockly\webeeblocks\project_files.js',
+  'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js',
+  'protos\Crazyflie.proto',
+  'protos\meshes\cf2_assembly.dae',
+  'protos\meshes\ccw_prop.dae',
+  'protos\textures\fast_helix.png',
+  'worlds\crazyflie_runtime_v2.wbt'
+)
+foreach ($relative in $required) {
+  Assert-Release (Test-Path -LiteralPath (Join-Path $testRoot $relative) -PathType Leaf) "Missing required release path: $relative"
+}
+
+$version = (Get-Content -LiteralPath (Join-Path $testRoot 'plugins\robot_windows\blockly_v2\vendor\VERSION') -Raw).Trim()
+Assert-Release ($version -eq '13.2.1') "Unexpected Blockly release version: $version"
+
+$forbidden = @(Get-ChildItem -LiteralPath $testRoot -Recurse -Force | Where-Object {
+  $_.Name -in @('node_modules', 'package.json', 'package-lock.json', 'Makefile') -or
+  $_.Extension -in @('.c', '.o', '.a')
+})
+Assert-Release ($forbidden.Count -eq 0) ("Development-only release paths: " + (($forbidden.FullName) -join ', '))
+
+$runtimeText = Get-ChildItem -LiteralPath $testRoot -Recurse -File | Where-Object {
+  $_.Extension -in @('.wbt', '.proto', '.html', '.css') -or $_.Name -in @('main.js', 'project_ui.js')
+}
+foreach ($file in $runtimeText) {
+  if ($file.Extension -in @('.wbt', '.proto')) {
+    $pattern = '(?i)"(?:https?|webots)://'
+  }
+  else {
+    $pattern = '(?i)(https?://|//cdn\.)'
+  }
+  $matches = Select-String -LiteralPath $file.FullName -Pattern $pattern
+  Assert-Release ($null -eq $matches) "Remote runtime dependency in $($file.FullName)"
+}
+
+$exe = Join-Path $testRoot 'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe'
+$bytes = [System.IO.File]::ReadAllBytes($exe)
+Assert-Release ($bytes.Length -gt 2 -and $bytes[0] -eq 0x4d -and $bytes[1] -eq 0x5a) 'Controller is not a Windows PE executable.'
+
+Get-ChildItem -LiteralPath (Join-Path $testRoot 'plugins') -Recurse -File -Filter '*.js' | ForEach-Object {
+  & node --check $_.FullName
+  if ($LASTEXITCODE -ne 0) { throw "JavaScript syntax failure in $($_.FullName)" }
+}
+
+& (Join-Path $testRoot 'Launch-WebeeBlocks.ps1') -ValidateOnly -WebotsHome $WebotsHome
+if ($LASTEXITCODE -ne 0) { throw 'Release launcher validation failed.' }
+
+Write-Host "PASS: Windows classroom archive is self-contained, checksummed, path-safe and launcher-ready ($($manifestEntries.Count) files)."

--- a/tools/ci/test_windows_release_contract.py
+++ b/tools/ci/test_windows_release_contract.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Static fail-closed contract for the Windows classroom release path."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BLOCKLY = ROOT / "plugins" / "robot_windows" / "blockly_v2"
+PACKAGING = ROOT / "packaging" / "windows"
+
+
+class WindowsReleaseContractTests(unittest.TestCase):
+    def test_robot_window_bridge_is_local_and_pinned(self) -> None:
+        main = (BLOCKLY / "main.js").read_text(encoding="utf-8")
+        self.assertIn("import('./webots/RobotWindow.js')", main)
+        self.assertNotIn("cyberbotics.com/wwi", main)
+        for name in ("RobotWindow.js", "request_methods.js"):
+            bridge = (BLOCKLY / "webots" / name).read_text(encoding="utf-8")
+            self.assertIn("c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b", bridge)
+        self.assertIn(
+            "from './request_methods.js'",
+            (BLOCKLY / "webots" / "RobotWindow.js").read_text(encoding="utf-8"),
+        )
+
+    def test_preparation_is_lockfile_exact(self) -> None:
+        for name in ("prepare_runtime_v2.ps1", "prepare_runtime_v2.sh"):
+            preparation = (ROOT / "tools" / name).read_text(encoding="utf-8")
+            self.assertIn("npm ci --ignore-scripts --no-audit --no-fund", preparation)
+            self.assertNotIn("npm install --ignore-scripts", preparation)
+        lock = (BLOCKLY / "package-lock.json").read_text(encoding="utf-8")
+        self.assertIn('"blockly": "13.2.1"', lock)
+        self.assertIn('"version": "13.2.1"', lock)
+
+    def test_packager_builds_and_removes_runtime_network_dependencies(self) -> None:
+        packager = (
+            ROOT / "tools" / "build_windows_classroom_release.ps1"
+        ).read_text(encoding="utf-8")
+        for required in (
+            "make -C '$controllerMsys'",
+            "crazyflie_runtime_v2.exe",
+            "Expected exactly four pinned remote references",
+            "../protos/Crazyflie.proto",
+            "textures/fast_helix.png",
+            "MANIFEST.sha256",
+            "Compression.ZipFile]::CreateFromDirectory",
+        ):
+            self.assertIn(required, packager)
+        self.assertIn("$worldText -match '\"(?:https?|webots)://'", packager)
+        self.assertIn("$protoText -match '\"(?:https?|webots)://'", packager)
+
+    def test_student_boundary_is_explicit(self) -> None:
+        readme = (PACKAGING / "README-WINDOWS.md").read_text(encoding="utf-8")
+        acceptance = (PACKAGING / "WINDOWS-ACCEPTANCE.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("Ni Git, ni Node.js, ni npm", readme)
+        self.assertIn("Statut : **NON VALIDÉ**", acceptance)
+        self.assertIn("réseau coupé", acceptance)
+        self.assertIn("30 min", acceptance)
+
+    def test_launcher_opens_only_the_packaged_world(self) -> None:
+        launcher = (PACKAGING / "Launch-WebeeBlocks.ps1").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("worlds\\crazyflie_runtime_v2.wbt", launcher)
+        self.assertIn("--mode=pause", launcher)
+        self.assertIn("$worldArgument = '\"' + $world + '\"'", launcher)
+        self.assertIn("-ValidateOnly", (ROOT / "tools" / "ci" / "test_windows_classroom_release.ps1").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_windows_release_contract.py
+++ b/tools/ci/test_windows_release_contract.py
@@ -11,17 +11,18 @@ PACKAGING = ROOT / "packaging" / "windows"
 
 
 class WindowsReleaseContractTests(unittest.TestCase):
-    def test_robot_window_bridge_is_local_and_pinned(self) -> None:
+    def test_robot_window_bridge_is_local_pinned_and_fail_safe(self) -> None:
         main = (BLOCKLY / "main.js").read_text(encoding="utf-8")
         self.assertIn("import('./webots/RobotWindow.js')", main)
         self.assertNotIn("cyberbotics.com/wwi", main)
-        for name in ("RobotWindow.js", "request_methods.js"):
-            bridge = (BLOCKLY / "webots" / name).read_text(encoding="utf-8")
+        robot_window = (BLOCKLY / "webots" / "RobotWindow.js").read_text(encoding="utf-8")
+        requests = (BLOCKLY / "webots" / "request_methods.js").read_text(encoding="utf-8")
+        for bridge in (robot_window, requests):
             self.assertIn("c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b", bridge)
-        self.assertIn(
-            "from './request_methods.js'",
-            (BLOCKLY / "webots" / "RobotWindow.js").read_text(encoding="utf-8"),
-        )
+        self.assertIn("from './request_methods.js'", robot_window)
+        self.assertIn("if (!messageMatch || !robotMatch)", robot_window)
+        self.assertIn("Malformed robot message ignored", robot_window)
+        self.assertIn("const value = separator === -1 ? ''", requests)
 
     def test_preparation_is_lockfile_exact(self) -> None:
         for name in ("prepare_runtime_v2.ps1", "prepare_runtime_v2.sh"):
@@ -37,7 +38,8 @@ class WindowsReleaseContractTests(unittest.TestCase):
             ROOT / "tools" / "build_windows_classroom_release.ps1"
         ).read_text(encoding="utf-8")
         for required in (
-            "make -C '$controllerMsys'",
+            "& $make -C $controllerDir clean",
+            "& $make -C $controllerDir",
             "crazyflie_runtime_v2.exe",
             "Expected exactly four pinned remote references",
             "../protos/Crazyflie.proto",
@@ -48,9 +50,11 @@ class WindowsReleaseContractTests(unittest.TestCase):
             self.assertIn(required, packager)
         self.assertIn("$worldText -match '\"(?:https?|webots)://'", packager)
         self.assertIn("$protoText -match '\"(?:https?|webots)://'", packager)
-        self.assertNotIn("cygpath.exe", packager)
+        self.assertNotIn("Convert-ToMsysPath", packager)
+        self.assertNotIn("bash -lc", packager)
         self.assertIn("msys64\\usr\\bin\\make.exe", packager)
         self.assertIn("msys64\\mingw64\\bin\\gcc.exe", packager)
+        self.assertIn("$env:WEBOTS_HOME = $webotsRoot", packager)
 
     def test_student_boundary_is_explicit(self) -> None:
         readme = (PACKAGING / "README-WINDOWS.md").read_text(encoding="utf-8")
@@ -62,13 +66,16 @@ class WindowsReleaseContractTests(unittest.TestCase):
         self.assertIn("réseau coupé", acceptance)
         self.assertIn("30 min", acceptance)
 
-    def test_launcher_opens_only_the_packaged_world(self) -> None:
+    def test_launcher_opens_only_packaged_world_with_r2025a(self) -> None:
         launcher = (PACKAGING / "Launch-WebeeBlocks.ps1").read_text(
             encoding="utf-8"
         )
         self.assertIn("worlds\\crazyflie_runtime_v2.wbt", launcher)
         self.assertIn("--mode=pause", launcher)
         self.assertIn("$worldArgument = '\"' + $world + '\"'", launcher)
+        self.assertIn("Test-WebotsR2025a", launcher)
+        self.assertIn("--version", launcher)
+        self.assertIn("-match 'R2025a'", launcher)
         self.assertIn("-ValidateOnly", (ROOT / "tools" / "ci" / "test_windows_classroom_release.ps1").read_text(encoding="utf-8"))
 
 

--- a/tools/ci/test_windows_release_contract.py
+++ b/tools/ci/test_windows_release_contract.py
@@ -48,6 +48,9 @@ class WindowsReleaseContractTests(unittest.TestCase):
             self.assertIn(required, packager)
         self.assertIn("$worldText -match '\"(?:https?|webots)://'", packager)
         self.assertIn("$protoText -match '\"(?:https?|webots)://'", packager)
+        self.assertNotIn("cygpath.exe", packager)
+        self.assertIn("msys64\\usr\\bin\\make.exe", packager)
+        self.assertIn("msys64\\mingw64\\bin\\gcc.exe", packager)
 
     def test_student_boundary_is_explicit(self) -> None:
         readme = (PACKAGING / "README-WINDOWS.md").read_text(encoding="utf-8")

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -16,6 +16,7 @@ EXPECTED = {
     "ci-runtime.yml": {
         "runtime-v2-core",
         "runtime-v2-windows-assets",
+        "runtime-v2-windows-release",
         "clean-checkout-runtime-v2",
         "runtime-v2-observability",
         "runtime-v2-project-files",
@@ -101,6 +102,10 @@ class WorkflowContractTests(unittest.TestCase):
             "python3 tools/ci/test_repository_hygiene.py",
             orchestrator,
         )
+        self.assertIn(
+            "python3 tools/ci/test_windows_release_contract.py",
+            orchestrator,
+        )
         self.assertIn("branches: [develop, main]", orchestrator)
         self.assertIn(
             "types: [opened, synchronize, reopened, ready_for_review]",
@@ -110,6 +115,19 @@ class WorkflowContractTests(unittest.TestCase):
             suite = (WORKFLOWS / name).read_text(encoding="utf-8")
             self.assertIn("  workflow_call:\n", suite)
             self.assertNotIn("  pull_request:\n", suite)
+
+    def test_windows_release_is_full_gate_only_and_pinned(self) -> None:
+        orchestrator = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+        runtime = (WORKFLOWS / "ci-runtime.yml").read_text(encoding="utf-8")
+        self.assertIn("full: ${{ needs.select.outputs.full == 'true' }}", orchestrator)
+        release = runtime.split("\n  runtime-v2-windows-release:\n", 1)[1]
+        self.assertIn("github.event_name != 'pull_request' || inputs.full", release)
+        self.assertIn("ref: c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b", release)
+        self.assertIn(
+            "9e326a54c104fc5fc88121e26014a409d1e35f0bbf30e23f3a712e7f842b08e7",
+            release,
+        )
+        self.assertIn("test_windows_classroom_release.ps1", release)
 
     def test_no_post_merge_push_trigger(self) -> None:
         for path in WORKFLOWS.glob("*.yml"):

--- a/tools/prepare_runtime_v2.ps1
+++ b/tools/prepare_runtime_v2.ps1
@@ -18,8 +18,8 @@ if ($nodeMajor -lt 22) {
 
 Push-Location $blocklyDir
 try {
-  & npm install --ignore-scripts --no-audit --no-fund
-  if ($LASTEXITCODE -ne 0) { throw "npm install failed with exit code $LASTEXITCODE." }
+  & npm ci --ignore-scripts --no-audit --no-fund
+  if ($LASTEXITCODE -ne 0) { throw "npm ci failed with exit code $LASTEXITCODE." }
 
   & npm run prepare:blockly
   if ($LASTEXITCODE -ne 0) { throw "npm run prepare:blockly failed with exit code $LASTEXITCODE." }
@@ -32,7 +32,9 @@ try {
   foreach ($relativePath in @(
     'vendor\blockly_compressed.js',
     'vendor\blocks_compressed.js',
-    'vendor\msg\fr.js'
+    'vendor\msg\fr.js',
+    'webots\RobotWindow.js',
+    'webots\request_methods.js'
   )) {
     $path = Join-Path $blocklyDir $relativePath
     if (-not (Test-Path -Path $path -PathType Leaf) -or (Get-Item $path).Length -le 0) {

--- a/tools/prepare_runtime_v2.sh
+++ b/tools/prepare_runtime_v2.sh
@@ -20,7 +20,7 @@ if [ "$node_major" -lt 22 ]; then
 fi
 
 cd "$BLOCKLY_DIR"
-npm install --ignore-scripts --no-audit --no-fund
+npm ci --ignore-scripts --no-audit --no-fund
 npm run prepare:blockly
 
 test "$(cat vendor/VERSION)" = "13.2.1"
@@ -28,5 +28,7 @@ test -s vendor/blockly_compressed.js
 test -s vendor/blocks_compressed.js
 test -s vendor/msg/fr.js
 test -d vendor/media
+test -s webots/RobotWindow.js
+test -s webots/request_methods.js
 
 echo "Runtime v2 Blockly assets ready: blockly@13.2.1"


### PR DESCRIPTION
## Product outcome

Deliver one coherent Windows classroom path for #81: a teacher downloads one checksummed ZIP, installs Webots R2025a, extracts the archive, and the student launches WebeeBlocks with one double-click. Normal use after preparation has no Git, Node.js, npm, compiler or network dependency.

## Included

- exact `package-lock.json` and `npm ci` preparation on Linux and Windows;
- local pinned Webots R2025a `RobotWindow.js` bridge instead of the runtime `cyberbotics.com` import, hardened to ignore malformed bridge/query inputs rather than throw;
- official Webots R2025a Windows installer pinned by SHA-256 and cached only after verification;
- Runtime v2 controller compiled directly with Webots’ bundled MSYS2/MinGW `make.exe`/GCC using native Windows paths;
- offline release world with local Crazyflie PROTO, two meshes and one texture from pinned Webots commit `c6793d8f7230a311c4bc2a3101d9f1a8bc0aa01b`;
- prepared Blockly 13.2.1, runtime contracts, Windows controller, local assets, launcher, notices and SHA-256 manifest in `WebeeBlocks-Windows-R2025a.zip`;
- archive extraction and validation under a path containing spaces;
- Windows project-file/whole-AST gate inside the existing fast Windows job;
- one-click launcher that rejects Webots versions other than R2025a, plus teacher instructions and weakest-PC offline acceptance sheet;
- full Windows release build only for full gates/nightly/main promotion; fast Windows AST and file contracts remain on Runtime PRs.

## Automated acceptance

The exact-head gate must prove:

1. all existing Linux/Webots behavior remains green;
2. Windows PowerShell prepares Blockly from the lockfile;
3. preflight and `.wbb` full-AST round-trip pass on Windows;
4. the official R2025a toolchain produces a non-empty PE controller;
5. the ZIP manifest verifies every file;
6. no development-only file or quoted remote runtime asset remains;
7. every shipped JavaScript file parses;
8. the launcher resolves **R2025a specifically** and the packaged world from a path containing spaces;
9. malformed vendored bridge/query input is fail-safe rather than an uncaught exception.

## Repair evidence

- `REFUTED` on `97cba256ab84da5fdde633bc2230ce5f5c6153e6`: invalid manual MSYS path conversion prevented the Windows controller build.
- `PROVEN_BY_CI` on later heads: Webots R2025a installs, the Runtime v2 controller builds into a Windows PE and the self-contained classroom ZIP is created successfully.
- `REFUTED` on `1ca4c668be9970168adba7821845f0f8f1c0e1f5`: the ZIP validator dereferenced `.FullName` on an empty forbidden-file result under StrictMode.
- `REFUTED` on `95c0daae91e369c83e097796f58caca91ef48a9c`: launcher parsing failed on a typographic apostrophe inside a single-quoted PowerShell string.
- `REFUTED` on `187f9f18ee298e53a310fc2400648ef39fbadd64`: launcher execution reached candidate discovery, where loop variable `$home` collided case-insensitively with read-only automatic variable `$HOME`.
- `PROVEN_BY_CI` on current head: `runtime-v2-windows-release` is fully green, including verified Webots R2025a install, native Windows controller build, self-contained ZIP validation from a path containing spaces, launcher validation and artifact upload.
- `REFUTED` on the first current-head attempt: the workflow was cancelled by an unrelated `gyro-gps-historical` checkout interruption; all completed product/runtime jobs were green and a targeted rerun of that cancelled job was requested without changing the candidate.
- `VERIFIED_BY_CODE_INSPECTION`: prior bridge/query/version review findings remain repaired and all inline review threads are resolved.
- `VERIFIED_BY_CI`: pending settlement of the targeted historical-job rerun for the exact head.

## Honest human boundary

This PR does **not** claim visible Windows support by CI alone. After merge, Emmanuel must run the generated archive on the least powerful classroom PC with network disabled and complete `WINDOWS-ACCEPTANCE.md`, including Edge/Chrome and Firefox file flows plus 30-minute stability. That result will decide whether #81 can close.

## Exact head

`08d4f70a2ced7c2ec6711702b0cab1ab9fe08c80`

Relates to #81 and #80.