### PR TITLE
Make trusted ntfy relaunch session-aware

### DIFF
--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -86,11 +86,15 @@ jobs:
               f"CI Gate terminé pour la PR #{number}.\n"
               f"HEAD: {head}\n"
               f"RESULT: {conclusion}\n"
-              "Relancer le Contrôleur pour reconstruire l’état GitHub."
+              "Si une session Contrôleur est active, ne pas en lancer une "
+              "seconde : elle reprendra automatiquement. Sinon, relancer le "
+              "Contrôleur."
           )
           copy_text = (
-              f"Reprends WebeeBlocks depuis GitHub. CI Gate terminé pour la PR "
-              f"#{number}, HEAD {head}, résultat {conclusion}."
+              f"Si aucune session Contrôleur n'est active, reprends WebeeBlocks "
+              f"depuis GitHub : CI Gate terminé pour la PR #{number}, HEAD "
+              f"{head}, résultat {conclusion}. Sinon, ne lance pas de seconde "
+              "session."
           )
           payload = {
               'topic': topic,


### PR DESCRIPTION
## Authorized stable-branch operation

Emmanuel explicitly authorized a PR to `main` limited to conditional ntfy wording so that a relaunch is requested only when no Controller session is active, followed by reconciliation into `develop`.

## Exact scope

- one file: `.github/workflows/controller-handoff-ntfy.yml`;
- change only the notification message and copy text;
- no event, permission, secret, checkout, network destination, validation or authority change;
- no product code.

## Acceptance oracle

- an active Controller session is explicitly told not to start a second session;
- a relaunch remains requested when no session is active;
- the trusted workflow security boundary is byte-for-byte unchanged outside these strings.

## Local evidence

- YAML parses;
- `permissions: {}` remains unchanged;
- exact diff contains one file and no added checkout, permission, secret, token or trigger line;
- `git diff --check` clean.

## Exact head

`948fa06d9fe4a5114dff98a06522fff33ad9113e`

No merge to `main` is claimed by this Worker; stable-branch integration remains a separately verified operation.