### PR TITLE
Finish the French student-facing interface

### DIFF
--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>WebeeBlocks Runtime v2</title>
+  <title>WebeeBlocks — Programmation du drone</title>
   <link rel="stylesheet" href="main.css">
   <link rel="stylesheet" href="execution_observer.css">
   <link rel="stylesheet" href="project_files.css">

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -298,11 +298,11 @@ window.onload = async function() {
     robotWindow = new module.default();
     runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true, simulationReset: true});
     robotWindow.receive = receiveMessage;
-    setRuntimeStatus('INITIALISATION', 'Attente du Runtime v2');
+    setRuntimeStatus('INITIALISATION', 'Connexion à la simulation');
     await runtimeBackend.waitUntilReady();
     if (runtimeBackend.capabilities && runtimeBackend.capabilities.simulationDebug === true) document.getElementById('debugPanel').hidden = false;
     updateRuntimeActions();
-    setRuntimeStatus('PRÊT', 'Runtime v2 connecté');
+    setRuntimeStatus('PRÊT', 'Simulation connectée');
   } catch (error) { setRuntimeFailure(error); }
 };
 

--- a/worlds/.crazyflie_runtime_v2.wbproj
+++ b/worlds/.crazyflie_runtime_v2.wbproj
@@ -1,2 +1,2 @@
 Webots Project File version R2025a
-robotWindow: Crazyflie Runtime v2
+robotWindow: Crazyflie WebeeBlocks

--- a/worlds/crazyflie_runtime_v2.wbt
+++ b/worlds/crazyflie_runtime_v2.wbt
@@ -9,12 +9,12 @@ WorldInfo {
   basicTimeStep 32
   randomSeed 1
   optimalThreadCount 1
-  title "WebeeBlocks Runtime v2 reactive obstacle"
+  title "WebeeBlocks — obstacle réactif"
 }
 Viewpoint {
   orientation -0.45 0.47 0.76 1.05
   position -2.4 -2.4 2.2
-  follow "Crazyflie Runtime v2"
+  follow "Crazyflie WebeeBlocks"
 }
 TexturedBackground { }
 TexturedBackgroundLight { }
@@ -42,7 +42,7 @@ DEF SECOND_OBSTACLE Solid {
 }
 
 Crazyflie {
-  name "Crazyflie Runtime v2"
+  name "Crazyflie WebeeBlocks"
   controller "crazyflie_runtime_v2"
   window "blockly_v2"
   supervisor TRUE


### PR DESCRIPTION
## Product outcome

Complete the software side of #79 so the classroom-facing WebeeBlocks identity and runtime status no longer expose the internal `Runtime v2` name. Students see French wording in the Robot Window and Webots activity while the existing Blockly 13.2.1 French localization remains unchanged.

## Scope

- replace the Robot Window title with `WebeeBlocks — Programmation du drone`;
- replace visible connection details with `Connexion à la simulation` / `Simulation connectée`;
- replace the Webots world title and robot name with French/classroom-facing wording;
- keep the `.wbproj` Robot Window binding aligned with the renamed robot.

## Acceptance oracle

- existing real `student-ui` Robot Window gate must remain green and continue proving Blockly 13.2.1 + Zelos, French built-in block text, French direction menu, French repeat tooltip, French accessibility label, semantic AST equality and keyboard path;
- Runtime/Webots gates must prove the robot rename does not break Robot Window routing, runtime semantics, reset/replay or packaged Windows behavior;
- code inspection must show no student-facing `Runtime v2` wording remains in the changed Robot Window/world identity paths.

## Non-goals

- no Blockly fork or renderer change;
- no AST, interpreter, backend or protocol identifier rename;
- no attempt to translate developer diagnostics, CI harnesses or internal machine identifiers;
- no activity/progression redesign.

## Human boundary

After merge, #79 still requires one representative visual check in the real classroom Webots/Robot Window path before the issue is closed, specifically watching for any remaining English or internal technical wording not exercised by automation.

Closes the software gap for #79; keep #79 open until that visual acceptance is recorded.

## Exact head

`c31b00bfcce6edd5a8f79499edf0a96d81a98c5d`