### PR TITLE
Reconcile trusted ntfy main history into develop

### DIFF
--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -86,11 +86,15 @@ jobs:
               f"CI Gate terminé pour la PR #{number}.\n"
               f"HEAD: {head}\n"
               f"RESULT: {conclusion}\n"
-              "Relancer le Contrôleur pour reconstruire l’état GitHub."
+              "Si une session Contrôleur est active, ne pas en lancer une "
+              "seconde : elle reprendra automatiquement. Sinon, relancer le "
+              "Contrôleur."
           )
           copy_text = (
-              f"Reprends WebeeBlocks depuis GitHub. CI Gate terminé pour la PR "
-              f"#{number}, HEAD {head}, résultat {conclusion}."
+              f"Si aucune session Contrôleur n'est active, reprends WebeeBlocks "
+              f"depuis GitHub : CI Gate terminé pour la PR #{number}, HEAD "
+              f"{head}, résultat {conclusion}. Sinon, ne lance pas de seconde "
+              "session."
           )
           payload = {
               'topic': topic,


### PR DESCRIPTION
## Outcome

Make the authorized trusted ntfy change from #121 part of `develop` history without replaying or reimplementing it.

## Exact ancestry

- first parent: `develop@f29fabb6054425bfeee1f48a8c96b59a07945064`;
- second parent: `main@6c1735cfd07c70396341dc734fddebe1f7028f6d`;
- exact head: `7352b16fa3bf67566aa4fd7cf612ded48ef589b5`.

## Content scope

- one modified file: `.github/workflows/controller-handoff-ntfy.yml`;
- resulting blob is exactly the trusted blob active on `main`: `cf0c3634d429c1a136d69459a3c225de50ea16b0`;
- no product, CI selector, permission, secret, trigger or authority change.

## Oracle

- merge-tree is conflict-free;
- resulting tree differs from current `develop` only by the conditional ntfy text;
- `git diff --check` is clean;
- the shared history prevents future duplicate reimplementation of this stable-branch operation.

This is a reconciliation PR required before reopening #120.