### PR TITLE
Restore packaged Windows controller startup

### DIFF
--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -108,7 +108,6 @@ jobs:
               raise SystemExit('Terminal handoff must contain an actionable detail')
 
           issue = event.get('issue') or {}
-          pull_request_event = event.get('pull_request') or {}
           is_pull_request = event_name == 'pull_request_review' or bool(issue.get('pull_request'))
           if status in {'READY_FOR_REVIEW', 'NO_GO', 'UNPROVEN'} and not is_pull_request:
               raise SystemExit(f'{status} requires a pull request')

--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -1,120 +1,202 @@
-name: CI Gate completion to ntfy
+name: Controller terminal handoff to ntfy
 
 on:
-  workflow_run:
-    workflows: [CI Gate]
-    types: [completed]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions: {}
 
 concurrency:
-  group: ci-gate-ntfy-${{ github.event.workflow_run.id }}
+  group: controller-terminal-ntfy-${{ github.event_name }}-${{ github.event.comment.id || github.event.review.id }}
   cancel-in-progress: false
 
 jobs:
   notify:
-    name: Relay trusted CI completion
+    name: Relay trusted terminal handoff
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0].base.ref == 'develop' &&
-      github.event.workflow_run.pull_requests[0].head.sha == github.event.workflow_run.head_sha &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.repository == 'djibian/webeeblocks' &&
+      github.actor == 'djibian'
     runs-on: ubuntu-latest
     steps:
-      - name: Validate event and publish notification
+      - name: Validate handoff and publish notification
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
         run: |
           python3 - <<'PY'
           import json
           import os
+          import re
           import urllib.request
+
+          REPOSITORY = 'djibian/webeeblocks'
+          TRUSTED_AUTHOR = 'djibian'
+          SHA = r'[0-9a-f]{40}'
+          COMMENT_PATTERN = re.compile(
+              rf'CONTROLLER_HANDOFF '
+              rf'(READY_FOR_REVIEW|HUMAN_REQUIRED|BLOCKED|SESSION_LIMIT) '
+              rf'({SHA})'
+          )
+          REVIEW_PATTERN = re.compile(rf'(NO_GO|UNPROVEN) ({SHA})')
+
+          def api_json(url):
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      'Accept': 'application/vnd.github+json',
+                      'User-Agent': 'webeeblocks-terminal-ntfy',
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.load(response)
+
+          def first_line_and_details(body):
+              normalized = (body or '').replace('\r\n', '\n')
+              first, separator, remainder = normalized.partition('\n')
+              details = remainder.strip() if separator else ''
+              return first.strip(), details
 
           with open(os.environ['GITHUB_EVENT_PATH'], encoding='utf-8') as stream:
               event = json.load(stream)
 
-          repository = event['repository']
-          run = event['workflow_run']
-          pull_requests = run.get('pull_requests') or []
-
-          if repository['full_name'] != 'djibian/webeeblocks':
+          repository = event.get('repository') or {}
+          sender = event.get('sender') or {}
+          if repository.get('full_name') != REPOSITORY:
               raise SystemExit('Unexpected repository')
-          if run['name'] != 'CI Gate' or run['event'] != 'pull_request':
-              raise SystemExit('Unexpected workflow run')
-          if run['status'] != 'completed':
-              raise SystemExit('Workflow run is not complete')
-          if run['head_repository']['full_name'] != repository['full_name']:
-              raise SystemExit('Only repository-owned candidate branches may notify')
-          if len(pull_requests) != 1 or pull_requests[0]['base']['ref'] != 'develop':
-              raise SystemExit('Expected exactly one pull request to develop')
+          if sender.get('login') != TRUSTED_AUTHOR:
+              raise SystemExit('Only the repository owner may emit a handoff')
 
-          pull_request = pull_requests[0]
-          number = int(pull_request['number'])
-          head = run['head_sha']
-          conclusion = run.get('conclusion') or 'unknown'
-          if len(head) != 40 or any(character not in '0123456789abcdef' for character in head):
-              raise SystemExit('Invalid head SHA')
-          current_request = urllib.request.Request(
-              f"https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
-              headers={
-                  'Accept': 'application/vnd.github+json',
-                  'User-Agent': 'webeeblocks-ci-gate-ntfy',
-              },
-          )
-          with urllib.request.urlopen(current_request, timeout=20) as response:
-              current_pull_request = json.load(response)
-          current_head = (current_pull_request.get('head') or {}).get('sha')
-          current_base = (current_pull_request.get('base') or {}).get('ref')
-          if current_head != head or current_base != 'develop':
-              print('PR no longer matches this completed run; stale event ignored.')
-              raise SystemExit(0)
+          event_name = os.environ.get('GITHUB_EVENT_NAME')
+          status = head = details = target_url = None
+          number = None
+
+          if event_name == 'pull_request_review':
+              if event.get('action') != 'submitted':
+                  raise SystemExit('Unexpected review action')
+              review = event.get('review') or {}
+              pull_request = event.get('pull_request') or {}
+              if (review.get('user') or {}).get('login') != TRUSTED_AUTHOR:
+                  raise SystemExit('Untrusted review author')
+              first_line, details = first_line_and_details(review.get('body'))
+              match = REVIEW_PATTERN.fullmatch(first_line)
+              if not match:
+                  print('Review is not a terminal controller handoff; ignored.')
+                  raise SystemExit(0)
+              status, head = match.groups()
+              number = int(pull_request['number'])
+              target_url = review.get('html_url') or pull_request.get('html_url')
+          elif event_name == 'issue_comment':
+              if event.get('action') != 'created':
+                  raise SystemExit('Unexpected comment action')
+              comment = event.get('comment') or {}
+              issue = event.get('issue') or {}
+              if (comment.get('user') or {}).get('login') != TRUSTED_AUTHOR:
+                  raise SystemExit('Untrusted comment author')
+              first_line, details = first_line_and_details(comment.get('body'))
+              match = COMMENT_PATTERN.fullmatch(first_line)
+              if not match:
+                  print('Comment is not a terminal controller handoff; ignored.')
+                  raise SystemExit(0)
+              status, head = match.groups()
+              number = int(issue['number'])
+              target_url = comment.get('html_url') or issue.get('html_url')
+          else:
+              raise SystemExit('Unexpected event type')
+
+          if not details:
+              raise SystemExit('Terminal handoff must contain an actionable detail')
+
+          issue = event.get('issue') or {}
+          is_pull_request = event_name == 'pull_request_review' or bool(issue.get('pull_request'))
+          if status in {'READY_FOR_REVIEW', 'NO_GO', 'UNPROVEN'} and not is_pull_request:
+              raise SystemExit(f'{status} requires a pull request')
+
+          if is_pull_request:
+              current = api_json(f'https://api.github.com/repos/{REPOSITORY}/pulls/{number}')
+              current_head = (current.get('head') or {}).get('sha')
+              current_base = (current.get('base') or {}).get('ref')
+              if current_head != head or current_base != 'develop':
+                  print('Handoff does not match the current PR head/base; ignored.')
+                  raise SystemExit(0)
+          else:
+              current = api_json(f'https://api.github.com/repos/{REPOSITORY}/commits/develop')
+              if current.get('sha') != head:
+                  print('Handoff does not match current develop; ignored.')
+                  raise SystemExit(0)
 
           topic = os.environ.get('NTFY_TOPIC', '').strip()
           if not topic:
-              print('NTFY_TOPIC is not configured; CI and GitHub remain authoritative.')
+              print('NTFY_TOPIC is not configured; GitHub remains authoritative.')
               raise SystemExit(0)
           if any(character in topic for character in '/?#') or len(topic) > 256:
               raise SystemExit('NTFY_TOPIC has an invalid format')
 
-          pull_request_url = (
-              f"https://github.com/djibian/webeeblocks/pull/{number}"
-          )
-          run_url = run['html_url']
-          success = conclusion == 'success'
-          title = 'WebeeBlocks — CI VERTE' if success else 'WebeeBlocks — CI TERMINÉE'
+          presentation = {
+              'READY_FOR_REVIEW': (
+                  'WebeeBlocks — REVUE À LANCER',
+                  'Relancer le Contrôleur en Reviewer-Integrator',
+                  4,
+                  ['mag', 'robot'],
+              ),
+              'NO_GO': (
+                  'WebeeBlocks — CORRECTION À LANCER',
+                  'Relancer le Contrôleur en Worker',
+                  4,
+                  ['wrench', 'robot'],
+              ),
+              'UNPROVEN': (
+                  'WebeeBlocks — PREUVE À ARBITRER',
+                  'Examiner la preuve manquante puis relancer le Contrôleur',
+                  5,
+                  ['warning', 'robot'],
+              ),
+              'HUMAN_REQUIRED': (
+                  'WebeeBlocks — INTERVENTION REQUISE',
+                  'Effectuer l’action humaine indiquée',
+                  5,
+                  ['raising_hand', 'robot'],
+              ),
+              'BLOCKED': (
+                  'WebeeBlocks — BLOCAGE À TRAITER',
+                  'Examiner le blocage avant de relancer le Contrôleur',
+                  5,
+                  ['no_entry', 'robot'],
+              ),
+              'SESSION_LIMIT': (
+                  'WebeeBlocks — SESSION À RELANCER',
+                  'Relancer le Contrôleur dans le même mode',
+                  4,
+                  ['hourglass', 'robot'],
+              ),
+          }
+          title, next_action, priority, tags = presentation[status]
+          context = f'PR #{number}' if is_pull_request else f'issue #{number}'
+          safe_details = details[:1400]
           message = (
-              f"CI Gate terminé pour la PR #{number}.\n"
-              f"HEAD: {head}\n"
-              f"RESULT: {conclusion}\n"
-              "Si une session Contrôleur est active, ne pas en lancer une "
-              "seconde : elle reprendra automatiquement. Sinon, relancer le "
-              "Contrôleur."
+              f'{status} — {context}\n'
+              f'SHA: {head}\n'
+              f'{safe_details}\n\n'
+              f'Action : {next_action}.'
           )
           copy_text = (
-              f"Si aucune session Contrôleur n'est active, reprends WebeeBlocks "
-              f"depuis GitHub : CI Gate terminé pour la PR #{number}, HEAD "
-              f"{head}, résultat {conclusion}. Sinon, ne lance pas de seconde "
-              "session."
+              f'Reprends WebeeBlocks depuis GitHub. Handoff {status} pour '
+              f'{context}, SHA {head}. {safe_details}'
           )
           payload = {
               'topic': topic,
               'title': title,
               'message': message,
-              'priority': 3 if success else 4,
-              'tags': ['white_check_mark' if success else 'warning', 'robot'],
-              'click': pull_request_url,
+              'priority': priority,
+              'tags': tags,
+              'click': target_url,
               'actions': [
                   {'action': 'copy', 'label': 'Copier', 'value': copy_text},
                   {
                       'action': 'view',
-                      'label': 'Ouvrir la PR',
-                      'url': pull_request_url,
+                      'label': 'Ouvrir GitHub',
+                      'url': target_url,
                       'clear': True,
-                  },
-                  {
-                      'action': 'view',
-                      'label': 'Voir la CI',
-                      'url': run_url,
                   },
               ],
           }
@@ -129,3 +211,4 @@ jobs:
                   raise RuntimeError(f'ntfy returned HTTP {response.status}')
               print(f'ntfy status: {response.status}')
           PY
+

--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -1,120 +1,203 @@
-name: CI Gate completion to ntfy
+name: Controller terminal handoff to ntfy
 
 on:
-  workflow_run:
-    workflows: [CI Gate]
-    types: [completed]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions: {}
 
 concurrency:
-  group: ci-gate-ntfy-${{ github.event.workflow_run.id }}
+  group: controller-terminal-ntfy-${{ github.event_name }}-${{ github.event.comment.id || github.event.review.id }}
   cancel-in-progress: false
 
 jobs:
   notify:
-    name: Relay trusted CI completion
+    name: Relay trusted terminal handoff
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0].base.ref == 'develop' &&
-      github.event.workflow_run.pull_requests[0].head.sha == github.event.workflow_run.head_sha &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.repository == 'djibian/webeeblocks' &&
+      github.actor == 'djibian'
     runs-on: ubuntu-latest
     steps:
-      - name: Validate event and publish notification
+      - name: Validate handoff and publish notification
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
         run: |
           python3 - <<'PY'
           import json
           import os
+          import re
           import urllib.request
+
+          REPOSITORY = 'djibian/webeeblocks'
+          TRUSTED_AUTHOR = 'djibian'
+          SHA = r'[0-9a-f]{40}'
+          COMMENT_PATTERN = re.compile(
+              rf'CONTROLLER_HANDOFF '
+              rf'(READY_FOR_REVIEW|HUMAN_REQUIRED|BLOCKED|SESSION_LIMIT) '
+              rf'({SHA})'
+          )
+          REVIEW_PATTERN = re.compile(rf'(NO_GO|UNPROVEN) ({SHA})')
+
+          def api_json(url):
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      'Accept': 'application/vnd.github+json',
+                      'User-Agent': 'webeeblocks-terminal-ntfy',
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.load(response)
+
+          def first_line_and_details(body):
+              normalized = (body or '').replace('\r\n', '\n')
+              first, separator, remainder = normalized.partition('\n')
+              details = remainder.strip() if separator else ''
+              return first.strip(), details
 
           with open(os.environ['GITHUB_EVENT_PATH'], encoding='utf-8') as stream:
               event = json.load(stream)
 
-          repository = event['repository']
-          run = event['workflow_run']
-          pull_requests = run.get('pull_requests') or []
-
-          if repository['full_name'] != 'djibian/webeeblocks':
+          repository = event.get('repository') or {}
+          sender = event.get('sender') or {}
+          if repository.get('full_name') != REPOSITORY:
               raise SystemExit('Unexpected repository')
-          if run['name'] != 'CI Gate' or run['event'] != 'pull_request':
-              raise SystemExit('Unexpected workflow run')
-          if run['status'] != 'completed':
-              raise SystemExit('Workflow run is not complete')
-          if run['head_repository']['full_name'] != repository['full_name']:
-              raise SystemExit('Only repository-owned candidate branches may notify')
-          if len(pull_requests) != 1 or pull_requests[0]['base']['ref'] != 'develop':
-              raise SystemExit('Expected exactly one pull request to develop')
+          if sender.get('login') != TRUSTED_AUTHOR:
+              raise SystemExit('Only the repository owner may emit a handoff')
 
-          pull_request = pull_requests[0]
-          number = int(pull_request['number'])
-          head = run['head_sha']
-          conclusion = run.get('conclusion') or 'unknown'
-          if len(head) != 40 or any(character not in '0123456789abcdef' for character in head):
-              raise SystemExit('Invalid head SHA')
-          current_request = urllib.request.Request(
-              f"https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
-              headers={
-                  'Accept': 'application/vnd.github+json',
-                  'User-Agent': 'webeeblocks-ci-gate-ntfy',
-              },
-          )
-          with urllib.request.urlopen(current_request, timeout=20) as response:
-              current_pull_request = json.load(response)
-          current_head = (current_pull_request.get('head') or {}).get('sha')
-          current_base = (current_pull_request.get('base') or {}).get('ref')
-          if current_head != head or current_base != 'develop':
-              print('PR no longer matches this completed run; stale event ignored.')
-              raise SystemExit(0)
+          event_name = os.environ.get('GITHUB_EVENT_NAME')
+          status = head = details = target_url = None
+          number = None
+
+          if event_name == 'pull_request_review':
+              if event.get('action') != 'submitted':
+                  raise SystemExit('Unexpected review action')
+              review = event.get('review') or {}
+              pull_request = event.get('pull_request') or {}
+              if (review.get('user') or {}).get('login') != TRUSTED_AUTHOR:
+                  raise SystemExit('Untrusted review author')
+              first_line, details = first_line_and_details(review.get('body'))
+              match = REVIEW_PATTERN.fullmatch(first_line)
+              if not match:
+                  print('Review is not a terminal controller handoff; ignored.')
+                  raise SystemExit(0)
+              status, head = match.groups()
+              number = int(pull_request['number'])
+              target_url = review.get('html_url') or pull_request.get('html_url')
+          elif event_name == 'issue_comment':
+              if event.get('action') != 'created':
+                  raise SystemExit('Unexpected comment action')
+              comment = event.get('comment') or {}
+              issue = event.get('issue') or {}
+              if (comment.get('user') or {}).get('login') != TRUSTED_AUTHOR:
+                  raise SystemExit('Untrusted comment author')
+              first_line, details = first_line_and_details(comment.get('body'))
+              match = COMMENT_PATTERN.fullmatch(first_line)
+              if not match:
+                  print('Comment is not a terminal controller handoff; ignored.')
+                  raise SystemExit(0)
+              status, head = match.groups()
+              number = int(issue['number'])
+              target_url = comment.get('html_url') or issue.get('html_url')
+          else:
+              raise SystemExit('Unexpected event type')
+
+          if not details:
+              raise SystemExit('Terminal handoff must contain an actionable detail')
+
+          issue = event.get('issue') or {}
+          pull_request_event = event.get('pull_request') or {}
+          is_pull_request = event_name == 'pull_request_review' or bool(issue.get('pull_request'))
+          if status in {'READY_FOR_REVIEW', 'NO_GO', 'UNPROVEN'} and not is_pull_request:
+              raise SystemExit(f'{status} requires a pull request')
+
+          if is_pull_request:
+              current = api_json(f'https://api.github.com/repos/{REPOSITORY}/pulls/{number}')
+              current_head = (current.get('head') or {}).get('sha')
+              current_base = (current.get('base') or {}).get('ref')
+              if current_head != head or current_base != 'develop':
+                  print('Handoff does not match the current PR head/base; ignored.')
+                  raise SystemExit(0)
+          else:
+              current = api_json(f'https://api.github.com/repos/{REPOSITORY}/commits/develop')
+              if current.get('sha') != head:
+                  print('Handoff does not match current develop; ignored.')
+                  raise SystemExit(0)
 
           topic = os.environ.get('NTFY_TOPIC', '').strip()
           if not topic:
-              print('NTFY_TOPIC is not configured; CI and GitHub remain authoritative.')
+              print('NTFY_TOPIC is not configured; GitHub remains authoritative.')
               raise SystemExit(0)
           if any(character in topic for character in '/?#') or len(topic) > 256:
               raise SystemExit('NTFY_TOPIC has an invalid format')
 
-          pull_request_url = (
-              f"https://github.com/djibian/webeeblocks/pull/{number}"
-          )
-          run_url = run['html_url']
-          success = conclusion == 'success'
-          title = 'WebeeBlocks — CI VERTE' if success else 'WebeeBlocks — CI TERMINÉE'
+          presentation = {
+              'READY_FOR_REVIEW': (
+                  'WebeeBlocks — REVUE À LANCER',
+                  'Relancer le Contrôleur en Reviewer-Integrator',
+                  4,
+                  ['mag', 'robot'],
+              ),
+              'NO_GO': (
+                  'WebeeBlocks — CORRECTION À LANCER',
+                  'Relancer le Contrôleur en Worker',
+                  4,
+                  ['wrench', 'robot'],
+              ),
+              'UNPROVEN': (
+                  'WebeeBlocks — PREUVE À ARBITRER',
+                  'Examiner la preuve manquante puis relancer le Contrôleur',
+                  5,
+                  ['warning', 'robot'],
+              ),
+              'HUMAN_REQUIRED': (
+                  'WebeeBlocks — INTERVENTION REQUISE',
+                  'Effectuer l’action humaine indiquée',
+                  5,
+                  ['raising_hand', 'robot'],
+              ),
+              'BLOCKED': (
+                  'WebeeBlocks — BLOCAGE À TRAITER',
+                  'Examiner le blocage avant de relancer le Contrôleur',
+                  5,
+                  ['no_entry', 'robot'],
+              ),
+              'SESSION_LIMIT': (
+                  'WebeeBlocks — SESSION À RELANCER',
+                  'Relancer le Contrôleur dans le même mode',
+                  4,
+                  ['hourglass', 'robot'],
+              ),
+          }
+          title, next_action, priority, tags = presentation[status]
+          context = f'PR #{number}' if is_pull_request else f'issue #{number}'
+          safe_details = details[:1400]
           message = (
-              f"CI Gate terminé pour la PR #{number}.\n"
-              f"HEAD: {head}\n"
-              f"RESULT: {conclusion}\n"
-              "Si une session Contrôleur est active, ne pas en lancer une "
-              "seconde : elle reprendra automatiquement. Sinon, relancer le "
-              "Contrôleur."
+              f'{status} — {context}\n'
+              f'SHA: {head}\n'
+              f'{safe_details}\n\n'
+              f'Action : {next_action}.'
           )
           copy_text = (
-              f"Si aucune session Contrôleur n'est active, reprends WebeeBlocks "
-              f"depuis GitHub : CI Gate terminé pour la PR #{number}, HEAD "
-              f"{head}, résultat {conclusion}. Sinon, ne lance pas de seconde "
-              "session."
+              f'Reprends WebeeBlocks depuis GitHub. Handoff {status} pour '
+              f'{context}, SHA {head}. {safe_details}'
           )
           payload = {
               'topic': topic,
               'title': title,
               'message': message,
-              'priority': 3 if success else 4,
-              'tags': ['white_check_mark' if success else 'warning', 'robot'],
-              'click': pull_request_url,
+              'priority': priority,
+              'tags': tags,
+              'click': target_url,
               'actions': [
                   {'action': 'copy', 'label': 'Copier', 'value': copy_text},
                   {
                       'action': 'view',
-                      'label': 'Ouvrir la PR',
-                      'url': pull_request_url,
+                      'label': 'Ouvrir GitHub',
+                      'url': target_url,
                       'clear': True,
-                  },
-                  {
-                      'action': 'view',
-                      'label': 'Voir la CI',
-                      'url': run_url,
                   },
               ],
           }

--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -1,120 +1,202 @@
-name: CI Gate completion to ntfy
+name: Controller terminal handoff to ntfy
 
 on:
-  workflow_run:
-    workflows: [CI Gate]
-    types: [completed]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions: {}
 
 concurrency:
-  group: ci-gate-ntfy-${{ github.event.workflow_run.id }}
+  group: controller-terminal-ntfy-${{ github.event_name }}-${{ github.event.comment.id || github.event.review.id }}
   cancel-in-progress: false
 
 jobs:
   notify:
-    name: Relay trusted CI completion
+    name: Relay trusted terminal handoff
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0].base.ref == 'develop' &&
-      github.event.workflow_run.pull_requests[0].head.sha == github.event.workflow_run.head_sha &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.repository == 'djibian/webeeblocks' &&
+      github.actor == 'djibian'
     runs-on: ubuntu-latest
     steps:
-      - name: Validate event and publish notification
+      - name: Validate handoff and publish notification
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
         run: |
           python3 - <<'PY'
           import json
           import os
+          import re
           import urllib.request
+
+          REPOSITORY = 'djibian/webeeblocks'
+          TRUSTED_AUTHOR = 'djibian'
+          SHA = r'[0-9a-f]{40}'
+          COMMENT_PATTERN = re.compile(
+              rf'CONTROLLER_HANDOFF '
+              rf'(READY_FOR_REVIEW|HUMAN_REQUIRED|BLOCKED|SESSION_LIMIT) '
+              rf'({SHA})'
+          )
+          REVIEW_PATTERN = re.compile(rf'(NO_GO|UNPROVEN) ({SHA})')
+
+          def api_json(url):
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      'Accept': 'application/vnd.github+json',
+                      'User-Agent': 'webeeblocks-terminal-ntfy',
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.load(response)
+
+          def first_line_and_details(body):
+              normalized = (body or '').replace('\r\n', '\n')
+              first, separator, remainder = normalized.partition('\n')
+              details = remainder.strip() if separator else ''
+              return first.strip(), details
 
           with open(os.environ['GITHUB_EVENT_PATH'], encoding='utf-8') as stream:
               event = json.load(stream)
 
-          repository = event['repository']
-          run = event['workflow_run']
-          pull_requests = run.get('pull_requests') or []
-
-          if repository['full_name'] != 'djibian/webeeblocks':
+          repository = event.get('repository') or {}
+          sender = event.get('sender') or {}
+          if repository.get('full_name') != REPOSITORY:
               raise SystemExit('Unexpected repository')
-          if run['name'] != 'CI Gate' or run['event'] != 'pull_request':
-              raise SystemExit('Unexpected workflow run')
-          if run['status'] != 'completed':
-              raise SystemExit('Workflow run is not complete')
-          if run['head_repository']['full_name'] != repository['full_name']:
-              raise SystemExit('Only repository-owned candidate branches may notify')
-          if len(pull_requests) != 1 or pull_requests[0]['base']['ref'] != 'develop':
-              raise SystemExit('Expected exactly one pull request to develop')
+          if sender.get('login') != TRUSTED_AUTHOR:
+              raise SystemExit('Only the repository owner may emit a handoff')
 
-          pull_request = pull_requests[0]
-          number = int(pull_request['number'])
-          head = run['head_sha']
-          conclusion = run.get('conclusion') or 'unknown'
-          if len(head) != 40 or any(character not in '0123456789abcdef' for character in head):
-              raise SystemExit('Invalid head SHA')
-          current_request = urllib.request.Request(
-              f"https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
-              headers={
-                  'Accept': 'application/vnd.github+json',
-                  'User-Agent': 'webeeblocks-ci-gate-ntfy',
-              },
-          )
-          with urllib.request.urlopen(current_request, timeout=20) as response:
-              current_pull_request = json.load(response)
-          current_head = (current_pull_request.get('head') or {}).get('sha')
-          current_base = (current_pull_request.get('base') or {}).get('ref')
-          if current_head != head or current_base != 'develop':
-              print('PR no longer matches this completed run; stale event ignored.')
-              raise SystemExit(0)
+          event_name = os.environ.get('GITHUB_EVENT_NAME')
+          status = head = details = target_url = None
+          number = None
+
+          if event_name == 'pull_request_review':
+              if event.get('action') != 'submitted':
+                  raise SystemExit('Unexpected review action')
+              review = event.get('review') or {}
+              pull_request = event.get('pull_request') or {}
+              if (review.get('user') or {}).get('login') != TRUSTED_AUTHOR:
+                  raise SystemExit('Untrusted review author')
+              first_line, details = first_line_and_details(review.get('body'))
+              match = REVIEW_PATTERN.fullmatch(first_line)
+              if not match:
+                  print('Review is not a terminal controller handoff; ignored.')
+                  raise SystemExit(0)
+              status, head = match.groups()
+              number = int(pull_request['number'])
+              target_url = review.get('html_url') or pull_request.get('html_url')
+          elif event_name == 'issue_comment':
+              if event.get('action') != 'created':
+                  raise SystemExit('Unexpected comment action')
+              comment = event.get('comment') or {}
+              issue = event.get('issue') or {}
+              if (comment.get('user') or {}).get('login') != TRUSTED_AUTHOR:
+                  raise SystemExit('Untrusted comment author')
+              first_line, details = first_line_and_details(comment.get('body'))
+              match = COMMENT_PATTERN.fullmatch(first_line)
+              if not match:
+                  print('Comment is not a terminal controller handoff; ignored.')
+                  raise SystemExit(0)
+              status, head = match.groups()
+              number = int(issue['number'])
+              target_url = comment.get('html_url') or issue.get('html_url')
+          else:
+              raise SystemExit('Unexpected event type')
+
+          if not details:
+              raise SystemExit('Terminal handoff must contain an actionable detail')
+
+          issue = event.get('issue') or {}
+          is_pull_request = event_name == 'pull_request_review' or bool(issue.get('pull_request'))
+          if status in {'READY_FOR_REVIEW', 'NO_GO', 'UNPROVEN'} and not is_pull_request:
+              raise SystemExit(f'{status} requires a pull request')
+
+          if is_pull_request:
+              current = api_json(f'https://api.github.com/repos/{REPOSITORY}/pulls/{number}')
+              current_head = (current.get('head') or {}).get('sha')
+              current_base = (current.get('base') or {}).get('ref')
+              if current_head != head or current_base != 'develop':
+                  print('Handoff does not match the current PR head/base; ignored.')
+                  raise SystemExit(0)
+          else:
+              current = api_json(f'https://api.github.com/repos/{REPOSITORY}/commits/develop')
+              if current.get('sha') != head:
+                  print('Handoff does not match current develop; ignored.')
+                  raise SystemExit(0)
 
           topic = os.environ.get('NTFY_TOPIC', '').strip()
           if not topic:
-              print('NTFY_TOPIC is not configured; CI and GitHub remain authoritative.')
+              print('NTFY_TOPIC is not configured; GitHub remains authoritative.')
               raise SystemExit(0)
           if any(character in topic for character in '/?#') or len(topic) > 256:
               raise SystemExit('NTFY_TOPIC has an invalid format')
 
-          pull_request_url = (
-              f"https://github.com/djibian/webeeblocks/pull/{number}"
-          )
-          run_url = run['html_url']
-          success = conclusion == 'success'
-          title = 'WebeeBlocks — CI VERTE' if success else 'WebeeBlocks — CI TERMINÉE'
+          presentation = {
+              'READY_FOR_REVIEW': (
+                  'WebeeBlocks — REVUE À LANCER',
+                  'Relancer le Contrôleur en Reviewer-Integrator',
+                  4,
+                  ['mag', 'robot'],
+              ),
+              'NO_GO': (
+                  'WebeeBlocks — CORRECTION À LANCER',
+                  'Relancer le Contrôleur en Worker',
+                  4,
+                  ['wrench', 'robot'],
+              ),
+              'UNPROVEN': (
+                  'WebeeBlocks — PREUVE À ARBITRER',
+                  'Examiner la preuve manquante puis relancer le Contrôleur',
+                  5,
+                  ['warning', 'robot'],
+              ),
+              'HUMAN_REQUIRED': (
+                  'WebeeBlocks — INTERVENTION REQUISE',
+                  'Effectuer l’action humaine indiquée',
+                  5,
+                  ['raising_hand', 'robot'],
+              ),
+              'BLOCKED': (
+                  'WebeeBlocks — BLOCAGE À TRAITER',
+                  'Examiner le blocage avant de relancer le Contrôleur',
+                  5,
+                  ['no_entry', 'robot'],
+              ),
+              'SESSION_LIMIT': (
+                  'WebeeBlocks — SESSION À RELANCER',
+                  'Relancer le Contrôleur dans le même mode',
+                  4,
+                  ['hourglass', 'robot'],
+              ),
+          }
+          title, next_action, priority, tags = presentation[status]
+          context = f'PR #{number}' if is_pull_request else f'issue #{number}'
+          safe_details = details[:1400]
           message = (
-              f"CI Gate terminé pour la PR #{number}.\n"
-              f"HEAD: {head}\n"
-              f"RESULT: {conclusion}\n"
-              "Si une session Contrôleur est active, ne pas en lancer une "
-              "seconde : elle reprendra automatiquement. Sinon, relancer le "
-              "Contrôleur."
+              f'{status} — {context}\n'
+              f'SHA: {head}\n'
+              f'{safe_details}\n\n'
+              f'Action : {next_action}.'
           )
           copy_text = (
-              f"Si aucune session Contrôleur n'est active, reprends WebeeBlocks "
-              f"depuis GitHub : CI Gate terminé pour la PR #{number}, HEAD "
-              f"{head}, résultat {conclusion}. Sinon, ne lance pas de seconde "
-              "session."
+              f'Reprends WebeeBlocks depuis GitHub. Handoff {status} pour '
+              f'{context}, SHA {head}. {safe_details}'
           )
           payload = {
               'topic': topic,
               'title': title,
               'message': message,
-              'priority': 3 if success else 4,
-              'tags': ['white_check_mark' if success else 'warning', 'robot'],
-              'click': pull_request_url,
+              'priority': priority,
+              'tags': tags,
+              'click': target_url,
               'actions': [
                   {'action': 'copy', 'label': 'Copier', 'value': copy_text},
                   {
                       'action': 'view',
-                      'label': 'Ouvrir la PR',
-                      'url': pull_request_url,
+                      'label': 'Ouvrir GitHub',
+                      'url': target_url,
                       'clear': True,
-                  },
-                  {
-                      'action': 'view',
-                      'label': 'Voir la CI',
-                      'url': run_url,
                   },
               ],
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,10 +106,28 @@ a head never independently approves that head.
 
 ## Terminal handoff
 
-Repository facts remain authoritative. Do not create a parallel state log.
+Repository facts remain authoritative. Handoff comments and reviews are
+append-only notification events, never a parallel state log.
 
-- CI settlement is transported by the trusted default-branch ntfy workflow.
+- Before a terminal stop that needs Emmanuel to act, publish exactly one
+  handoff artifact for the terminal status and current full SHA. Do not
+  duplicate an artifact already present for that status/SHA.
+- Worker `READY_FOR_REVIEW`: add a PR comment whose first line is
+  `CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>`, followed by the outcome,
+  evidence and the request to launch a fresh Reviewer-Integrator.
+- Reviewer `NO_GO` or `UNPROVEN`: the native PR review is the handoff. Its
+  first line remains `NO_GO <head-sha>` or `UNPROVEN <head-sha>`, followed by
+  the smallest actionable repair or proof boundary. Do not add a second
+  comment.
+- `HUMAN_REQUIRED`, `BLOCKED` or `SESSION_LIMIT`: add a comment to the
+  active PR, or otherwise to the relevant issue, whose first line is
+  `CONTROLLER_HANDOFF <status> <sha>`, followed by one precise action. Use the
+  current PR head SHA for a PR and current `develop` SHA for an issue-only
+  handoff.
+- A pending or settled CI, `GO` and `COMPLETED` are silent. They never emit a
+  handoff artifact or ntfy request.
 - Mention `@djibian` only when a human decision or physical action is required.
 - A final report begins with its terminal status and states the mode, outcome
   or reviewed SHA, tests, PR/commit, `develop` state, `main` state and the next
   actionable event.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,16 @@ a head never independently approves that head.
 
 ## Productive session
 
-- Treat a manual launch as one productive session of about 60 minutes maximum.
+- Treat a manual launch as one continuous productive session. Around 60
+  minutes, perform a progress checkpoint; elapsed time alone is not a reason
+  to stop.
+- At that checkpoint, reconstruct the exact GitHub state and continue while
+  the current mode is making safe, material progress. Material progress
+  includes a causal diagnosis, a tested correction, a new head, a settled gate
+  analysis, or movement toward the mode's required handoff.
+- Stop as `BLOCKED` when about 30 minutes produce no material progress, or
+  when the same causal correction cycle repeats twice without new evidence.
+  Do not count bounded CI waiting as lack of progress.
 - A pending `CI Gate` is not a reason to stop. Wait idly, poll moderately, then
   continue from the result while the current mode can still progress safely.
 - When readily available, use up to five recent comparable non-cancelled gate
@@ -46,7 +55,9 @@ a head never independently approves that head.
 - After each significant transition—push, settled gate, review verdict or
   merge—re-read the PR head, exact gate and relevant GitHub state.
 - End only as `COMPLETED`, `READY_FOR_REVIEW`, `HUMAN_REQUIRED`, `BLOCKED` or
-  `SESSION_LIMIT`. ntfy remains the fallback when no session is active.
+  `SESSION_LIMIT`. Reserve `SESSION_LIMIT` for an actual platform/runtime
+  limit; never choose it solely because about 60 minutes elapsed. ntfy remains
+  the fallback when no session is active.
 
 ## Worker
 

--- a/docs/CONTROLLER_NOTIFICATIONS.md
+++ b/docs/CONTROLLER_NOTIFICATIONS.md
@@ -1,44 +1,64 @@
 # Controller notifications
 
-Notifications transport an external event; they never store Controller state.
+Notifications transport a terminal handoff; they never store Controller state.
 
-## CI settlement
+## When ntfy is sent
 
-The trusted default-branch workflow observes only completion of the top-level
-`CI Gate`. It performs no checkout, executes no candidate code, writes nothing
-to GitHub and has no merge authority.
+CI pending and CI completion are silent. An active Controller session waits,
+polls moderately and continues from the exact result without asking Emmanuel
+to relaunch it.
 
-For the PR and exact head attached to the completed run, it sends one ntfy
-message containing:
+The trusted default-branch workflow sends one notification only when a terminal
+Controller handoff requires an external action:
 
-- PR number;
-- full head SHA;
-- the GitHub conclusion;
-- the workflow-run URL.
+| Status | GitHub artifact | Requested action |
+| --- | --- | --- |
+| `READY_FOR_REVIEW` | PR comment | launch a fresh Reviewer-Integrator |
+| `NO_GO` | native PR review | launch a Worker to repair the same PR |
+| `UNPROVEN` | native PR review | arbitrate or obtain the missing proof |
+| `HUMAN_REQUIRED` | PR or issue comment | perform the stated human action |
+| `BLOCKED` | PR or issue comment | resolve the stated blocker |
+| `SESSION_LIMIT` | PR or issue comment | relaunch the same mode |
 
-The event is ignored when its embedded current PR head differs from the
-completed run SHA. Every accepted notification still includes the exact SHA,
-so the Controller can reject any event superseded after delivery.
+`GO`, `COMPLETED`, ordinary comments/reviews and every CI event are silent.
 
-The message says that CI settled, not that the change is approved. An active
-Controller session also polls moderately and reconstructs the result itself.
-When no session is active, the notification prompts a fresh launch, which
-chooses Worker or Reviewer-Integrator from GitHub.
+## Strict handoff protocol
 
-## Human action
+Worker and non-review terminal comments use an exact first line:
 
-When a product decision, permission or physical test is indispensable, the
-Controller mentions `@djibian` in the relevant issue or PR and asks one precise
-question with a recommendation. GitHub Mobile is the durable fallback.
+```text
+CONTROLLER_HANDOFF <STATUS> <full-sha>
+```
 
-No `READY_FOR_CONTROLLER`, `WAITING_EXTERNAL`, Draft transition or issue-log
-comment is required to derive a mode.
+The allowed comment statuses are `READY_FOR_REVIEW`, `HUMAN_REQUIRED`,
+`BLOCKED` and `SESSION_LIMIT`. The following lines must contain a precise,
+actionable detail.
+
+Reviewer handoffs use the existing native review verdict as the exact first
+line:
+
+```text
+NO_GO <full-sha>
+UNPROVEN <full-sha>
+```
+
+The workflow accepts an event only when:
+
+- repository and author are exactly the trusted repository owner;
+- a PR handoff names the current full head SHA of a PR to `develop`;
+- an issue-only handoff names the current full `develop` SHA;
+- the first line matches the strict grammar and details are non-empty.
+
+Stale or ordinary events are ignored. The Controller emits at most one artifact
+for a terminal status/SHA. GitHub remains authoritative if ntfy delivery fails.
 
 ## Security
 
 - fixed ntfy server `https://ntfy.sh/`;
 - secret limited to `NTFY_TOPIC`;
-- no candidate checkout or import;
-- no GitHub write permission;
-- an event whose embedded PR head already differs from the run SHA is ignored;
+- `permissions: {}`;
+- no candidate checkout, import or execution;
+- no GitHub write, CI orchestration or merge authority;
+- event JSON is parsed as data and current public GitHub state is revalidated;
 - transport failure cannot change CI, review or merge truth.
+

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,17 +57,22 @@ the protected up-to-date requirement is the pre-merge integration proof.
 
 ## Productive waiting
 
-A manual Controller launch is a productive session of about 60 minutes. Within
-its current mode it waits for `CI Gate`, polls moderately and resumes from the
-settled result. It uses recent comparable durations when readily available;
-otherwise the first wait is four minutes, followed by checks about every minute.
+A manual Controller launch is one productive session. Around 60 minutes it
+reconstructs the exact state and records a progress checkpoint, but continues
+while safe, material progress is occurring. It waits for `CI Gate`, polls
+moderately and resumes from the settled result. It uses recent comparable
+durations when readily available; otherwise the first wait is four minutes,
+followed by checks about every minute.
 
-The trusted workflow on the default branch still observes completion without
-checkout or candidate execution and sends one ntfy message containing the PR,
-full head, result and link. This is the fallback when no session is active or a
-session reaches its limit; it is not workflow state.
+CI pending and CI completion are silent: the active session observes them
+directly. The trusted default-branch workflow sends ntfy only after a terminal
+Controller handoff that requires Emmanuel to intervene or launch the next fresh
+mode: `READY_FOR_REVIEW`, `NO_GO`, `UNPROVEN`, `HUMAN_REQUIRED`, `BLOCKED`
+or `SESSION_LIMIT`. `GO` and `COMPLETED` remain silent.
 
-Issue comments, Draft/Ready and notification payloads are not controller state.
+Handoff comments and reviews contain an exact status/SHA and actionable detail,
+but do not store Controller state. Draft/Ready and notification payloads are not
+role locks or workflow state.
 
 ## Repository protections
 
@@ -95,3 +100,4 @@ authority; it is not required for the current manual-release model.
 The full gate also builds the Windows classroom ZIP with the official Webots
 R2025a toolchain. Runtime-only PRs retain the fast Windows AST and project-file
 contract; nightly runs and promotions rebuild the complete offline artifact.
+

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -124,7 +124,13 @@ Get-ChildItem -LiteralPath $contractsSource -File -Filter '*.js' | ForEach-Objec
 Copy-RequiredFile `
   (Join-Path $repoRoot 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js') `
   (Join-Path $packageDir 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js')
-Copy-RequiredFile $controllerBinary (Join-Path $packageDir 'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe')
+$packagedControllerDir = Join-Path $packageDir 'controllers\crazyflie_runtime_v2'
+Copy-RequiredFile $controllerBinary (Join-Path $packagedControllerDir 'crazyflie_runtime_v2.exe')
+$runtimeIni = @'
+[environment variables with paths]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/lib/controller:$(WEBOTS_HOME)/msys64/mingw64/bin
+'@
+Write-Utf8NoBom (Join-Path $packagedControllerDir 'runtime.ini') (($runtimeIni.TrimEnd()) + "`n")
 
 $crazyflieRoot = Join-Path $projectsRoot 'robots\bitcraze\crazyflie\protos'
 $protoSource = Join-Path $crazyflieRoot 'Crazyflie.proto'

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -124,15 +124,7 @@ Get-ChildItem -LiteralPath $contractsSource -File -Filter '*.js' | ForEach-Objec
 Copy-RequiredFile `
   (Join-Path $repoRoot 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js') `
   (Join-Path $packageDir 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js')
-$packagedControllerDir = Join-Path $packageDir 'controllers\crazyflie_runtime_v2'
-Copy-RequiredFile $controllerBinary (Join-Path $packagedControllerDir 'crazyflie_runtime_v2.exe')
-$controllerRuntimeIni = @'
-; Keep the prebuilt classroom controller tied to the installed Webots R2025a
-; runtime instead of relying on the administrator or user PATH.
-[environment variables with paths]
-WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/lib/controller:$(WEBOTS_HOME)/msys64/mingw64/bin
-'@
-Write-Utf8NoBom (Join-Path $packagedControllerDir 'runtime.ini') ($controllerRuntimeIni.Trim() + "`n")
+Copy-RequiredFile $controllerBinary (Join-Path $packageDir 'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe')
 
 $crazyflieRoot = Join-Path $projectsRoot 'robots\bitcraze\crazyflie\protos'
 $protoSource = Join-Path $crazyflieRoot 'Crazyflie.proto'

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -124,7 +124,15 @@ Get-ChildItem -LiteralPath $contractsSource -File -Filter '*.js' | ForEach-Objec
 Copy-RequiredFile `
   (Join-Path $repoRoot 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js') `
   (Join-Path $packageDir 'plugins\robot_windows\blockly\google-blockly-31ee4ea\blocks\crazyflie_v2.js')
-Copy-RequiredFile $controllerBinary (Join-Path $packageDir 'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe')
+$packagedControllerDir = Join-Path $packageDir 'controllers\crazyflie_runtime_v2'
+Copy-RequiredFile $controllerBinary (Join-Path $packagedControllerDir 'crazyflie_runtime_v2.exe')
+$controllerRuntimeIni = @'
+; Keep the prebuilt classroom controller tied to the installed Webots R2025a
+; runtime instead of relying on the administrator or user PATH.
+[environment variables with paths]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/lib/controller:$(WEBOTS_HOME)/msys64/mingw64/bin
+'@
+Write-Utf8NoBom (Join-Path $packagedControllerDir 'runtime.ini') ($controllerRuntimeIni.Trim() + "`n")
 
 $crazyflieRoot = Join-Path $projectsRoot 'robots\bitcraze\crazyflie\protos'
 $protoSource = Join-Path $crazyflieRoot 'Crazyflie.proto'

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prevent the productive-session contract from regressing into CI handoffs."""
+"""Prevent the productive-session and terminal-handoff contracts from regressing."""
 
 from pathlib import Path
 import unittest
@@ -30,19 +30,50 @@ class ControllerContractTests(unittest.TestCase):
         self.assertNotIn("about 60 minutes maximum", contract)
         self.assertNotIn("Do not poll", contract)
 
-    def test_documentation_keeps_two_fresh_modes_and_ntfy_fallback(self) -> None:
+    def test_terminal_handoff_is_exact_and_ci_is_silent(self) -> None:
+        contract = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
         development = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
             encoding="utf-8"
         )
         notifications = (ROOT / "docs" / "CONTROLLER_NOTIFICATIONS.md").read_text(
             encoding="utf-8"
         )
+        workflow = (
+            ROOT / ".github" / "workflows" / "controller-handoff-ntfy.yml"
+        ).read_text(encoding="utf-8")
+
         self.assertIn("one continuous Worker", development)
         self.assertIn("one fresh\n  Reviewer-Integrator", development)
-        self.assertIn("fallback when no session is active", development)
-        self.assertIn("polls moderately", notifications)
+        self.assertIn("CI pending and CI completion are silent", development)
+        self.assertIn(
+            "CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>", contract
+        )
+        self.assertIn("NO_GO <head-sha>", contract)
+        self.assertIn("UNPROVEN <head-sha>", contract)
+        self.assertIn(
+            "A pending or settled CI, `GO` and `COMPLETED` are silent",
+            contract,
+        )
+        for status in (
+            "READY_FOR_REVIEW",
+            "NO_GO",
+            "UNPROVEN",
+            "HUMAN_REQUIRED",
+            "BLOCKED",
+            "SESSION_LIMIT",
+        ):
+            self.assertIn(status, notifications)
+
+        self.assertIn("issue_comment:", workflow)
+        self.assertIn("pull_request_review:", workflow)
+        self.assertIn("permissions: {}", workflow)
+        self.assertNotIn("workflow_run:", workflow)
+        self.assertNotIn("actions/checkout", workflow)
+        self.assertNotIn("observes completion", development)
+        self.assertNotIn("fallback when no session is active", development)
         self.assertNotIn("never waits inside", development)
 
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -11,15 +11,23 @@ ROOT = Path(__file__).resolve().parents[2]
 class ControllerContractTests(unittest.TestCase):
     def test_worker_waits_but_never_self_approves(self) -> None:
         contract = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn("one continuous productive session", contract)
+        self.assertIn("perform a progress checkpoint", contract)
+        self.assertIn("elapsed time alone is not a reason", contract)
+        self.assertIn("Stop as `BLOCKED` when about 30 minutes", contract)
+        self.assertIn("same causal correction cycle repeats twice", contract)
+        self.assertIn("Do not count bounded CI waiting as lack of progress", contract)
         self.assertIn("A pending `CI Gate` is not a reason to stop", contract)
-        self.assertIn("about 60 minutes maximum", contract)
         self.assertIn("five recent comparable non-cancelled gate", contract)
         self.assertIn("check about every 60 seconds", contract)
+        self.assertIn("Reserve `SESSION_LIMIT` for an actual platform/runtime", contract)
+        self.assertIn("never choose it solely because about 60 minutes elapsed", contract)
         self.assertIn("`READY_FOR_REVIEW`", contract)
         self.assertIn(
             "The launch that writes\na head never independently approves that head",
             contract,
         )
+        self.assertNotIn("about 60 minutes maximum", contract)
         self.assertNotIn("Do not poll", contract)
 
     def test_documentation_keeps_two_fresh_modes_and_ntfy_fallback(self) -> None:

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -70,8 +70,8 @@ $version = (Get-Content -LiteralPath (Join-Path $testRoot 'plugins\robot_windows
 Assert-Release ($version -eq '13.2.1') "Unexpected Blockly release version: $version"
 
 $runtimeIni = Get-Content -LiteralPath (Join-Path $testRoot 'controllers\crazyflie_runtime_v2\runtime.ini') -Raw
-Assert-Release ($runtimeIni -match '(?m)^\[environment variables with paths\]$') 'Controller runtime.ini lacks the path-aware environment section.'
-Assert-Release ($runtimeIni -match '(?m)^WEBOTS_LIBRARY_PATH\s*=\s*\$\(WEBOTS_HOME\)/lib/controller:\$\(WEBOTS_HOME\)/msys64/mingw64/bin$') 'Controller runtime.ini does not bind the prebuilt executable to Webots R2025a libraries.'
+Assert-Release ($runtimeIni -match '(?m)^\[environment variables with paths\]\r?$') 'Controller runtime.ini lacks the path-aware environment section.'
+Assert-Release ($runtimeIni -match '(?m)^WEBOTS_LIBRARY_PATH\s*=\s*\$\(WEBOTS_HOME\)/lib/controller:\$\(WEBOTS_HOME\)/msys64/mingw64/bin\r?$') 'Controller runtime.ini does not bind the prebuilt executable to Webots R2025a libraries.'
 
 $forbidden = @(Get-ChildItem -LiteralPath $testRoot -Recurse -Force | Where-Object {
   $_.Name -in @('node_modules', 'package.json', 'package-lock.json', 'Makefile') -or

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -114,13 +114,12 @@ $stderrPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stderr.lo
 Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
 if ($world.Contains('"')) { throw 'The packaged world path contains an unsupported quote.' }
 $webotsArguments = '--stdout --stderr --batch --minimize --no-rendering --mode=fast "' + $world + '"'
-$oldQtQpaPlatform = $env:QT_QPA_PLATFORM
 $oldQtOpenGl = $env:QT_OPENGL
 try {
-  # GitHub-hosted Windows runners have no interactive desktop. Webots is a Qt/OpenGL
-  # application even with rendering disabled, so give this CI-only startup oracle an
-  # explicit offscreen/software platform while preserving the packaged controller env.
-  $env:QT_QPA_PLATFORM = 'offscreen'
+  # Keep the native Windows Qt platform plugin selected by the installed Webots
+  # runtime. The Windows package ships qwindows.dll; forcing an unavailable
+  # offscreen QPA backend makes Webots terminate before loading the world.
+  # Software OpenGL remains CI-only and does not alter the packaged controller.
   $env:QT_OPENGL = 'software'
   $process = Start-Process `
     -FilePath $webotsExe `
@@ -131,7 +130,6 @@ try {
     -PassThru
 }
 finally {
-  $env:QT_QPA_PLATFORM = $oldQtQpaPlatform
   $env:QT_OPENGL = $oldQtOpenGl
 }
 $ready = $false

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -112,15 +112,17 @@ $world = Join-Path $testRoot 'worlds\crazyflie_runtime_v2.wbt'
 $stdoutPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stdout.log'
 $stderrPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stderr.log'
 Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
-$worldArgument = '"' + $world + '"'
+if ($world.Contains('"')) { throw 'The packaged world path contains an unsupported quote.' }
+$webotsArguments = '--stdout --stderr --batch --minimize --no-rendering --mode=fast "' + $world + '"'
 $process = Start-Process `
   -FilePath $webotsExe `
-  -ArgumentList @('--stdout', '--stderr', '--batch', '--mode=fast', $worldArgument) `
+  -ArgumentList $webotsArguments `
   -WorkingDirectory $testRoot `
   -RedirectStandardOutput $stdoutPath `
   -RedirectStandardError $stderrPath `
   -PassThru
 $ready = $false
+$earlyExitCode = $null
 try {
   $deadline = [DateTime]::UtcNow.AddSeconds(35)
   do {
@@ -131,7 +133,11 @@ try {
       break
     }
     $process.Refresh()
-  } while (-not $process.HasExited -and [DateTime]::UtcNow -lt $deadline)
+    if ($process.HasExited) {
+      $earlyExitCode = $process.ExitCode
+      break
+    }
+  } while ([DateTime]::UtcNow -lt $deadline)
 }
 finally {
   $process.Refresh()
@@ -143,7 +149,8 @@ finally {
 if (-not $ready) {
   $stdout = if (Test-Path -LiteralPath $stdoutPath) { Get-Content -LiteralPath $stdoutPath -Raw } else { '<no stdout>' }
   $stderr = if (Test-Path -LiteralPath $stderrPath) { Get-Content -LiteralPath $stderrPath -Raw } else { '<no stderr>' }
-  throw "Packaged Webots world never reached controller READY.`nSTDOUT:`n$stdout`nSTDERR:`n$stderr"
+  $exitDetail = if ($null -eq $earlyExitCode) { 'timeout' } else { "exit=$earlyExitCode" }
+  throw "Packaged Webots world never reached controller READY ($exitDetail).`nSTDOUT:`n$stdout`nSTDERR:`n$stderr"
 }
 
 Write-Host "PASS: Windows classroom archive is self-contained, checksummed, path-safe, launcher-ready and starts its packaged controller ($($manifestEntries.Count) files)."

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -106,62 +106,68 @@ Get-ChildItem -LiteralPath (Join-Path $testRoot 'plugins') -Recurse -File -Filte
 & (Join-Path $testRoot 'Launch-WebeeBlocks.ps1') -ValidateOnly -WebotsHome $WebotsHome
 if ($LASTEXITCODE -ne 0) { throw 'Release launcher validation failed.' }
 
-$webotsExe = Join-Path $WebotsHome 'msys64\mingw64\bin\webots.exe'
-Assert-Release (Test-Path -LiteralPath $webotsExe -PathType Leaf) 'Webots console executable is missing for packaged startup proof.'
-$world = Join-Path $testRoot 'worlds\crazyflie_runtime_v2.wbt'
-$stdoutPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stdout.log'
-$stderrPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stderr.log'
-Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
-if ($world.Contains('"')) { throw 'The packaged world path contains an unsupported quote.' }
-$webotsArguments = '--stdout --stderr --batch --minimize --no-rendering --mode=fast "' + $world + '"'
-$oldQtOpenGl = $env:QT_OPENGL
+# GitHub-hosted Windows has no trustworthy interactive Webots/Robot Window session.
+# Prove the diagnosed product boundary directly instead: the executable extracted
+# from the exact ZIP must load with only the two Webots runtime directories that
+# runtime.ini declares (plus Windows system DLL locations), enter libController,
+# and reach its deterministic IPC connection path. A missing runtime DLL fails
+# before this marker and therefore cannot pass this oracle.
+$controllerStdout = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-controller.stdout.log'
+$controllerStderr = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-controller.stderr.log'
+Remove-Item -LiteralPath $controllerStdout, $controllerStderr -Force -ErrorAction SilentlyContinue
+$oldWebotsHome = $env:WEBOTS_HOME
+$oldControllerUrl = $env:WEBOTS_CONTROLLER_URL
+$oldPath = $env:PATH
+$process = $null
 try {
-  # Keep the native Windows Qt platform plugin selected by the installed Webots
-  # runtime. The Windows package ships qwindows.dll; forcing an unavailable
-  # offscreen QPA backend makes Webots terminate before loading the world.
-  # Software OpenGL remains CI-only and does not alter the packaged controller.
-  $env:QT_OPENGL = 'software'
+  $env:WEBOTS_HOME = $WebotsHome
+  $env:WEBOTS_CONTROLLER_URL = 'ipc://65535'
+  $env:PATH = @(
+    (Join-Path $WebotsHome 'lib\controller'),
+    (Join-Path $WebotsHome 'msys64\mingw64\bin'),
+    (Join-Path $env:SystemRoot 'System32'),
+    $env:SystemRoot
+  ) -join ';'
+
   $process = Start-Process `
-    -FilePath $webotsExe `
-    -ArgumentList $webotsArguments `
-    -WorkingDirectory $testRoot `
-    -RedirectStandardOutput $stdoutPath `
-    -RedirectStandardError $stderrPath `
+    -FilePath $exe `
+    -WorkingDirectory (Split-Path $exe -Parent) `
+    -RedirectStandardOutput $controllerStdout `
+    -RedirectStandardError $controllerStderr `
     -PassThru
-}
-finally {
-  $env:QT_OPENGL = $oldQtOpenGl
-}
-$ready = $false
-$earlyExitCode = $null
-try {
-  $deadline = [DateTime]::UtcNow.AddSeconds(35)
+
+  $enteredLibController = $false
+  $deadline = [DateTime]::UtcNow.AddSeconds(8)
   do {
-    Start-Sleep -Seconds 1
-    $stdout = if (Test-Path -LiteralPath $stdoutPath) { Get-Content -LiteralPath $stdoutPath -Raw } else { '' }
-    if ($stdout -match '(?m)^WEBEEBLOCKS_RUNTIME_V2 READY\s*$') {
-      $ready = $true
+    Start-Sleep -Milliseconds 250
+    $stderr = if (Test-Path -LiteralPath $controllerStderr) { Get-Content -LiteralPath $controllerStderr -Raw } else { '' }
+    if ($stderr -match 'Cannot connect to Webots instance') {
+      $enteredLibController = $true
       break
     }
     $process.Refresh()
-    if ($process.HasExited) {
-      $earlyExitCode = $process.ExitCode
-      break
-    }
+    if ($process.HasExited) { break }
   } while ([DateTime]::UtcNow -lt $deadline)
-}
-finally {
-  $process.Refresh()
-  if (-not $process.HasExited) {
-    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-    $process.WaitForExit()
+
+  if (-not $enteredLibController) {
+    $process.Refresh()
+    $exitDetail = if ($process.HasExited) { "exit=$($process.ExitCode)" } else { 'timeout' }
+    $stdout = if (Test-Path -LiteralPath $controllerStdout) { Get-Content -LiteralPath $controllerStdout -Raw } else { '<no stdout>' }
+    $stderr = if (Test-Path -LiteralPath $controllerStderr) { Get-Content -LiteralPath $controllerStderr -Raw } else { '<no stderr>' }
+    throw "Packaged controller did not enter the Webots controller runtime ($exitDetail).`nSTDOUT:`n$stdout`nSTDERR:`n$stderr"
   }
 }
-if (-not $ready) {
-  $stdout = if (Test-Path -LiteralPath $stdoutPath) { Get-Content -LiteralPath $stdoutPath -Raw } else { '<no stdout>' }
-  $stderr = if (Test-Path -LiteralPath $stderrPath) { Get-Content -LiteralPath $stderrPath -Raw } else { '<no stderr>' }
-  $exitDetail = if ($null -eq $earlyExitCode) { 'timeout' } else { "exit=$earlyExitCode" }
-  throw "Packaged Webots world never reached controller READY ($exitDetail).`nSTDOUT:`n$stdout`nSTDERR:`n$stderr"
+finally {
+  if ($null -ne $process) {
+    $process.Refresh()
+    if (-not $process.HasExited) {
+      Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+      $process.WaitForExit()
+    }
+  }
+  $env:WEBOTS_HOME = $oldWebotsHome
+  $env:WEBOTS_CONTROLLER_URL = $oldControllerUrl
+  $env:PATH = $oldPath
 }
 
-Write-Host "PASS: Windows classroom archive is self-contained, checksummed, path-safe, launcher-ready and starts its packaged controller ($($manifestEntries.Count) files)."
+Write-Host "PASS: Windows classroom archive is self-contained, checksummed, path-safe, launcher-ready and its packaged controller loads through the declared Webots R2025a runtime ($($manifestEntries.Count) files)."

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -48,6 +48,7 @@ $required = @(
   'README-WINDOWS.md',
   'WINDOWS-ACCEPTANCE.md',
   'controllers\crazyflie_runtime_v2\crazyflie_runtime_v2.exe',
+  'controllers\crazyflie_runtime_v2\runtime.ini',
   'plugins\robot_windows\blockly_v2\blockly_v2.html',
   'plugins\robot_windows\blockly_v2\vendor\VERSION',
   'plugins\robot_windows\blockly_v2\vendor\blockly_compressed.js',
@@ -67,6 +68,10 @@ foreach ($relative in $required) {
 
 $version = (Get-Content -LiteralPath (Join-Path $testRoot 'plugins\robot_windows\blockly_v2\vendor\VERSION') -Raw).Trim()
 Assert-Release ($version -eq '13.2.1') "Unexpected Blockly release version: $version"
+
+$runtimeIni = Get-Content -LiteralPath (Join-Path $testRoot 'controllers\crazyflie_runtime_v2\runtime.ini') -Raw
+Assert-Release ($runtimeIni -match '(?m)^\[environment variables with paths\]$') 'Controller runtime.ini lacks the path-aware environment section.'
+Assert-Release ($runtimeIni -match '(?m)^WEBOTS_LIBRARY_PATH\s*=\s*\$\(WEBOTS_HOME\)/lib/controller:\$\(WEBOTS_HOME\)/msys64/mingw64/bin$') 'Controller runtime.ini does not bind the prebuilt executable to Webots R2025a libraries.'
 
 $forbidden = @(Get-ChildItem -LiteralPath $testRoot -Recurse -Force | Where-Object {
   $_.Name -in @('node_modules', 'package.json', 'package-lock.json', 'Makefile') -or
@@ -101,4 +106,44 @@ Get-ChildItem -LiteralPath (Join-Path $testRoot 'plugins') -Recurse -File -Filte
 & (Join-Path $testRoot 'Launch-WebeeBlocks.ps1') -ValidateOnly -WebotsHome $WebotsHome
 if ($LASTEXITCODE -ne 0) { throw 'Release launcher validation failed.' }
 
-Write-Host "PASS: Windows classroom archive is self-contained, checksummed, path-safe and launcher-ready ($($manifestEntries.Count) files)."
+$webotsExe = Join-Path $WebotsHome 'msys64\mingw64\bin\webots.exe'
+Assert-Release (Test-Path -LiteralPath $webotsExe -PathType Leaf) 'Webots console executable is missing for packaged startup proof.'
+$world = Join-Path $testRoot 'worlds\crazyflie_runtime_v2.wbt'
+$stdoutPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stdout.log'
+$stderrPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stderr.log'
+Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
+$worldArgument = '"' + $world + '"'
+$process = Start-Process `
+  -FilePath $webotsExe `
+  -ArgumentList @('--stdout', '--stderr', '--batch', '--mode=fast', $worldArgument) `
+  -WorkingDirectory $testRoot `
+  -RedirectStandardOutput $stdoutPath `
+  -RedirectStandardError $stderrPath `
+  -PassThru
+$ready = $false
+try {
+  $deadline = [DateTime]::UtcNow.AddSeconds(35)
+  do {
+    Start-Sleep -Seconds 1
+    $stdout = if (Test-Path -LiteralPath $stdoutPath) { Get-Content -LiteralPath $stdoutPath -Raw } else { '' }
+    if ($stdout -match '(?m)^WEBEEBLOCKS_RUNTIME_V2 READY\s*$') {
+      $ready = $true
+      break
+    }
+    $process.Refresh()
+  } while (-not $process.HasExited -and [DateTime]::UtcNow -lt $deadline)
+}
+finally {
+  $process.Refresh()
+  if (-not $process.HasExited) {
+    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    $process.WaitForExit()
+  }
+}
+if (-not $ready) {
+  $stdout = if (Test-Path -LiteralPath $stdoutPath) { Get-Content -LiteralPath $stdoutPath -Raw } else { '<no stdout>' }
+  $stderr = if (Test-Path -LiteralPath $stderrPath) { Get-Content -LiteralPath $stderrPath -Raw } else { '<no stderr>' }
+  throw "Packaged Webots world never reached controller READY.`nSTDOUT:`n$stdout`nSTDERR:`n$stderr"
+}
+
+Write-Host "PASS: Windows classroom archive is self-contained, checksummed, path-safe, launcher-ready and starts its packaged controller ($($manifestEntries.Count) files)."

--- a/tools/ci/test_windows_classroom_release.ps1
+++ b/tools/ci/test_windows_classroom_release.ps1
@@ -114,13 +114,26 @@ $stderrPath = Join-Path $env:RUNNER_TEMP 'webeeblocks-packaged-runtime.stderr.lo
 Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
 if ($world.Contains('"')) { throw 'The packaged world path contains an unsupported quote.' }
 $webotsArguments = '--stdout --stderr --batch --minimize --no-rendering --mode=fast "' + $world + '"'
-$process = Start-Process `
-  -FilePath $webotsExe `
-  -ArgumentList $webotsArguments `
-  -WorkingDirectory $testRoot `
-  -RedirectStandardOutput $stdoutPath `
-  -RedirectStandardError $stderrPath `
-  -PassThru
+$oldQtQpaPlatform = $env:QT_QPA_PLATFORM
+$oldQtOpenGl = $env:QT_OPENGL
+try {
+  # GitHub-hosted Windows runners have no interactive desktop. Webots is a Qt/OpenGL
+  # application even with rendering disabled, so give this CI-only startup oracle an
+  # explicit offscreen/software platform while preserving the packaged controller env.
+  $env:QT_QPA_PLATFORM = 'offscreen'
+  $env:QT_OPENGL = 'software'
+  $process = Start-Process `
+    -FilePath $webotsExe `
+    -ArgumentList $webotsArguments `
+    -WorkingDirectory $testRoot `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -PassThru
+}
+finally {
+  $env:QT_QPA_PLATFORM = $oldQtQpaPlatform
+  $env:QT_OPENGL = $oldQtOpenGl
+}
 $ready = $false
 $earlyExitCode = $null
 try {

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -64,34 +64,44 @@ class WorkflowContractTests(unittest.TestCase):
         transport = (WORKFLOWS / "controller-handoff-ntfy.yml").read_text(
             encoding="utf-8"
         )
-        self.assertIn("  workflow_run:\n", transport)
-        self.assertIn("workflows: [CI Gate]", transport)
+        self.assertIn("  issue_comment:\n", transport)
+        self.assertIn("  pull_request_review:\n", transport)
+        self.assertNotIn("  workflow_run:\n", transport)
+        self.assertNotIn("workflows: [CI Gate]", transport)
+        self.assertIn("github.repository == 'djibian/webeeblocks'", transport)
+        self.assertIn("github.actor == 'djibian'", transport)
+        self.assertIn("sender.get('login') != TRUSTED_AUTHOR", transport)
         self.assertIn(
-            "pull_requests[0].head.sha == github.event.workflow_run.head_sha",
-            transport,
-        )
-        self.assertIn(
-            "https://api.github.com/repos/djibian/webeeblocks/pulls/{number}",
+            "https://api.github.com/repos/{REPOSITORY}/pulls/{number}",
             transport,
         )
         self.assertIn(
             "current_head != head or current_base != 'develop'",
             transport,
         )
-        self.assertLess(
-            transport.index("current_request = urllib.request.Request("),
-            transport.index("topic = os.environ.get('NTFY_TOPIC'"),
-        )
-        self.assertIn("permissions: {}", transport)
-        self.assertNotIn("  pull_request:\n", transport)
-        self.assertNotIn("actions/checkout", transport)
-        self.assertNotIn("github.token", transport)
-        self.assertIn("Si une session Contrôleur est active", transport)
-        self.assertIn("ne lance pas de seconde", transport)
-        self.assertNotIn(
-            '"Relancer le Contrôleur pour reconstruire l’état GitHub."',
+        self.assertIn(
+            "https://api.github.com/repos/{REPOSITORY}/commits/develop",
             transport,
         )
+        self.assertLess(
+            transport.index("if is_pull_request:"),
+            transport.index("topic = os.environ.get('NTFY_TOPIC'"),
+        )
+        for status in (
+            "READY_FOR_REVIEW",
+            "NO_GO",
+            "UNPROVEN",
+            "HUMAN_REQUIRED",
+            "BLOCKED",
+            "SESSION_LIMIT",
+        ):
+            self.assertIn(status, transport)
+        self.assertIn("permissions: {}", transport)
+        self.assertNotIn("  pull_request:\n", transport)
+        self.assertNotIn("  pull_request_target:\n", transport)
+        self.assertNotIn("actions/checkout", transport)
+        self.assertNotIn("github.token", transport)
+        self.assertNotIn("CI Gate terminé", transport)
 
     def test_every_oracle_job_is_preserved_once(self) -> None:
         observed: set[str] = set()
@@ -206,3 +216,4 @@ class WorkflowContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Outcome

Repair the Windows classroom package after the real weakest-PC acceptance failure recorded in #81: the packaged Runtime v2 controller must start from the extracted release using the installed Webots R2025a runtime, without relying on an administrator/user PATH.

## Cause boundary

The previous release proved that `crazyflie_runtime_v2.exe` compiled and was present in the ZIP, but did not prove that the extracted executable could resolve the Webots controller runtime on Windows. The real classroom test then timed out in `INITIALISATION`, consistent with the controller never reaching the Webots controller API / `WEBEEBLOCKS_RUNTIME_V2 READY` path.

Webots supports a controller-local `runtime.ini`; `WEBOTS_LIBRARY_PATH` is prepended to the platform library search path. This slice packages that explicit binding to `$(WEBOTS_HOME)/lib/controller` and `$(WEBOTS_HOME)/msys64/mingw64/bin`.

## Acceptance oracle

The full Windows release validation extracts the exact classroom ZIP under a path containing spaces, verifies the packaged `runtime.ini`, and launches the **packaged controller executable itself** with a deliberately constrained PATH containing only the two Webots runtime directories declared by `runtime.ini` plus Windows system DLL locations. It targets a nonexistent deterministic Webots IPC endpoint and fails unless the process gets far enough into the official Webots `libController` runtime to emit `Cannot connect to Webots instance`.

This is a causal loader/startup proof for the diagnosed package defect: a missing Webots runtime DLL fails before that marker and cannot pass. It does not claim that a GitHub-hosted Windows runner is a trustworthy GUI/Robot Window environment.

The earlier attempt to require full packaged-world `READY` on GitHub-hosted Windows was intentionally removed after two exact-head runs showed Webots itself terminating before world/controller output (`exit=3` while an unavailable Qt offscreen backend was forced, then `exit=1` with the native Windows Qt backend). Webots' own headless guidance still requires a usable graphical/OpenGL environment, and #81 explicitly requires human Windows acceptance rather than a fake PASS when hosted Windows cannot provide a trustworthy real GUI/Robot Window gate.

## Scope

- package `controllers/crazyflie_runtime_v2/runtime.ini` with explicit Webots runtime library paths;
- include and validate it through the checksum manifest;
- prove from the extracted ZIP, under a path containing spaces and without user/admin PATH inheritance, that the packaged PE loads the declared Webots R2025a runtime and enters `libController`;
- keep the actual Webots world / Robot Window / browser acceptance human as required by #81.

## Human-requested controller contract adjustment

The previous Worker session stopped at about 60 minutes immediately after pushing a new head, before reconstructing the post-push state or diagnosing the resulting gate. At Emmanuel's explicit request, this PR also changes only the productive-session timing clause in `AGENTS.md`:

- 60 minutes is a progress checkpoint, not a stop condition;
- continue while safe, material progress is occurring;
- stop `BLOCKED` after about 30 minutes without material progress or two repeated causal cycles without new evidence;
- reserve `SESSION_LIMIT` for an actual platform/runtime limit.

All role, single-PR, exact-head review and human-authority boundaries remain unchanged.

## Non-goals / human boundary

- no change to AST, interpreter, controller behavior, Robot Window UI, project-file semantics or safety rules;
- no automated claim that the browser receives the handshake on a real classroom PC;
- weakest-PC GUI/offline/stability acceptance remains human.

Closes the diagnosed startup subproblem of #81; #81 remains open pending real Windows acceptance.

## Main reconciliation and terminal notifications

At Emmanuel's explicit request, the authorized terminal-handoff workflow merged by #125 is reconciled here through the true second parent `main@3dc3c098a693b478c039e4268097c3d03c068152`. The same commit aligns `AGENTS.md`, the development and notification documentation, and the controller-contract regression test:

- CI pending and completion are silent;
- ntfy is emitted only for `READY_FOR_REVIEW`, `NO_GO`, `UNPROVEN`, `HUMAN_REQUIRED`, `BLOCKED` and `SESSION_LIMIT`;
- `GO` and `COMPLETED` are silent;
- every accepted terminal artifact is author- and exact-SHA-validated;
- the workflow retains `permissions: {}`, no checkout and no candidate execution.

This reconciliation is governance/transport-only and does not broaden the Windows product claim.