### PR TITLE
Fix observed Windows classroom launch and Blockly UX blockers

### DIFF
--- a/experiments/runtime-v2-student-ui/probe.py
+++ b/experiments/runtime-v2-student-ui/probe.py
@@ -113,17 +113,19 @@ RENDER_LOCALE=r'''(() => {
  const logicOr=workspace.getBlocksByType('logic_operation',false).find(block=>block.getFieldValue('OP')==='OR'&&block.getRelativeToSurfaceXY().x>500);
  const range=workspace.getBlocksByType('webeeblocks_v2_range',false).find(block=>block.getRelativeToSurfaceXY().x>500);
  const repeat=workspace.getBlocksByType('controls_repeat_ext',false)[0];
- if(!logicAnd||!logicOr||!range||!repeat)throw new Error('rendered locale evidence blocks missing');
+ const condition=workspace.getBlocksByType('controls_if',false)[0];
+ if(!logicAnd||!logicOr||!range||!repeat||!condition)throw new Error('rendered locale evidence blocks missing');
  const field=range.getField('DIRECTION');
  const fieldRoot=field.getSvgRoot();
  const repeatRoot=repeat.getSvgRoot();
  const repeatPath=repeatRoot&&repeatRoot.querySelector('.blocklyPath');
+ const repeatText=[...(repeatRoot&&repeatRoot.querySelectorAll('.blocklyText')||[])].find(el=>(el.textContent||'').trim().toLowerCase().startsWith('répéter'));
  return {
    logicAndText:logicAnd.toString(),logicAndSvgText:logicAnd.getSvgRoot().textContent,
    logicOrText:logicOr.toString(),logicOrSvgText:logicOr.getSvgRoot().textContent,
    logicRects:[rect(logicAnd.getSvgRoot()),rect(logicOr.getSvgRoot())],directionFieldRect:rect(fieldRoot),directionFieldText:fieldRoot.textContent,
    directionFieldRole:fieldRoot.getAttribute('role'),directionFieldAriaLabel:fieldRoot.getAttribute('aria-label'),
-   repeatRect:rect(repeatPath||repeatRoot),
+   repeatRect:rect(repeatText||repeatPath||repeatRoot),repeatSvgText:repeatRoot.textContent,conditionSvgText:condition.getSvgRoot().textContent,
    workspaceAriaLabel:document.getElementById('blocklyDiv').getAttribute('aria-label')
  };
 })()'''
@@ -223,6 +225,12 @@ def main():
     for expected in ('vrai','ou','faux'):
         if expected not in rendered_or:
             raise RuntimeError('rendered OR program lacks '+expected+': '+rendered_or)
+    condition_text=rendered['conditionSvgText'].lower()
+    repeat_text=rendered['repeatSvgText'].lower()
+    if 'alors' not in condition_text or ' faire' in condition_text:
+        raise RuntimeError('rendered condition must use "alors": '+condition_text)
+    if 'faire' in repeat_text:
+        raise RuntimeError('rendered repeat block must not display "faire": '+repeat_text)
     if rendered['workspaceAriaLabel']!='Programme Blockly':
         raise RuntimeError('rendered workspace accessibility label is not French: '+str(rendered['workspaceAriaLabel']))
     screenshot=Path(a.screenshot)
@@ -253,4 +261,5 @@ def main():
     Path(a.output).write_text(json.dumps({'ast':ast,'astMatchesExpected':True,'locale':locale,'renderedLocale':rendered,'directionMenu':direction_menu,'repeatTooltip':tooltip,'initial':initial,'keyboard':key,'responsive800':responsive,'final':final},ensure_ascii=False,indent=2),encoding='utf-8')
     try:c.call('Browser.close')
     except Exception:pass
+
 if __name__=='__main__': main()

--- a/packaging/windows/Launch-WebeeBlocks.ps1
+++ b/packaging/windows/Launch-WebeeBlocks.ps1
@@ -49,11 +49,11 @@ if ([string]::IsNullOrWhiteSpace($webots)) {
 }
 
 if ($ValidateOnly) {
-  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world version=R2025a"
+  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world version=R2025a mode=run"
   exit 0
 }
 
 if ($world.Contains('"')) { throw 'Le chemin du monde contient un guillemet non pris en charge.' }
 $worldArgument = '"' + $world + '"'
-Start-Process -FilePath $webots -ArgumentList @('--mode=pause', $worldArgument) -WorkingDirectory $PSScriptRoot
-Write-Host "WebeeBlocks demarre. La fenetre Blockly va s'ouvrir dans le navigateur configure par Webots."
+Start-Process -FilePath $webots -ArgumentList @('--mode=run', $worldArgument) -WorkingDirectory $PSScriptRoot
+Write-Host "WebeeBlocks demarre. La simulation et la fenetre Blockly vont s'initialiser automatiquement."

--- a/packaging/windows/Launch-WebeeBlocks.ps1
+++ b/packaging/windows/Launch-WebeeBlocks.ps1
@@ -49,11 +49,11 @@ if ([string]::IsNullOrWhiteSpace($webots)) {
 }
 
 if ($ValidateOnly) {
-  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world version=R2025a mode=run"
+  Write-Host "WEBEEBLOCKS_WINDOWS_LAUNCHER_OK webots=$webots world=$world version=R2025a mode=realtime"
   exit 0
 }
 
 if ($world.Contains('"')) { throw 'Le chemin du monde contient un guillemet non pris en charge.' }
 $worldArgument = '"' + $world + '"'
-Start-Process -FilePath $webots -ArgumentList @('--mode=run', $worldArgument) -WorkingDirectory $PSScriptRoot
+Start-Process -FilePath $webots -ArgumentList @('--mode=realtime', $worldArgument) -WorkingDirectory $PSScriptRoot
 Write-Host "WebeeBlocks demarre. La simulation et la fenetre Blockly vont s'initialiser automatiquement."

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="main.css">
   <link rel="stylesheet" href="execution_observer.css">
   <link rel="stylesheet" href="project_files.css">
+  <link rel="stylesheet" href="classroom_fixes.css">
   <script src="vendor/blockly_compressed.js"></script>
   <script src="vendor/blocks_compressed.js"></script>
   <script src="vendor/msg/fr.js"></script>
@@ -58,6 +59,7 @@
     </nav>
   </main>
   <script src="main.js"></script>
+  <script src="classroom_fixes.js"></script>
   <script src="project_ui.js?rev=20260830-1"></script>
 </body>
 </html>

--- a/plugins/robot_windows/blockly_v2/classroom_fixes.css
+++ b/plugins/robot_windows/blockly_v2/classroom_fixes.css
@@ -1,0 +1,10 @@
+/* Keep selected Blockly categories readable on low-end classroom displays. */
+.blocklyToolboxSelected .blocklyToolboxCategoryLabel,
+.blocklyTreeSelected .blocklyTreeLabel {
+  color: #17212b !important;
+}
+
+body[data-runtime-state="À COMPLÉTER"] #runtimeState {
+  background: #fff2cc;
+  color: #725500;
+}

--- a/plugins/robot_windows/blockly_v2/classroom_fixes.js
+++ b/plugins/robot_windows/blockly_v2/classroom_fixes.js
@@ -1,0 +1,22 @@
+(function() {
+  'use strict';
+
+  // Pedagogical wording validated on the target classroom PC.
+  if (window.Blockly && Blockly.Msg) {
+    Blockly.Msg.CONTROLS_IF_MSG_THEN = 'alors';
+    Blockly.Msg.CONTROLS_REPEAT_INPUT_DO = '';
+  }
+
+  window.addEventListener('load', function() {
+    var submit = document.getElementById('submit');
+    if (!submit || typeof window.runProgram !== 'function') return;
+
+    submit.onclick = function() {
+      if (window.workspace && typeof workspace.getTopBlocks === 'function' && workspace.getTopBlocks(false).length === 0) {
+        setRuntimeStatus('À COMPLÉTER', 'Ajoutez au moins une instruction avant de lancer le vol');
+        return;
+      }
+      return runProgram();
+    };
+  });
+})();

--- a/plugins/robot_windows/blockly_v2/classroom_fixes.js
+++ b/plugins/robot_windows/blockly_v2/classroom_fixes.js
@@ -1,11 +1,30 @@
 (function() {
   'use strict';
 
-  // Pedagogical wording validated on the target classroom PC.
-  if (window.Blockly && Blockly.Msg) {
-    Blockly.Msg.CONTROLS_IF_MSG_THEN = 'alors';
-    Blockly.Msg.CONTROLS_REPEAT_INPUT_DO = '';
+  function localizeBlockInit(type, messages) {
+    if (!window.Blockly || !Blockly.Blocks || !Blockly.Msg || !Blockly.Blocks[type] || typeof Blockly.Blocks[type].init !== 'function') return;
+    var definition = Blockly.Blocks[type];
+    var originalInit = definition.init;
+    definition.init = function() {
+      var previous = {};
+      Object.keys(messages).forEach(function(key) {
+        previous[key] = Blockly.Msg[key];
+        Blockly.Msg[key] = messages[key];
+      });
+      try {
+        return originalInit.call(this);
+      } finally {
+        Object.keys(messages).forEach(function(key) {
+          Blockly.Msg[key] = previous[key];
+        });
+      }
+    };
   }
+
+  // Keep Blockly's upstream French message registry intact while adapting the
+  // two rendered classroom blocks to the wording observed as clearer by pupils.
+  localizeBlockInit('controls_if', {CONTROLS_IF_MSG_THEN: 'alors'});
+  localizeBlockInit('controls_repeat_ext', {CONTROLS_REPEAT_INPUT_DO: ''});
 
   window.addEventListener('load', function() {
     var submit = document.getElementById('submit');

--- a/tools/build_windows_classroom_release.ps1
+++ b/tools/build_windows_classroom_release.ps1
@@ -102,7 +102,7 @@ foreach ($name in @('Launch-WebeeBlocks.cmd', 'Launch-WebeeBlocks.ps1', 'README-
 
 $blocklySource = Join-Path $repoRoot 'plugins\robot_windows\blockly_v2'
 $blocklyTarget = Join-Path $packageDir 'plugins\robot_windows\blockly_v2'
-foreach ($name in @('blockly_v2.html', 'execution_observer.css', 'main.css', 'main.js', 'project_files.css', 'project_ui.js')) {
+foreach ($name in @('blockly_v2.html', 'execution_observer.css', 'main.css', 'main.js', 'project_files.css', 'project_ui.js', 'classroom_fixes.css', 'classroom_fixes.js')) {
   Copy-RequiredFile (Join-Path $blocklySource $name) (Join-Path $blocklyTarget $name)
 }
 foreach ($directory in @('vendor', 'webots')) {

--- a/tools/ci/test_windows_release_contract.py
+++ b/tools/ci/test_windows_release_contract.py
@@ -78,8 +78,9 @@ class WindowsReleaseContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("worlds\\crazyflie_runtime_v2.wbt", launcher)
-        self.assertIn("--mode=run", launcher)
+        self.assertIn("--mode=realtime", launcher)
         self.assertNotIn("--mode=pause", launcher)
+        self.assertNotIn("--mode=run", launcher)
         self.assertIn("$worldArgument = '\"' + $world + '\"'", launcher)
         self.assertIn("Test-WebotsR2025a", launcher)
         self.assertIn("--version", launcher)

--- a/tools/ci/test_windows_release_contract.py
+++ b/tools/ci/test_windows_release_contract.py
@@ -41,6 +41,8 @@ class WindowsReleaseContractTests(unittest.TestCase):
             "& $make -C $controllerDir clean",
             "& $make -C $controllerDir",
             "crazyflie_runtime_v2.exe",
+            "classroom_fixes.css",
+            "classroom_fixes.js",
             "Expected exactly four pinned remote references",
             "../protos/Crazyflie.proto",
             "textures/fast_helix.png",
@@ -55,6 +57,11 @@ class WindowsReleaseContractTests(unittest.TestCase):
         self.assertIn("msys64\\usr\\bin\\make.exe", packager)
         self.assertIn("msys64\\mingw64\\bin\\gcc.exe", packager)
         self.assertIn("$env:WEBOTS_HOME = $webotsRoot", packager)
+
+    def test_classroom_ui_loads_packaged_fixes(self) -> None:
+        html = (BLOCKLY / "blockly_v2.html").read_text(encoding="utf-8")
+        self.assertIn('href="classroom_fixes.css"', html)
+        self.assertIn('src="classroom_fixes.js"', html)
 
     def test_student_boundary_is_explicit(self) -> None:
         readme = (PACKAGING / "README-WINDOWS.md").read_text(encoding="utf-8")
@@ -71,7 +78,8 @@ class WindowsReleaseContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("worlds\\crazyflie_runtime_v2.wbt", launcher)
-        self.assertIn("--mode=pause", launcher)
+        self.assertIn("--mode=run", launcher)
+        self.assertNotIn("--mode=pause", launcher)
         self.assertIn("$worldArgument = '\"' + $world + '\"'", launcher)
         self.assertIn("Test-WebotsR2025a", launcher)
         self.assertIn("--version", launcher)


### PR DESCRIPTION
## Linked outcome
Continues #81 from the human acceptance findings recorded on 2 September 2026.

## Outcome
Make the packaged Windows classroom path start the Webots simulation without requiring a manual ▶ action, and close the deterministic student-facing UX defects observed on the target PC: readable selected toolbox categories, explicit refusal of an empty program, and the requested French control wording.

## Acceptance oracle
- exact Windows release artifact contains the new classroom UX assets;
- launcher validation remains green and the packaged launcher uses Webots `--mode=realtime` rather than starting paused or using deprecated `--mode=run`;
- packaged JavaScript passes syntax checks and the existing Windows release integrity/self-contained checks;
- exact-head `CI Gate` is green.

## Scope
- `Launch-WebeeBlocks.ps1` startup sequencing;
- Runtime v2 classroom-only Blockly presentation/empty-program guard/wording;
- Windows release packaging of those assets.

## Non-goals
- no change to the Blockly → AST → preflight → interpreter → backend pipeline;
- no claim that this PR repairs the separately observed Edge initialization failure;
- no Firefox File System Access emulation: #87 currently defines unsupported-browser behavior separately;
- no real Crazyflie work, `main` promotion, or physical Windows acceptance.

## Human boundary
After integration, the resulting exact Windows artifact still requires human retest on the reference low-end classroom PC for startup/browser behavior and, only once those blockers are cleared, the 30-minute stability acceptance.

## Evidence before publication
- causal inspection: launcher was explicitly using `--mode=pause`, matching the observed need to press ▶;
- Reviewer falsification established that Webots R2025a treats deprecated `--mode=run` as FAST; the repair now uses supported `--mode=realtime`;
- full diff inspected against `develop`;
- packaging audit found and repaired an explicit-file-list omission that otherwise would have produced a false green artifact.