### PR TITLE
Align post-merge human handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,16 @@ a head never independently approves that head.
 4. On `GO`, immediately re-read the head and gate, then merge unchanged into
    `develop`. Never merge to `main`.
 5. On `NO_GO` or `UNPROVEN`, stop without repairing the candidate in the same
-   launch. After a merge, stop as `COMPLETED`; do not start another slice.
+   launch. After a merge, reconstruct the new `develop` state and the linked
+   product boundary, but do not start another slice in the same launch:
+   - if physical evidence, a human decision or another human action is required
+     before safe software progress, stop as `HUMAN_REQUIRED` with one precise
+     issue-level handoff;
+   - if product work remains and only a fresh Worker launch may start the next
+     slice, stop as `HUMAN_REQUIRED` with an issue-level handoff asking Emmanuel
+     to relaunch the Controller;
+   - stop as silent `COMPLETED` only when no Emmanuel action and no next product
+     slice are currently required or relevant.
 
 ## CI and evidence
 
@@ -124,10 +133,11 @@ append-only notification events, never a parallel state log.
   `CONTROLLER_HANDOFF <status> <sha>`, followed by one precise action. Use the
   current PR head SHA for a PR and current `develop` SHA for an issue-only
   handoff.
-- A pending or settled CI, `GO` and `COMPLETED` are silent. They never emit a
-  handoff artifact or ntfy request.
+- A pending or settled CI and `GO` are silent. `COMPLETED` is silent only when
+  no action from Emmanuel and no fresh Worker launch is needed. A required
+  physical test, human decision or Controller relaunch after merge uses the
+  issue-level `HUMAN_REQUIRED` handoff instead.
 - Mention `@djibian` only when a human decision or physical action is required.
 - A final report begins with its terminal status and states the mode, outcome
   or reviewed SHA, tests, PR/commit, `develop` state, `main` state and the next
   actionable event.
-

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,7 +68,11 @@ CI pending and CI completion are silent: the active session observes them
 directly. The trusted default-branch workflow sends ntfy only after a terminal
 Controller handoff that requires Emmanuel to intervene or launch the next fresh
 mode: `READY_FOR_REVIEW`, `NO_GO`, `UNPROVEN`, `HUMAN_REQUIRED`, `BLOCKED`
-or `SESSION_LIMIT`. `GO` and `COMPLETED` remain silent.
+or `SESSION_LIMIT`. `GO` is silent. After a successful merge, the Reviewer
+reconstructs the new `develop` state: if a physical test, human decision or
+fresh Worker launch is required, it emits an issue-level `HUMAN_REQUIRED`;
+`COMPLETED` remains silent only when there is genuinely nothing for Emmanuel to
+do and no next product slice to start.
 
 Handoff comments and reviews contain an exact status/SHA and actionable detail,
 but do not store Controller state. Draft/Ready and notification payloads are not
@@ -100,4 +104,3 @@ authority; it is not required for the current manual-release model.
 The full gate also builds the Windows classroom ZIP with the official Webots
 R2025a toolchain. Runtime-only PRs retain the fast Windows AST and project-file
 contract; nightly runs and promotions rebuild the complete offline artifact.
-

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -51,6 +51,21 @@ class ControllerContractTests(unittest.TestCase):
         self.assertIn("NO_GO <head-sha>", contract)
         self.assertIn("UNPROVEN <head-sha>", contract)
         self.assertIn(
+            "A pending or settled CI and `GO` are silent", contract
+        )
+        self.assertIn(
+            "physical test, human decision or Controller relaunch after merge uses the",
+            contract,
+        )
+        self.assertIn(
+            "stop as `HUMAN_REQUIRED` with an issue-level handoff asking Emmanuel",
+            contract,
+        )
+        self.assertIn(
+            "`COMPLETED` remains silent only when there is genuinely nothing for Emmanuel to",
+            development,
+        )
+        self.assertNotIn(
             "A pending or settled CI, `GO` and `COMPLETED` are silent",
             contract,
         )
@@ -76,4 +91,3 @@ class ControllerContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Outcome

Close the post-merge notification gap observed after PR #126 without changing the trusted ntfy workflow.

After a Reviewer-Integrator earns `GO` and merges to `develop`, it now reconstructs the new integration state before stopping:
- if a physical test, human decision or other human action is required before safe software progress, it emits an issue-level `CONTROLLER_HANDOFF HUMAN_REQUIRED <develop-sha>`;
- if product work remains and only a fresh Worker launch may start the next slice, it emits the same issue-level `HUMAN_REQUIRED` asking Emmanuel to relaunch the Controller;
- `COMPLETED` remains silent only when no Emmanuel action and no next product slice are currently required or relevant.

## Scope

- `AGENTS.md` durable Controller contract;
- `docs/DEVELOPMENT.md` matching operational documentation;
- `tools/ci/test_controller_contract.py` regression assertions.

## Non-goals

- no product code;
- no ntfy workflow change;
- no CI topology change;
- no branch/ruleset change;
- no `main` change;
- no change to Worker/Reviewer independence or human-only release authority.

## Why now

PR #126 merged successfully and still required a real Windows retest, but the prior blanket rule that `GO` and `COMPLETED` were silent produced no notification. The existing trusted relay already supports issue-level `HUMAN_REQUIRED`, so only the durable Controller contract needed reconciliation.

Explicitly authorized by Emmanuel on 2 September 2026.