### PR TITLE
Keep classroom UI coherent during active execution

### DIFF
--- a/experiments/runtime-v2-student-ui/probe.py
+++ b/experiments/runtime-v2-student-ui/probe.py
@@ -125,7 +125,7 @@ RENDER_LOCALE=r'''(() => {
    logicOrText:logicOr.toString(),logicOrSvgText:logicOr.getSvgRoot().textContent,
    logicRects:[rect(logicAnd.getSvgRoot()),rect(logicOr.getSvgRoot())],directionFieldRect:rect(fieldRoot),directionFieldText:fieldRoot.textContent,
    directionFieldRole:fieldRoot.getAttribute('role'),directionFieldAriaLabel:fieldRoot.getAttribute('aria-label'),
-   repeatRect:rect(repeatText||repeatPath||repeatRoot),repeatSvgText:repeatRoot.textContent,conditionSvgText:condition.getSvgRoot().textContent,
+   repeatRect:rect(repeatPath||repeatText||repeatRoot),repeatSvgText:repeatRoot.textContent,conditionSvgText:condition.getSvgRoot().textContent,
    workspaceAriaLabel:document.getElementById('blocklyDiv').getAttribute('aria-label')
  };
 })()'''

--- a/experiments/runtime-v2-student-ui/probe.py
+++ b/experiments/runtime-v2-student-ui/probe.py
@@ -118,14 +118,25 @@ RENDER_LOCALE=r'''(() => {
  const field=range.getField('DIRECTION');
  const fieldRoot=field.getSvgRoot();
  const repeatRoot=repeat.getSvgRoot();
- const repeatPath=repeatRoot&&repeatRoot.querySelector('.blocklyPath');
  const repeatText=[...(repeatRoot&&repeatRoot.querySelectorAll('.blocklyText')||[])].find(el=>(el.textContent||'').trim().toLowerCase().startsWith('répéter'));
+ const rb=repeatRoot.getBoundingClientRect();
+ let repeatHoverRect=null;
+ outer: for(let y=Math.ceil(rb.top)+2;y<Math.floor(rb.bottom);y+=4){
+   for(let x=Math.ceil(rb.left)+2;x<Math.floor(rb.right);x+=4){
+     const hit=document.elementFromPoint(x,y);
+     if(hit&&repeatRoot.contains(hit)){
+       repeatHoverRect={x:x-1,y:y-1,width:2,height:2,hitTag:hit.tagName,hitClass:String(hit.getAttribute&&hit.getAttribute('class')||'')};
+       break outer;
+     }
+   }
+ }
+ if(!repeatHoverRect)throw new Error('no real hit-tested hover point on repeat block');
  return {
    logicAndText:logicAnd.toString(),logicAndSvgText:logicAnd.getSvgRoot().textContent,
    logicOrText:logicOr.toString(),logicOrSvgText:logicOr.getSvgRoot().textContent,
    logicRects:[rect(logicAnd.getSvgRoot()),rect(logicOr.getSvgRoot())],directionFieldRect:rect(fieldRoot),directionFieldText:fieldRoot.textContent,
    directionFieldRole:fieldRoot.getAttribute('role'),directionFieldAriaLabel:fieldRoot.getAttribute('aria-label'),
-   repeatRect:rect(repeatPath||repeatText||repeatRoot),repeatSvgText:repeatRoot.textContent,conditionSvgText:condition.getSvgRoot().textContent,
+   repeatRect:repeatHoverRect,repeatSvgText:repeatRoot.textContent,conditionSvgText:condition.getSvgRoot().textContent,
    workspaceAriaLabel:document.getElementById('blocklyDiv').getAttribute('aria-label')
  };
 })()'''

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -135,7 +135,7 @@ function receiveMessage(value) {
 
 function setDebugControls(paused) {
   document.getElementById('stepNext').disabled = !paused;
-  document.getElementById('stepContinue').disabled = !runtimeRunning;
+  document.getElementById('stepContinue').disabled = !paused;
   document.getElementById('stepMode').disabled = runtimeRunning || runtimeResetPending;
 }
 function studentDirectionLabel(direction) {

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -77,8 +77,7 @@
 
   window.addEventListener('webeeblocks-runtime-v2', function(event) {
     var state = event && event.detail ? event.detail.state : null;
-    if (state === 'RÉINITIALISATION') setRuntimeLocked(true);
-    else if (runtimeLocked) setRuntimeLocked(false);
+    setRuntimeLocked(state === 'EN VOL' || state === 'RÉINITIALISATION');
   });
 
   window.addEventListener('load', function() {

--- a/tools/ci/test_runtime_v2_observability.js
+++ b/tools/ci/test_runtime_v2_observability.js
@@ -1,9 +1,21 @@
 'use strict';
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const Interpreter = require('../../plugins/robot_windows/blockly/webeeblocks/interpreter.js');
 const Observer = require('../../plugins/robot_windows/blockly/webeeblocks/execution_observer.js');
 const Outcome = require('../../plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js');
 const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_backend.js');
+
+const mainSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/main.js'), 'utf8');
+const projectUiSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
+assert.match(mainSource, /getElementById\('stepContinue'\)\.disabled = !paused;/);
+assert.doesNotMatch(mainSource, /getElementById\('stepContinue'\)\.disabled = !runtimeRunning;/);
+assert.match(projectUiSource, /setRuntimeLocked\(state === 'EN VOL' \|\| state === 'RÉINITIALISATION'\);/);
+assert.match(projectUiSource, /blocklyDiv\.inert = runtimeLocked;/);
+assert.match(projectUiSource, /if \(open\) open\.disabled = locked;/);
+assert.match(projectUiSource, /if \(busy \|\| !supported \|\| runtimeLocked\) return null;/);
+
 function block(id,type,inputs){return{id,type,_next:null,_inputs:inputs||{},getNextBlock(){return this._next;},getInputTargetBlock(name){return this._inputs[name]||null;}};}
 function link(){var blocks=Array.from(arguments);for(var i=0;i<blocks.length-1;i++)blocks[i]._next=blocks[i+1];return blocks[0];}
 function ast(){return{version:1,semantics:'webeeblocks-ast-v1',program:[{kind:'takeoff',height_m:1},{kind:'repeat',count:3,body:[{kind:'if',condition:{kind:'compare',op:'LT',left:{kind:'range',direction:'front',unit:'m'},right:{kind:'number',value:.5}},then:[{kind:'move',direction:'left',distance_m:.3}],else:[{kind:'move',direction:'forward',distance_m:.3}]}]},{kind:'land'}]};}
@@ -27,5 +39,5 @@ async function until(p,label){var start=Date.now();while(Date.now()-start<1000){
   assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4],['move','left',.3],['range','front',.8],['move','forward',.3],['range','front',.3],['move','left',.3],['land']]);
   var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(wwi.capabilities.simulationDebug,true);
   var physical=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:false});assert.notStrictEqual(physical.capabilities.simulationDebug,true);
-  console.log('PASS: observability is optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
+  console.log('PASS: execution state keeps project/workspace coherent, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
 })().catch(e=>{console.error(e.stack||e);process.exit(1);});


### PR DESCRIPTION
Issue: #81

## Outcome
Keep the program shown to students coherent with the program actually executing in Webots.

## Changes
- lock Blockly structural interaction while runtime state is `EN VOL` (and preserve the existing reset lock);
- guard project-file operations during that lock, which disables `Ouvrir` while execution is active;
- make `Continuer` available only at a real step-debug pause, not merely whenever a program is running;
- strengthen the existing observability test contract around those execution-state invariants.

## Acceptance oracle
`CI Gate` on the exact PR HEAD, including Runtime v2 observability and Windows asset checks. The observability test now fails closed if `Continuer` is tied to generic running state or if `EN VOL` no longer maps to the Blockly/project-file lock.

## Non-goals
- unsupported/orphan Blockly validation and pedagogical error wording;
- Edge/Firefox acceptance;
- `main`, release promotion, physical Crazyflie flight.

Human report on #81 already establishes Chrome/offline functional acceptance for the preceding #126 slice; this PR addresses only the newly observed execution-state coherence defects.