### PR TITLE
Explain invalid Blockly programs before execution

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/activity_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/activity_contract.js
@@ -7,8 +7,9 @@
   'use strict';
   var BACKEND_ACTION_KINDS = ['takeoff', 'move', 'vertical', 'turn', 'wait', 'set_speed', 'land'];
   function fail(message) { throw new Error('activity contract: ' + message); }
+  function studentFail(message, detail) { var error = new Error('activity contract: ' + message); error.code = 'PROGRAM_INVALID'; error.studentDetail = detail; throw error; }
   function workspaceTypes(workspace) { if (!workspace || typeof workspace.getAllBlocks !== 'function') fail('invalid Blockly workspace'); return workspace.getAllBlocks(false).map(function(block) { return block.type; }); }
-  function preflightWorkspace(profile, workspace) { var allowed = new Set(profile.toolbox); var types = workspaceTypes(workspace); types.forEach(function(type) { if (!allowed.has(type)) fail('block forbidden by profile: ' + type); }); return types; }
+  function preflightWorkspace(profile, workspace) { var allowed = new Set(profile.toolbox); var types = workspaceTypes(workspace); types.forEach(function(type) { if (!allowed.has(type)) studentFail('block forbidden by profile: ' + type, 'Un bloc de ce programme n’est pas disponible dans cette activité. Supprimez-le avant de lancer.'); }); return types; }
   function applyFieldBounds(profile, workspace) { var definitions = profile.parameterBounds || {}; workspace.getAllBlocks(false).forEach(function(block) { var fields = definitions[block.type] || {}; Object.keys(fields).forEach(function(fieldName) { var field = block.getField(fieldName); if (!field || typeof field.setConstraints !== 'function') fail('field bound target unavailable: ' + block.type + '.' + fieldName); var bounds = fields[fieldName]; field.setConstraints(bounds.min, bounds.max, bounds.step); }); }); }
   function collectAst(ast) {
     var statements = new Set(), ranges = new Set(), moves = new Set(), verticals = new Set();

--- a/plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js
+++ b/plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js
@@ -6,6 +6,10 @@
 })(typeof self !== 'undefined' ? self : this, function() {
   'use strict';
 
+  function isRetryable(error) {
+    return !!(error && error.code === 'PROGRAM_INVALID');
+  }
+
   function classify(error) {
     var machineCode = error && typeof error.code === 'string' ? error.code : null;
     if (machineCode === 'PROGRAM_INVALID') {
@@ -29,5 +33,5 @@
     };
   }
 
-  return {classify: classify};
+  return {classify: classify, isRetryable: isRetryable};
 });

--- a/plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js
+++ b/plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js
@@ -8,6 +8,13 @@
 
   function classify(error) {
     var machineCode = error && typeof error.code === 'string' ? error.code : null;
+    if (machineCode === 'PROGRAM_INVALID') {
+      return {
+        state: 'À CORRIGER',
+        detail: error && typeof error.studentDetail === 'string' && error.studentDetail ? error.studentDetail : 'Le programme doit être corrigé avant de lancer.',
+        machineCode: machineCode
+      };
+    }
     if (machineCode === 'UNSAFE_OR_TIMEOUT') {
       return {
         state: 'ARRÊTÉ',

--- a/plugins/robot_windows/blockly/webeeblocks/semantic_ast.js
+++ b/plugins/robot_windows/blockly/webeeblocks/semantic_ast.js
@@ -9,6 +9,7 @@
   var LIMITS = Object.freeze({height_m:{min:0.2,max:1.5},distance_m:{min:0.1,max:2.0},vertical_m:{min:0.1,max:0.8},wait_s:{min:0.1,max:5.0},speed_m_s:{min:0.1,max:0.6},repeat:{min:1,max:20}});
   var SENSOR_DIRECTIONS = Object.freeze(['front','back','left','right','up']);
   function fail(message){throw new Error('semantic AST: '+message);}
+  function studentFail(message,detail){var error=new Error('semantic AST: '+message);error.code='PROGRAM_INVALID';error.studentDetail=detail;throw error;}
   function finite(value,name){var n=Number(value);if(!Number.isFinite(n))fail(name+' must be finite');return n;}
   function bounded(value,name,limits){var n=finite(value,name);if(n<limits.min||n>limits.max)fail(name+' out of bounds: '+n);return n;}
   function field(block,name){if(!block||typeof block.getFieldValue!=='function')fail('invalid Blockly block');return block.getFieldValue(name);}
@@ -60,7 +61,13 @@
     }
   }
 
-  function compileWorkspace(workspace){if(!workspace||typeof workspace.getTopBlocks!=='function')fail('invalid Blockly workspace');var tops=workspace.getTopBlocks(true);if(tops.length!==1)fail('Crazyflie program must have exactly one top-level sequence');var program=compileSequence(tops[0]);validateFlightBoundaries(program);return{version:1,semantics:'webeeblocks-ast-v1',program:program};}
+  function compileWorkspace(workspace){
+    if(!workspace||typeof workspace.getTopBlocks!=='function')fail('invalid Blockly workspace');
+    var tops=workspace.getTopBlocks(true);
+    if(tops.length===0)studentFail('Crazyflie program must have exactly one top-level sequence','Construisez un programme relié avant de lancer.');
+    if(tops.length!==1)studentFail('Crazyflie program must have exactly one top-level sequence','Des blocs sont détachés du programme principal. Reliez-les ou supprimez-les avant de lancer.');
+    var program=compileSequence(tops[0]);validateFlightBoundaries(program);return{version:1,semantics:'webeeblocks-ast-v1',program:program};
+  }
 
   return{LIMITS:LIMITS,SENSOR_DIRECTIONS:SENSOR_DIRECTIONS,compileExpression:compileExpression,compileStatement:compileStatement,compileSequence:compileSequence,compileWorkspace:compileWorkspace,validateFlightBoundaries:validateFlightBoundaries};
 });

--- a/plugins/robot_windows/blockly_v2/classroom_fixes.css
+++ b/plugins/robot_windows/blockly_v2/classroom_fixes.css
@@ -4,7 +4,8 @@
   color: #17212b !important;
 }
 
-body[data-runtime-state="À COMPLÉTER"] #runtimeState {
+body[data-runtime-state="À COMPLÉTER"] #runtimeState,
+body[data-runtime-state="À CORRIGER"] #runtimeState {
   background: #fff2cc;
   color: #725500;
 }

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -255,7 +255,9 @@ async function runProgram() {
     });
     runtimeRunning = false; runtimeTerminal = true; setRuntimeStatus('TERMINÉ', 'Programme exécuté');
   } catch (error) {
-    runtimeRunning = false; runtimeTerminal = true; setRuntimeFailure(error);
+    runtimeRunning = false;
+    runtimeTerminal = !WebeeBlocksRuntimeOutcome.isRetryable(error);
+    setRuntimeFailure(error);
   } finally {
     if (runtimeDebug) runtimeDebug.finish();
     stepMode.disabled = false;

--- a/tools/ci/test_runtime_v2_observability.js
+++ b/tools/ci/test_runtime_v2_observability.js
@@ -9,8 +9,12 @@ const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_
 
 const mainSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/main.js'), 'utf8');
 const projectUiSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
+const classroomFixesSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/classroom_fixes.css'), 'utf8');
 assert.match(mainSource, /getElementById\('stepContinue'\)\.disabled = !paused;/);
 assert.doesNotMatch(mainSource, /getElementById\('stepContinue'\)\.disabled = !runtimeRunning;/);
+assert.match(mainSource, /submit\.disabled = !ready \|\| runtimeRunning \|\| runtimeTerminal \|\| runtimeResetPending;/);
+assert.match(mainSource, /runtimeTerminal = !WebeeBlocksRuntimeOutcome\.isRetryable\(error\);/);
+assert.match(classroomFixesSource, /body\[data-runtime-state="À CORRIGER"\] #runtimeState/);
 assert.match(projectUiSource, /setRuntimeLocked\(state === 'EN VOL' \|\| state === 'RÉINITIALISATION'\);/);
 assert.match(projectUiSource, /blocklyDiv\.inert = runtimeLocked;/);
 assert.match(projectUiSource, /if \(open\) open\.disabled = locked;/);
@@ -37,7 +41,7 @@ async function until(p,label){var start=Date.now();while(Date.now()-start<1000){
   await until(()=>pauses.length===6,'if');assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4]]);assert.deepStrictEqual(pauses[5].slice(0,2),['if','if']);assert.strictEqual(pauses[5][3],false);obs.next();
   await until(()=>pauses.length===7,'chosen move');assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4]]);assert.deepStrictEqual(pauses[6].slice(0,2),['left-action','move']);obs.continueRun();await run;obs.finish();
   assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4],['move','left',.3],['range','front',.8],['move','forward',.3],['range','front',.3],['move','left',.3],['land']]);
-  var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(wwi.capabilities.simulationDebug,true);
+  var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(Outcome.isRetryable({code:'PROGRAM_INVALID'}),true);assert.strictEqual(Outcome.isRetryable(error),false);assert.strictEqual(Outcome.isRetryable(Error('technical')),false);assert.strictEqual(wwi.capabilities.simulationDebug,true);
   var physical=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:false});assert.notStrictEqual(physical.capabilities.simulationDebug,true);
-  console.log('PASS: execution state keeps project/workspace coherent, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
+  console.log('PASS: execution state keeps project/workspace coherent, program validation remains retryable without reset, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
 })().catch(e=>{console.error(e.stack||e);process.exit(1);});

--- a/tools/ci/test_runtime_v2_observability.js
+++ b/tools/ci/test_runtime_v2_observability.js
@@ -2,9 +2,11 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 const Interpreter = require('../../plugins/robot_windows/blockly/webeeblocks/interpreter.js');
 const Observer = require('../../plugins/robot_windows/blockly/webeeblocks/execution_observer.js');
 const Outcome = require('../../plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js');
+const ActivityContract = require('../../plugins/robot_windows/blockly/webeeblocks/activity_contract.js');
 const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_backend.js');
 
 const mainSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/main.js'), 'utf8');
@@ -12,8 +14,6 @@ const projectUiSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/r
 const classroomFixesSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/classroom_fixes.css'), 'utf8');
 assert.match(mainSource, /getElementById\('stepContinue'\)\.disabled = !paused;/);
 assert.doesNotMatch(mainSource, /getElementById\('stepContinue'\)\.disabled = !runtimeRunning;/);
-assert.match(mainSource, /submit\.disabled = !ready \|\| runtimeRunning \|\| runtimeTerminal \|\| runtimeResetPending;/);
-assert.match(mainSource, /runtimeTerminal = !WebeeBlocksRuntimeOutcome\.isRetryable\(error\);/);
 assert.match(classroomFixesSource, /body\[data-runtime-state="À CORRIGER"\] #runtimeState/);
 assert.match(projectUiSource, /setRuntimeLocked\(state === 'EN VOL' \|\| state === 'RÉINITIALISATION'\);/);
 assert.match(projectUiSource, /blocklyDiv\.inert = runtimeLocked;/);
@@ -26,7 +26,63 @@ function ast(){return{version:1,semantics:'webeeblocks-ast-v1',program:[{kind:'t
 function backend(values){var r=values.slice(),trace=[];return{trace,async takeoff(h){trace.push(['takeoff',h]);},async land(){trace.push(['land']);},async move(d,x){trace.push(['move',d,x]);},async vertical(){throw Error('unused');},async turn(){throw Error('unused');},async wait(){throw Error('unused');},async setSpeed(){throw Error('unused');},async readRange(d){var v=r.shift();trace.push(['range',d,v]);return v;}};}
 function workspace(){var range=block('range-front','webeeblocks_v2_range'),num=block('threshold','math_number'),cmp=block('compare','logic_compare',{A:range,B:num}),left=block('left-action','webeeblocks_v2_move'),forward=block('forward-action','webeeblocks_v2_move'),iff=block('if','controls_if',{IF0:cmp,DO0:left,ELSE:forward}),repeat=block('repeat','controls_repeat_ext',{DO:iff}),takeoff=block('takeoff','webeeblocks_v2_takeoff'),land=block('land','webeeblocks_v2_land');link(takeoff,repeat,land);var all={takeoff,repeat,if:iff,compare:cmp,'range-front':range,threshold:num,'left-action':left,'forward-action':forward,land};return{getTopBlocks(){return[takeoff];},getBlockById(id){return all[id]||null;},highlightBlock(){}};}
 async function until(p,label){var start=Date.now();while(Date.now()-start<1000){if(p())return;await new Promise(r=>setTimeout(r,0));}throw Error('timeout '+label);}
+
+async function proveProgramInvalidRetryWithoutReset() {
+  const elements = {};
+  function element(id) {
+    if (!elements[id]) elements[id] = {id, disabled:false, hidden:false, checked:false, textContent:'', addEventListener(){}};
+    return elements[id];
+  }
+  const testWorkspace = {valid:false, getAllBlocks(){return [{type:this.valid?'allowed':'forbidden'}];}};
+  let compileCalls = 0;
+  let interpreterRuns = 0;
+  const compiler = {compileWorkspace(){compileCalls += 1; return {version:1,semantics:'webeeblocks-ast-v1',program:[{kind:'takeoff',height_m:1},{kind:'land'}]};}};
+  const interpreter = {async run(){interpreterRuns += 1;}};
+  const uiBackend = {ready:true, capabilities:{actions:['takeoff','land'],rangeDirections:[],moveDirections:[],verticalDirections:[],simulationDebug:true,simulationReset:true}};
+  const profile = {toolbox:['allowed'],parameterBounds:{},runtime:{allowedStatementKinds:['takeoff','land'],rangeDirections:[],moveDirections:[],verticalDirections:[],astBounds:{}}};
+  const context = {
+    console:{log(){},error(){}},
+    Blockly:{Theme:{defineTheme(){return{};}},Themes:{Classic:{}},Events:{UI:'ui'},Blocks:{}},
+    document:{getElementById:element,body:{dataset:{}},createElement(){return{setAttribute(){},appendChild(){}};}},
+    window:{dispatchEvent(){},addEventListener(){}},
+    CustomEvent:function(type,init){this.type=type;this.detail=init&&init.detail;},
+    WebeeBlocksRuntimeOutcome:Outcome,
+    WebeeBlocksActivityContract:ActivityContract,
+    WebeeBlocksSemanticAst:compiler,
+    WebeeBlocksInterpreter:interpreter,
+    WebeeBlocksExecutionObserver:{create(){return null;}},
+    WebeeBlocksActivities:{BLOCK_CATALOG:{}},
+    WebeeBlocksActivityProfiles:{},
+    WebeeBlocksWwiBackend:function(){},
+    setTimeout,clearTimeout,Promise
+  };
+  vm.createContext(context);
+  vm.runInContext(mainSource, context, {filename:'blockly_v2/main.js'});
+  context.runtimeProfile = profile;
+  context.workspace = testWorkspace;
+  context.runtimeBackend = uiBackend;
+  element('stepMode').checked = false;
+  context.updateRuntimeActions();
+  assert.strictEqual(element('submit').disabled,false,'ready runtime must initially allow Lancer');
+
+  await context.runProgram();
+  assert.strictEqual(compileCalls,0,'invalid block reached compiler');
+  assert.strictEqual(interpreterRuns,0,'invalid block reached interpreter/backend path');
+  assert.strictEqual(element('runtimeState').textContent,'À CORRIGER');
+  assert.strictEqual(context.runtimeTerminal,false,'PROGRAM_INVALID became terminal');
+  assert.strictEqual(element('submit').disabled,false,'Lancer stayed disabled after PROGRAM_INVALID');
+
+  testWorkspace.valid = true;
+  context.onWorkspaceChange({type:'change'});
+  assert.strictEqual(element('submit').disabled,false,'workspace correction should not require reset');
+  await context.runProgram();
+  assert.strictEqual(compileCalls,1,'corrected workspace did not reach compiler on second attempt');
+  assert.strictEqual(interpreterRuns,1,'corrected workspace did not execute on second attempt');
+  assert.strictEqual(element('runtimeState').textContent,'TERMINÉ');
+}
+
 (async()=>{
+  await proveProgramInvalidRetryWithoutReset();
   var a=backend([.4,.8,.3]),b=backend([.4,.8,.3]),program=ast();
   await Interpreter.run(program,a,{maxSteps:1000});
   await Interpreter.run(program,b,{maxSteps:1000,hooks:{onNode(){},beforeStep(){},onSensor(){}}});
@@ -43,5 +99,5 @@ async function until(p,label){var start=Date.now();while(Date.now()-start<1000){
   assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4],['move','left',.3],['range','front',.8],['move','forward',.3],['range','front',.3],['move','left',.3],['land']]);
   var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(Outcome.isRetryable({code:'PROGRAM_INVALID'}),true);assert.strictEqual(Outcome.isRetryable(error),false);assert.strictEqual(Outcome.isRetryable(Error('technical')),false);assert.strictEqual(wwi.capabilities.simulationDebug,true);
   var physical=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:false});assert.notStrictEqual(physical.capabilities.simulationDebug,true);
-  console.log('PASS: execution state keeps project/workspace coherent, program validation remains retryable without reset, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
+  console.log('PASS: invalid programs are retryable through the real UI runtime without reset, execution state stays coherent, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
 })().catch(e=>{console.error(e.stack||e);process.exit(1);});

--- a/tools/ci/test_runtime_v2_preflight.js
+++ b/tools/ci/test_runtime_v2_preflight.js
@@ -1,5 +1,9 @@
 'use strict';
+const assert = require('assert');
 const Interpreter = require('../../plugins/robot_windows/blockly/webeeblocks/interpreter.js');
+const ActivityContract = require('../../plugins/robot_windows/blockly/webeeblocks/activity_contract.js');
+const SemanticAst = require('../../plugins/robot_windows/blockly/webeeblocks/semantic_ast.js');
+const Outcome = require('../../plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js');
 
 let actions = 0;
 const backend = {
@@ -25,6 +29,18 @@ async function mustReject(ast, pattern) {
     throw new Error('malformed AST was not rejected as expected');
   if (actions !== 0)
     throw new Error('malformed AST reached backend before rejection: ' + actions);
+}
+
+function mustRejectStudentValidation(action, detailPattern) {
+  let error = null;
+  try { action(); } catch (caught) { error = caught; }
+  assert(error, 'student program validation did not reject');
+  assert.strictEqual(error.code, 'PROGRAM_INVALID');
+  assert(detailPattern.test(error.studentDetail), 'unexpected student detail: ' + error.studentDetail);
+  const outcome = Outcome.classify(error);
+  assert.strictEqual(outcome.state, 'À CORRIGER');
+  assert.strictEqual(outcome.machineCode, 'PROGRAM_INVALID');
+  assert(detailPattern.test(outcome.detail), 'validation detail was not preserved in runtime outcome');
 }
 
 (async function() {
@@ -58,7 +74,39 @@ async function mustReject(ast, pattern) {
     ]
   }, /must be finite/);
 
-  console.log('PASS Runtime v2 whole-AST validation rejects before backend actions');
+  mustRejectStudentValidation(
+    () => SemanticAst.compileWorkspace({getTopBlocks: () => [{type: 'webeeblocks_v2_takeoff'}, {type: 'webeeblocks_v2_land'}]}),
+    /détachés du programme principal/
+  );
+  mustRejectStudentValidation(
+    () => SemanticAst.compileWorkspace({getTopBlocks: () => []}),
+    /programme relié/
+  );
+
+  let compilerCalled = false;
+  let interpreterCalled = false;
+  let validationError = null;
+  try {
+    await ActivityContract.execute(
+      {toolbox: ['webeeblocks_v2_takeoff'], parameterBounds: {}, runtime: {}},
+      {getAllBlocks: () => [{type: 'logic_negate'}]},
+      {compileWorkspace: () => { compilerCalled = true; return {}; }},
+      {run: async () => { interpreterCalled = true; }},
+      {}
+    );
+  } catch (error) { validationError = error; }
+  assert(validationError, 'forbidden Blockly block was not rejected');
+  assert.strictEqual(validationError.code, 'PROGRAM_INVALID');
+  assert(/pas disponible dans cette activité/.test(validationError.studentDetail));
+  assert.strictEqual(compilerCalled, false, 'forbidden block reached AST compiler');
+  assert.strictEqual(interpreterCalled, false, 'forbidden block reached interpreter/backend path');
+  assert.deepStrictEqual(Outcome.classify(validationError), {
+    state: 'À CORRIGER',
+    detail: 'Un bloc de ce programme n’est pas disponible dans cette activité. Supprimez-le avant de lancer.',
+    machineCode: 'PROGRAM_INVALID'
+  });
+
+  console.log('PASS Runtime v2 preflight rejects malformed AST and gives fail-closed student guidance for forbidden or disconnected Blockly programs');
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
Issue: #81

## Outcome
Keep classroom feedback pedagogical and fail-closed when a student tries to run an invalid Blockly program.

## Changes
- preserve the existing preflight rejection for blocks forbidden by the current activity, but expose it as a student correction instead of a generic technical failure;
- preserve the semantic AST requirement for exactly one connected top-level sequence, with distinct student-facing guidance for an empty workspace and for detached/orphan chains;
- map these validation failures to `À CORRIGER` while keeping technical diagnostics and machine code `PROGRAM_INVALID` available;
- extend the Runtime v2 preflight oracle to prove forbidden blocks stop before compilation/interpreter execution and disconnected programs remain rejected.

## Acceptance oracle
Exact-head `CI Gate`, including Runtime v2 preflight/core and selected Runtime/Webots suites. The targeted preflight test fails if forbidden Blockly reaches compilation/interpreter or if the student-facing validation code/detail is lost.

## Non-goals
- changing AST semantics or backend behavior;
- algorithmic hints or automatic diagnosis of a student's strategy;
- Edge/Firefox acceptance;
- `main`, release promotion, physical Windows acceptance or real Crazyflie flight.

## Human boundary
After integration, #81 still requires the planned real Chrome/Windows retest and formal 30-minute stability acceptance; this PR only closes the structural program-validation defect observed during the previous classroom test.