### PR TITLE
Adopt critical-path roadmap scheduler

### DIFF
--- a/.github/workflows/controller-handoff-ntfy.yml
+++ b/.github/workflows/controller-handoff-ntfy.yml
@@ -1,4 +1,4 @@
-name: Controller terminal handoff to ntfy
+name: Controller action handoff to ntfy
 
 on:
   issue_comment:
@@ -9,12 +9,12 @@ on:
 permissions: {}
 
 concurrency:
-  group: controller-terminal-ntfy-${{ github.event_name }}-${{ github.event.comment.id || github.event.review.id }}
+  group: controller-action-ntfy-${{ github.event_name }}-${{ github.event.comment.id || github.event.review.id }}
   cancel-in-progress: false
 
 jobs:
   notify:
-    name: Relay trusted terminal handoff
+    name: Relay trusted human action
     if: >-
       github.repository == 'djibian/webeeblocks' &&
       github.actor == 'djibian'
@@ -38,14 +38,14 @@ jobs:
               rf'(READY_FOR_REVIEW|HUMAN_REQUIRED|BLOCKED|SESSION_LIMIT) '
               rf'({SHA})'
           )
-          REVIEW_PATTERN = re.compile(rf'(NO_GO|UNPROVEN) ({SHA})')
+          REVIEW_PATTERN = re.compile(rf'NO_GO ({SHA})')
 
           def api_json(url):
               request = urllib.request.Request(
                   url,
                   headers={
                       'Accept': 'application/vnd.github+json',
-                      'User-Agent': 'webeeblocks-terminal-ntfy',
+                      'User-Agent': 'webeeblocks-action-ntfy',
                   },
               )
               with urllib.request.urlopen(request, timeout=20) as response:
@@ -81,9 +81,10 @@ jobs:
               first_line, details = first_line_and_details(review.get('body'))
               match = REVIEW_PATTERN.fullmatch(first_line)
               if not match:
-                  print('Review is not a terminal controller handoff; ignored.')
+                  print('Review does not request a Controller relaunch; ignored.')
                   raise SystemExit(0)
-              status, head = match.groups()
+              status = 'NO_GO'
+              head = match.group(1)
               number = int(pull_request['number'])
               target_url = review.get('html_url') or pull_request.get('html_url')
           elif event_name == 'issue_comment':
@@ -96,7 +97,7 @@ jobs:
               first_line, details = first_line_and_details(comment.get('body'))
               match = COMMENT_PATTERN.fullmatch(first_line)
               if not match:
-                  print('Comment is not a terminal controller handoff; ignored.')
+                  print('Comment does not request a human action; ignored.')
                   raise SystemExit(0)
               status, head = match.groups()
               number = int(issue['number'])
@@ -105,11 +106,11 @@ jobs:
               raise SystemExit('Unexpected event type')
 
           if not details:
-              raise SystemExit('Terminal handoff must contain an actionable detail')
+              raise SystemExit('Human-action handoff must contain an actionable detail')
 
           issue = event.get('issue') or {}
           is_pull_request = event_name == 'pull_request_review' or bool(issue.get('pull_request'))
-          if status in {'READY_FOR_REVIEW', 'NO_GO', 'UNPROVEN'} and not is_pull_request:
+          if status in {'READY_FOR_REVIEW', 'NO_GO'} and not is_pull_request:
               raise SystemExit(f'{status} requires a pull request')
 
           if is_pull_request:
@@ -133,41 +134,35 @@ jobs:
               raise SystemExit('NTFY_TOPIC has an invalid format')
 
           presentation = {
+              'HUMAN_REQUIRED': (
+                  'WebeeBlocks — TEST À EFFECTUER',
+                  'Effectuer le test ou relevé manuel indiqué',
+                  5,
+                  ['test_tube', 'robot'],
+              ),
               'READY_FOR_REVIEW': (
-                  'WebeeBlocks — REVUE À LANCER',
-                  'Relancer le Contrôleur en Reviewer-Integrator',
+                  'WebeeBlocks — RELANCE CONTRÔLEUR',
+                  'Relancer le Contrôleur pour la revue indépendante',
                   4,
-                  ['mag', 'robot'],
+                  ['arrows_counterclockwise', 'robot'],
               ),
               'NO_GO': (
-                  'WebeeBlocks — CORRECTION À LANCER',
-                  'Relancer le Contrôleur en Worker',
+                  'WebeeBlocks — RELANCE CONTRÔLEUR',
+                  'Relancer le Contrôleur en Worker pour la réparation indiquée',
                   4,
-                  ['wrench', 'robot'],
-              ),
-              'UNPROVEN': (
-                  'WebeeBlocks — PREUVE À ARBITRER',
-                  'Examiner la preuve manquante puis relancer le Contrôleur',
-                  5,
-                  ['warning', 'robot'],
-              ),
-              'HUMAN_REQUIRED': (
-                  'WebeeBlocks — INTERVENTION REQUISE',
-                  'Effectuer l’action humaine indiquée',
-                  5,
-                  ['raising_hand', 'robot'],
+                  ['arrows_counterclockwise', 'robot'],
               ),
               'BLOCKED': (
-                  'WebeeBlocks — BLOCAGE À TRAITER',
-                  'Examiner le blocage avant de relancer le Contrôleur',
-                  5,
-                  ['no_entry', 'robot'],
+                  'WebeeBlocks — RELANCE CONTRÔLEUR',
+                  'Relancer le Contrôleur avec le blocage indiqué',
+                  4,
+                  ['arrows_counterclockwise', 'robot'],
               ),
               'SESSION_LIMIT': (
-                  'WebeeBlocks — SESSION À RELANCER',
-                  'Relancer le Contrôleur dans le même mode',
+                  'WebeeBlocks — RELANCE CONTRÔLEUR',
+                  'Relancer le Contrôleur pour poursuivre depuis GitHub',
                   4,
-                  ['hourglass', 'robot'],
+                  ['arrows_counterclockwise', 'robot'],
               ),
           }
           title, next_action, priority, tags = presentation[status]
@@ -211,4 +206,3 @@ jobs:
                   raise RuntimeError(f'ntfy returned HTTP {response.status}')
               print(f'ntfy status: {response.status}')
           PY
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,142 +2,258 @@
 
 ## Product boundary
 
-Read `docs/PRODUCT_VISION.md` before selecting a new product slice. Preserve the
-backend-neutral pipeline:
+Read `docs/PRODUCT_VISION.md` and `docs/ROADMAP.md` at the exact current
+`develop` SHA before selecting new work. Preserve the backend-neutral pipeline:
 
 `activity -> Blockly -> AST -> preflight -> interpreter -> backend`
 
 Never weaken a safety rule or oracle to obtain a green result. Real Crazyflie
 flight and release promotion remain human decisions.
 
-## Repository authority
+## Authority and roadmap
 
 - `develop` is the protected integration branch.
 - `main` is the human-controlled stable branch. Never write, merge or promote
-  to it without Emmanuel's explicit authorization for that operation.
-- Use one short-lived branch and one active pull request toward `develop`.
-- GitHub branch, PR, review and check facts are the only workflow state.
-- Issues describe product outcomes; they are not queues, locks or role tokens.
+  to it without Emmanuel's explicit authorization for that exact operation.
+- Product objectives and acceptance boundaries come from
+  `docs/PRODUCT_VISION.md` and the relevant GitHub issues.
+- `docs/ROADMAP.md` is a derived, versioned projection of the best current
+  decomposition and dependency graph. It never overrides a newer product
+  decision or stronger GitHub evidence.
+- GitHub branch, PR, review, check and issue facts are the workflow state.
+  Do not add queues, lock issues, role tokens or a second status database.
+- Keep one active integration PR toward `develop`. In addition, at most one
+  independent preparatory context may be alive at a time. That context may be
+  research, diagnosis or a preparatory branch, but it has no right to become a
+  second PR and no right to integration until it is revalidated against the
+  then-current `develop`.
 - Do not modify the Controller task, this contract or notification workflows
-  from a product slice unless the human request is specifically about them.
+  from an ordinary product slice unless the human request specifically concerns
+  governance or those mechanisms.
 
-## One controller, two fresh modes
+## Scheduling objective
 
-| Current GitHub state | Mode |
-| --- | --- |
-| No active PR | **Worker** delivers one vertical product slice |
-| Active PR with failing evidence or requested changes | **Worker** repairs that PR |
-| Active PR with pending evidence | wait, then reconstruct before selecting or resuming a mode |
-| Active PR exact-head green without a current verdict | **Reviewer-Integrator** |
-| Active PR with `GO <head>` | **Reviewer-Integrator** rechecks and merges |
-| Human authority or physical evidence required | stop and ask one precise question |
+Optimize the project critical path, not session duration. Use unavoidable
+external waits for useful independent work, but never invent work merely to keep
+a session busy.
 
-A launch may wait, but it has one mode after selection. The launch that writes
-a head never independently approves that head.
+At the beginning and after every push, settled CI, review verdict, human result
+or merge:
+
+1. resolve the exact `develop` SHA and reread this contract, product vision and
+   roadmap at that SHA;
+2. reconstruct the active PR, exact head, CI Gate, reviews, threads, linked
+   issue and relevant human evidence;
+3. reconcile the affected roadmap subgraph when new evidence invalidates a
+   dependency or decomposition assumption;
+4. select the next action using the rules below.
+
+### Critical-path rules
+
+If an active PR exists, it owns the integration lane.
+
+- If this launch may safely advance that PR, do so before starting reserve work.
+- If the PR is waiting only on an external event that this launch cannot speed
+  up, such as CI or a human physical/manual test, use the wait for one
+  independent roadmap atom when useful. Return to the PR at the next safe
+  checkpoint once the event settles.
+- If the PR has reached a freshness barrier where a new Controller launch is
+  required by independent review, stop and request the relaunch. Do not delay
+  the critical path by filling the session with secondary work.
+- A launch that writes a candidate head never independently reviews, approves
+  or merges that candidate head.
+- A Reviewer that records `NO_GO` does not repair that candidate in the same
+  launch; a fresh Worker launch is required.
+- A Reviewer that merges an unchanged `GO` head may reconstruct the new state
+  and continue as Worker on a different atom in the same launch, because it did
+  not write the reviewed candidate.
+
+If no active PR exists, scan roadmap objectives in priority order and take the
+first useful atom whose dependencies are satisfied and whose next action is
+currently executable.
+
+### Independence test
+
+Before using an external wait for another atom, verify conservatively that:
+
+- it does not modify the active PR branch;
+- it does not depend on an unresolved result of the waiting work;
+- it does not touch the same unstable component, shared contract, CI,
+  notification or governance surface in a way that can invalidate either side;
+- the likely merge of the active PR will not conceptually invalidate the
+  preparatory result;
+- neither work item weakens or substitutes the other's acceptance proof.
+
+Absence of a roadmap dependency is not by itself proof of independence. If in
+doubt, treat the atoms as dependent.
+
+### WIP limit and checkpoints
+
+- Keep at most one active integration PR plus one preparatory context.
+- Work on only one context at a time.
+- Preempt reserve work only at a safe checkpoint: complete the current small
+  coherent unit, preserve the evidence/notes or branch state, then reconstruct
+  the priority PR.
+- A preparatory branch becomes stale when `develop` moves. Before publication
+  as a PR, reconstruct it on the current `develop`, recheck its assumptions and
+  rerun the relevant evidence.
+- Do not create a chain of parked branches. Finish, discard or clearly park the
+  single preparatory context before starting another one.
+
+## Living roadmap
+
+`docs/ROADMAP.md` is intentionally rolling and compact. Decompose only far
+enough to choose useful near-term work and expose real dependency gates.
+
+- After a proof, experiment or technical discovery changes a dependency,
+  update the affected local subgraph before relying on the old dependency for
+  future scheduling.
+- Do not retain a dependency merely because it used to be listed when recent
+  proof refutes it, and do not remove one without explicit technical evidence
+  or justification.
+- Do not rewrite distant speculative work into many pseudo-tasks. Expand a
+  later convergence node only when it becomes relevant to scheduling.
+- Completed atoms may be condensed into a short baseline rather than retained
+  as a manual `DONE` status. Git history, PRs and issues preserve the evidence.
+- Roadmap maintenance must not create a competing integration PR. Include a
+  causally related roadmap adjustment in the current PR when appropriate;
+  otherwise reconcile it when the integration lane is next free.
 
 ## Productive session
 
-- Treat a manual launch as one continuous productive session. Around 60
-  minutes, perform a progress checkpoint; elapsed time alone is not a reason
-  to stop.
-- At that checkpoint, reconstruct the exact GitHub state and continue while
-  the current mode is making safe, material progress. Material progress
-  includes a causal diagnosis, a tested correction, a new head, a settled gate
-  analysis, or movement toward the mode's required handoff.
-- Stop as `BLOCKED` when about 30 minutes produce no material progress, or
-  when the same causal correction cycle repeats twice without new evidence.
-  Do not count bounded CI waiting as lack of progress.
-- A pending `CI Gate` is not a reason to stop. Wait idly, poll moderately, then
-  continue from the result while the current mode can still progress safely.
-- When readily available, use up to five recent comparable non-cancelled gate
-  durations for the first wait. Use their median, clamped to 2–8 minutes; fall
-  back to 4 minutes. After that, check about every 60 seconds, never tightly.
-- After each significant transition—push, settled gate, review verdict or
-  merge—re-read the PR head, exact gate and relevant GitHub state.
+Treat a manual launch as one continuous productive session, but do not optimize
+for elapsed time.
+
+- Around 60 minutes, reconstruct state and perform a progress checkpoint;
+  elapsed time alone is not a reason to stop.
+- Material progress includes causal diagnosis, tested correction, a new head,
+  settled evidence, a research conclusion that changes the roadmap, or movement
+  toward a required proof.
+- Stop `BLOCKED` after about 30 minutes without material progress, or after the
+  same causal correction cycle repeats twice without new evidence.
+- A pending CI is not a reason to stop. If there is no useful independent atom,
+  wait and poll moderately. When readily available, use up to five comparable
+  non-cancelled gate durations for the first wait; use their median clamped to
+  2-8 minutes, falling back to 4 minutes. After that, never poll tightly.
+- If useful reserve work is active, prefer checking the waiting CI at safe
+  reserve checkpoints rather than interrupting useful work every minute.
+- Never retry a failure without identifying a cause. A targeted rerun is
+  acceptable only for a demonstrated external transient.
 - End only as `COMPLETED`, `READY_FOR_REVIEW`, `HUMAN_REQUIRED`, `BLOCKED` or
-  `SESSION_LIMIT`. Reserve `SESSION_LIMIT` for an actual platform/runtime
-  limit; never choose it solely because about 60 minutes elapsed. ntfy remains
-  the fallback when no session is active.
+  `SESSION_LIMIT`. Reserve `SESSION_LIMIT` for a real platform/runtime limit.
 
 ## Worker
 
-1. Select one user-observable, releasable or otherwise complete vertical slice.
-   A standalone CI gate or governance adjustment is not a product slice.
-2. Define the linked issue, outcome, acceptance oracle, scope, non-goals and
-   human boundary.
-3. Diagnose before broadening. Use local or targeted tests before publication.
-4. Implement the complete slice on one branch and open one Ready PR to
-   `develop`. Keep repairs on that same PR.
+1. If repairing an active PR, keep the same branch and smallest causal repair
+   boundary.
+2. Otherwise select the highest-priority executable roadmap atom and derive the
+   smallest complete vertical product slice, bounded research result or proof
+   that advances its parent issue.
+3. Define outcome, acceptance oracle, scope, non-goals and human boundary before
+   broadening implementation.
+4. Use targeted local evidence before publication. Product code reaches
+   `develop` through one Ready PR; research that requires no repository change
+   may conclude with evidence on the parent issue and roadmap reconciliation.
 5. Inspect the full diff and publish evidence without claiming more than the
    oracle exercises.
-6. After every push, wait for the exact-head `CI Gate`. On failure, identify a
-   cause before changing code or retrying; a targeted rerun is acceptable only
-   for a demonstrated external transient. Repair the same PR and repeat.
-7. When the exact head is green, stop as `READY_FOR_REVIEW`. Do not review,
-   approve or merge a candidate written by this launch.
+6. After every push, follow the critical-path scheduling rules while the exact
+   head CI Gate settles. Repair causal failures on the same PR.
+7. When a head written by this launch is exact-head green and ready for an
+   independent verdict, stop `READY_FOR_REVIEW`. A fresh Reviewer-Integrator is
+   the fastest valid action; do not keep doing reserve work merely to prolong
+   the session.
 
 ## Reviewer-Integrator
 
 1. Resolve the full head SHA, base `develop`, complete diff, linked outcome,
-   unresolved review threads and the exact `CI Gate` result.
+   unresolved review threads and exact CI Gate result.
 2. Try to falsify the claim: hidden skip, stale result, weak assertion,
-   untested platform boundary, scope creep or product regression.
+   untested platform boundary, scope creep, safety regression or product
+   regression.
 3. Record one verdict for the full SHA:
    - `GO <sha>` when the scoped outcome is proven;
    - `NO_GO <sha>` with the smallest repair boundary;
-   - `UNPROVEN <sha>` when the required evidence cannot be obtained.
-4. On `GO`, immediately re-read the head and gate, then merge unchanged into
-   `develop`. Never merge to `main`.
-5. On `NO_GO` or `UNPROVEN`, stop without repairing the candidate in the same
-   launch. After a merge, reconstruct the new `develop` state and the linked
-   product boundary, but do not start another slice in the same launch:
-   - if physical evidence, a human decision or another human action is required
-     before safe software progress, stop as `HUMAN_REQUIRED` with one precise
-     issue-level handoff;
-   - if product work remains and only a fresh Worker launch may start the next
-     slice, stop as `HUMAN_REQUIRED` with an issue-level handoff asking Emmanuel
-     to relaunch the Controller;
-   - stop as silent `COMPLETED` only when no Emmanuel action and no next product
-     slice are currently required or relevant.
+   - `VERDICT UNPROVEN <sha>` when required evidence cannot currently be
+     obtained.
+4. On `GO`, immediately reread the head and gate, then merge unchanged into
+   `develop`. Never merge to `main`. Reconstruct state and continue on the next
+   executable atom when useful.
+5. On `NO_GO`, stop after the native review; a fresh Worker launch is required.
+6. On `UNPROVEN`, do not fabricate a pass. If the missing evidence is a concrete
+   human/manual test, publish the single test handoff described below, park the
+   PR and use an independent reserve atom if one exists. Otherwise report the
+   evidence gap without generating an ntfy event merely because proof is
+   missing.
+
+## Optional Copilot review probation
+
+Copilot Code Review is optional and Reviewer-Integrator-only. The existing
+probation covers at most three eligible technical PRs beginning 2 September
+2026; do not request a fourth without new human authorization.
+
+- First identify the principal risks independently and verify that no Copilot
+  review has already been requested for the PR.
+- Use at most one `copilot-pull-request-reviewer[bot]` request per PR, only for
+  substantive technical logic such as Windows/PowerShell paths and quoting,
+  browser/async JavaScript, C/C++, parsing/validation, Actions/scripts or
+  fail-closed error handling. Do not use it for governance, documentation,
+  translation or trivial declarative changes.
+- Continue independent review while waiting and do not wait more than about two
+  minutes. Never request a second Copilot review for the same PR.
+- Verify every finding yourself. Classify useful findings as `CONFIRMED`,
+  `FALSE_POSITIVE`, `NON_BLOCKING` or `STALE`. Copilot never supplies a verdict,
+  proof, code repair or merge authority.
 
 ## CI and evidence
 
-- `CI Gate` is the only required PR check. Its conservative selector runs both
-  suites for workflow, shared or unknown changes.
-- Runtime-only and Webots/legacy suites may be selected independently.
-- The full suite runs on schedule and for promotion PRs to `main`.
-- A skipped selected suite is a failure. A genuine unsupported environment is
-  `UNPROVEN`, never a pass.
+- `CI Gate` is the only required PR decision check. Its conservative selector
+  runs both suites for workflow, shared or unknown changes.
+- Runtime-only and Webots/legacy suites may be selected independently. The full
+  suite runs on schedule and for promotion PRs to `main`.
+- A skipped selected suite is a failure. Unsupported evidence is `UNPROVEN`,
+  never a pass.
 - Network availability must not be an acceptance oracle. Dependencies used by
-  tests are pinned and prepared outside the behavioral assertion.
-- Use `PROVEN_BY_TEST`, `VERIFIED_BY_CI`, `VERIFIED_BY_CODE_INSPECTION`,
-  `UNPROVEN`, `REFUTED`, `FALSE_POSITIVE` and `REGRESSION` when useful.
+  behavioral tests are pinned and prepared outside the assertion.
+- Use `PROVEN_BY_TEST`, `VERIFIED_BY_CI`, `VERIFIED_BY_PRIMARY_SOURCE`,
+  `VERIFIED_BY_CODE_INSPECTION`, `UNPROVEN`, `REFUTED`, `FALSE_POSITIVE` and
+  `REGRESSION` when useful.
 
-## Terminal handoff
+## Human handoffs and ntfy
 
-Repository facts remain authoritative. Handoff comments and reviews are
-append-only notification events, never a parallel state log.
+GitHub remains authoritative. Notifications exist only when Emmanuel must do a
+real test/manual evidence step or must relaunch the Controller.
 
-- Before a terminal stop that needs Emmanuel to act, publish exactly one
-  handoff artifact for the terminal status and current full SHA. Do not
-  duplicate an artifact already present for that status/SHA.
-- Worker `READY_FOR_REVIEW`: add a PR comment whose first line is
-  `CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>`, followed by the outcome,
-  evidence and the request to launch a fresh Reviewer-Integrator.
-- Reviewer `NO_GO` or `UNPROVEN`: the native PR review is the handoff. Its
-  first line remains `NO_GO <head-sha>` or `UNPROVEN <head-sha>`, followed by
-  the smallest actionable repair or proof boundary. Do not add a second
-  comment.
-- `HUMAN_REQUIRED`, `BLOCKED` or `SESSION_LIMIT`: add a comment to the
-  active PR, or otherwise to the relevant issue, whose first line is
-  `CONTROLLER_HANDOFF <status> <sha>`, followed by one precise action. Use the
-  current PR head SHA for a PR and current `develop` SHA for an issue-only
-  handoff.
-- A pending or settled CI and `GO` are silent. `COMPLETED` is silent only when
-  no action from Emmanuel and no fresh Worker launch is needed. A required
-  physical test, human decision or Controller relaunch after merge uses the
-  issue-level `HUMAN_REQUIRED` handoff instead.
-- Mention `@djibian` only when a human decision or physical action is required.
-- A final report begins with its terminal status and states the mode, outcome
-  or reviewed SHA, tests, PR/commit, `develop` state, `main` state and the next
-  actionable event.
+### Test notification
+
+Use `CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>` only for a concrete human or
+physical test/manual evidence action. Describe exactly one test and the result
+to report. This handoff may be non-terminal: after publishing it, continue on
+one independent atom when useful.
+
+Do not repeat the same unresolved human test merely because `develop` later
+moves. Check existing issue/PR handoffs and human evidence first.
+
+### Relaunch notification
+
+A notification asking Emmanuel to relaunch is appropriate only when the current
+session must stop and a fresh Controller launch is the next useful action:
+
+- Worker exact-head green: PR comment first line
+  `CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>`;
+- Reviewer `NO_GO`: native review first line `NO_GO <head-sha>`;
+- a genuine blockage for which a fresh Controller run is the next action:
+  `CONTROLLER_HANDOFF BLOCKED <sha>`;
+- real platform/runtime exhaustion:
+  `CONTROLLER_HANDOFF SESSION_LIMIT <sha>`.
+
+Do not emit these relaunch handoffs while useful work in the same launch can
+still advance the critical path. Do not duplicate an already-current handoff.
+
+`VERDICT UNPROVEN`, pending/settled CI, `GO`, merges, roadmap changes, context
+switches and silent `COMPLETED` do not trigger ntfy. If `UNPROVEN` requires a
+human test, use the separate `HUMAN_REQUIRED` test handoff once.
+
+Mention `@djibian` only for a concrete human/manual test or a decision that must
+be made before the announced relaunch. A final report states the current
+outcome, PR/head when relevant, evidence, `develop` and `main`, any waiting human
+test, and the next actionable event.

--- a/docs/CONTROLLER_NOTIFICATIONS.md
+++ b/docs/CONTROLLER_NOTIFICATIONS.md
@@ -1,56 +1,77 @@
 # Controller notifications
 
-Notifications transport a terminal handoff; they never store Controller state.
+Notifications transport a requested human action; they never store Controller
+state and they are intentionally narrower than GitHub evidence.
 
 ## When ntfy is sent
 
-CI pending and CI completion are silent. An active Controller session waits,
-polls moderately and continues from the exact result without asking Emmanuel
-to relaunch it.
+There are only two notification purposes:
 
-The trusted default-branch workflow sends one notification only when a terminal
-Controller handoff requires an external action:
+1. **TEST** — Emmanuel must perform a concrete manual/physical test or collect
+   human-only evidence.
+2. **RELAUNCH** — the current Controller session must stop and a fresh Controller
+   launch is the next useful action.
 
-| Status | GitHub artifact | Requested action |
+Everything else is silent: CI pending/completion, `GO`, merges, roadmap changes,
+context switches, ordinary comments/reviews and `UNPROVEN` by itself.
+
+| GitHub artifact | Meaning for ntfy | Session effect |
 | --- | --- | --- |
-| `READY_FOR_REVIEW` | PR comment | launch a fresh Reviewer-Integrator |
-| `NO_GO` | native PR review | launch a Worker to repair the same PR |
-| `UNPROVEN` | native PR review | arbitrate or obtain the missing proof |
-| `HUMAN_REQUIRED` | PR or issue comment | perform the stated human action |
-| `BLOCKED` | PR or issue comment | resolve the stated blocker |
-| `SESSION_LIMIT` | PR or issue comment | relaunch the same mode |
+| `CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>` | TEST | may continue on one independent atom |
+| `CONTROLLER_HANDOFF READY_FOR_REVIEW <sha>` | RELAUNCH for independent review | stop |
+| native review `NO_GO <sha>` | RELAUNCH for fresh Worker repair | stop |
+| `CONTROLLER_HANDOFF BLOCKED <sha>` | RELAUNCH only when a fresh run is useful | stop |
+| `CONTROLLER_HANDOFF SESSION_LIMIT <sha>` | RELAUNCH after real platform/runtime limit | stop |
 
-`GO`, `COMPLETED`, ordinary comments/reviews and every CI event are silent.
+A missing proof that does not itself require Emmanuel is recorded as
+`VERDICT UNPROVEN <sha>` and does not match the ntfy transport grammar. If the
+missing proof is a human test, publish the separate `HUMAN_REQUIRED` test
+handoff once.
 
 ## Strict handoff protocol
 
-Worker and non-review terminal comments use an exact first line:
+Comment handoffs use an exact first line:
 
 ```text
 CONTROLLER_HANDOFF <STATUS> <full-sha>
 ```
 
-The allowed comment statuses are `READY_FOR_REVIEW`, `HUMAN_REQUIRED`,
-`BLOCKED` and `SESSION_LIMIT`. The following lines must contain a precise,
-actionable detail.
+The transport-recognized comment statuses are `READY_FOR_REVIEW`,
+`HUMAN_REQUIRED`, `BLOCKED` and `SESSION_LIMIT`. The following lines contain one
+precise actionable detail.
 
-Reviewer handoffs use the existing native review verdict as the exact first
-line:
+The only native review that requests a relaunch is:
 
 ```text
 NO_GO <full-sha>
-UNPROVEN <full-sha>
 ```
+
+`GO <full-sha>` and `VERDICT UNPROVEN <full-sha>` remain GitHub evidence but are
+silent notification-wise.
 
 The workflow accepts an event only when:
 
 - repository and author are exactly the trusted repository owner;
-- a PR handoff names the current full head SHA of a PR to `develop`;
+- a PR handoff names the current full HEAD SHA of a PR to `develop`;
 - an issue-only handoff names the current full `develop` SHA;
 - the first line matches the strict grammar and details are non-empty.
 
-Stale or ordinary events are ignored. The Controller emits at most one artifact
-for a terminal status/SHA. GitHub remains authoritative if ntfy delivery fails.
+Stale or ordinary events are ignored. The Controller must not duplicate an
+already-current relaunch handoff or an unresolved identical human test. GitHub
+remains authoritative if ntfy delivery fails.
+
+## Compatibility during develop/main separation
+
+GitHub executes the trusted notification workflow from the default branch. The
+optimized Controller protocol therefore deliberately reuses the existing
+transport-recognized statuses: once the new `AGENTS.md` is authoritative,
+`HUMAN_REQUIRED` is emitted only for a test and the other recognized statuses
+only for a required relaunch. `VERDICT UNPROVEN` intentionally does not match
+the older `UNPROVEN <sha>` review grammar.
+
+This means the semantic migration does not require an unauthorized direct write
+to `main`. The updated workflow wording reaches `main` only through a later
+human-authorized normal promotion.
 
 ## Security
 
@@ -61,4 +82,3 @@ for a terminal status/SHA. GitHub remains authoritative if ntfy delivery fails.
 - no GitHub write, CI orchestration or merge authority;
 - event JSON is parsed as data and current public GitHub state is revalidated;
 - transport failure cannot change CI, review or merge truth.
-

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,34 +2,71 @@
 
 ## Purpose
 
-This document describes the small GitHub-native control plane used to develop
-WebeeBlocks through productive manual sessions without maintaining a second
-workflow state.
+WebeeBlocks uses a small GitHub-native control plane. A manual Controller session
+protects the current integration critical path and uses unavoidable external
+waits for useful independent work without creating a second workflow state.
 
-## Branches
+The operational authority is the exact-`develop` `AGENTS.md`. Product objectives
+come from `docs/PRODUCT_VISION.md` and GitHub issues. `docs/ROADMAP.md` is a
+rolling, derived dependency projection used only to choose useful work.
+
+## Branches and integration lane
 
 | Branch | Purpose | Authority |
 | --- | --- | --- |
 | `develop` | current integrated product | Controller through reviewed PRs |
 | `main` | stable classroom/release line | Emmanuel only |
-| `feature/<issue>-<slug>` | one vertical slice | deleted after merge |
+| short-lived branch | one integration candidate or bounded preparation | Controller under `AGENTS.md` |
 
-Archive tags or `archive/*` references preserve pre-migration and unique
-historical heads. They are evidence, not active development branches.
+`main` and `develop` remain reconcilable. A release is promoted from `develop`
+to `main` only with Emmanuel's explicit authorization for that exact operation.
 
-`main` and `develop` must remain reconcilable. A human hotfix on `main` is
-merged back into `develop`; a release is promoted from `develop` to `main`.
+Only one integration PR toward `develop` is active. At most one additional
+independent preparatory context may exist. It may contain research, diagnosis or
+a preparatory branch, but it cannot become a concurrent integration PR. If
+`develop` moves, preparatory code must be reconstructed and revalidated against
+the new base before publication.
 
 ## Unit of delivery
 
-A pull request delivers the smallest complete vertical outcome, not the
-smallest possible code edit. It includes its acceptance oracle and any human or
-physical boundary. Several coherent implementation commits are preferable to
-several CI-only pull requests for the same outcome.
+An integration PR delivers the smallest complete vertical product outcome or
+other complete governed change, not the smallest code edit. It contains its
+acceptance proof and any human boundary. Research that requires no product code
+may instead conclude through issue evidence and roadmap reconciliation.
 
-Only one integration PR is active. Worker and Reviewer-Integrator remain fresh,
-separate launches for the same head. Waiting for CI does not split one mode into
-several launches.
+The launch that writes a candidate HEAD never independently reviews or merges
+that HEAD. A fresh Reviewer-Integrator falsifies it. Conversely, after a
+Reviewer merges an unchanged candidate it did not write, that same launch may
+continue as Worker on a different roadmap atom.
+
+## Critical-path scheduling
+
+The Controller optimizes project throughput, not session length.
+
+1. An active PR owns the integration lane.
+2. If the current launch can safely advance it, that work has priority.
+3. If it is waiting only for CI or a human/manual test, the Controller may use
+   the wait for one demonstrably independent roadmap atom.
+4. If progress on the priority PR requires a fresh Controller launch, the
+   current session stops and requests that relaunch instead of producing
+   secondary busywork.
+5. Reserve work is preempted only at a safe checkpoint when the priority path
+   becomes actionable again.
+
+No explicit queue or scheduler state is stored. The Controller reconstructs the
+active PR, exact HEAD, gate, reviews, issue evidence and current roadmap after
+material transitions.
+
+## Roadmap
+
+`docs/ROADMAP.md` is deliberately compact and rolling. It records near-term
+atoms, dependencies and exit proofs only far enough to choose the next useful
+work. New technical evidence may add, remove or rewrite a local dependency.
+Completed atoms can be condensed into the baseline; Git history and issues
+preserve the evidence.
+
+The roadmap never overrides a newer product decision and does not contain
+manual `TODO/READY/BLOCKED/DONE` workflow status.
 
 ## CI topology
 
@@ -39,68 +76,70 @@ several launches.
 - `ci-runtime.yml`: Runtime, Blockly, project-file and Windows contracts;
 - `ci-webots.yml`: Webots, Crazyflie and retained legacy regression contracts.
 
-The selector is conservative:
+The selector remains conservative: documentation-only changes run policy
+checks; isolated Runtime changes run Runtime; controller/world/legacy changes
+run Webots and Runtime when shared behavior is affected; workflow/shared/unknown
+changes run both suites; scheduled runs and PRs to `main` run both suites.
 
-- documentation-only changes run policy checks only;
-- isolated Runtime UI/AST changes run the Runtime suite;
-- controller/world/legacy changes run the Webots suite and Runtime when the
-  shared execution path may be affected;
-- workflow, selector, shared or unknown changes run both suites;
-- scheduled runs and PRs to `main` run both suites.
-
-The final gate fails when selection fails, when any selected suite is skipped,
-cancelled or fails, or when its result cannot be interpreted. Individual jobs
-remain visible for diagnosis, but branch protection requires only `CI Gate`.
-
-There is no post-merge duplicate suite on `develop`. A current merge-ref plus
-the protected up-to-date requirement is the pre-merge integration proof.
+The final gate fails when selection fails, when a selected suite is skipped,
+cancelled or fails, or when its result cannot be interpreted. Branch protection
+requires only `CI Gate`.
 
 ## Productive waiting
 
-A manual Controller launch is one productive session. Around 60 minutes it
-reconstructs the exact state and records a progress checkpoint, but continues
-while safe, material progress is occurring. It waits for `CI Gate`, polls
-moderately and resumes from the settled result. It uses recent comparable
-durations when readily available; otherwise the first wait is four minutes,
-followed by checks about every minute.
+A manual launch is one productive session. Around 60 minutes it reconstructs
+state and makes a progress checkpoint; elapsed time alone is not a stop reason.
+A pending CI is not a stop reason either.
 
-CI pending and CI completion are silent: the active session observes them
-directly. The trusted default-branch workflow sends ntfy only after a terminal
-Controller handoff that requires Emmanuel to intervene or launch the next fresh
-mode: `READY_FOR_REVIEW`, `NO_GO`, `UNPROVEN`, `HUMAN_REQUIRED`, `BLOCKED`
-or `SESSION_LIMIT`. `GO` is silent. After a successful merge, the Reviewer
-reconstructs the new `develop` state: if a physical test, human decision or
-fresh Worker launch is required, it emits an issue-level `HUMAN_REQUIRED`;
-`COMPLETED` remains silent only when there is genuinely nothing for Emmanuel to
-do and no next product slice to start.
+When no independent work is useful, the session waits and polls moderately,
+using recent comparable durations when readily available. When reserve work is
+useful, CI is checked at safe reserve checkpoints rather than interrupting that
+work tightly.
 
-Handoff comments and reviews contain an exact status/SHA and actionable detail,
-but do not store Controller state. Draft/Ready and notification payloads are not
-role locks or workflow state.
+The Controller stops `BLOCKED` after roughly 30 minutes without material
+progress or after the same causal correction cycle repeats twice without new
+evidence. Blind reruns are forbidden.
+
+## Human actions and notifications
+
+ntfy is deliberately narrower than GitHub evidence. It alerts Emmanuel only
+for two kinds of action:
+
+1. a concrete human/manual or physical **test/evidence step**;
+2. a **Controller relaunch** that is the next useful action.
+
+CI, `GO`, merges, roadmap changes, context switches, ordinary comments and
+`UNPROVEN` by itself are silent.
+
+`HUMAN_REQUIRED` is reserved for a precise test/manual evidence action and may
+be non-terminal: once the handoff is published, the Controller may continue on
+one independent atom. Relaunch events use `READY_FOR_REVIEW`, `NO_GO`,
+`BLOCKED` or `SESSION_LIMIT` only when the current session truly must stop and a
+fresh Controller launch is useful.
+
+The trusted default-branch relay validates the repository owner and exact
+current PR HEAD/base or exact `develop` SHA before accessing the ntfy secret.
+The handoff is notification transport, never workflow state.
 
 ## Repository protections
 
-`develop` requires a PR, the `CI Gate`, an up-to-date branch and resolved
-blocking conversations. Force-push and branch deletion are disabled.
+`develop` requires a PR, `CI Gate`, an up-to-date branch and resolved blocking
+conversations. Force-push and branch deletion are disabled.
 
-`main` requires a promotion PR, the full gate and Emmanuel's explicit merge.
-It cannot be pushed, force-pushed or deleted by the Controller.
-
-If GitHub operations use the same account for human and automation, procedural
-human-only authority cannot be distinguished cryptographically. A separate
-least-privilege GitHub App is required before granting unattended release
-authority; it is not required for the current manual-release model.
+`main` requires a promotion PR, the full gate and Emmanuel's explicit merge. It
+cannot be written or merged by the Controller without exact human authority.
 
 ## Operational targets
 
-- two launches for a green slice: one continuous Worker, then one fresh
-  Reviewer-Integrator;
-- no additional launch merely because CI is pending;
+- one active integration PR and at most one independent preparatory context;
+- no extra launch merely because CI or a human test is pending;
+- immediate fresh launch when independent review/repair is the critical-path
+  requirement;
 - no network-caused rerun of a behavioral oracle;
-- one required check and at most one active integration PR;
-- two permanent development branches and automatic feature-branch deletion;
-- full regression nightly and before human promotion.
+- one required decision check (`CI Gate`);
+- full regression nightly and before human promotion;
+- no queue, role token, agent fleet or duplicated workflow-state database.
 
 The full gate also builds the Windows classroom ZIP with the official Webots
-R2025a toolchain. Runtime-only PRs retain the fast Windows AST and project-file
-contract; nightly runs and promotions rebuild the complete offline artifact.
+R2025a toolchain. Runtime-only PRs retain the fast Windows AST/project-file
+contract; full runs rebuild the complete offline artifact.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,170 @@
+# WebeeBlocks — execution roadmap
+
+This file is the rolling operational projection of the product work. It is not
+a second source of product truth and it is not a status database.
+
+Authority order:
+
+`PRODUCT_VISION.md -> product issues -> ROADMAP.md -> Controller execution`
+
+GitHub PR/check/review facts describe the live state. Product issues define the
+outcomes and acceptance boundaries. This roadmap only decomposes enough of the
+near-term path to let the Controller choose useful work and expose real
+dependencies.
+
+## Scheduling principles
+
+1. Protect the current integration critical path.
+2. Use unavoidable CI or human-test waits for one independent reserve atom.
+3. Keep one active integration PR plus at most one preparatory context.
+4. Never invent work merely to keep a Controller session active.
+5. Reconcile the affected local subgraph when new evidence changes a dependency.
+6. Expand distant work only when it becomes relevant to scheduling.
+
+## Product priority
+
+1. **#81 — Windows classroom deployment**
+2. **#80 — one-click unified classroom interface**
+3. **#79 — fully French student interface**
+4. **#66 — progressive pedagogical activity model**
+
+Reserve / research when higher-priority work is externally waiting:
+
+- **#70 — world altitude over surface discontinuities**
+- **#87 — Firefox direct `.wbb` parity**, deferred behind more valuable reserve
+  work unless new evidence changes that order.
+
+Convergence later:
+
+- **#72 — teacher-authorized final real-flight activity**, gated by the
+  pedagogical progression and proven physical backend/capabilities.
+
+## Current baseline
+
+Recent #81 work has established the real low-end Windows classroom Chrome path:
+one-action launch, Robot Window `PRÊT`, offline operation, execution/debug,
+project files and usable performance. PR #128 addressed execution-state/UI
+coherence and PR #129 addressed student-facing invalid-program handling. The
+remaining #81 acceptance is therefore primarily real human revalidation and the
+formal stability gate, not another speculative packaging redesign.
+
+Chrome remains the reference browser for the current product-development phase.
+Known Edge and Firefox gaps do not block the next Chrome-based product slices;
+Firefox final same-file semantics remain tracked by #87.
+
+## Near-term graph
+
+### W1 — real Chrome coherence retest
+
+- parent: #81
+- depends: integrated execution-state and invalid-program corrections
+- action: human/manual test on the lowest-spec classroom Windows PC with the
+  current exact release artifact
+- proof: one-action offline startup to `PRÊT`; normal and step execution;
+  coherent workspace/file controls during execution; student-facing invalid
+  program behavior; Open/Save/Save As; no regression of the previously proven
+  Chrome path
+- scheduling: human gate. A pending W1 must not globally idle the Controller;
+  notify once, then use an independent reserve atom when available.
+
+### W2 — formal 30-minute low-end Windows stability acceptance
+
+- parent: #81
+- depends: W1 passes
+- action: human/manual stability run on the same lowest-spec classroom PC
+- proof: 30 minutes offline with repeated run/reset/open/save cycles, usable
+  real-time simulation, fluid Blockly interaction and no progressive memory,
+  responsiveness or connection degradation; record the machine/browser/Webots
+  facts required by #81
+
+### W3 — final Windows browser/deployment closure
+
+- parent: #81
+- depends: W2 and the later browser boundary selected by current product
+  priorities
+- proof: #81 acceptance criteria can be closed without pretending unsupported
+  browser behavior is proven
+- note: do not expand this node while Chrome-based product work remains the
+  validated development path.
+
+### U1 — characterize whether the current standard one-action path closes #80-A
+
+- parent: #80
+- depends: current proven Chrome/Webots one-action baseline
+- action: bounded research/characterization, not a new integration PR while
+  another PR owns the lane
+- proof: compare the present standard Webots + Robot Window launch against #80
+  criteria for window management, startup, recovery, offline use and classroom
+  friction; state whether option A is already sufficient or what smallest
+  discriminating gap remains before investigating option B
+- independence: suitable reserve work while W1/W2 wait on Emmanuel, provided no
+  unstable #81 implementation surface is modified.
+
+### F1 — inventory remaining visible non-French student surfaces
+
+- parent: #79
+- depends: current Runtime v2 UI
+- action: bounded audit only while another integration PR owns the lane
+- proof: precise remaining student-visible strings/surfaces, separated from
+  internal identifiers and machine diagnostics, with no AST/backend translation
+- note: implementation becomes a normal vertical PR only when the integration
+  lane is free and after checking whether U1 changes the presentation surface.
+
+### B1 — formalize the declarative activity model and compact progression
+
+- parent: #66
+- depends: PRODUCT_VISION.md
+- action: bounded design/research of the smallest versionable activity/profile
+  schema and representative 8-12 activity progression
+- proof: a coherent model that preserves generic blocks and the
+  `activity/profile -> Blockly -> AST -> preflight -> interpreter -> backend`
+  pipeline without student progress state or a graphical activity studio
+- note: mass activity production waits until the #80 presentation direction is
+  sufficiently settled.
+
+### X1 — reconstruct the current Crazyflie altitude causal path
+
+- parent: #70
+- depends: current Bitcraze primary documentation/code and preserved #70 evidence
+- action: independent firmware/source research covering EKF, UKF, downward ToF,
+  optical-flow height scaling and the autonomous setpoint/controller path
+- proof: evidence-classified causal model sufficient to design the smallest
+  non-motorized discriminating experiment required by #70
+- independence: preferred deep reserve work when current Runtime/UI work is
+  externally waiting; do not modify Runtime v2 or perform motorized flight.
+
+## Later gates kept intentionally coarse
+
+### P — physical backend capability and safety
+
+- parents: physical-backend product work and #70 evidence
+- depends: demonstrated Crazyradio/deck capability path and backend-neutral AST
+- proof direction: capability contract, preflight, arming/abort/failsafe and
+  simulation/physical AST continuity without granting authority to student code
+- expand only when this becomes near-term work.
+
+### FF — Firefox same-file project semantics
+
+- parent: #87
+- depends: preserved native-bridge/browser evidence
+- proof direction: causal diagnosis first, implementation only after a viable
+  same-file path is proven
+- keep deferred while higher-value critical/reserve work remains executable.
+
+### R — final real-flight activity
+
+- parent: #72
+- depends: coherent progression + proven physical backend + any #70 capability
+  required by the chosen final mission
+- proof direction: exact simulation-validated student program, explicit teacher
+  authorization, independent preflight/failsafe and representative safe real
+  execution
+- do not decompose the detailed final course before these gates converge.
+
+## Roadmap maintenance rule
+
+A proof or experiment that changes a prerequisite changes this file before the
+old prerequisite is used to schedule later work. Keep the edit local: remove or
+rewrite the affected dependency, or add a newly demonstrated gate. Completed
+near-term atoms may be condensed into the baseline instead of accumulating
+manual status fields.

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -8,23 +8,31 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def flat(text: str) -> str:
+    """Normalize Markdown wrapping without weakening phrase-level assertions."""
+    return " ".join(text.split())
+
+
 class ControllerContractTests(unittest.TestCase):
     def test_critical_path_scheduler_preserves_review_independence_and_bounded_wip(self) -> None:
-        contract = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
-        roadmap = (ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
-        development = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
+        contract_raw = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        roadmap_raw = (ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+        development_raw = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
             encoding="utf-8"
         )
+        contract = flat(contract_raw)
+        roadmap = flat(roadmap_raw)
+        development = flat(development_raw)
 
         self.assertIn("Optimize the project critical path, not session duration", contract)
         self.assertIn("one active integration PR", contract)
-        self.assertIn("at most one\n  independent preparatory context", contract)
+        self.assertIn("at most one independent preparatory context", contract)
         self.assertIn("If an active PR exists, it owns the integration lane", contract)
         self.assertIn("waiting only on an external event", contract)
-        self.assertIn("use the wait for one\n  independent roadmap atom", contract)
-        self.assertIn("fresh Controller launch is\n  required by independent review", contract)
-        self.assertIn("Do not delay\n  the critical path", contract)
-        self.assertIn("never independently reviews, approves\n  or merges that candidate head", contract)
+        self.assertIn("use the wait for one independent roadmap atom", contract)
+        self.assertIn("a new Controller launch is required by independent review", contract)
+        self.assertIn("Do not delay the critical path", contract)
+        self.assertIn("never independently reviews, approves or merges that candidate head", contract)
         self.assertIn("A Reviewer that records `NO_GO` does not repair", contract)
         self.assertIn("A Reviewer that merges an unchanged `GO` head may", contract)
         self.assertIn("Absence of a roadmap dependency is not by itself proof", contract)
@@ -37,8 +45,8 @@ class ControllerContractTests(unittest.TestCase):
         self.assertIn("Stop `BLOCKED` after about 30 minutes", contract)
         self.assertIn("same causal correction cycle repeats twice", contract)
         self.assertIn("A pending CI is not a reason to stop", contract)
-        self.assertIn("five comparable\n  non-cancelled gate durations", contract)
-        self.assertIn("prefer checking the waiting CI at safe\n  reserve checkpoints", contract)
+        self.assertIn("five comparable non-cancelled gate durations", contract)
+        self.assertIn("prefer checking the waiting CI at safe reserve checkpoints", contract)
         self.assertIn("Reserve `SESSION_LIMIT` for a real platform/runtime limit", contract)
         self.assertNotIn("about 60 minutes maximum", contract)
         self.assertNotIn("Do not poll", contract)
@@ -50,44 +58,47 @@ class ControllerContractTests(unittest.TestCase):
         self.assertIn("W1 — real Chrome coherence retest", roadmap)
         self.assertIn("U1 — characterize whether the current standard one-action path", roadmap)
         self.assertIn("X1 — reconstruct the current Crazyflie altitude causal path", roadmap)
-        self.assertNotIn("status: DONE", roadmap)
-        self.assertNotIn("status: READY", roadmap)
+        self.assertNotIn("status: DONE", roadmap_raw)
+        self.assertNotIn("status: READY", roadmap_raw)
 
         self.assertIn("optimizes project throughput, not session length", development)
         self.assertIn("Only one integration PR toward `develop` is active", development)
-        self.assertIn("At most one additional\nindependent preparatory context", development)
+        self.assertIn("At most one additional independent preparatory context", development)
         self.assertIn("If progress on the priority PR requires a fresh Controller launch", development)
-        self.assertIn("instead of producing\n   secondary busywork", development)
+        self.assertIn("instead of producing secondary busywork", development)
 
     def test_notifications_mean_only_test_or_relaunch_and_ci_is_silent(self) -> None:
-        contract = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
-        development = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
+        contract_raw = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        development_raw = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
             encoding="utf-8"
         )
-        notifications = (ROOT / "docs" / "CONTROLLER_NOTIFICATIONS.md").read_text(
+        notifications_raw = (ROOT / "docs" / "CONTROLLER_NOTIFICATIONS.md").read_text(
             encoding="utf-8"
         )
         workflow = (
             ROOT / ".github" / "workflows" / "controller-handoff-ntfy.yml"
         ).read_text(encoding="utf-8")
+        contract = flat(contract_raw)
+        development = flat(development_raw)
+        notifications = flat(notifications_raw)
 
         self.assertIn(
-            "Notifications exist only when Emmanuel must do a\nreal test/manual evidence step or must relaunch the Controller",
+            "Notifications exist only when Emmanuel must do a real test/manual evidence step or must relaunch the Controller",
             contract,
         )
-        self.assertIn("CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>", contract)
+        self.assertIn("CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>", contract_raw)
         self.assertIn("This handoff may be non-terminal", contract)
-        self.assertIn("CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>", contract)
-        self.assertIn("NO_GO <head-sha>", contract)
-        self.assertIn("VERDICT UNPROVEN <sha>", contract)
-        self.assertIn("`VERDICT UNPROVEN`, pending/settled CI, `GO`, merges", contract)
+        self.assertIn("CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>", contract_raw)
+        self.assertIn("NO_GO <head-sha>", contract_raw)
+        self.assertIn("VERDICT UNPROVEN <sha>", contract_raw)
+        self.assertIn("`VERDICT UNPROVEN`, pending/settled CI, `GO`, merges", contract_raw)
         self.assertIn("do not trigger ntfy", contract)
 
         self.assertIn("There are only two notification purposes", notifications)
-        self.assertIn("**TEST**", notifications)
-        self.assertIn("**RELAUNCH**", notifications)
+        self.assertIn("**TEST**", notifications_raw)
+        self.assertIn("**RELAUNCH**", notifications_raw)
         self.assertIn("may continue on one independent atom", notifications)
-        self.assertIn("`VERDICT UNPROVEN <sha>`", notifications)
+        self.assertIn("`VERDICT UNPROVEN <sha>`", notifications_raw)
         self.assertIn("does not match the ntfy transport grammar", notifications)
         self.assertIn("semantic migration does not require an unauthorized direct write", notifications)
 

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prevent the productive-session and terminal-handoff contracts from regressing."""
+"""Prevent the critical-path scheduler and human-action contracts from regressing."""
 
 from pathlib import Path
 import unittest
@@ -9,28 +9,57 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class ControllerContractTests(unittest.TestCase):
-    def test_worker_waits_but_never_self_approves(self) -> None:
+    def test_critical_path_scheduler_preserves_review_independence_and_bounded_wip(self) -> None:
         contract = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        roadmap = (ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+        development = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Optimize the project critical path, not session duration", contract)
+        self.assertIn("one active integration PR", contract)
+        self.assertIn("at most one\n  independent preparatory context", contract)
+        self.assertIn("If an active PR exists, it owns the integration lane", contract)
+        self.assertIn("waiting only on an external event", contract)
+        self.assertIn("use the wait for one\n  independent roadmap atom", contract)
+        self.assertIn("fresh Controller launch is\n  required by independent review", contract)
+        self.assertIn("Do not delay\n  the critical path", contract)
+        self.assertIn("never independently reviews, approves\n  or merges that candidate head", contract)
+        self.assertIn("A Reviewer that records `NO_GO` does not repair", contract)
+        self.assertIn("A Reviewer that merges an unchanged `GO` head may", contract)
+        self.assertIn("Absence of a roadmap dependency is not by itself proof", contract)
+        self.assertIn("A preparatory branch becomes stale when `develop` moves", contract)
+        self.assertIn("Do not create a chain of parked branches", contract)
+
         self.assertIn("one continuous productive session", contract)
         self.assertIn("perform a progress checkpoint", contract)
         self.assertIn("elapsed time alone is not a reason", contract)
-        self.assertIn("Stop as `BLOCKED` when about 30 minutes", contract)
+        self.assertIn("Stop `BLOCKED` after about 30 minutes", contract)
         self.assertIn("same causal correction cycle repeats twice", contract)
-        self.assertIn("Do not count bounded CI waiting as lack of progress", contract)
-        self.assertIn("A pending `CI Gate` is not a reason to stop", contract)
-        self.assertIn("five recent comparable non-cancelled gate", contract)
-        self.assertIn("check about every 60 seconds", contract)
-        self.assertIn("Reserve `SESSION_LIMIT` for an actual platform/runtime", contract)
-        self.assertIn("never choose it solely because about 60 minutes elapsed", contract)
-        self.assertIn("`READY_FOR_REVIEW`", contract)
-        self.assertIn(
-            "The launch that writes\na head never independently approves that head",
-            contract,
-        )
+        self.assertIn("A pending CI is not a reason to stop", contract)
+        self.assertIn("five comparable\n  non-cancelled gate durations", contract)
+        self.assertIn("prefer checking the waiting CI at safe\n  reserve checkpoints", contract)
+        self.assertIn("Reserve `SESSION_LIMIT` for a real platform/runtime limit", contract)
         self.assertNotIn("about 60 minutes maximum", contract)
         self.assertNotIn("Do not poll", contract)
 
-    def test_terminal_handoff_is_exact_and_ci_is_silent(self) -> None:
+        self.assertIn("rolling operational projection", roadmap)
+        self.assertIn("Protect the current integration critical path", roadmap)
+        self.assertIn("Keep one active integration PR plus at most one preparatory context", roadmap)
+        self.assertIn("Never invent work merely to keep a Controller session active", roadmap)
+        self.assertIn("W1 — real Chrome coherence retest", roadmap)
+        self.assertIn("U1 — characterize whether the current standard one-action path", roadmap)
+        self.assertIn("X1 — reconstruct the current Crazyflie altitude causal path", roadmap)
+        self.assertNotIn("status: DONE", roadmap)
+        self.assertNotIn("status: READY", roadmap)
+
+        self.assertIn("optimizes project throughput, not session length", development)
+        self.assertIn("Only one integration PR toward `develop` is active", development)
+        self.assertIn("At most one additional\nindependent preparatory context", development)
+        self.assertIn("If progress on the priority PR requires a fresh Controller launch", development)
+        self.assertIn("instead of producing\n   secondary busywork", development)
+
+    def test_notifications_mean_only_test_or_relaunch_and_ci_is_silent(self) -> None:
         contract = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
         development = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
             encoding="utf-8"
@@ -42,51 +71,40 @@ class ControllerContractTests(unittest.TestCase):
             ROOT / ".github" / "workflows" / "controller-handoff-ntfy.yml"
         ).read_text(encoding="utf-8")
 
-        self.assertIn("one continuous Worker", development)
-        self.assertIn("one fresh\n  Reviewer-Integrator", development)
-        self.assertIn("CI pending and CI completion are silent", development)
         self.assertIn(
-            "CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>", contract
+            "Notifications exist only when Emmanuel must do a\nreal test/manual evidence step or must relaunch the Controller",
+            contract,
         )
+        self.assertIn("CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>", contract)
+        self.assertIn("This handoff may be non-terminal", contract)
+        self.assertIn("CONTROLLER_HANDOFF READY_FOR_REVIEW <head-sha>", contract)
         self.assertIn("NO_GO <head-sha>", contract)
-        self.assertIn("UNPROVEN <head-sha>", contract)
-        self.assertIn(
-            "A pending or settled CI and `GO` are silent", contract
-        )
-        self.assertIn(
-            "physical test, human decision or Controller relaunch after merge uses the",
-            contract,
-        )
-        self.assertIn(
-            "stop as `HUMAN_REQUIRED` with an issue-level handoff asking Emmanuel",
-            contract,
-        )
-        self.assertIn(
-            "`COMPLETED` remains silent only when there is genuinely nothing for Emmanuel to",
-            development,
-        )
-        self.assertNotIn(
-            "A pending or settled CI, `GO` and `COMPLETED` are silent",
-            contract,
-        )
-        for status in (
-            "READY_FOR_REVIEW",
-            "NO_GO",
-            "UNPROVEN",
-            "HUMAN_REQUIRED",
-            "BLOCKED",
-            "SESSION_LIMIT",
-        ):
-            self.assertIn(status, notifications)
+        self.assertIn("VERDICT UNPROVEN <sha>", contract)
+        self.assertIn("`VERDICT UNPROVEN`, pending/settled CI, `GO`, merges", contract)
+        self.assertIn("do not trigger ntfy", contract)
+
+        self.assertIn("There are only two notification purposes", notifications)
+        self.assertIn("**TEST**", notifications)
+        self.assertIn("**RELAUNCH**", notifications)
+        self.assertIn("may continue on one independent atom", notifications)
+        self.assertIn("`VERDICT UNPROVEN <sha>`", notifications)
+        self.assertIn("does not match the ntfy transport grammar", notifications)
+        self.assertIn("semantic migration does not require an unauthorized direct write", notifications)
+
+        self.assertIn("CI, `GO`, merges, roadmap changes", development)
+        self.assertIn("and `UNPROVEN` by itself are silent", development)
+        self.assertIn("`HUMAN_REQUIRED` is reserved for a precise test", development)
+        self.assertIn("Relaunch events use `READY_FOR_REVIEW`, `NO_GO`", development)
 
         self.assertIn("issue_comment:", workflow)
         self.assertIn("pull_request_review:", workflow)
         self.assertIn("permissions: {}", workflow)
         self.assertNotIn("workflow_run:", workflow)
         self.assertNotIn("actions/checkout", workflow)
-        self.assertNotIn("observes completion", development)
-        self.assertNotIn("fallback when no session is active", development)
-        self.assertNotIn("never waits inside", development)
+        self.assertIn("WebeeBlocks — TEST À EFFECTUER", workflow)
+        self.assertIn("WebeeBlocks — RELANCE CONTRÔLEUR", workflow)
+        self.assertNotIn("UNPROVEN", workflow)
+        self.assertNotIn("PREUVE À ARBITRER", workflow)
 
 
 if __name__ == "__main__":

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static contract for the V3 CI topology and trusted transport boundary."""
+"""Static contract for the CI topology and trusted transport boundary."""
 
 from pathlib import Path
 import re
@@ -90,12 +90,15 @@ class WorkflowContractTests(unittest.TestCase):
         for status in (
             "READY_FOR_REVIEW",
             "NO_GO",
-            "UNPROVEN",
             "HUMAN_REQUIRED",
             "BLOCKED",
             "SESSION_LIMIT",
         ):
             self.assertIn(status, transport)
+        self.assertNotIn("UNPROVEN", transport)
+        self.assertIn("WebeeBlocks — TEST À EFFECTUER", transport)
+        self.assertIn("WebeeBlocks — RELANCE CONTRÔLEUR", transport)
+        self.assertNotIn("PREUVE À ARBITRER", transport)
         self.assertIn("permissions: {}", transport)
         self.assertNotIn("  pull_request:\n", transport)
         self.assertNotIn("  pull_request_target:\n", transport)


### PR DESCRIPTION
## Outcome

Replace the V3 one-mode/one-slice session rule with a bounded critical-path scheduler:

- add a rolling `docs/ROADMAP.md` derived from product issues;
- keep one active integration PR plus at most one independent preparatory context;
- use external CI/human-test waits for useful independent work, but stop immediately when a fresh Controller launch is the fastest valid critical-path action;
- allow a Reviewer that merges an unchanged candidate to continue on a different atom in the same session;
- keep writer/reviewer independence per candidate HEAD and preserve all `main` authority/safety/oracle boundaries;
- make human-test waits local to their roadmap atom rather than global project stops;
- constrain ntfy semantics to only concrete human tests/manual evidence and Controller relaunches.

The handoff formats remain backward-compatible with the relay currently active from the default `main` branch: `HUMAN_REQUIRED` is now reserved for tests, while `READY_FOR_REVIEW`, `NO_GO`, `BLOCKED` and `SESSION_LIMIT` are emitted only when a fresh Controller launch is actually required. `VERDICT UNPROVEN` is intentionally silent. No `main` write is part of this PR.

The Controller task bootstrap has also been simplified outside the repository so that exact-SHA `AGENTS.md` remains authoritative before and after this migration; while this PR is unmerged it still obeys the current V3 contract.

## Non-goals

- no multi-agent fleet;
- no multiple integration PRs;
- no queue/status database/GitHub Project;
- no CI Gate or product-runtime behavior change;
- no `main` promotion.

Closes #22