### PR TITLE
Require action-ready support before human handoffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,13 @@ that has just been outranked by newly executable higher-priority work.
 
 - If this launch may safely advance the priority PR, do so before starting
   reserve work.
+- Treat a human/manual proof as an external wait only after the Human-readiness
+  gate below passes. If its required support is missing or stale, preparing and
+  proving that support remains critical-path technical work, not a human wait.
 - If the priority PR is waiting only on an external event that this launch
-  cannot speed up, such as CI or a human physical/manual test, use the wait for
-  one independent roadmap atom when useful. Return to the priority path at the
-  next safe checkpoint once the event settles.
+  cannot speed up, such as CI or an action-ready human physical/manual test,
+  use the wait for one independent roadmap atom when useful. Return to the
+  priority path at the next safe checkpoint once the event settles.
 - A PR created only from reserve work while a higher-priority atom was
   externally blocked is yieldable. If new human/external evidence makes that
   higher-priority atom executable, stop reserve work at the next safe
@@ -193,11 +196,13 @@ for elapsed time.
    `develop`. Never merge to `main`. Reconstruct state and continue on the next
    executable atom when useful.
 5. On `NO_GO`, stop after the native review; a fresh Worker launch is required.
-6. On `UNPROVEN`, do not fabricate a pass. If the missing evidence is a concrete
-   human/manual test, publish the single test handoff described below, park the
-   PR and use an independent reserve atom if one exists. Otherwise report the
-   evidence gap without generating an ntfy event merely because proof is
-   missing.
+6. On `UNPROVEN`, do not fabricate a pass. If the next proof type is a
+   human/manual test, apply the Human-readiness gate below before publishing a
+   test handoff. If the gate is not satisfied, finish any Controller-executable
+   technical preparation first or report the evidence gap silently; do not ask
+   Emmanuel to perform a downstream test that is not yet executable. Otherwise
+   report the evidence gap without generating an ntfy event merely because
+   proof is missing.
 
 ## Optional Copilot review probation
 
@@ -237,15 +242,42 @@ probation covers at most three eligible technical PRs beginning 2 September
 GitHub remains authoritative. Notifications exist only when Emmanuel must do a
 real test/manual evidence step or must relaunch the Controller.
 
+### Human-readiness gate
+
+The fact that the next proof type is human does not mean the human action is
+ready. Before any `HUMAN_REQUIRED`, prove that the requested action is
+immediately executable:
+
+- identify the exact target revision, version or deployed state to be tested;
+- verify that every required support exists now and is accessible to Emmanuel:
+  artifact, ZIP, binary, firmware, dataset, report, deployed version or other
+  material/software prerequisite;
+- bind that support to the target with explicit provenance, or document a
+  technically justified equivalence when byte-for-byte/exact-SHA identity is
+  not the relevant property;
+- verify that the procedure and requested result can be performed without an
+  uncompleted technical preparation step.
+
+A green aggregate CI result is not proof that a human-test support exists. A
+skipped artifact-producing job, an expired or unavailable artifact, a stale
+binary/firmware, or an unverified deployment fails this gate. If the Controller
+can perform the missing build, package, deploy, export or provenance step, that
+work stays on the critical path and must happen before `HUMAN_REQUIRED`. If a
+separate human-only prerequisite is unavoidable, request only that prerequisite
+when it is itself action-ready; never request the downstream test prematurely.
+
 ### Test notification
 
-Use `CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>` only for a concrete human or
-physical test/manual evidence action. Describe exactly one test and the result
-to report. This handoff may be non-terminal: after publishing it, continue on
-one independent atom when useful.
+Use `CONTROLLER_HANDOFF HUMAN_REQUIRED <sha>` only after the Human-readiness
+gate passes for one concrete human or physical test/manual evidence action.
+Describe exactly one test, the exact support/target to use, how to access it and
+the result to report. This handoff may be non-terminal: after publishing it,
+continue on one independent atom when useful.
 
 Do not repeat the same unresolved human test merely because `develop` later
-moves. Check existing issue/PR handoffs and human evidence first.
+moves. Check existing issue/PR handoffs and human evidence first. If the target
+or required support changes, re-evaluate Human readiness before relying on an
+older handoff.
 
 ### Relaunch notification
 
@@ -265,7 +297,8 @@ still advance the critical path. Do not duplicate an already-current handoff.
 
 `VERDICT UNPROVEN`, pending/settled CI, `GO`, merges, roadmap changes, context
 switches and silent `COMPLETED` do not trigger ntfy. If `UNPROVEN` requires a
-human test, use the separate `HUMAN_REQUIRED` test handoff once.
+human test, use the separate `HUMAN_REQUIRED` test handoff only after Human
+readiness is proven.
 
 Mention `@djibian` only for a concrete human/manual test or a decision that must
 be made before the announced relaunch. A final report states the current

--- a/docs/CONTROLLER_NOTIFICATIONS.md
+++ b/docs/CONTROLLER_NOTIFICATIONS.md
@@ -25,8 +25,28 @@ context switches, ordinary comments/reviews and `UNPROVEN` by itself.
 
 A missing proof that does not itself require Emmanuel is recorded as
 `VERDICT UNPROVEN <sha>` and does not match the ntfy transport grammar. If the
-missing proof is a human test, publish the separate `HUMAN_REQUIRED` test
-handoff once.
+next proof type is human, the Controller must first pass the Human-readiness
+gate in `AGENTS.md`; only an action-ready human test gets a `HUMAN_REQUIRED`
+handoff.
+
+## Human-readiness prerequisite
+
+`HUMAN_REQUIRED` means not only that human evidence is logically next, but that
+Emmanuel can perform the requested action immediately. Before emitting it, the
+Controller verifies the exact target, existence and accessibility of every
+required support, provenance or justified equivalence to the target, and the
+absence of remaining Controller-executable preparation.
+
+A green aggregate CI result does not prove that a required ZIP, firmware,
+binary, dataset, report or deployment exists. In particular, a skipped
+artifact-producing job, expired/unavailable artifact, stale support or
+unverified deployment means the downstream human test is not ready and ntfy
+must stay silent until the prerequisite is repaired or replaced by an
+action-ready human prerequisite.
+
+The ntfy relay intentionally does not attempt to infer arbitrary support
+readiness from GitHub events. Readiness is a Controller-side precondition before
+the trusted handoff is created.
 
 ## Strict handoff protocol
 
@@ -40,7 +60,9 @@ The transport-recognized comment statuses are `READY_FOR_REVIEW`,
 `HUMAN_REQUIRED`, `BLOCKED` and `SESSION_LIMIT`. The following lines contain one
 precise actionable detail.
 
-The only native review that requests a relaunch is:
+A `HUMAN_REQUIRED` detail identifies the exact target/support to use, how
+Emmanuel can access it and the result to report. The only native review that
+requests a relaunch is:
 
 ```text
 NO_GO <full-sha>
@@ -57,8 +79,9 @@ The workflow accepts an event only when:
 - the first line matches the strict grammar and details are non-empty.
 
 Stale or ordinary events are ignored. The Controller must not duplicate an
-already-current relaunch handoff or an unresolved identical human test. GitHub
-remains authoritative if ntfy delivery fails.
+already-current relaunch handoff or an unresolved identical human test. If the
+target/support changes, Human readiness is re-evaluated rather than relying on
+an older handoff. GitHub remains authoritative if ntfy delivery fails.
 
 ## Compatibility during develop/main separation
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,16 +54,20 @@ The Controller optimizes project throughput, not session length.
 
 1. An active priority PR owns the integration lane.
 2. If the current launch can safely advance it, that work has priority.
-3. If it is waiting only for CI or a human/manual test, the Controller may use
-   the wait for one demonstrably independent roadmap atom.
-4. If a reserve PR is open and newly settled external evidence makes a
+3. A human proof is an external wait only after its required support is proven
+   action-ready; missing build/package/deploy/export/provenance work stays on
+   the technical critical path.
+4. If the priority path is waiting only for CI or an action-ready human/manual
+   test, the Controller may use the wait for one demonstrably independent
+   roadmap atom.
+5. If a reserve PR is open and newly settled external evidence makes a
    higher-priority atom executable, the reserve PR yields at a safe checkpoint;
    close it without merge when necessary rather than making the critical path
    wait behind reserve integration.
-5. If progress on the priority PR requires a fresh Controller launch, the
+6. If progress on the priority PR requires a fresh Controller launch, the
    current session stops and requests that relaunch instead of producing
    secondary busywork.
-6. Reserve work is preempted only at a safe checkpoint when the priority path
+7. Reserve work is preempted only at a safe checkpoint when the priority path
    becomes actionable again.
 
 No explicit queue or scheduler state is stored. The Controller reconstructs the
@@ -124,15 +128,25 @@ for two kinds of action:
 CI, `GO`, merges, roadmap changes, context switches, ordinary comments and
 `UNPROVEN` by itself are silent.
 
-`HUMAN_REQUIRED` is reserved for a precise test/manual evidence action and may
-be non-terminal: once the handoff is published, the Controller may continue on
-one independent atom. Relaunch events use `READY_FOR_REVIEW`, `NO_GO`,
-`BLOCKED` or `SESSION_LIMIT` only when the current session truly must stop and a
-fresh Controller launch is useful.
+Before `HUMAN_REQUIRED`, the Controller applies a Human-readiness gate. The next
+proof being human is not enough: the exact target must be identified, every
+required artifact/binary/firmware/dataset/report/deployment must exist and be
+accessible, its provenance or justified equivalence to the target must be
+proven, and no Controller-executable preparation may remain. A green aggregate
+CI result does not substitute for this check; a skipped artifact-producing job,
+an expired artifact or an unverified deployment leaves the human test not ready.
+
+`HUMAN_REQUIRED` is reserved for a precise, action-ready test/manual evidence
+action and may be non-terminal: once the handoff is published, the Controller
+may continue on one independent atom. Relaunch events use `READY_FOR_REVIEW`,
+`NO_GO`, `BLOCKED` or `SESSION_LIMIT` only when the current session truly must
+stop and a fresh Controller launch is useful.
 
 The trusted default-branch relay validates the repository owner and exact
 current PR HEAD/base or exact `develop` SHA before accessing the ntfy secret.
-The handoff is notification transport, never workflow state.
+The relay does not infer arbitrary test-support readiness; that is a Controller
+precondition before the handoff is emitted. The handoff is notification
+transport, never workflow state.
 
 ## Repository protections
 
@@ -147,6 +161,8 @@ cannot be written or merged by the Controller without exact human authority.
 - one active integration PR and at most one independent preparatory context;
 - no priority inversion from a reserve PR after higher-priority external
   evidence settles;
+- no `HUMAN_REQUIRED` before target, support, provenance, accessibility and
+  procedure are proven action-ready;
 - no extra launch merely because CI or a human test is pending;
 - immediate fresh launch when independent review/repair is the critical-path
   requirement;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,18 +81,27 @@ new physical evidence is requested.
 ### W1 — real Chrome coherence retest
 
 - parent: #81
-- depends: integrated execution-state and invalid-program corrections
-- action: human/manual test on the lowest-spec classroom Windows PC with the
-  current exact release artifact
+- depends: integrated execution-state and invalid-program corrections plus a
+  Human-readiness gate proving an accessible current Windows release artifact
+  for the exact test target
+- action: human/manual test on the lowest-spec classroom Windows PC with that
+  proven current release artifact
+- readiness: before `HUMAN_REQUIRED`, verify the artifact exists now, is
+  downloadable/usable by Emmanuel, and has explicit provenance to the exact
+  target revision or a documented technically equivalent tree/state. A green
+  aggregate gate is insufficient: if `runtime-v2-windows-release` or any other
+  required artifact-producing job was skipped, or the artifact is expired,
+  stale or unavailable, W1 is not executable and technical preparation stays
+  on the critical path.
 - proof: one-action offline startup to `PRÊT`; normal and step execution;
   coherent workspace/file controls during execution; student-facing invalid
   program behavior; Open/Save/Save As; no regression of the previously proven
   Chrome path
-- scheduling: human gate. A pending W1 must not globally idle the Controller;
-  notify once, then use an independent reserve atom when available. If the W1
-  result arrives while a reserve PR owns the lane and makes #81 executable,
-  apply the reserve-PR yield rule rather than making #81 wait behind reserve
-  integration.
+- scheduling: human gate only after readiness passes. A ready-but-pending W1
+  must not globally idle the Controller; notify once, then use an independent
+  reserve atom when available. If the W1 result arrives while a reserve PR owns
+  the lane and makes #81 executable, apply the reserve-PR yield rule rather than
+  making #81 wait behind reserve integration.
 
 ### W2 — formal 30-minute low-end Windows stability acceptance
 

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -80,6 +80,51 @@ class ControllerContractTests(unittest.TestCase):
         self.assertIn("If progress on the priority PR requires a fresh Controller launch", development)
         self.assertIn("instead of producing secondary busywork", development)
 
+    def test_human_required_is_gated_by_action_ready_support(self) -> None:
+        contract_raw = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        roadmap_raw = (ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+        development_raw = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
+            encoding="utf-8"
+        )
+        notifications_raw = (ROOT / "docs" / "CONTROLLER_NOTIFICATIONS.md").read_text(
+            encoding="utf-8"
+        )
+        contract = flat(contract_raw)
+        roadmap = flat(roadmap_raw)
+        development = flat(development_raw)
+        notifications = flat(notifications_raw)
+
+        self.assertIn("### Human-readiness gate", contract_raw)
+        self.assertIn(
+            "The fact that the next proof type is human does not mean the human action is ready",
+            contract,
+        )
+        self.assertIn("identify the exact target revision, version or deployed state", contract)
+        self.assertIn("verify that every required support exists now and is accessible", contract)
+        self.assertIn("bind that support to the target with explicit provenance", contract)
+        self.assertIn("without an uncompleted technical preparation step", contract)
+        self.assertIn("A green aggregate CI result is not proof", contract)
+        self.assertIn("skipped artifact-producing job", contract)
+        self.assertIn("must happen before `HUMAN_REQUIRED`", contract)
+        self.assertIn("only after the Human-readiness gate passes", contract)
+
+        self.assertIn("Human-readiness gate proving an accessible current Windows release artifact", roadmap)
+        self.assertIn("runtime-v2-windows-release", roadmap_raw)
+        self.assertIn("W1 is not executable", roadmap)
+        self.assertIn("human gate only after readiness passes", roadmap)
+
+        self.assertIn("Before `HUMAN_REQUIRED`, the Controller applies a Human-readiness gate", development)
+        self.assertIn("skipped artifact-producing job", development)
+        self.assertIn(
+            "no `HUMAN_REQUIRED` before target, support, provenance, accessibility and procedure are proven action-ready",
+            development,
+        )
+
+        self.assertIn("## Human-readiness prerequisite", notifications_raw)
+        self.assertIn("human evidence is logically next", notifications)
+        self.assertIn("ntfy must stay silent", notifications)
+        self.assertIn("relay intentionally does not attempt to infer arbitrary support readiness", notifications)
+
     def test_notifications_mean_only_test_or_relaunch_and_ci_is_silent(self) -> None:
         contract_raw = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
         development_raw = (ROOT / "docs" / "DEVELOPMENT.md").read_text(
@@ -117,8 +162,8 @@ class ControllerContractTests(unittest.TestCase):
 
         self.assertIn("CI, `GO`, merges, roadmap changes", development)
         self.assertIn("and `UNPROVEN` by itself are silent", development)
-        self.assertIn("`HUMAN_REQUIRED` is reserved for a precise test", development)
-        self.assertIn("Relaunch events use `READY_FOR_REVIEW`, `NO_GO`", development)
+        self.assertIn("`HUMAN_REQUIRED` is reserved for a precise, action-ready test", development)
+        self.assertIn("Relaunch events use `READY_FOR_REVIEW`,", development)
 
         self.assertIn("issue_comment:", workflow)
         self.assertIn("pull_request_review:", workflow)


### PR DESCRIPTION
## Outcome

Close the gap between “the next proof type is human” and “the requested human action is actually executable”.

Before any `HUMAN_REQUIRED`, the Controller must now prove a Human-readiness gate:

- exact target revision/version/deployed state identified;
- every required support (artifact, ZIP, binary, firmware, dataset, report, deployment, etc.) exists and is accessible now;
- provenance or technically justified equivalence binds that support to the target;
- no Controller-executable build/package/deploy/export/provenance step remains.

A green aggregate CI result is explicitly insufficient. A skipped artifact-producing job, expired/unavailable artifact, stale binary/firmware or unverified deployment leaves the human test non-executable and ntfy silent.

## Regression captured

The historical #129 case had a green `CI Gate`, but `runtime-v2-windows-release` was skipped and no Windows release artifact existed in that run. Under this contract, W1 would therefore remain technical preparation rather than becoming a premature `HUMAN_REQUIRED`.

## Scope

- `AGENTS.md`: authoritative generic Human-readiness gate and scheduler integration;
- `docs/ROADMAP.md`: W1 explicitly requires an accessible provenance-bound Windows release artifact;
- `docs/DEVELOPMENT.md`: architecture explanation and operational target;
- `docs/CONTROLLER_NOTIFICATIONS.md`: TEST transport only after readiness; relay itself does not infer arbitrary support readiness;
- `tools/ci/test_controller_contract.py`: regression oracle protecting the invariant.

No product code, CI topology, ntfy workflow, branch protection or `main` change.

## WIP/preemption note

Reserve PR #134 was closed without merge and its branch retained as the single preparatory context because finishing its still-UNPROVEN firmware prototype would have materially delayed this explicit higher-priority governance correction.