### PR TITLE
Make CI evidence targets explicit

### DIFF
--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -1005,7 +1005,7 @@ jobs:
           assert locale['directionOptions']==expected_directions, locale['directionOptions']
           assert locale['sensorText']=='devant = 1 m · derrière = 2 m · à gauche = 3 m · à droite = 4 m · au-dessus = 5 m', locale['sensorText']
           visible=' '.join(locale['blocks'].values()).lower()
-          assert not re.search(r'\b(repeat|if|do|else|and|or|true|false)\b',visible), locale['blocks']
+          assert not re.search(r'\\b(repeat|if|do|else|and|or|true|false)\\b',visible), locale['blocks']
           assert i['viewport']=={'width':1366,'height':768}, i['viewport']
           assert all(i['controls'].values()), i['controls']
           assert i['geometry']['toolbar'] and i['geometry']['toolbar']['width']>0, i['geometry']

--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -3,6 +3,10 @@ name: CI Runtime Suite
 on:
   workflow_call:
     inputs:
+      target_sha:
+        description: Exact WebeeBlocks Git object to prove.
+        required: true
+        type: string
       full:
         description: Build the complete Windows classroom release.
         required: false
@@ -18,6 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -41,6 +47,8 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -85,6 +93,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -194,6 +204,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -407,6 +419,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -522,6 +536,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -545,6 +561,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -658,6 +676,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -880,6 +900,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -983,7 +1005,7 @@ jobs:
           assert locale['directionOptions']==expected_directions, locale['directionOptions']
           assert locale['sensorText']=='devant = 1 m · derrière = 2 m · à gauche = 3 m · à droite = 4 m · au-dessus = 5 m', locale['sensorText']
           visible=' '.join(locale['blocks'].values()).lower()
-          assert not re.search(r'\\b(repeat|if|do|else|and|or|true|false)\\b',visible), locale['blocks']
+          assert not re.search(r'\b(repeat|if|do|else|and|or|true|false)\b',visible), locale['blocks']
           assert i['viewport']=={'width':1366,'height':768}, i['viewport']
           assert all(i['controls'].values()), i['controls']
           assert i['geometry']['toolbar'] and i['geometry']['toolbar']['width']>0, i['geometry']
@@ -1022,6 +1044,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Checkout pinned Webots R2025a release assets
         uses: actions/checkout@v4

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -2,6 +2,11 @@ name: CI Webots Suite
 
 on:
   workflow_call:
+    inputs:
+      target_sha:
+        description: Exact WebeeBlocks Git object to prove.
+        required: true
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -14,6 +19,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -59,6 +66,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -102,6 +111,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Generate exact semantic mission from real Blockly 2020
         shell: bash
@@ -226,6 +237,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Validate challenge UX sources
         run: |
@@ -427,6 +440,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -475,6 +490,8 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -569,6 +586,8 @@ jobs:
     timeout-minutes: 16
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Validate parametric Blockly/runtime syntax
         run: |
@@ -763,6 +782,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -808,6 +829,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Validate browser-side runtime transport syntax
         run: |
@@ -989,6 +1012,8 @@ jobs:
     timeout-minutes: 7
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -1059,6 +1084,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -1150,6 +1177,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -1276,6 +1305,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Validate student-grid fixtures and harness
         shell: bash
@@ -1457,6 +1488,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -1481,6 +1514,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Checkout pinned Webots R2025a projects
         uses: actions/checkout@v4
@@ -1614,6 +1649,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Checkout pinned Webots R2025a projects
         uses: actions/checkout@v4
@@ -1749,6 +1786,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Checkout pinned Webots R2025a projects
         uses: actions/checkout@v4
@@ -1923,6 +1962,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Checkout pinned Webots R2025a projects
         uses: actions/checkout@v4
@@ -2037,7 +2078,7 @@ jobs:
           fi
 
           if ! grep -Fq 'WEBEEBLOCKS_CI_SENSOR_PROBE_BEHAVIOR_EXECUTED' "$LOG"; then
-            echo '::error::sensorProbing did not reach Gyro, GPS, distance and color outputs.'
+            echo '::error::sensorProbing did not reach Gyro, GPS, DistanceSensor and color outputs.'
             exit 1
           fi
 
@@ -2065,6 +2106,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Pull official Webots R2025a image
         run: docker pull cyberbotics/webots:R2025a-ubuntu22.04
@@ -2149,6 +2192,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
 
       - name: Checkout pinned Webots R2025a projects
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Verify selector
@@ -56,6 +57,7 @@ jobs:
     if: ${{ needs.select.outputs.runtime == 'true' }}
     uses: ./.github/workflows/ci-runtime.yml
     with:
+      target_sha: ${{ github.sha }}
       full: ${{ needs.select.outputs.full == 'true' }}
 
   webots:
@@ -63,6 +65,8 @@ jobs:
     needs: select
     if: ${{ needs.select.outputs.webots == 'true' }}
     uses: ./.github/workflows/ci-webots.yml
+    with:
+      target_sha: ${{ github.sha }}
 
   gate:
     name: CI Gate
@@ -71,6 +75,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Require every selected suite
         env:

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -135,6 +135,23 @@ class WorkflowContractTests(unittest.TestCase):
             self.assertIn("  workflow_call:\n", suite)
             self.assertNotIn("  pull_request:\n", suite)
 
+    def test_reusable_suites_receive_an_explicit_git_target(self) -> None:
+        orchestrator = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+        self.assertEqual(orchestrator.count("target_sha: ${{ github.sha }}"), 2)
+        self.assertEqual(orchestrator.count("ref: ${{ github.sha }}"), 2)
+
+        target_ref = "ref: ${{ inputs.target_sha || github.sha }}"
+        for name in ("ci-runtime.yml", "ci-webots.yml"):
+            suite = (WORKFLOWS / name).read_text(encoding="utf-8")
+            self.assertIn("      target_sha:\n", suite, name)
+            self.assertIn("        required: true\n", suite, name)
+            self.assertIn("        type: string\n", suite, name)
+            all_checkouts = suite.count("uses: actions/checkout@v4")
+            external_checkouts = suite.count("repository: cyberbotics/webots")
+            repository_checkouts = all_checkouts - external_checkouts
+            self.assertGreater(repository_checkouts, 0, name)
+            self.assertEqual(suite.count(target_ref), repository_checkouts, name)
+
     def test_windows_release_is_full_gate_only_and_pinned(self) -> None:
         orchestrator = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
         runtime = (WORKFLOWS / "ci-runtime.yml").read_text(encoding="utf-8")
@@ -219,4 +236,3 @@ class WorkflowContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Tranche 1 — explicit evidence target only

Refactorise l’adressage Git des preuves CI sans changer leur rôle décisionnel.

### Intended change
- `CI Gate` transmet explicitement son objet Git courant (`github.sha`) aux suites Runtime et Webots via `target_sha`.
- Tous les checkouts du dépôt WebeeBlocks dans les deux suites utilisent cette cible explicite.
- Les checkouts externes Cyberbotics restent épinglés exactement comme avant.
- Les checkouts de l’orchestrateur `select` et `gate` rendent également explicite le même `github.sha` qu’Actions utilisait implicitement.

Pour une PR normale, `github.sha` reste donc le merge SHA synthétique utilisé avant ce refactoring : **la cible Git effective de `CI Gate` ne change pas**.

Le fallback `inputs.target_sha || github.sha` conserve le comportement des lancements directs `workflow_dispatch` des suites existantes ; il n’ajoute aucun nouveau mode d’exécution.

### Preserved invariants
- même sélecteur et mêmes sorties `runtime` / `webots` / `full` ;
- mêmes conditions `if` et mêmes jobs ;
- mêmes oracles et mêmes preuves ;
- même job décisionnel requis nommé `CI Gate` ;
- aucune nouvelle preuve Candidate Evidence ;
- aucun raccord `UNPROVEN` ;
- aucun trigger post-merge ;
- aucun changement de roadmap, notification ou `main`.

`tools/ci/test_workflow_contract.py` vérifie désormais que les deux suites reçoivent une cible explicite et que chaque checkout WebeeBlocks est lié à cette cible, tout en excluant les checkouts Cyberbotics épinglés.

### Diff inspection
Une réécriture intermédiaire avait introduit deux dérives hors périmètre. La dérive de regex Runtime a été restaurée. Il reste une variation **strictement diagnostique** dans `ci-webots.yml` (`distance` → `DistanceSensor` dans un message d’erreur) : elle ne modifie aucune condition, assertion, branchement ni code retour et n’est pas utilisée comme oracle. Elle est signalée ici pour que la revue ne la confonde pas avec un changement fonctionnel.

### Acceptance oracle

`CI Gate avant ≡ CI Gate après` : même sélection, mêmes conditions, même cible Git effective, mêmes preuves et même required check. La seule différence architecturale recherchée est que la cible des suites est désormais fournie explicitement.