### PR TITLE
Add exact-head Candidate Evidence capability

### DIFF
--- a/.github/workflows/candidate-evidence.yml
+++ b/.github/workflows/candidate-evidence.yml
@@ -12,8 +12,26 @@ permissions:
   contents: read
 
 jobs:
+  validate_target:
+    name: Validate exact candidate SHA
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Reject mutable or malformed targets
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "${#TARGET_SHA}" -eq 40
+          case "$TARGET_SHA" in
+            *[!0-9a-fA-F]*|'')
+              echo "target_sha must be a full 40-hex Git commit SHA" >&2
+              exit 1
+              ;;
+          esac
+
   candidate_runtime:
     name: Candidate Runtime evidence
+    needs: validate_target
     uses: ./.github/workflows/ci-runtime.yml
     with:
       target_sha: ${{ inputs.target_sha }}
@@ -21,6 +39,7 @@ jobs:
 
   candidate_webots:
     name: Candidate Webots evidence
+    needs: validate_target
     uses: ./.github/workflows/ci-webots.yml
     with:
       target_sha: ${{ inputs.target_sha }}

--- a/.github/workflows/candidate-evidence.yml
+++ b/.github/workflows/candidate-evidence.yml
@@ -12,29 +12,29 @@ permissions:
   contents: read
 
 jobs:
-  candidate-runtime:
+  candidate_runtime:
     name: Candidate Runtime evidence
     uses: ./.github/workflows/ci-runtime.yml
     with:
       target_sha: ${{ inputs.target_sha }}
       full: true
 
-  candidate-webots:
+  candidate_webots:
     name: Candidate Webots evidence
     uses: ./.github/workflows/ci-webots.yml
     with:
       target_sha: ${{ inputs.target_sha }}
 
-  candidate-evidence:
+  candidate_evidence:
     name: Candidate Evidence
     if: ${{ always() }}
-    needs: [candidate-runtime, candidate-webots]
+    needs: [candidate_runtime, candidate_webots]
     runs-on: ubuntu-22.04
     steps:
       - name: Require complete deterministic candidate evidence
         env:
-          RUNTIME_RESULT: ${{ needs.candidate-runtime.result }}
-          WEBOTS_RESULT: ${{ needs.candidate-webots.result }}
+          RUNTIME_RESULT: ${{ needs.candidate_runtime.result }}
+          WEBOTS_RESULT: ${{ needs.candidate_webots.result }}
         run: |
           set -euo pipefail
           test "$RUNTIME_RESULT" = "success"

--- a/.github/workflows/candidate-evidence.yml
+++ b/.github/workflows/candidate-evidence.yml
@@ -1,0 +1,42 @@
+name: Candidate Evidence
+
+on:
+  workflow_call:
+    inputs:
+      target_sha:
+        description: Exact candidate HEAD to prove.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  candidate-runtime:
+    name: Candidate Runtime evidence
+    uses: ./.github/workflows/ci-runtime.yml
+    with:
+      target_sha: ${{ inputs.target_sha }}
+      full: true
+
+  candidate-webots:
+    name: Candidate Webots evidence
+    uses: ./.github/workflows/ci-webots.yml
+    with:
+      target_sha: ${{ inputs.target_sha }}
+
+  candidate-evidence:
+    name: Candidate Evidence
+    if: ${{ always() }}
+    needs: [candidate-runtime, candidate-webots]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Require complete deterministic candidate evidence
+        env:
+          RUNTIME_RESULT: ${{ needs.candidate-runtime.result }}
+          WEBOTS_RESULT: ${{ needs.candidate-webots.result }}
+        run: |
+          set -euo pipefail
+          test "$RUNTIME_RESULT" = "success"
+          test "$WEBOTS_RESULT" = "success"
+          echo "Complete deterministic evidence acquired for ${{ inputs.target_sha }}"

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static contract for the CI topology and trusted transport boundary."""
+"""Static contract for the CI topology, candidate evidence and trusted transport boundary."""
 
 from pathlib import Path
 import re
@@ -12,6 +12,11 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 TRANSPORT_WORKFLOWS = {"controller-handoff-ntfy.yml"}
 
 EXPECTED = {
+    "candidate-evidence.yml": {
+        "candidate-runtime",
+        "candidate-webots",
+        "candidate-evidence",
+    },
     "ci.yml": {"select", "runtime", "webots", "gate"},
     "ci-runtime.yml": {
         "runtime-v2-core",
@@ -56,7 +61,7 @@ def job_ids(text: str) -> set[str]:
 
 
 class WorkflowContractTests(unittest.TestCase):
-    def test_only_three_ci_workflows_plus_transport_exist(self) -> None:
+    def test_expected_workflows_plus_transport_exist(self) -> None:
         names = {path.name for path in WORKFLOWS.glob("*.yml")}
         self.assertEqual(names, set(EXPECTED).union(TRANSPORT_WORKFLOWS))
 
@@ -106,7 +111,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("github.token", transport)
         self.assertNotIn("CI Gate terminé", transport)
 
-    def test_every_oracle_job_is_preserved_once(self) -> None:
+    def test_every_workflow_job_is_preserved_once(self) -> None:
         observed: set[str] = set()
         for name, expected in EXPECTED.items():
             current = job_ids((WORKFLOWS / name).read_text(encoding="utf-8"))
@@ -130,10 +135,36 @@ class WorkflowContractTests(unittest.TestCase):
             "types: [opened, synchronize, reopened, ready_for_review]",
             orchestrator,
         )
-        for name in ("ci-runtime.yml", "ci-webots.yml"):
+        for name in ("candidate-evidence.yml", "ci-runtime.yml", "ci-webots.yml"):
             suite = (WORKFLOWS / name).read_text(encoding="utf-8")
             self.assertIn("  workflow_call:\n", suite)
             self.assertNotIn("  pull_request:\n", suite)
+
+    def test_candidate_evidence_is_exact_head_full_and_dormant(self) -> None:
+        candidate = (WORKFLOWS / "candidate-evidence.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("name: Candidate Evidence\n", candidate)
+        self.assertIn("  workflow_call:\n", candidate)
+        self.assertNotIn("  workflow_dispatch:\n", candidate)
+        self.assertNotIn("  pull_request:\n", candidate)
+        self.assertNotIn("  pull_request_review:\n", candidate)
+        self.assertNotIn("  issue_comment:\n", candidate)
+        self.assertNotIn("  push:\n", candidate)
+        self.assertIn("permissions:\n  contents: read\n", candidate)
+        self.assertIn("      target_sha:\n", candidate)
+        self.assertIn("        required: true\n", candidate)
+        self.assertIn("        type: string\n", candidate)
+        self.assertEqual(candidate.count("target_sha: ${{ inputs.target_sha }}"), 2)
+        self.assertIn("uses: ./.github/workflows/ci-runtime.yml", candidate)
+        self.assertIn("uses: ./.github/workflows/ci-webots.yml", candidate)
+        self.assertIn("      full: true\n", candidate)
+        self.assertIn(
+            "needs: [candidate-runtime, candidate-webots]",
+            candidate,
+        )
+        self.assertNotIn("actions/checkout", candidate)
+        self.assertNotIn("CI Gate", candidate)
 
     def test_reusable_suites_receive_an_explicit_git_target(self) -> None:
         orchestrator = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
@@ -152,7 +183,7 @@ class WorkflowContractTests(unittest.TestCase):
             self.assertGreater(repository_checkouts, 0, name)
             self.assertEqual(suite.count(target_ref), repository_checkouts, name)
 
-    def test_windows_release_is_full_gate_only_and_pinned(self) -> None:
+    def test_windows_release_requires_full_or_non_pr_and_is_pinned(self) -> None:
         orchestrator = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
         runtime = (WORKFLOWS / "ci-runtime.yml").read_text(encoding="utf-8")
         self.assertIn("full: ${{ needs.select.outputs.full == 'true' }}", orchestrator)

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -13,9 +13,9 @@ TRANSPORT_WORKFLOWS = {"controller-handoff-ntfy.yml"}
 
 EXPECTED = {
     "candidate-evidence.yml": {
-        "candidate-runtime",
-        "candidate-webots",
-        "candidate-evidence",
+        "candidate_runtime",
+        "candidate_webots",
+        "candidate_evidence",
     },
     "ci.yml": {"select", "runtime", "webots", "gate"},
     "ci-runtime.yml": {
@@ -160,7 +160,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("uses: ./.github/workflows/ci-webots.yml", candidate)
         self.assertIn("      full: true\n", candidate)
         self.assertIn(
-            "needs: [candidate-runtime, candidate-webots]",
+            "needs: [candidate_runtime, candidate_webots]",
             candidate,
         )
         self.assertNotIn("actions/checkout", candidate)

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -13,6 +13,7 @@ TRANSPORT_WORKFLOWS = {"controller-handoff-ntfy.yml"}
 
 EXPECTED = {
     "candidate-evidence.yml": {
+        "validate_target",
         "candidate_runtime",
         "candidate_webots",
         "candidate_evidence",
@@ -155,6 +156,11 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("      target_sha:\n", candidate)
         self.assertIn("        required: true\n", candidate)
         self.assertIn("        type: string\n", candidate)
+        self.assertIn("  validate_target:\n", candidate)
+        self.assertIn("TARGET_SHA: ${{ inputs.target_sha }}", candidate)
+        self.assertIn('test "${#TARGET_SHA}" -eq 40', candidate)
+        self.assertIn("*[!0-9a-fA-F]*|'')", candidate)
+        self.assertEqual(candidate.count("needs: validate_target"), 2)
         self.assertEqual(candidate.count("target_sha: ${{ inputs.target_sha }}"), 2)
         self.assertIn("uses: ./.github/workflows/ci-runtime.yml", candidate)
         self.assertIn("uses: ./.github/workflows/ci-webots.yml", candidate)


### PR DESCRIPTION
## Tranche 2 — Candidate Evidence exact-HEAD, non automatisé

Ajoute une capacité réutilisable `Candidate Evidence` sans modifier `CI Gate` ni raccorder `UNPROVEN`.

### Outcome
Un caller futur peut fournir explicitement un `target_sha` et demander l'ensemble des preuves/préparations déterministes déjà définies :
- Runtime avec `full: true`, donc release Windows comprise ;
- suite Webots complète ;
- agrégation finale `Candidate Evidence` qui échoue si l'une des deux suites n'est pas verte.

### Boundaries
- `candidate-evidence.yml` n'écoute aucun événement métier : uniquement `workflow_call` ;
- aucun `pull_request`, `workflow_dispatch`, `pull_request_review`, commentaire, push ou trigger post-merge ;
- aucune écriture, aucun secret, seulement `contents: read` ;
- aucun checkout propre au wrapper : il transmet le même `target_sha` aux suites adressables intégrées par #138 ;
- le succès de cette capacité n'est pas un `GO` et ne crée aucun second required check ;
- aucun raccord `UNPROVEN` (tranche 3) ;
- aucun changement de `AGENTS.md`, roadmap, notifications ou `main`.

### Evidence
`tools/ci/test_workflow_contract.py` verrouille que le wrapper reste dormant, exact-target, read-only, compose exactement Runtime + Webots, force `full: true` pour Runtime et ne contient pas `CI Gate`.

La PR modifie un workflow : le `CI Gate` conservateur doit donc exécuter les suites complètes existantes, dont la construction/validation de `WebeeBlocks-Windows-R2025a`. Cette exécution prouve les capacités enfants sur la cible CI de la PR ; le passage inchangé du `target_sha` par le wrapper est vérifié statiquement. Le premier déclenchement événementiel du wrapper lui-même appartient volontairement à la tranche 3 plutôt que d'ajouter ici un trigger de test permanent ou un protocole provisoire.

### Acceptance oracle
La tranche est acceptable si le diff reste limité au wrapper dormant + son contrat, le `CI Gate` exact-head est vert avec release Windows produite, et la revue indépendante ne trouve aucun moyen pour `Candidate Evidence` de choisir implicitement sa cible, d'écrire dans le dépôt ou de devenir un second oracle de décision PR.