### PR TITLE
Automate exact-HEAD Candidate Evidence after UNPROVEN

### DIFF
--- a/.github/workflows/candidate-evidence-on-unproven.yml
+++ b/.github/workflows/candidate-evidence-on-unproven.yml
@@ -1,0 +1,182 @@
+name: Candidate Evidence on UNPROVEN
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+concurrency:
+  group: candidate-evidence-unproven-${{ github.event.pull_request.number }}-${{ github.event.review.commit_id }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate trusted UNPROVEN
+    if: >-
+      github.event.review.state == 'commented' &&
+      github.event.review.user.login == 'djibian' &&
+      github.event.pull_request.base.ref == 'develop' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
+    outputs:
+      target_sha: ${{ steps.validate.outputs.target_sha }}
+    steps:
+      - id: validate
+        name: Bind verdict to live PR HEAD and review history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_PATH: ${{ github.event_path }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          import urllib.request
+
+          TRUSTED_AUTHOR = "djibian"
+          SHA_RE = re.compile(r"[0-9a-f]{40}")
+          UNPROVEN_RE = re.compile(r"VERDICT UNPROVEN ([0-9a-f]{40})")
+          VERDICT_PREFIXES = ("GO ", "NO_GO ", "VERDICT UNPROVEN ")
+
+          def ignore(reason):
+              print(f"Candidate Evidence not started: {reason}")
+              raise SystemExit(0)
+
+          def first_line(body):
+              lines = (body or "").splitlines()
+              return lines[0] if lines else ""
+
+          def parse_verdict(line):
+              for prefix in VERDICT_PREFIXES:
+                  if not line.startswith(prefix):
+                      continue
+                  sha = line[len(prefix):]
+                  if not SHA_RE.fullmatch(sha):
+                      return ("MALFORMED", None)
+                  return (prefix.strip(), sha)
+              return None
+
+          with open(os.environ["EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          review = event.get("review") or {}
+          event_pr = event.get("pull_request") or {}
+          repository = os.environ["REPOSITORY"]
+
+          if str(review.get("state", "")).lower() != "commented":
+              ignore("review state is not commented")
+          if (review.get("user") or {}).get("login") != TRUSTED_AUTHOR:
+              ignore("review author is not trusted")
+          if (event_pr.get("base") or {}).get("ref") != "develop":
+              ignore("event PR base is not develop")
+          if ((event_pr.get("head") or {}).get("repo") or {}).get("full_name") != repository:
+              ignore("event PR is not from the same repository")
+
+          line = first_line(review.get("body"))
+          match = UNPROVEN_RE.fullmatch(line)
+          if not match:
+              ignore("first line is not the canonical UNPROVEN verdict")
+          declared_sha = match.group(1)
+          if review.get("commit_id") != declared_sha:
+              ignore("declared SHA differs from review.commit_id")
+
+          number = event_pr.get("number")
+          if not isinstance(number, int):
+              raise RuntimeError("pull request number missing from review event")
+
+          token = os.environ["GH_TOKEN"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "User-Agent": "webeeblocks-candidate-evidence",
+          }
+
+          def api_get(path):
+              request = urllib.request.Request(
+                  f"https://api.github.com/repos/{repository}{path}",
+                  headers=headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.load(response)
+
+          live_pr = api_get(f"/pulls/{number}")
+          if live_pr.get("state") != "open":
+              ignore("live PR is not open")
+          if (live_pr.get("base") or {}).get("ref") != "develop":
+              ignore("live PR base is not develop")
+          if ((live_pr.get("head") or {}).get("repo") or {}).get("full_name") != repository:
+              ignore("live PR is not from the same repository")
+          if (live_pr.get("head") or {}).get("sha") != declared_sha:
+              ignore("live PR HEAD differs from declared SHA")
+
+          reviews = []
+          page = 1
+          while True:
+              batch = api_get(f"/pulls/{number}/reviews?per_page=100&page={page}")
+              if not isinstance(batch, list):
+                  raise RuntimeError("unexpected reviews API response")
+              reviews.extend(batch)
+              if len(batch) < 100:
+                  break
+              page += 1
+              if page > 100:
+                  raise RuntimeError("review pagination exceeded safety bound")
+
+          current_id = review.get("id")
+          trusted_verdicts = []
+          for item in reviews:
+              if (item.get("user") or {}).get("login") != TRUSTED_AUTHOR:
+                  continue
+              if str(item.get("state", "")).lower() != "commented":
+                  continue
+              if item.get("commit_id") != declared_sha:
+                  continue
+              parsed = parse_verdict(first_line(item.get("body")))
+              if parsed is None:
+                  continue
+              kind, verdict_sha = parsed
+              if kind == "MALFORMED" or verdict_sha != declared_sha:
+                  ignore("trusted verdict history for this HEAD is ambiguous")
+              trusted_verdicts.append(
+                  (item.get("submitted_at") or "", int(item.get("id")), kind)
+              )
+
+          trusted_verdicts.sort(key=lambda item: (item[0], item[1]))
+          current_positions = [
+              index
+              for index, item in enumerate(trusted_verdicts)
+              if item[1] == int(current_id)
+          ]
+          if len(current_positions) != 1:
+              ignore("current review is not uniquely present in live review history")
+
+          current_position = current_positions[0]
+          if trusted_verdicts[current_position][2] != "VERDICT UNPROVEN":
+              ignore("current trusted verdict is not UNPROVEN")
+
+          previous = trusted_verdicts[:current_position]
+          if any(item[2] == "VERDICT UNPROVEN" for item in previous):
+              ignore("an earlier trusted UNPROVEN already exists for this PR HEAD")
+          if any(item[2] in {"GO", "NO_GO"} for item in previous):
+              ignore("trusted verdict history for this HEAD is contradictory")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"target_sha={declared_sha}\n")
+          print(f"Candidate Evidence authorized for PR #{number} at {declared_sha}")
+          PY
+
+  evidence:
+    name: Run exact-HEAD Candidate Evidence
+    needs: validate
+    if: needs.validate.outputs.target_sha != ''
+    permissions:
+      contents: read
+    uses: ./.github/workflows/candidate-evidence.yml
+    with:
+      target_sha: ${{ needs.validate.outputs.target_sha }}

--- a/.github/workflows/candidate-evidence-on-unproven.yml
+++ b/.github/workflows/candidate-evidence-on-unproven.yml
@@ -28,7 +28,6 @@ jobs:
         name: Bind verdict to live PR HEAD and review history
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_PATH: ${{ github.event_path }}
           REPOSITORY: ${{ github.repository }}
         run: |
           python3 - <<'PY'
@@ -61,7 +60,7 @@ jobs:
                   return (prefix.strip(), sha)
               return None
 
-          with open(os.environ["EVENT_PATH"], encoding="utf-8") as handle:
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
               event = json.load(handle)
 
           review = event.get("review") or {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           python3 tools/ci/test_select_ci.py
           python3 tools/ci/test_ci_gate.py
           python3 tools/ci/test_workflow_contract.py
+          python3 tools/ci/test_candidate_evidence_trigger.py
           python3 tools/ci/test_localize_webots_world.py
           python3 tools/ci/test_repository_hygiene.py
           python3 tools/ci/test_windows_release_contract.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,3 +304,46 @@ Mention `@djibian` only for a concrete human/manual test or a decision that must
 be made before the announced relaunch. A final report states the current
 outcome, PR/head when relevant, evidence, `develop` and `main`, any waiting human
 test, and the next actionable event.
+
+## Candidate evidence escalation
+
+Evidence is attached to the decision its failure must block. If required
+evidence would prevent merging the current candidate, obtain it on that exact
+candidate before merge. Evidence meaningful only for an integrated combination
+or milestone belongs on `develop` after integration. Never merge a PR while
+evidence required for one of its merge-blocking claims remains `UNPROVEN`.
+
+For an active PR, `VERDICT UNPROVEN <sha>` is the strict canonical signal that
+an independent Reviewer has not refuted the candidate but merge-blocking
+evidence for that exact HEAD is still missing. Submitted verdict reviews are
+append-only operational evidence: never edit one to change its meaning, and
+never submit a second `VERDICT UNPROVEN` for the same PR HEAD.
+
+The read-only `pull_request_review` listener may authorize exactly one
+`Candidate Evidence` escalation for a trusted canonical UNPROVEN review after
+binding the declared SHA to `review.commit_id` and the live same-repository PR
+HEAD on base `develop`, and after confirming that no earlier trusted UNPROVEN
+exists for that HEAD. Ambiguous, contradictory, stale, forked or malformed
+review state fails closed and starts no evidence run.
+
+`Candidate Evidence` is supplementary exact-HEAD deterministic evidence, not a
+second `CI Gate`, not a required check and never a `GO` by itself. It runs the
+integrated Runtime evidence with `full: true` plus the Webots evidence on the
+explicit immutable candidate SHA. Its start and completion are silent: they do
+not generate ntfy notifications.
+
+After recording an eligible UNPROVEN verdict, keep the productive Reviewer
+session alive and poll the resulting Candidate Evidence moderately when
+possible. When it settles, reconstruct the live PR and exact unchanged HEAD from
+GitHub before deciding again. A successful evidence run can justify a later
+`GO` review only if the scoped claim is now actually proven. A causal candidate
+defect can justify `NO_GO`. If deterministic preparation has merely made a real
+human/manual proof action-ready, apply the Human-readiness gate and use
+`HUMAN_REQUIRED`. If evidence is still genuinely unavailable, keep the gap
+`UNPROVEN` and silent rather than fabricating a pass or emitting another
+UNPROVEN review.
+
+A later evidence-driven `GO` or `NO_GO` is a new append-only review based on new
+evidence; it never edits the earlier UNPROVEN review. A human action must never
+be requested merely to perform deterministic technical preparation that the
+infrastructure can perform itself.

--- a/tools/ci/test_candidate_evidence_trigger.py
+++ b/tools/ci/test_candidate_evidence_trigger.py
@@ -44,6 +44,8 @@ class CandidateEvidenceTriggerTests(unittest.TestCase):
         self.assertNotIn("contents: write", text)
         self.assertNotIn("pull-requests: write", text)
         self.assertNotIn("issues: write", text)
+        self.assertNotIn("${{ github.event_path }}", text)
+        self.assertIn('os.environ["GITHUB_EVENT_PATH"]', text)
 
     def test_event_gate_is_trusted_same_repo_develop_commented_review(self) -> None:
         text = self.listener

--- a/tools/ci/test_candidate_evidence_trigger.py
+++ b/tools/ci/test_candidate_evidence_trigger.py
@@ -7,12 +7,14 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 LISTENER = ROOT / ".github" / "workflows" / "candidate-evidence-on-unproven.yml"
+CONTRACT = ROOT / "AGENTS.md"
 
 
 class CandidateEvidenceTriggerTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.listener = LISTENER.read_text(encoding="utf-8")
+        cls.contract = CONTRACT.read_text(encoding="utf-8")
 
     def test_only_submitted_reviews_can_trigger(self) -> None:
         text = self.listener
@@ -112,6 +114,26 @@ class CandidateEvidenceTriggerTests(unittest.TestCase):
         self.assertNotIn("label", text.lower())
         self.assertNotIn("READY_FOR_REVIEW", text)
         self.assertNotIn("HUMAN_REQUIRED", text)
+
+    def test_controller_contract_places_and_reassesses_candidate_evidence(self) -> None:
+        text = self.contract
+        for required in (
+            "## Candidate evidence escalation",
+            "Evidence is attached to the decision its failure must block",
+            "Never merge a PR while",
+            "never submit a second `VERDICT UNPROVEN` for the same PR HEAD",
+            "authorize exactly one",
+            "binding the declared SHA to `review.commit_id`",
+            "not a second `CI Gate`",
+            "not a required check and never a `GO` by itself",
+            "Its start and completion are silent",
+            "keep the productive Reviewer session alive",
+            "reconstruct the live PR and exact unchanged HEAD",
+            "A causal candidate defect can justify `NO_GO`",
+            "apply the Human-readiness gate and use `HUMAN_REQUIRED`",
+            "never edits the earlier UNPROVEN review",
+        ):
+            self.assertIn(required, text)
 
 
 if __name__ == "__main__":

--- a/tools/ci/test_candidate_evidence_trigger.py
+++ b/tools/ci/test_candidate_evidence_trigger.py
@@ -10,6 +10,10 @@ LISTENER = ROOT / ".github" / "workflows" / "candidate-evidence-on-unproven.yml"
 CONTRACT = ROOT / "AGENTS.md"
 
 
+def flat(text: str) -> str:
+    return " ".join(text.split())
+
+
 class CandidateEvidenceTriggerTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -116,7 +120,7 @@ class CandidateEvidenceTriggerTests(unittest.TestCase):
         self.assertNotIn("HUMAN_REQUIRED", text)
 
     def test_controller_contract_places_and_reassesses_candidate_evidence(self) -> None:
-        text = self.contract
+        text = flat(self.contract)
         for required in (
             "## Candidate evidence escalation",
             "Evidence is attached to the decision its failure must block",

--- a/tools/ci/test_candidate_evidence_trigger.py
+++ b/tools/ci/test_candidate_evidence_trigger.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Static fail-closed contract for UNPROVEN -> Candidate Evidence escalation."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LISTENER = ROOT / ".github" / "workflows" / "candidate-evidence-on-unproven.yml"
+
+
+class CandidateEvidenceTriggerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.listener = LISTENER.read_text(encoding="utf-8")
+
+    def test_only_submitted_reviews_can_trigger(self) -> None:
+        text = self.listener
+        self.assertIn("  pull_request_review:\n    types: [submitted]\n", text)
+        for forbidden in (
+            "  pull_request_target:\n",
+            "  issue_comment:\n",
+            "  workflow_dispatch:\n",
+            "  repository_dispatch:\n",
+            "  workflow_run:\n",
+            "  push:\n",
+        ):
+            self.assertNotIn(forbidden, text)
+
+    def test_listener_is_read_only_and_does_not_checkout_candidate_code(self) -> None:
+        text = self.listener
+        self.assertIn("permissions: {}\n", text)
+        self.assertIn("      pull-requests: read\n", text)
+        self.assertIn("      contents: read\n", text)
+        self.assertNotIn("actions: read", text)
+        self.assertNotIn("actions/checkout", text)
+        self.assertNotIn("secrets:", text)
+        self.assertNotIn("contents: write", text)
+        self.assertNotIn("pull-requests: write", text)
+        self.assertNotIn("issues: write", text)
+
+    def test_event_gate_is_trusted_same_repo_develop_commented_review(self) -> None:
+        text = self.listener
+        for required in (
+            "github.event.review.state == 'commented'",
+            "github.event.review.user.login == 'djibian'",
+            "github.event.pull_request.base.ref == 'develop'",
+            "github.event.pull_request.head.repo.full_name == github.repository",
+        ):
+            self.assertIn(required, text)
+
+    def test_canonical_unproven_and_triple_sha_binding_are_fail_closed(self) -> None:
+        text = self.listener
+        self.assertIn(
+            'UNPROVEN_RE = re.compile(r"VERDICT UNPROVEN ([0-9a-f]{40})")',
+            text,
+        )
+        self.assertIn("match = UNPROVEN_RE.fullmatch(line)", text)
+        self.assertIn("declared_sha = match.group(1)", text)
+        self.assertIn("review.get(\"commit_id\") != declared_sha", text)
+        self.assertIn(
+            "(live_pr.get(\"head\") or {}).get(\"sha\") != declared_sha",
+            text,
+        )
+        self.assertIn("target_sha={declared_sha}", text)
+
+    def test_live_pr_is_reread_and_must_still_be_open_same_repo_develop(self) -> None:
+        text = self.listener
+        self.assertIn('live_pr = api_get(f"/pulls/{number}")', text)
+        self.assertIn('live_pr.get("state") != "open"', text)
+        self.assertIn('(live_pr.get("base") or {}).get("ref") != "develop"', text)
+        self.assertIn(
+            '((live_pr.get("head") or {}).get("repo") or {}).get("full_name") != repository',
+            text,
+        )
+
+    def test_review_history_is_paginated_and_first_unproven_is_unique(self) -> None:
+        text = self.listener
+        self.assertIn(
+            'api_get(f"/pulls/{number}/reviews?per_page=100&page={page}")',
+            text,
+        )
+        self.assertIn("if page > 100:", text)
+        self.assertIn("current review is not uniquely present in live review history", text)
+        self.assertIn("an earlier trusted UNPROVEN already exists for this PR HEAD", text)
+        self.assertIn("trusted verdict history for this HEAD is contradictory", text)
+        self.assertIn("item.get(\"commit_id\") != declared_sha", text)
+        self.assertIn("(item.get(\"user\") or {}).get(\"login\") != TRUSTED_AUTHOR", text)
+
+    def test_duplicate_events_are_serialized_without_cancelling_valid_work(self) -> None:
+        text = self.listener
+        self.assertIn(
+            "group: candidate-evidence-unproven-${{ github.event.pull_request.number }}-${{ github.event.review.commit_id }}",
+            text,
+        )
+        self.assertIn("  cancel-in-progress: false\n", text)
+
+    def test_only_validated_sha_reaches_existing_candidate_evidence_capability(self) -> None:
+        text = self.listener
+        self.assertIn("    needs: validate\n", text)
+        self.assertIn("    if: needs.validate.outputs.target_sha != ''\n", text)
+        self.assertIn("uses: ./.github/workflows/candidate-evidence.yml", text)
+        self.assertIn("target_sha: ${{ needs.validate.outputs.target_sha }}", text)
+        self.assertNotIn("full:", text)
+        self.assertNotIn("ci-runtime.yml", text)
+        self.assertNotIn("ci-webots.yml", text)
+
+    def test_listener_is_not_a_notification_or_command_bus(self) -> None:
+        text = self.listener
+        self.assertNotIn("CONTROLLER_HANDOFF", text)
+        self.assertNotIn("ntfy", text.lower())
+        self.assertNotIn("label", text.lower())
+        self.assertNotIn("READY_FOR_REVIEW", text)
+        self.assertNotIn("HUMAN_REQUIRED", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -12,6 +12,7 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 TRANSPORT_WORKFLOWS = {"controller-handoff-ntfy.yml"}
 
 EXPECTED = {
+    "candidate-evidence-on-unproven.yml": {"validate", "evidence"},
     "candidate-evidence.yml": {
         "validate_target",
         "candidate_runtime",


### PR DESCRIPTION
## Tranche 3 — raccord minimal `UNPROVEN` → `Candidate Evidence`

Ajoute le listener strict qui transforme un verdict indépendant `VERDICT UNPROVEN <HEAD>` en une unique acquisition de preuve déterministe sur ce HEAD exact, en réutilisant la capacité intégrée par #139.

### Outcome
Pour une PR same-repository vers `develop`, une review `COMMENTED` soumise par `djibian` dont la première ligne est exactement `VERDICT UNPROVEN <40-hex-sha>` peut déclencher une seule `Candidate Evidence` si et seulement si :
- le SHA déclaré est aussi `review.commit_id` ;
- le HEAD relu de la PR ouverte est toujours ce SHA ;
- la base relue est toujours `develop` ;
- la PR relue est toujours same-repository ;
- l’historique paginé ne contient aucun UNPROVEN trusted antérieur pour ce HEAD et n’est pas contradictoire.

Tout écart échoue fermé et ne lance aucune preuve.

### Boundaries
- `pull_request_review: submitted` uniquement ;
- aucun `pull_request_target`, commentaire-command bus, label, workflow_dispatch, post-merge trigger ou A+ ;
- validation sans checkout, avec seulement `pull-requests: read` ;
- job Evidence avec seulement `contents: read` ;
- aucun secret, aucune écriture, aucun `actions: read` ;
- aucun changement Runtime/Webots/Candidate Evidence ;
- `CI Gate` garde son rôle unique de check requis ; il exécute seulement un nouvel oracle statique ;
- Candidate Evidence reste silencieux et son succès ne vaut jamais `GO` ;
- aucun changement de `main` ni des notifications ntfy.

### Contrat Contrôleur
`AGENTS.md` formalise l’emplacement des preuves, interdit la fusion tant qu’une preuve merge-blocking reste UNPROVEN, rend les reviews de verdict append-only, interdit un second UNPROVEN sur le même HEAD et demande au Reviewer de rester productif pendant Candidate Evidence puis de reconstruire le même HEAD avant GO / NO_GO / HUMAN_REQUIRED.

### Evidence avant revue
`tools/ci/test_candidate_evidence_trigger.py` verrouille les scénarios hostiles statiques : mauvais trigger/permissions, auteur/base/fork, grammaire canonique, triple SHA, relecture live, pagination, duplicate UNPROVEN, concurrency et appel exclusivement via la capacité Candidate Evidence existante.

### Preuve discriminante attendue en revue
La revue indépendante doit particulièrement falsifier le listener. Si le seul élément encore non prouvé est son déclenchement événementiel réel, le Reviewer peut publier `VERDICT UNPROVEN <HEAD>` sur le HEAD exact : ce verdict doit provoquer Candidate Evidence sur ce même HEAD, sans intervention humaine ni modification du candidat. Le Reviewer réévalue ensuite les preuves acquises ; Candidate Evidence n’accorde jamais automatiquement GO.