### PR TITLE
Ignore purely visual top-level Blockly moves

### DIFF
--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -265,8 +265,12 @@ async function runProgram() {
   }
 }
 
+function isPureVisualWorkspaceMove(event) {
+  return !!(event && event.type === Blockly.Events.BLOCK_MOVE &&
+    event.oldParentId == null && event.newParentId == null);
+}
 function onWorkspaceChange(event) {
-  if (!event || event.type === Blockly.Events.UI) return;
+  if (!event || event.type === Blockly.Events.UI || isPureVisualWorkspaceMove(event)) return;
   try { WebeeBlocksActivityContract.applyFieldBounds(runtimeProfile, workspace); } catch (error) { console.error(error); }
   if (!runtimeRunning && runtimeTerminal)
     document.getElementById('runtimeDetail').textContent = 'Programme modifié — réinitialisez la simulation avant de relancer';

--- a/tools/ci/test_runtime_v2_observability.js
+++ b/tools/ci/test_runtime_v2_observability.js
@@ -42,7 +42,7 @@ async function proveProgramInvalidRetryWithoutReset() {
   const profile = {toolbox:['allowed'],parameterBounds:{},runtime:{allowedStatementKinds:['takeoff','land'],rangeDirections:[],moveDirections:[],verticalDirections:[],astBounds:{}}};
   const context = {
     console:{log(){},error(){}},
-    Blockly:{Theme:{defineTheme(){return{};}},Themes:{Classic:{}},Events:{UI:'ui'},Blocks:{}},
+    Blockly:{Theme:{defineTheme(){return{};}},Themes:{Classic:{}},Events:{UI:'ui',BLOCK_MOVE:'move'},Blocks:{}},
     document:{getElementById:element,body:{dataset:{}},createElement(){return{setAttribute(){},appendChild(){}};}},
     window:{dispatchEvent(){},addEventListener(){}},
     CustomEvent:function(type,init){this.type=type;this.detail=init&&init.detail;},
@@ -79,6 +79,15 @@ async function proveProgramInvalidRetryWithoutReset() {
   assert.strictEqual(compileCalls,1,'corrected workspace did not reach compiler on second attempt');
   assert.strictEqual(interpreterRuns,1,'corrected workspace did not execute on second attempt');
   assert.strictEqual(element('runtimeState').textContent,'TERMINÉ');
+  assert.strictEqual(element('runtimeDetail').textContent,'Programme exécuté');
+
+  context.onWorkspaceChange({type:'move',oldParentId:null,newParentId:null});
+  assert.strictEqual(element('runtimeDetail').textContent,'Programme exécuté',
+    'moving an unconnected top-level stack visually must not require simulation reset');
+
+  context.onWorkspaceChange({type:'move',oldParentId:null,newParentId:'parent-block'});
+  assert.strictEqual(element('runtimeDetail').textContent,'Programme modifié — réinitialisez la simulation avant de relancer',
+    'a structural Blockly move must still require simulation reset');
 }
 
 (async()=>{


### PR DESCRIPTION
## Scope
Fix the W2 product finding recorded on #81 where dragging an unconnected top-level Blockly stack to a new screen position incorrectly displays `Programme modifié — réinitialisez la simulation avant de relancer`.

## Change
- treat a Blockly `BLOCK_MOVE` with no parent before or after as a purely visual workspace move;
- preserve the reset warning for structural moves that can change program semantics;
- add a discriminating runtime UI test covering both cases.

## Boundary
No AST, interpreter, backend, project-file or checkpoint/governance behavior is changed.

Refs #81