### PR TITLE
Make missing landing a student-correctable error

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/semantic_ast.js
+++ b/plugins/robot_windows/blockly/webeeblocks/semantic_ast.js
@@ -51,7 +51,7 @@
 
   function rejectNestedFlightBoundaries(sequence){(sequence||[]).forEach(function(statement){if(statement.kind==='takeoff'||statement.kind==='land')fail('takeoff and land are only allowed at top-level boundaries');if(statement.kind==='repeat')rejectNestedFlightBoundaries(statement.body);if(statement.kind==='if'){rejectNestedFlightBoundaries(statement.then);rejectNestedFlightBoundaries(statement.else);}});}
   function validateFlightBoundaries(program){
-    if(program.length<2||program[0].kind!=='takeoff'||program[program.length-1].kind!=='land')fail('program must start with takeoff and end with land');
+    if(program.length<2||program[0].kind!=='takeoff'||program[program.length-1].kind!=='land')studentFail('program must start with takeoff and end with land','Le programme doit commencer par « décoller » et se terminer par « atterrir ».');
     for(var i=0;i<program.length;i++){
       var statement=program[i];
       if(statement.kind==='takeoff'&&i!==0)fail('takeoff is only allowed as the first top-level statement');

--- a/tools/ci/test_runtime_v2_preflight.js
+++ b/tools/ci/test_runtime_v2_preflight.js
@@ -158,6 +158,14 @@ async function proveUnavailableBackendCapabilityIsStudentCorrectable() {
     () => SemanticAst.compileWorkspace({getTopBlocks: () => []}),
     /programme relié/
   );
+  mustRejectStudentValidation(
+    () => SemanticAst.compileWorkspace({getTopBlocks: () => [{
+      type: 'webeeblocks_v2_takeoff',
+      getFieldValue: name => name === 'HEIGHT' ? 0.5 : null,
+      getNextBlock: () => null
+    }]}),
+    /se terminer par « atterrir »/
+  );
 
   let compilerCalled = false;
   let interpreterCalled = false;
@@ -184,7 +192,7 @@ async function proveUnavailableBackendCapabilityIsStudentCorrectable() {
 
   await proveUnavailableBackendCapabilityIsStudentCorrectable();
 
-  console.log('PASS Runtime v2 preflight rejects malformed AST and gives fail-closed student guidance for forbidden, disconnected, or backend-unavailable Blockly programs');
+  console.log('PASS Runtime v2 preflight rejects malformed AST and gives fail-closed student guidance for missing flight boundaries, forbidden, disconnected, or backend-unavailable Blockly programs');
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
## Scope
Fix the W2 finding on #81 where a program that omits the final `atterrir` block surfaces as a generic technical error.

## Change
- classify invalid top-level flight boundaries as `PROGRAM_INVALID`;
- show a French student-facing correction message requiring `décoller` first and `atterrir` last;
- add a preflight regression test for a takeoff-only program.

## Boundary
No AST shape, interpreter semantics, backend protocol, safety rule, project-file behavior or governance mechanism is weakened.

Refs #81