### PR TITLE
Add voluntary stop for active simulation flights

### DIFF
--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -339,11 +339,12 @@ int main(void) {
         continue;
       }
       if (request.kind == REQUEST_STOP) {
-        if (command == CMD_IDLE || command == CMD_RESET) {
+        if (command == CMD_RESET) {
           response_error(request.id, "NOT_RUNNING");
           continue;
         }
-        response_error(active_id, "USER_STOPPED");
+        if (active_id >= 1)
+          response_error(active_id, "USER_STOPPED");
         target_x = x;
         target_y = y;
         target_z = z;

--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -45,7 +45,8 @@ typedef enum {
   REQUEST_MOVE,
   REQUEST_LAND,
   REQUEST_RANGE,
-  REQUEST_RESET
+  REQUEST_RESET,
+  REQUEST_STOP
 } request_kind_t;
 
 typedef struct {
@@ -163,6 +164,8 @@ static request_t parse_request(const char *message) {
       request.kind = REQUEST_LAND;
     else if (strcmp(command, "RESET") == 0)
       request.kind = REQUEST_RESET;
+    else if (strcmp(command, "STOP") == 0)
+      request.kind = REQUEST_STOP;
     return request;
   }
 
@@ -333,6 +336,28 @@ int main(void) {
         continue;
       if (request.kind == REQUEST_INVALID) {
         response_error(request.id, "INVALID_REQUEST");
+        continue;
+      }
+      if (request.kind == REQUEST_STOP) {
+        if (command == CMD_IDLE || command == CMD_RESET) {
+          response_error(request.id, "NOT_RUNNING");
+          continue;
+        }
+        response_error(active_id, "USER_STOPPED");
+        target_x = x;
+        target_y = y;
+        target_z = z;
+        target_yaw = yaw;
+        airborne = z > origin_z + ALT_TOL ? 1 : 0;
+        failsafe_latched = 1;
+        command = CMD_IDLE;
+        active_id = -1;
+        active_value = 0.0;
+        active_direction[0] = '\0';
+        stable_since = -1.0;
+        response_ok(request.id);
+        if (!airborne)
+          stop_motors(m1, m2, m3, m4);
         continue;
       }
       if (command != CMD_IDLE) {

--- a/plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js
+++ b/plugins/robot_windows/blockly/webeeblocks/runtime_outcome.js
@@ -19,6 +19,13 @@
         machineCode: machineCode
       };
     }
+    if (machineCode === 'USER_STOPPED') {
+      return {
+        state: 'ARRÊTÉ',
+        detail: 'Vol arrêté — réinitialisez la simulation avant de relancer',
+        machineCode: machineCode
+      };
+    }
     if (machineCode === 'UNSAFE_OR_TIMEOUT') {
       return {
         state: 'ARRÊTÉ',

--- a/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
+++ b/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
@@ -27,6 +27,7 @@
     this.pending = Object.create(null);
     this.ready = false;
     this.readyWaiters = [];
+    this.simulationStopped = false;
     var capabilities = {
       actions: ['takeoff', 'move', 'land'],
       rangeDirections: ['front'],
@@ -122,13 +123,18 @@
     return true;
   };
 
-  RuntimeV2WwiBackend.prototype.takeoff = function(heightM) { return this._request(['TAKEOFF', Number(heightM).toPrecision(17)]); };
-  RuntimeV2WwiBackend.prototype.move = function(direction, distanceM) { return this._request(['MOVE', String(direction), Number(distanceM).toPrecision(17)]); };
-  RuntimeV2WwiBackend.prototype.land = function() { return this._request(['LAND']); };
-  RuntimeV2WwiBackend.prototype.readRange = function(direction) { return this._request(['RANGE', String(direction)]); };
+  RuntimeV2WwiBackend.prototype._guardSimulationStopped = function() {
+    return this.simulationStopped ? Promise.reject(new RuntimeV2BackendError('USER_STOPPED')) : null;
+  };
+
+  RuntimeV2WwiBackend.prototype.takeoff = function(heightM) { return this._guardSimulationStopped() || this._request(['TAKEOFF', Number(heightM).toPrecision(17)]); };
+  RuntimeV2WwiBackend.prototype.move = function(direction, distanceM) { return this._guardSimulationStopped() || this._request(['MOVE', String(direction), Number(distanceM).toPrecision(17)]); };
+  RuntimeV2WwiBackend.prototype.land = function() { return this._guardSimulationStopped() || this._request(['LAND']); };
+  RuntimeV2WwiBackend.prototype.readRange = function(direction) { return this._guardSimulationStopped() || this._request(['RANGE', String(direction)]); };
   RuntimeV2WwiBackend.prototype.stopSimulation = function() {
     if (!this.capabilities || this.capabilities.simulationStop !== true)
       return Promise.reject(new Error('Runtime v2 simulation stop unavailable'));
+    this.simulationStopped = true;
     return this._request(['STOP']);
   };
   RuntimeV2WwiBackend.prototype.resetSimulation = function() {
@@ -139,6 +145,7 @@
     var self = this;
     return this._request(['RESET']).then(function(value) {
       self.ready = true;
+      self.simulationStopped = false;
       return value;
     }, function(error) {
       self.ready = true;

--- a/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
+++ b/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
@@ -37,6 +37,8 @@
       capabilities.simulationDebug = true;
     if (options && options.simulationReset === true)
       capabilities.simulationReset = true;
+    if (options && options.simulationStop === true)
+      capabilities.simulationStop = true;
     this.capabilities = Object.freeze(capabilities);
   }
 
@@ -124,6 +126,11 @@
   RuntimeV2WwiBackend.prototype.move = function(direction, distanceM) { return this._request(['MOVE', String(direction), Number(distanceM).toPrecision(17)]); };
   RuntimeV2WwiBackend.prototype.land = function() { return this._request(['LAND']); };
   RuntimeV2WwiBackend.prototype.readRange = function(direction) { return this._request(['RANGE', String(direction)]); };
+  RuntimeV2WwiBackend.prototype.stopSimulation = function() {
+    if (!this.capabilities || this.capabilities.simulationStop !== true)
+      return Promise.reject(new Error('Runtime v2 simulation stop unavailable'));
+    return this._request(['STOP']);
+  };
   RuntimeV2WwiBackend.prototype.resetSimulation = function() {
     if (!this.capabilities || this.capabilities.simulationReset !== true)
       return Promise.reject(new Error('Runtime v2 simulation reset unavailable'));

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -33,6 +33,7 @@
       <button id="projectSave" type="button">Enregistrer</button>
       <button id="projectSaveAs" type="button">Enregistrer sous</button>
       <button id="resetSimulation" type="button" hidden disabled>Réinitialiser</button>
+      <button id="stopSimulation" type="button" hidden disabled>Arrêter le vol</button>
       <button id="submit" disabled>Lancer le vol</button>
     </div>
   </header>

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -5,6 +5,7 @@ var runtimeBackend = null;
 var runtimeRunning = false;
 var runtimeTerminal = false;
 var runtimeResetPending = false;
+var runtimeStopPending = false;
 var runtimeDebug = null;
 
 var WEBEEBLOCKS_WORKSPACE_SCALE = 0.90;
@@ -41,11 +42,17 @@ function updateRuntimeActions() {
   var ready = !!(runtimeBackend && runtimeBackend.ready);
   var submit = document.getElementById('submit');
   var reset = document.getElementById('resetSimulation');
-  submit.disabled = !ready || runtimeRunning || runtimeTerminal || runtimeResetPending;
+  var stop = document.getElementById('stopSimulation');
+  submit.disabled = !ready || runtimeRunning || runtimeTerminal || runtimeResetPending || runtimeStopPending;
+  if (stop) {
+    var stopSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationStop === true);
+    stop.hidden = !stopSupported || !runtimeRunning;
+    stop.disabled = !stopSupported || !ready || !runtimeRunning || runtimeStopPending;
+  }
   if (reset) {
     var resetSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationReset === true);
     reset.hidden = !resetSupported;
-    reset.disabled = !resetSupported || !ready || runtimeRunning || runtimeResetPending || !runtimeTerminal;
+    reset.disabled = !resetSupported || !ready || runtimeRunning || runtimeResetPending || runtimeStopPending || !runtimeTerminal;
   }
 }
 
@@ -195,6 +202,26 @@ function serializedWorkspace() {
   return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
+async function stopSimulation() {
+  if (!runtimeRunning || runtimeStopPending || !runtimeBackend || !runtimeBackend.ready)
+    return;
+  if (!runtimeBackend.capabilities || runtimeBackend.capabilities.simulationStop !== true)
+    return;
+  runtimeStopPending = true;
+  updateRuntimeActions();
+  setDebugControls(false);
+  try {
+    await runtimeBackend.stopSimulation();
+  } catch (error) {
+    runtimeRunning = false;
+    runtimeTerminal = true;
+    setRuntimeFailure(error);
+  } finally {
+    runtimeStopPending = false;
+    updateRuntimeActions();
+  }
+}
+
 async function resetSimulation() {
   if (runtimeRunning || runtimeResetPending || !runtimeTerminal || !runtimeBackend || !runtimeBackend.ready)
     return;
@@ -283,6 +310,7 @@ function wireWorkspaceControls() {
     workspace.setScale(WEBEEBLOCKS_WORKSPACE_SCALE); if (typeof workspace.scrollCenter === 'function') workspace.scrollCenter();
   });
   document.getElementById('resetSimulation').addEventListener('click', resetSimulation);
+  document.getElementById('stopSimulation').addEventListener('click', stopSimulation);
 }
 
 window.onload = async function() {
@@ -302,7 +330,7 @@ window.onload = async function() {
   try {
     var module = await import('./webots/RobotWindow.js');
     robotWindow = new module.default();
-    runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true, simulationReset: true});
+    runtimeBackend = new WebeeBlocksWwiBackend(robotWindow, {timeoutMs: 35000, simulationDebug: true, simulationReset: true, simulationStop: true});
     robotWindow.receive = receiveMessage;
     setRuntimeStatus('INITIALISATION', 'Connexion à la simulation');
     await runtimeBackend.waitUntilReady();

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -6,6 +6,7 @@ var runtimeRunning = false;
 var runtimeTerminal = false;
 var runtimeResetPending = false;
 var runtimeStopPending = false;
+var runtimeStopRequested = false;
 var runtimeDebug = null;
 
 var WEBEEBLOCKS_WORKSPACE_SCALE = 0.90;
@@ -46,8 +47,8 @@ function updateRuntimeActions() {
   submit.disabled = !ready || runtimeRunning || runtimeTerminal || runtimeResetPending || runtimeStopPending;
   if (stop) {
     var stopSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationStop === true);
-    stop.hidden = !stopSupported || !runtimeRunning;
-    stop.disabled = !stopSupported || !ready || !runtimeRunning || runtimeStopPending;
+    stop.hidden = !stopSupported || !runtimeRunning || runtimeStopRequested;
+    stop.disabled = !stopSupported || !ready || !runtimeRunning || runtimeStopPending || runtimeStopRequested;
   }
   if (reset) {
     var resetSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationReset === true);
@@ -196,6 +197,12 @@ function wireDebugControls() {
   document.getElementById('stepContinue').addEventListener('click', function() { runtimeDebug.continueRun(); });
 }
 
+function userStoppedError() {
+  var error = new Error('Runtime v2 simulation stopped by user');
+  error.code = 'USER_STOPPED';
+  return error;
+}
+
 function serializedWorkspace() {
   if (!workspace || !Blockly.serialization || !Blockly.serialization.workspaces)
     throw new Error('Blockly workspace serialization unavailable');
@@ -208,12 +215,15 @@ async function stopSimulation() {
   if (!runtimeBackend.capabilities || runtimeBackend.capabilities.simulationStop !== true)
     return;
   runtimeStopPending = true;
+  runtimeStopRequested = true;
   updateRuntimeActions();
   setDebugControls(false);
+  if (runtimeDebug) runtimeDebug.continueRun();
   try {
     await runtimeBackend.stopSimulation();
+    runtimeTerminal = true;
+    setRuntimeFailure(userStoppedError());
   } catch (error) {
-    runtimeRunning = false;
     runtimeTerminal = true;
     setRuntimeFailure(error);
   } finally {
@@ -243,6 +253,7 @@ async function resetSimulation() {
     if (runtimeProfile !== profile)
       throw new Error('Simulation reset changed activity profile');
     runtimeTerminal = false;
+    runtimeStopRequested = false;
     renderSensorValues({});
     renderVariables(null);
     if (runtimeDebug) runtimeDebug.finish();
@@ -260,7 +271,7 @@ async function resetSimulation() {
 }
 
 async function runProgram() {
-  if (runtimeRunning || runtimeTerminal || runtimeResetPending || !runtimeBackend || !runtimeBackend.ready) return;
+  if (runtimeRunning || runtimeTerminal || runtimeResetPending || runtimeStopPending || !runtimeBackend || !runtimeBackend.ready) return;
   var submit = document.getElementById('submit');
   var stepMode = document.getElementById('stepMode');
   var debugRequested = stepMode.checked === true;
@@ -270,6 +281,7 @@ async function runProgram() {
   }
   submit.disabled = true;
   runtimeTerminal = false;
+  runtimeStopRequested = false;
   var hooks = runtimeDebug ? runtimeDebug.begin(debugRequested) : null;
   try {
     await WebeeBlocksActivityContract.execute(runtimeProfile, workspace, WebeeBlocksSemanticAst, WebeeBlocksInterpreter, runtimeBackend, {
@@ -280,6 +292,7 @@ async function runProgram() {
         runtimeRunning = true; setDebugControls(false); setRuntimeStatus('EN VOL', 'Programme réactif en cours');
       }
     });
+    if (runtimeStopRequested) throw userStoppedError();
     runtimeRunning = false; runtimeTerminal = true; setRuntimeStatus('TERMINÉ', 'Programme exécuté');
   } catch (error) {
     runtimeRunning = false;

--- a/tools/ci/test_runtime_v2_observability.js
+++ b/tools/ci/test_runtime_v2_observability.js
@@ -25,6 +25,11 @@ assert.match(mainSource, /await runtimeBackend\.stopSimulation\(\)/);
 assert.match(controllerSource, /request\.kind == REQUEST_STOP/);
 assert.match(controllerSource, /response_error\(active_id, "USER_STOPPED"\)/);
 assert.match(controllerSource, /target_x = x;[\s\S]*target_y = y;[\s\S]*target_z = z;[\s\S]*failsafe_latched = 1;/);
+assert.doesNotMatch(controllerSource, /command == CMD_IDLE \|\| command == CMD_RESET/);
+assert.match(controllerSource, /if \(active_id >= 1\)[\s\S]*response_error\(active_id, "USER_STOPPED"\)/);
+assert.match(mainSource, /runtimeStopRequested = true;/);
+assert.match(mainSource, /runtimeDebug\.continueRun\(\)/);
+assert.match(mainSource, /if \(runtimeStopRequested\) throw userStoppedError\(\);/);
 
 function block(id,type,inputs){return{id,type,_next:null,_inputs:inputs||{},getNextBlock(){return this._next;},getInputTargetBlock(name){return this._inputs[name]||null;}};}
 function link(){var blocks=Array.from(arguments);for(var i=0;i<blocks.length-1;i++)blocks[i]._next=blocks[i+1];return blocks[0];}
@@ -113,7 +118,7 @@ async function proveProgramInvalidRetryWithoutReset() {
   await until(()=>pauses.length===7,'chosen move');assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4]]);assert.deepStrictEqual(pauses[6].slice(0,2),['left-action','move']);obs.continueRun();await run;obs.finish();
   assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4],['move','left',.3],['range','front',.8],['move','forward',.3],['range','front',.3],['move','left',.3],['land']]);
   var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true,simulationStop:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(Outcome.isRetryable({code:'PROGRAM_INVALID'}),true);assert.strictEqual(Outcome.isRetryable(error),false);assert.strictEqual(Outcome.isRetryable(Error('technical')),false);assert.strictEqual(wwi.capabilities.simulationDebug,true);assert.strictEqual(wwi.capabilities.simulationStop,true);
-  var stopSent=[],stopBackend=new WwiBackend({send:m=>stopSent.push(m)},{timeoutMs:500,simulationStop:true});
+  var stopSent=[],stopBackend=new WwiBackend({send:m=>stopSent.push(m)},{timeoutMs:500,simulationStop:true,simulationReset:true});
   var activeMove=stopBackend.move('forward',2),stopRequest=stopBackend.stopSimulation();
   assert.match(stopSent[0],/ REQUEST 1 MOVE forward /);assert.match(stopSent[1],/ REQUEST 2 STOP$/);
   stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR USER_STOPPED');
@@ -124,6 +129,10 @@ async function proveProgramInvalidRetryWithoutReset() {
   assert.strictEqual(Object.keys(stopBackend.pending).length,0);
   assert.strictEqual(stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 OK'),true);
   assert.strictEqual(Object.keys(stopBackend.pending).length,0);
+  var sentBeforeBlockedMove=stopSent.length,blockedMove=stopBackend.move('forward',.3),blockedError;try{await blockedMove;}catch(e){blockedError=e;}
+  assert.strictEqual(blockedError.code,'USER_STOPPED');assert.strictEqual(stopSent.length,sentBeforeBlockedMove,'stopped backend emitted a later AST action');
+  var resetRequest=stopBackend.resetSimulation();assert.match(stopSent[stopSent.length-1],/ REQUEST 3 RESET$/);stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 3 OK');await resetRequest;
+  var afterReset=stopBackend.move('forward',.3);assert.match(stopSent[stopSent.length-1],/ REQUEST 4 MOVE forward /);stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 4 OK');await afterReset;
   var physical=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:false});assert.notStrictEqual(physical.capabilities.simulationDebug,true);
   console.log('PASS: invalid programs are retryable through the real UI runtime without reset, execution state stays coherent, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
 })().catch(e=>{console.error(e.stack||e);process.exit(1);});

--- a/tools/ci/test_runtime_v2_observability.js
+++ b/tools/ci/test_runtime_v2_observability.js
@@ -10,6 +10,7 @@ const ActivityContract = require('../../plugins/robot_windows/blockly/webeeblock
 const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_backend.js');
 
 const mainSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/main.js'), 'utf8');
+const controllerSource = fs.readFileSync(path.resolve(__dirname, '../../controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c'), 'utf8');
 const projectUiSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
 const classroomFixesSource = fs.readFileSync(path.resolve(__dirname, '../../plugins/robot_windows/blockly_v2/classroom_fixes.css'), 'utf8');
 assert.match(mainSource, /getElementById\('stepContinue'\)\.disabled = !paused;/);
@@ -19,6 +20,11 @@ assert.match(projectUiSource, /setRuntimeLocked\(state === 'EN VOL' \|\| state =
 assert.match(projectUiSource, /blocklyDiv\.inert = runtimeLocked;/);
 assert.match(projectUiSource, /if \(open\) open\.disabled = locked;/);
 assert.match(projectUiSource, /if \(busy \|\| !supported \|\| runtimeLocked\) return null;/);
+assert.match(mainSource, /getElementById\('stopSimulation'\)/);
+assert.match(mainSource, /await runtimeBackend\.stopSimulation\(\)/);
+assert.match(controllerSource, /request\.kind == REQUEST_STOP/);
+assert.match(controllerSource, /response_error\(active_id, "USER_STOPPED"\)/);
+assert.match(controllerSource, /target_x = x;[\s\S]*target_y = y;[\s\S]*target_z = z;[\s\S]*failsafe_latched = 1;/);
 
 function block(id,type,inputs){return{id,type,_next:null,_inputs:inputs||{},getNextBlock(){return this._next;},getInputTargetBlock(name){return this._inputs[name]||null;}};}
 function link(){var blocks=Array.from(arguments);for(var i=0;i<blocks.length-1;i++)blocks[i]._next=blocks[i+1];return blocks[0];}
@@ -106,7 +112,18 @@ async function proveProgramInvalidRetryWithoutReset() {
   await until(()=>pauses.length===6,'if');assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4]]);assert.deepStrictEqual(pauses[5].slice(0,2),['if','if']);assert.strictEqual(pauses[5][3],false);obs.next();
   await until(()=>pauses.length===7,'chosen move');assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4]]);assert.deepStrictEqual(pauses[6].slice(0,2),['left-action','move']);obs.continueRun();await run;obs.finish();
   assert.deepStrictEqual(c.trace,[['takeoff',1],['range','front',.4],['move','left',.3],['range','front',.8],['move','forward',.3],['range','front',.3],['move','left',.3],['land']]);
-  var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(Outcome.isRetryable({code:'PROGRAM_INVALID'}),true);assert.strictEqual(Outcome.isRetryable(error),false);assert.strictEqual(Outcome.isRetryable(Error('technical')),false);assert.strictEqual(wwi.capabilities.simulationDebug,true);
+  var sent=[],wwi=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:true,simulationStop:true});var req=wwi.move('forward',2);wwi.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR UNSAFE_OR_TIMEOUT');var error;try{await req;}catch(e){error=e;}assert.strictEqual(error.code,'UNSAFE_OR_TIMEOUT');assert.strictEqual(error.message,'Runtime v2 backend error: UNSAFE_OR_TIMEOUT');assert.deepStrictEqual(Outcome.classify(error),{state:'ARRÊTÉ',detail:'L’action n’a pas pu être terminée',machineCode:'UNSAFE_OR_TIMEOUT'});assert.strictEqual(Outcome.classify(Error('technical')).state,'ERREUR');assert.strictEqual(Outcome.isRetryable({code:'PROGRAM_INVALID'}),true);assert.strictEqual(Outcome.isRetryable(error),false);assert.strictEqual(Outcome.isRetryable(Error('technical')),false);assert.strictEqual(wwi.capabilities.simulationDebug,true);assert.strictEqual(wwi.capabilities.simulationStop,true);
+  var stopSent=[],stopBackend=new WwiBackend({send:m=>stopSent.push(m)},{timeoutMs:500,simulationStop:true});
+  var activeMove=stopBackend.move('forward',2),stopRequest=stopBackend.stopSimulation();
+  assert.match(stopSent[0],/ REQUEST 1 MOVE forward /);assert.match(stopSent[1],/ REQUEST 2 STOP$/);
+  stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 ERR USER_STOPPED');
+  var stoppedError;try{await activeMove;}catch(e){stoppedError=e;}
+  assert.strictEqual(stoppedError.code,'USER_STOPPED');
+  assert.deepStrictEqual(Outcome.classify(stoppedError),{state:'ARRÊTÉ',detail:'Vol arrêté — réinitialisez la simulation avant de relancer',machineCode:'USER_STOPPED'});
+  stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 2 OK');await stopRequest;
+  assert.strictEqual(Object.keys(stopBackend.pending).length,0);
+  assert.strictEqual(stopBackend.handleMessage('WEBEEBLOCKS_RUNTIME_V2 RESPONSE 1 OK'),true);
+  assert.strictEqual(Object.keys(stopBackend.pending).length,0);
   var physical=new WwiBackend({send:m=>sent.push(m)},{timeoutMs:500,simulationDebug:false});assert.notStrictEqual(physical.capabilities.simulationDebug,true);
   console.log('PASS: invalid programs are retryable through the real UI runtime without reset, execution state stays coherent, Continue is pause-only, observability remains optional, semantic stepping hides branch outcomes, raw sensor is fresh, movement waits for its own step, and machine codes remain testable.');
 })().catch(e=>{console.error(e.stack||e);process.exit(1);});


### PR DESCRIPTION
## Scope
Implement #147: allow a student to stop an active **simulation** flight without modifying the Blockly program.

## Change
- add a simulation-only `Arrêter le vol` action visible only while Runtime v2 is executing;
- add a dedicated WWI `STOP` request outside the student AST;
- accept STOP before generic BUSY handling in the Webots controller;
- reject the active action as `USER_STOPPED`, hold the current measured pose when airborne, latch reset-required state, and prevent queued AST actions from continuing;
- classify `USER_STOPPED` as neutral `ARRÊTÉ` with reset/replay guidance;
- add regression evidence for UI wiring, protocol cancellation, pending-request cleanup and late-response no-op behavior.

## Safety boundary
STOP does not inject `land`, does not bypass the existing reset requirement, and does not add a Blockly statement or physical-flight control path. Existing timeout/failsafe semantics remain intact.

Refs #147
Refs #81