### PR TITLE
Require final reconstruction before Controller termination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,11 @@ At launch and after every durable transition:
 5. otherwise start the highest-value product work not already sufficiently
    covered, in an isolated short branch; publish a PR only once real durable work
    exists, Draft if still mutable and Ready if complete;
-6. if no useful eligible action exists, terminate silently.
+6. before terminating, resolve exact current main and rebuild relevant engaged
+   GitHub work one final time, then apply this Controller loop again. Terminate
+   silently only if that reconstruction exposes no useful eligible action.
+   Completion of the execution's current local work is never by itself a
+   termination condition.
 
 Pending CI is not a reason to notify or globally idle. Use its latency for
 independent useful work when available.

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -69,6 +69,11 @@ class ContractTests(unittest.TestCase):
         ):
             self.assertNotIn(obsolete, combined)
 
+    def test_termination_requires_final_reconstruction(self):
+        self.assertIn("rebuild relevant engaged GitHub work one final time", self.contract)
+        self.assertIn("Terminate silently only if that reconstruction exposes no useful eligible action", self.contract)
+        self.assertIn("current local work is never by itself a termination condition", self.contract)
+
     def test_roadmap_records_w1_w2_and_findings(self):
         self.assertIn("W1 — coherence: PASS", self.roadmap)
         self.assertIn("W2 — 30-minute stability: PASS", self.roadmap)


### PR DESCRIPTION
## Problem

V4 Controllers have twice terminated after completing their local action while useful eligible engaged work still remained in GitHub.

- In one run, the Controller stopped after restoring/progressing the current work while #145 still remained to be closed.
- In the clearest reproduction, the Controller published `GO 2250beb629aed3fe9ec3af6c477cf9b20b60e809` on #145 after exact-candidate CI succeeded, while #145 was Ready, clean, up to date with `main`, and immediately mergeable. It then terminated instead of merging. #150 also had a bounded applicable NO_GO that could be progressed.

The demonstrated gap is termination proof, not scheduling: the existing Controller loop already prefers reducing engaged work and uses pending CI latency productively.

## Change

- Require one final reconstruction of exact current `main` and relevant engaged GitHub work before termination, followed by another application of the Controller loop.
- State explicitly that completion of the execution's current local work is not by itself a termination condition.
- Add a minimal static oracle protecting exactly those semantics.

## Scope

Only:
- `AGENTS.md`
- `tools/ci/test_controller_contract.py`

No workflow, CI, notification, human-checkpoint, roadmap, external prompt, product-code, scheduler, or V4-principle changes.