### PR TITLE
Harden V4 optimistic candidate integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,12 +53,22 @@ Each execution works in its own isolated worktree/checkout and branch context.
 Draft and Ready are the collaboration states for a PR.
 
 - Draft means mutable work in progress.
-- Ready means an exact candidate frozen for validation.
-- CI, independent review and verdict are decision evidence only for the exact
-  Ready HEAD they name. A Draft may run non-decision checks, but it must never
-  publish the required check context named `CI Gate`.
-- Any new HEAD is a new candidate. Before substantive mutation of a Ready PR,
-  return it to Draft; after mutation, mark it Ready and obtain fresh CI/review.
+- Ready means the current exact HEAD is offered for validation and is expected
+  to remain stable under the normal collaboration protocol; it is not a
+  coordination lock.
+- CI and positive independent review/GO evidence are decision-authoritative only
+  for the exact Ready HEAD they name. A Draft may run non-decision checks, but it
+  must never publish the required check context named `CI Gate`.
+- Any new HEAD is a new candidate. Positive decision evidence for prior HEADs
+  cannot authorize it.
+- Findings from authoritative refutations remain decision-relevant while
+  applicable. Before a later candidate can receive GO, its independent review
+  must establish every still-applicable such finding as resolved or no longer
+  applicable.
+- A Controller that observes a Ready PR and intends substantive mutation must
+  return it to Draft first; after mutation, mark it Ready and obtain fresh
+  CI/review. Concurrent Ready/push races are tolerated and reconciled from the
+  resulting exact HEAD.
 - An execution that mutated a PR cannot provide its independent review during
   the same execution. It may repair that PR after recording NO_GO; another
   execution supplies the next independent review.
@@ -81,6 +91,9 @@ make it unsuitable as the base for subsequent development.
 - A Ready candidate may enter main only with successful exact-candidate CI, an
   applicable independent GO, no unresolved applicable refutation, and an
   up-to-date base as required by branch protection.
+- Integration must be conditional on the exact validated PR HEAD and must use
+  that SHA as `expected_head_sha`. If the PR HEAD moves before the merge effect,
+  the merge must fail/no-op and the Controller reconstructs current GitHub state.
 - Integration is serialized. If another merge moves the base and updating a PR
   creates a new HEAD, obtain fresh CI and fresh independent review.
 - A late NO_GO on an already merged candidate becomes durable trunk-health

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -38,14 +38,21 @@ class ContractTests(unittest.TestCase):
         self.assertIn("Durability does not imply trust", self.development)
         self.assertIn("github-actions[bot]", self.notifications)
 
-    def test_exact_candidate_and_independent_review(self):
+    def test_optimistic_candidate_validation_and_exact_head_integration(self):
         self.assertIn("Draft means mutable work in progress", self.contract)
-        self.assertIn("Ready means an exact candidate frozen for validation", self.contract)
-        self.assertIn("Any new HEAD is a new candidate", self.contract)
+        self.assertIn("Ready means the current exact HEAD is offered for validation", self.contract)
+        self.assertIn("it is not a coordination lock", self.contract)
+        self.assertIn("Positive decision evidence for prior HEADs cannot authorize it", self.contract)
+        self.assertIn("Findings from authoritative refutations remain decision-relevant while applicable", self.contract)
+        self.assertIn("Before a later candidate can receive GO", self.contract)
+        self.assertIn("independent review must establish every still-applicable such finding as resolved or no longer applicable", self.contract)
+        self.assertIn("observes a Ready PR and intends substantive mutation", self.contract)
+        self.assertIn("Concurrent Ready/push races are tolerated", self.contract)
         self.assertIn("must never publish the required check context named `CI Gate`", self.contract)
-        self.assertIn("fresh CI and fresh independent review", self.contract)
         self.assertIn("mutated a PR cannot provide its independent review", self.contract)
         self.assertIn("may repair that PR after recording NO_GO", self.contract)
+        self.assertIn("`expected_head_sha`", self.contract)
+        self.assertIn("merge must fail/no-op and the Controller reconstructs current GitHub state", self.contract)
 
     def test_healthy_main_and_late_refutation(self):
         self.assertIn("main is the single long-lived trunk", self.contract)


### PR DESCRIPTION
## Why

The multi-Controller stress test showed that Draft/Ready remains useful for collaboration but cannot act as a transactional lock under concurrent pushes. The safety model should therefore be explicit about where authority actually lives.

## Change

- `Ready` is an expected-stability convention, not a coordination lock.
- Positive decision evidence authorizes only the exact SHA it names.
- Findings from authoritative refutations remain decision-relevant while applicable; a later candidate cannot receive GO until its independent review establishes them resolved or no longer applicable.
- Integration must use the validated PR SHA as `expected_head_sha`; a moved HEAD causes fail/no-op and reconstruction.

## Scope

Only:
- `AGENTS.md`
- `tools/ci/test_controller_contract.py`

No CI/workflow, notification, checkpoint, roadmap, prompt, product-code, scheduler, lock, lease, ownership, or agent-state changes.