### PR TITLE
Define reference Crazyflie deck capability coverage

### DIFF
--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -67,6 +67,22 @@ The same student program should be able to target Webots and, when relevant and 
 
 Activity authoring does **not** currently require a teacher-facing graphical editor. Activities may be maintained as declarative, versionable files and created/modified by the project owner with AI/development assistance. Do not build a large “activity studio” without a demonstrated need.
 
+## Reference Crazyflie capability coverage
+
+The reference physical platform is **Crazyflie 2.1 with Flow Deck V2, Multi-ranger and a bottom-mounted Color LED Deck**.
+
+WebeeBlocks should cover as completely as practical the **pedagogically useful capabilities** of this reference hardware through the smallest coherent set of generic, composable Blockly primitives. The objective is capability coverage, not maximum block count or one block per firmware feature.
+
+Capability breadth belongs to the global Blockly/runtime catalogue. Individual activity profiles expose only the subset needed for their learning objective, so a rich platform does not imply a complex beginner toolbox.
+
+For student-facing capabilities, preserve when relevant the same intent through:
+
+`activity/profile → Blockly → backend-neutral AST → preflight → shared interpreter → backend`
+
+A capability intended for both simulation and real hardware should have an observable equivalent in Webots and on the physical backend once that backend is proven safe. Internal estimator diagnostics, firmware tuning parameters and safety mechanisms remain infrastructure unless a demonstrated pedagogical need makes them student-facing.
+
+The Webots reference Crazyflie should eventually represent the bottom-mounted Color LED Deck with a **simple, reasonably recognizable model and a visible controllable light surface**. Simulate the pedagogically observable light effect, not deck electronics, electrical consumption, thermal behavior or photometric fidelity.
+
 ## Execution observability
 
 WebeeBlocks should make program execution observable **without helping the student solve the algorithm**.
@@ -182,3 +198,4 @@ WebeeBlocks is not intended to become:
 9. **Generic configurable activities over task-specific product forks**.
 10. **WebeeBlocks stays a focused training tool; Moodle and evaluation remain external concerns**.
 11. **Blockly 13.2.1 + Zelos is the fixed visual-programming foundation; Scratch familiarity guides ergonomics without turning WebeeBlocks into a Scratch clone**.
+12. **Broad reference-hardware capability coverage through a small generic Blockly vocabulary, with simulation/physical continuity where relevant**.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,11 @@ here.
 3. **#79 — fully French student interface**
 4. **#66 — progressive pedagogical activity model**
 
+Secondary / opportunistic product work:
+
+- **#157 — reference Crazyflie/deck capability coverage**, complementing #66
+  without displacing the current pedagogical progression priority.
+
 Research / later work:
 
 - **#70 — world altitude over surface discontinuities**
@@ -132,6 +137,24 @@ revalidated on that current source before new physical evidence is requested.
 - note: mass activity production may rely on the settled option A presentation
   direction but still follows current product priority.
 
+### C1 — cover the reference Crazyflie/deck capability surface
+
+- parent: #157
+- depends: PRODUCT_VISION.md and the generic activity/profile architecture
+- target hardware: Crazyflie 2.1 + Flow Deck V2 + Multi-ranger +
+  bottom-mounted Color LED Deck
+- action: inventory pedagogically useful capabilities, map each to the smallest
+  generic/composable Blockly and backend-neutral semantics, then implement
+  missing slices without maximizing block count
+- proof: a compact capability matrix covering Blockly/AST, Webots and physical
+  backend support or an explicit justified exclusion
+- simulation direction: where relevant, student-facing capabilities have an
+  observable Webots equivalent; Color LED coverage may use a simple,
+  reasonably recognizable bottom-deck model with a visible controllable light
+  surface rather than detailed electronics simulation
+- scheduling: secondary/opportunistic product work; do not displace #66 merely
+  to broaden hardware coverage.
+
 ### X3 — reconstruct and validate the minimal surface-offset Lab prototype
 
 - parent: #70
@@ -170,8 +193,8 @@ revalidated on that current source before new physical evidence is requested.
 ### R — final real-flight activity
 
 - parent: #72
-- depends: coherent progression + proven physical backend + any #70 capability
-  required by the chosen final mission
+- depends: coherent progression + relevant #157 capability coverage + proven
+  physical backend + any #70 capability required by the chosen final mission
 - proof direction: exact simulation-validated student program, explicit teacher
   authorization, independent preflight/failsafe and representative safe real
   execution


### PR DESCRIPTION
## Scope

Formalize the product objective agreed in #157 without starting the implementation itself.

## Product intent

The reference hardware is now explicit:

- Crazyflie 2.1
- Flow Deck V2
- Multi-ranger
- bottom-mounted Color LED Deck

WebeeBlocks should cover the pedagogically useful capability surface through the smallest coherent set of generic/composable Blockly primitives, with simulation/physical continuity where relevant.

## Color LED simulation direction

The Webots target is deliberately bounded: a simple, reasonably recognizable bottom-mounted deck with a visible controllable light surface. This does not request detailed electronics, thermal or photometric simulation.

## Roadmap

#157 is added as secondary/opportunistic product work complementing #66, and as relevant capability input to the eventual #72 real-flight activity. It does not displace the current pedagogical progression priority.

## Boundary

Only:
- `docs/PRODUCT_VISION.md`
- `docs/ROADMAP.md`

No runtime, Blockly, Webots model, CI, workflow or governance change is included in this PR.

Refs #157