### PR TITLE
Inventory reference Crazyflie capability coverage

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -1,0 +1,56 @@
+# Reference Crazyflie capability matrix
+
+This matrix records the **currently integrated** student-facing capability surface
+for the reference hardware in issue #157. It is a product inventory, not a
+workflow-state database and not a claim that a physical backend is already
+proven.
+
+Status vocabulary:
+
+- **covered** — the generic Blockly/AST intent and the current Webots execution
+  path both support the capability;
+- **partial** — generic semantics exist, but the current Webots backend exposes
+  only part of the intended hardware surface;
+- **missing** — no current student-facing generic semantics/Webots behavior
+  exists;
+- **infrastructure only** — the capability is useful internally but is not a
+  student-facing primitive;
+- **physical unproven** — no current integrated evidence establishes the
+  corresponding real-Crazyflie student execution path.
+
+| Reference capability | Generic Blockly / AST | Current Webots path | Physical path | Current profile exposure | Status / smallest gap |
+| --- | --- | --- | --- | --- | --- |
+| Take off / land | `webeeblocks_v2_takeoff`, `webeeblocks_v2_land` → `takeoff`, `land` | Current WWI backend advertises and implements both actions | Physical student backend not proven | Progression 1+ | **covered** in simulation; **physical unproven** |
+| Horizontal movement | `webeeblocks_v2_move` → `move(direction, distance)` with forward/back/left/right AST vocabulary | Current WWI backend advertises only forward/left | Physical student backend not proven | Progression 1: forward; progression 3: forward/left; broader reactive profile declares four directions | **partial**: Webots backend must close back/right before claiming full generic coverage |
+| Vertical movement | `webeeblocks_v2_vertical` → `vertical(up/down, distance)` | Current WWI backend explicitly rejects vertical execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
+| Yaw turn | `webeeblocks_v2_turn` → `turn(angle)` | Current WWI backend explicitly rejects turn execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
+| Wait / pacing | `webeeblocks_v2_wait` → `wait(seconds)` | Current WWI backend explicitly rejects wait execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
+| Speed selection | `webeeblocks_v2_speed` → `set_speed(speed)` | Current WWI backend explicitly rejects speed execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
+| Multi-ranger directional distance | `webeeblocks_v2_range` → `range(direction)`; AST vocabulary has front/back/left/right/up | Current WWI backend advertises only front | Physical student backend not proven | Progression 3 exposes front; broad reactive profile declares front/back/left/right/up | **partial**: close remaining useful Webots directions before broader profile claims are executable |
+| Flow Deck V2 downward range | No `down` value exists in the current student range AST vocabulary | Downward ranging/flow is robot infrastructure rather than a student-visible Runtime v2 range direction | #70 contains physical research evidence, but not a proven student backend | Hardware prerequisite is named in profiles; no dedicated student block | **missing** as a student-facing capability; decide whether downward range has a real pedagogical use before adding vocabulary |
+| Flow Deck V2 optical flow / stabilization | No direct student primitive by design | Used as simulation/flight infrastructure, not as an algorithm block | Physical behavior belongs to backend/safety validation | Implicit hardware requirement | **infrastructure only**; do not expose estimator/flow internals without a pedagogical need |
+| Multi-ranger upward range | Generic AST already admits `up` | Current WWI backend does not advertise `up` | Physical student backend not proven | Broad reactive profile declares `up` | **partial** |
+| Bottom Color LED Deck light/color | No current block, AST statement, interpreter action or backend capability | No integrated controllable light surface found | Physical student backend not proven | None | **missing**: smallest coherent future slice is one generic color/light intent plus a simple visible bottom-deck Webots surface |
+| Estimator diagnostics / tuning | No student vocabulary | Internal only | #70 Lab/research only | None | **infrastructure only** by product rule |
+
+## Conclusions for #157
+
+The generic AST already covers more motion and ranging intent than the current
+Webots WWI backend advertises. The next capability work should therefore prefer
+**closing existing generic simulation gaps before adding block families**.
+
+Two genuine vocabulary decisions remain visible:
+
+1. whether Flow Deck downward range is pedagogically useful enough to justify a
+   generic student-facing `down` range direction;
+2. the Color LED Deck, which currently has no student-facing semantics at all
+   and should be added later as a small generic light/color capability rather
+   than deck-specific electronics controls.
+
+Physical support remains explicitly unproven for student execution. Do not turn
+source availability, Lab firmware experiments, or simulation coverage into a
+real-hardware support claim. The eventual physical backend must preserve the
+same backend-neutral AST intent and independent preflight/safety boundary.
+
+This inventory should be updated only when integrated product evidence changes a
+row; live PR/CI/review state remains on GitHub rather than in this document.


### PR DESCRIPTION
## Scope

Adds the bounded #157 capability matrix requested by the roadmap, based only on current integrated product evidence.

The matrix separates:
- generic Blockly/AST vocabulary;
- current Webots WWI backend support;
- physical-backend proof status;
- activity-profile exposure;
- intentional infrastructure-only capabilities.

It identifies existing simulation gaps before proposing new block families, and records the two genuine vocabulary questions: Flow Deck downward range and the currently missing Color LED light/color semantics.

No Runtime, AST, backend, workflow or safety behavior changes.

Refs #157