### PR TITLE
Harden Blockly browser oracle against runner startup jitter

### DIFF
--- a/tools/ci/run_crazyflie_blockly_l_mission.py
+++ b/tools/ci/run_crazyflie_blockly_l_mission.py
@@ -27,6 +27,7 @@ L_SOURCE = ROOT / "controllers" / "crazyflie_l_course" / "crazyflie_l_course.c"
 ARTIFACT_DIR = ROOT / "ci-artifacts" / "crazyflie-blockly-l"
 MISSION_PATH = ARTIFACT_DIR / "mission.json"
 RESULT_RE = re.compile(r'<pre id="mission-result">(.*?)</pre>', re.DOTALL)
+BROWSER_TIMEOUT_SECONDS = 60
 
 EXPECTED = [
     {"type": "TAKEOFF", "value": 1.0},
@@ -119,7 +120,7 @@ def run_browser(harness_path: Path) -> dict[str, object]:
     process = subprocess.Popen(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     timed_out = False
     try:
-        stdout, stderr = process.communicate(timeout=30)
+        stdout, stderr = process.communicate(timeout=BROWSER_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
         timed_out = True
         process.kill()

--- a/tools/ci/run_historical_blockly_oracle.py
+++ b/tools/ci/run_historical_blockly_oracle.py
@@ -35,6 +35,7 @@ EXPECTED_PYTHON_SHA256 = {
 }
 PROGRAMS = tuple(EXPECTED_PYTHON_SHA256)
 RESULT_RE = re.compile(r'<pre id="oracle-result">(.*?)</pre>', re.DOTALL)
+BROWSER_TIMEOUT_SECONDS = 60
 
 
 class ScriptParser(HTMLParser):
@@ -126,7 +127,7 @@ def run_browser(harness_path: Path) -> dict[str, object]:
     )
     timed_out = False
     try:
-        stdout, stderr = process.communicate(timeout=30)
+        stdout, stderr = process.communicate(timeout=BROWSER_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired:
         # Some hosted Chrome builds can finish --dump-dom yet linger during
         # browser shutdown. Kill the browser, collect its already-produced DOM,


### PR DESCRIPTION
## Scope

Hardens the two historical Blockly headless-browser CI oracles after repeated hosted-runner startup timeouts blocked an unrelated Ready candidate.

### Causal evidence
- #161 exact candidate `20dce41e300e7b17c77212c7ea765096f17e99db` failed twice in `Webots suite / crazyflie-blockly-l` around the harness's hard-coded 30 s browser boundary, despite not modifying that oracle;
- after #161 was reanchored on current main as `c8907c482bc60035e7818b5f2d5444ac5b601923`, `crazyflie-blockly-l` passed but `encoders-historical` independently failed in `run_historical_blockly_oracle.py` at the same 30 s boundary before `oracle-result` was emitted;
- both harnesses retain exact DOM/semantic-output validation after browser completion or forced shutdown, so additional startup budget does not turn missing evidence into a pass.

### Change
Increase only the headless-browser process budget from 30 s to 60 s, through named constants, in both historical Blockly browser harnesses. The L oracle still requires the exact mission DOM payload, unsupported-block fail-closed behavior, exact semantic command list and downstream Webots geometry/STOP assertions. The shared historical oracle still requires all six exact generated-program payloads, five non-empty compilable outputs and their pinned SHA-256 digests. A browser that produces no valid oracle payload still fails.

### Boundary
CI reliability only. No product Runtime, Blockly semantics, activity/profile, Webots controller, safety rule, semantic acceptance threshold, checkpoint, notification or physical-flight behavior changes.