### PR TITLE
Execute vertical movement in Runtime v2 Webots

### DIFF
--- a/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
+++ b/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c
@@ -35,6 +35,7 @@ typedef enum {
   CMD_IDLE,
   CMD_TAKEOFF,
   CMD_MOVE,
+  CMD_VERTICAL,
   CMD_LAND,
   CMD_RESET
 } command_t;
@@ -43,6 +44,7 @@ typedef enum {
   REQUEST_INVALID,
   REQUEST_TAKEOFF,
   REQUEST_MOVE,
+  REQUEST_VERTICAL,
   REQUEST_LAND,
   REQUEST_RANGE,
   REQUEST_RESET,
@@ -152,6 +154,13 @@ static request_t parse_request(const char *message) {
     strncpy(request.direction, direction, sizeof(request.direction) - 1);
     return request;
   }
+  if (sscanf(message, PREFIX " REQUEST %d VERTICAL %31s %lf %1s", &id, direction, &value, extra) == 3) {
+    request.id = id;
+    request.kind = REQUEST_VERTICAL;
+    request.value = value;
+    strncpy(request.direction, direction, sizeof(request.direction) - 1);
+    return request;
+  }
   if (sscanf(message, PREFIX " REQUEST %d RANGE %31s %1s", &id, direction, extra) == 2) {
     request.id = id;
     request.kind = REQUEST_RANGE;
@@ -185,6 +194,11 @@ static void trace_takeoff(double value) {
 
 static void trace_move(const char *direction, double value) {
   printf(PREFIX " TRACE MOVE %s distance=%.9f stop=1\n", direction, value);
+  fflush(stdout);
+}
+
+static void trace_vertical(const char *direction, double value) {
+  printf(PREFIX " TRACE VERTICAL %s distance=%.9f stop=1\n", direction, value);
   fflush(stdout);
 }
 
@@ -461,6 +475,30 @@ int main(void) {
         action_start = now;
         continue;
       }
+      if (request.kind == REQUEST_VERTICAL) {
+        if (!airborne || !isfinite(request.value) || request.value < 0.1 || request.value > 0.8 ||
+            (strcmp(request.direction, "up") != 0 && strcmp(request.direction, "down") != 0)) {
+          response_error(request.id, "INVALID_VERTICAL");
+          continue;
+        }
+        const double next_target_z = z + (strcmp(request.direction, "up") == 0 ? request.value : -request.value);
+        if (next_target_z < origin_z + 0.2 || next_target_z > origin_z + 1.5) {
+          response_error(request.id, "VERTICAL_LIMIT");
+          continue;
+        }
+        active_id = request.id;
+        active_value = request.value;
+        strncpy(active_direction, request.direction, sizeof(active_direction) - 1);
+        active_direction[sizeof(active_direction) - 1] = '\0';
+        target_x = x;
+        target_y = y;
+        target_yaw = yaw;
+        target_z = next_target_z;
+        command = CMD_VERTICAL;
+        stable_since = -1.0;
+        action_start = now;
+        continue;
+      }
       if (request.kind == REQUEST_LAND) {
         if (!airborne) {
           response_error(request.id, "INVALID_LAND");
@@ -568,6 +606,30 @@ int main(void) {
           stable_since = now;
         if (now - stable_since >= STOP_WINDOW) {
           trace_move(active_direction, active_value);
+          response_ok(active_id);
+          command = CMD_IDLE;
+          stable_since = -1.0;
+        }
+      } else {
+        stable_since = -1.0;
+      }
+    } else if (command == CMD_VERTICAL) {
+      const double error_x = target_x - x;
+      const double error_y = target_y - y;
+      const double body_x = error_x * cy + error_y * sy;
+      const double body_y = -error_x * sy + error_y * cy;
+      desired.vx = POSITION_KP * body_x;
+      desired.vy = POSITION_KP * body_y;
+      clip_vector(&desired.vx, &desired.vy, VX_MAX);
+      desired.yaw_rate = clip(YAW_KP * wrap_angle(target_yaw - yaw), YAW_RATE_MAX);
+      desired.altitude = target_z;
+      if (hypot(error_x, error_y) <= POSITION_TOL && fabs(wrap_angle(target_yaw - yaw)) <= YAW_TOL &&
+          hypot(actual.vx, actual.vy) < SPEED_TOL && fabs(actual.yaw_rate) < YAW_RATE_TOL && fabs(vz) < VZ_TOL &&
+          fabs(z - target_z) < ALT_TOL) {
+        if (stable_since < 0.0)
+          stable_since = now;
+        if (now - stable_since >= STOP_WINDOW) {
+          trace_vertical(active_direction, active_value);
           response_ok(active_id);
           command = CMD_IDLE;
           stable_since = -1.0;

--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -22,7 +22,7 @@ Status vocabulary:
 | --- | --- | --- | --- | --- | --- | --- |
 | Take off / land | Crazyflie 2.1 airframe / flight control | `webeeblocks_v2_takeoff`, `webeeblocks_v2_land` → `takeoff`, `land` | Current WWI backend advertises and implements both actions | Physical student backend not proven | Progression 1+ | **covered** in simulation; **physical unproven** |
 | Horizontal movement | Crazyflie 2.1 airframe / flight control | `webeeblocks_v2_move` → `move(direction, distance)` with forward/back/left/right AST vocabulary | Current WWI backend advertises and executes forward/back/left/right | Physical student backend not proven | Progression 1: forward; progression 3: forward/left; broader reactive profile declares four directions | **covered** in simulation for the generic horizontal vocabulary; **physical unproven** |
-| Vertical movement | Crazyflie 2.1 airframe / flight control | `webeeblocks_v2_vertical` → `vertical(up/down, distance)` | Current WWI backend explicitly rejects vertical execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
+| Vertical movement | Crazyflie 2.1 airframe / flight control | `webeeblocks_v2_vertical` → `vertical(up/down, distance)` | Current WWI backend advertises and executes up/down with horizontal-position/yaw hold and bounded altitude targets | Physical student backend not proven | Broad reactive profile only | **covered** in simulation for the generic vertical vocabulary; **physical unproven** |
 | Yaw turn | Crazyflie 2.1 airframe / flight control | `webeeblocks_v2_turn` → `turn(angle)` | Current WWI backend explicitly rejects turn execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
 | Wait / pacing | Generic Runtime timing semantic; no dedicated hardware source | `webeeblocks_v2_wait` → `wait(seconds)` | Current WWI backend explicitly rejects wait execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
 | Speed selection | Crazyflie 2.1 airframe / flight control | `webeeblocks_v2_speed` → `set_speed(speed)` | Current WWI backend explicitly rejects speed execution | Physical student backend not proven | Broad reactive profile only | **partial/missing execution** |
@@ -35,8 +35,8 @@ Status vocabulary:
 
 ## Conclusions for #157
 
-The generic AST already covers more motion and ranging intent than the current
-Webots WWI backend advertises. The next capability work should therefore prefer
+The generic AST still covers more motion and ranging intent than the current
+Webots WWI backend advertises. Capability work should therefore continue to prefer
 **closing existing generic simulation gaps before adding block families**.
 
 Two genuine vocabulary decisions remain visible:

--- a/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
+++ b/plugins/robot_windows/blockly/webeeblocks/wwi_backend.js
@@ -29,10 +29,10 @@
     this.readyWaiters = [];
     this.simulationStopped = false;
     var capabilities = {
-      actions: ['takeoff', 'move', 'land'],
+      actions: ['takeoff', 'move', 'vertical', 'land'],
       rangeDirections: ['front', 'left', 'right'],
       moveDirections: ['forward', 'back', 'left', 'right'],
-      verticalDirections: []
+      verticalDirections: ['up', 'down']
     };
     if (options && options.simulationDebug === true)
       capabilities.simulationDebug = true;
@@ -129,6 +129,7 @@
 
   RuntimeV2WwiBackend.prototype.takeoff = function(heightM) { return this._guardSimulationStopped() || this._request(['TAKEOFF', Number(heightM).toPrecision(17)]); };
   RuntimeV2WwiBackend.prototype.move = function(direction, distanceM) { return this._guardSimulationStopped() || this._request(['MOVE', String(direction), Number(distanceM).toPrecision(17)]); };
+  RuntimeV2WwiBackend.prototype.vertical = function(direction, distanceM) { return this._guardSimulationStopped() || this._request(['VERTICAL', String(direction), Number(distanceM).toPrecision(17)]); };
   RuntimeV2WwiBackend.prototype.land = function() { return this._guardSimulationStopped() || this._request(['LAND']); };
   RuntimeV2WwiBackend.prototype.readRange = function(direction) { return this._guardSimulationStopped() || this._request(['RANGE', String(direction)]); };
   RuntimeV2WwiBackend.prototype.stopSimulation = function() {
@@ -152,7 +153,6 @@
       throw error;
     });
   };
-  RuntimeV2WwiBackend.prototype.vertical = function() { return Promise.reject(new Error('Runtime v2 Webots backend vertical capability unavailable')); };
   RuntimeV2WwiBackend.prototype.turn = function() { return Promise.reject(new Error('Runtime v2 Webots backend turn capability unavailable')); };
   RuntimeV2WwiBackend.prototype.wait = function() { return Promise.reject(new Error('Runtime v2 Webots backend wait capability unavailable')); };
   RuntimeV2WwiBackend.prototype.setSpeed = function() { return Promise.reject(new Error('Runtime v2 Webots backend speed capability unavailable')); };

--- a/tools/ci/prepare_runtime_v2_webots.py
+++ b/tools/ci/prepare_runtime_v2_webots.py
@@ -56,6 +56,32 @@ move_end_replacement = r'''          trace_move(active_direction, active_value);
 if move_end_needle not in controller:
     raise SystemExit('Runtime v2 MOVE end instrumentation point not found')
 controller = controller.replace(move_end_needle, move_end_replacement, 1)
+vertical_start_needle = '''        target_x = x;
+        target_y = y;
+        target_yaw = yaw;
+        target_z = next_target_z;
+        command = CMD_VERTICAL;'''
+vertical_start_replacement = r'''        target_x = x;
+        target_y = y;
+        target_yaw = yaw;
+        target_z = next_target_z;
+        printf(PREFIX " CI VERTICAL_START %s x=%.9f y=%.9f z=%.9f yaw=%.9f target_z=%.9f\n",
+               request.direction, x, y, z, yaw, target_z);
+        fflush(stdout);
+        command = CMD_VERTICAL;'''
+if vertical_start_needle not in controller:
+    raise SystemExit('Runtime v2 VERTICAL start instrumentation point not found')
+controller = controller.replace(vertical_start_needle, vertical_start_replacement, 1)
+vertical_end_needle = '''          trace_vertical(active_direction, active_value);
+          response_ok(active_id);'''
+vertical_end_replacement = r'''          trace_vertical(active_direction, active_value);
+          printf(PREFIX " CI VERTICAL_END %s x=%.9f y=%.9f z=%.9f yaw=%.9f\n",
+                 active_direction, x, y, z, yaw);
+          fflush(stdout);
+          response_ok(active_id);'''
+if vertical_end_needle not in controller:
+    raise SystemExit('Runtime v2 VERTICAL end instrumentation point not found')
+controller = controller.replace(vertical_end_needle, vertical_end_replacement, 1)
 controller_path.write_text(controller, encoding='utf-8')
 
 script = r'''
@@ -274,8 +300,11 @@ script = r'''
     await runtimeBackend.takeoff(0.35);
     await runtimeBackend.move('back', 0.20);
     await runtimeBackend.move('right', 0.20);
+    await runtimeBackend.vertical('up', 0.10);
+    await runtimeBackend.vertical('down', 0.10);
     await runtimeBackend.land();
     await report('HORIZONTAL_MOVES_OK', {directions:['back','right']});
+    await report('VERTICAL_MOVES_OK', {directions:['up','down'], distance_m:0.10});
 
     await report('DONE', document.getElementById('runtimeDetail').textContent);
     await chain;


### PR DESCRIPTION
## Scope

Closes the next reuse-first #157 C1b simulation gap by executing the already-existing generic `vertical(up/down, distance)` semantic through Runtime v2 Webots. No new Blockly block or AST family is introduced.

### Product path
- `webeeblocks_v2_vertical` and the backend-neutral `vertical(up/down, distance)` AST/interpreter path already exist;
- the WWI backend now advertises `vertical` with `up/down` and emits a `VERTICAL` request;
- the Webots controller executes bounded vertical targets while holding current horizontal position and yaw;
- vertical requests are accepted only while airborne, with distance `0.1..0.8 m` and target altitude constrained to `0.2..1.5 m` above the reset origin;
- existing STOP, reset, unsafe-attitude and action-timeout fail-closed behavior remains applicable.

### Automated proof
The real Runtime v2 Robot Window/Webots harness now executes `up 0.10 m` then `down 0.10 m`, records controller start/end geometry, and fails if either request cannot complete. Existing horizontal/range/runtime assertions remain intact.

The reference capability matrix is updated to record vertical movement as simulation-covered while keeping physical student execution explicitly unproven.

### Boundary
No physical backend claim, real flight, new student block family, downward-range vocabulary, Color LED behavior, governance, checkpoint or notification change.

Refs #157.