### PR TITLE
Make roadmap planning adaptive without changing product authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,34 @@ only when the result can no longer affect any relevant future decision. A late
 PASS/FAIL after NOT_NEEDED remains historical evidence for its original subject
 and does not reopen the request or become evidence for a newer state.
 
+## Adaptive planning
+
+**Goals constrain; plans adapt.** Product goals, priorities, invariants and
+applicable governance constraints constrain planning, but priority alone does not
+prescribe execution order, actionability or establish a dependency. Operational
+paths, decomposition and sequencing are revisable by default.
+
+**Dependencies need justification.** Impose ordering only when an applicable
+product constraint, demonstrable logical or technical necessity, or durable
+evidence establishes it. Prior placement in a plan, roadmap sequence or issue
+history is not sufficient justification by itself.
+
+**Pull the smallest useful complete result.** Prefer reducing useful engaged work
+when that is a strong next result; otherwise take the smallest complete result
+that usefully advances or unblocks an active product outcome. Reducing engaged
+work may mean validating, integrating, repairing, completing, closing or
+abandoning a branch, candidate, duplicate or transient decomposition. Do not
+continue work merely because effort has already been invested when current
+evidence makes it dominated, obsolete, unsafe or no longer useful. Abandoning
+work never abandons a product goal or priority unless durable product authority
+changes that goal or priority.
+
+**Persist knowledge, not planning scaffolding.** Materialize durable evidence,
+constraints, discoveries and conclusions that can affect future decisions.
+Transient paths, decompositions, controller-local rankings and internal planning
+representations need no durable representation unless their conclusions can
+affect a later decision.
+
 ## Controller loop
 
 At launch and after every durable transition:
@@ -141,18 +169,27 @@ At launch and after every durable transition:
    relevant PRs, exact HEADs, CI, reviews, issues and evidence;
 2. if main is known unhealthy, contribute to restoration first unless a credible
    repair path is durably engaged and another independent action is more useful;
-3. prefer useful actions that reduce remaining engaged work: validate/integrate
-   a Ready PR this execution did not mutate, repair/complete existing work, or
-   close a dominated duplicate;
-4. otherwise progress existing useful work;
-5. otherwise start the highest-value product work not already sufficiently
-   covered, in an isolated short branch; publish a PR only once real durable work
-   exists, Draft if still mutable and Ready if complete;
+3. prefer a useful action that reduces remaining engaged work when it is a strong
+   next result: validate/integrate a Ready PR this execution did not mutate,
+   repair/complete existing useful work, or close/abandon a dominated duplicate
+   or obsolete path;
+4. otherwise select the smallest useful complete result that best advances the
+   current product priorities and is not already sufficiently covered. Compare
+   progressing existing work with starting new work using product value,
+   unblocking, evidence, uncertainty and useful independent parallelism rather
+   than age, sunk cost or prior plan placement;
+5. execute that result through an existing suitable branch/PR or an isolated
+   short branch; publish a PR only once real durable work exists, Draft if still
+   mutable and Ready if complete;
 6. before terminating, resolve exact current main and rebuild relevant engaged
    GitHub work one final time, then apply this Controller loop again. Terminate
    silently only if that reconstruction exposes no useful eligible action.
    Completion of the execution's current local work is never by itself a
    termination condition.
+
+Product priority is a strong selection signal, not a strict execution queue. A
+higher-priority outcome does not block independent useful work merely because it
+remains incomplete.
 
 Pending CI is not a reason to notify or globally idle. Use its latency for
 independent useful work when available.
@@ -170,9 +207,18 @@ independent useful work when available.
 
 ## Roadmap
 
-docs/ROADMAP.md expresses product intent, priority, dependencies and exit
-criteria. GitHub provides live execution state. Roadmap prose never overrides
-newer GitHub evidence.
+docs/ROADMAP.md expresses product intent, product priorities, justified
+dependencies and exit criteria. GitHub provides live execution state. Product
+priority guides selection but does not by itself establish actionability,
+dependency or execution order. Roadmap numbering, textual order, prior plan
+placement and issue history are not execution queues and do not create a
+dependency without separate justification. Roadmap prose never overrides newer
+GitHub evidence.
+
+When evidence changes a prerequisite or another conclusion that can affect a
+later decision, materialize the smallest affected durable conclusion. Do not
+persist transient Controller paths, decompositions or local rankings merely to
+record a plan.
 
 Do not modify this contract or checkpoint/notification mechanisms from an
 ordinary product PR unless the requested work specifically concerns governance.

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -76,6 +76,23 @@ class ContractTests(unittest.TestCase):
         ):
             self.assertNotIn(obsolete, combined)
 
+    def test_adaptive_planning_preserves_product_authority_without_execution_queue(self):
+        self.assertIn("## Adaptive planning", self.raw)
+        self.assertIn("Goals constrain; plans adapt.", self.contract)
+        self.assertIn("Dependencies need justification.", self.contract)
+        self.assertIn("demonstrable logical or technical necessity", self.contract)
+        self.assertIn("Prior placement in a plan, roadmap sequence or issue history is not sufficient justification", self.contract)
+        self.assertIn("Pull the smallest useful complete result.", self.contract)
+        self.assertIn("Do not continue work merely because effort has already been invested", self.contract)
+        self.assertIn("Abandoning work never abandons a product goal or priority", self.contract)
+        self.assertIn("Persist knowledge, not planning scaffolding.", self.contract)
+        self.assertIn("controller-local rankings", self.contract)
+        self.assertIn("smallest useful complete result that best advances the current product priorities", self.contract)
+        self.assertIn("Product priority is a strong selection signal, not a strict execution queue", self.contract)
+        self.assertIn("higher-priority outcome does not block independent useful work merely because it remains incomplete", self.contract)
+        self.assertIn("Roadmap numbering, textual order, prior plan placement and issue history are not execution queues", self.contract)
+        self.assertNotIn("start the highest-value product work", self.contract)
+
     def test_termination_requires_final_reconstruction(self):
         self.assertIn("rebuild relevant engaged GitHub work one final time", self.contract)
         self.assertIn("Terminate silently only if that reconstruction exposes no useful eligible action", self.contract)


### PR DESCRIPTION
## Scope

Makes Controller planning reconstructible from current product priorities, constraints and durable evidence instead of treating roadmap/order or already-engaged work as an execution queue.

### Governance change

Adds four planning principles to `AGENTS.md`:

- **Goals constrain; plans adapt.**
- **Dependencies need justification.**
- **Pull the smallest useful complete result.**
- **Persist knowledge, not planning scaffolding.**

The Controller loop now:
- still prefers useful reduction of engaged work when that is a strong next result;
- otherwise selects the smallest useful complete result that best advances current product priorities;
- compares existing and new work using value, unblocking, evidence, uncertainty and useful independent parallelism;
- treats product priority as a strong selection signal, not a strict execution queue;
- rejects roadmap order, prior plan placement and sunk cost as dependency/ordering authority by themselves.

### Authority boundary

This does **not** grant Controllers additional product authority. Product goals, priorities, invariants and governance constraints remain authoritative. A Controller may adapt path/decomposition/sequencing; it may not invent, abandon or reprioritize product goals without durable product authority.

### Dependency boundary

Ordering requires an applicable product constraint, demonstrable logical/technical necessity, or durable evidence. A technical preference alone is insufficient.

### Durable-state boundary

Durable evidence, constraints, discoveries and decision-relevant conclusions are persisted. Controller-local paths, decompositions and rankings are not persisted merely as planning scaffolding.

### Files

- `AGENTS.md`
- `tools/ci/test_controller_contract.py`

No change to `docs/ROADMAP.md`, `docs/PRODUCT_VISION.md`, Runtime, CI topology, checkpoint/notification mechanisms or product priorities.

### Falsification cases for independent review

Please specifically test that the contract permits and constrains these cases:

1. a higher-priority outcome remains incomplete while an independent lower-priority slice is currently the stronger complete result;
2. a Ready candidate can be validated/integrated without waiting for unrelated higher-priority work;
3. engaged work can be abandoned when current evidence makes it dominated/obsolete without abandoning its product objective;
4. a mere technical preference cannot manufacture a dependency;
5. independent Controllers may choose different useful slices while remaining constrained by the same product priorities;
6. roadmap numbering/order does not become a hidden execution queue.

This execution mutated the candidate and therefore must not provide its independent GO.