### PR TITLE
[EXPERIMENT] V5 durable authority anchor

### DIFF
--- a/.github/workflows/v5-authority-anchor.yml
+++ b/.github/workflows/v5-authority-anchor.yml
@@ -1,67 +1,26 @@
-name: V5 Authority Anchor Experiment
+name: V5 Authority Anchor Cleanup
 
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize]
+    types: [synchronize]
 
 permissions:
-  contents: read
-  statuses: write
+  contents: write
 
 jobs:
-  anchor:
-    name: Authority anchor semantics
+  cleanup:
+    name: Cleanup authority anchor experiment
     runs-on: ubuntu-22.04
     steps:
-      - name: Create two same-context commit statuses and probe mutation endpoints
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+      - name: Delete experiment branch conditionally
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_REF: refs/heads/experiment/v5-authority-anchor
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          api="https://api.github.com/repos/$REPO/statuses/$HEAD_SHA"
-          context="v5-authority-anchor/test"
-
-          create() {
-            local state="$1"
-            curl --fail-with-body -sS -L               -X POST               -H "Accept: application/vnd.github+json"               -H "Authorization: Bearer $GH_TOKEN"               -H "X-GitHub-Api-Version: 2022-11-28"               "$api"               -d "$(jq -nc --arg state "$state" --arg context "$context"                 '{state:$state,context:$context,description:("V5 anchor "+$state)}')"
-          }
-
-          first=$(create failure)
-          first_id=$(printf '%s' "$first" | jq -r '.id')
-          second=$(create success)
-          second_id=$(printf '%s' "$second" | jq -r '.id')
-
-          echo "FIRST_ID=$first_id"
-          echo "SECOND_ID=$second_id"
-
-          list=$(curl --fail-with-body -sS -L             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/commits/$HEAD_SHA/statuses?per_page=100")
-
-          count=$(printf '%s' "$list" | jq --arg context "$context" '[.[] | select(.context==$context)] | length')
-          ids=$(printf '%s' "$list" | jq -r --arg context "$context" '[.[] | select(.context==$context) | .id] | join(",")')
-          echo "COUNT=$count"
-          echo "LIST_IDS=$ids"
-          test "$count" -eq 2
-
-          set +e
-          patch_code=$(curl -sS -o /tmp/patch.out -w '%{http_code}' -L             -X PATCH             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/statuses/$first_id"             -d '{"state":"success"}')
-          delete_code=$(curl -sS -o /tmp/delete.out -w '%{http_code}' -L             -X DELETE             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/statuses/$first_id")
-          set -e
-
-          echo "PATCH_CODE=$patch_code"
-          echo "DELETE_CODE=$delete_code"
-          cat /tmp/patch.out || true
-          cat /tmp/delete.out || true
-
-          test "$patch_code" -ge 400
-          test "$delete_code" -ge 400
-
-          list_after=$(curl --fail-with-body -sS -L             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/commits/$HEAD_SHA/statuses?per_page=100")
-
-          count_after=$(printf '%s' "$list_after" | jq --arg context "$context" '[.[] | select(.context==$context)] | length')
-          states_after=$(printf '%s' "$list_after" | jq -r --arg context "$context" '[.[] | select(.context==$context) | .state] | join(",")')
-          echo "COUNT_AFTER=$count_after"
-          echo "STATES_AFTER=$states_after"
-          test "$count_after" -eq 2
+          git push --force-with-lease="$TARGET_REF:$EXPECTED_SHA" origin ":$TARGET_REF"

--- a/.github/workflows/v5-authority-anchor.yml
+++ b/.github/workflows/v5-authority-anchor.yml
@@ -1,0 +1,67 @@
+name: V5 Authority Anchor Experiment
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  anchor:
+    name: Authority anchor semantics
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create two same-context commit statuses and probe mutation endpoints
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/$REPO/statuses/$HEAD_SHA"
+          context="v5-authority-anchor/test"
+
+          create() {
+            local state="$1"
+            curl --fail-with-body -sS -L               -X POST               -H "Accept: application/vnd.github+json"               -H "Authorization: Bearer $GH_TOKEN"               -H "X-GitHub-Api-Version: 2022-11-28"               "$api"               -d "$(jq -nc --arg state "$state" --arg context "$context"                 '{state:$state,context:$context,description:("V5 anchor "+$state)}')"
+          }
+
+          first=$(create failure)
+          first_id=$(printf '%s' "$first" | jq -r '.id')
+          second=$(create success)
+          second_id=$(printf '%s' "$second" | jq -r '.id')
+
+          echo "FIRST_ID=$first_id"
+          echo "SECOND_ID=$second_id"
+
+          list=$(curl --fail-with-body -sS -L             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/commits/$HEAD_SHA/statuses?per_page=100")
+
+          count=$(printf '%s' "$list" | jq --arg context "$context" '[.[] | select(.context==$context)] | length')
+          ids=$(printf '%s' "$list" | jq -r --arg context "$context" '[.[] | select(.context==$context) | .id] | join(",")')
+          echo "COUNT=$count"
+          echo "LIST_IDS=$ids"
+          test "$count" -eq 2
+
+          set +e
+          patch_code=$(curl -sS -o /tmp/patch.out -w '%{http_code}' -L             -X PATCH             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/statuses/$first_id"             -d '{"state":"success"}')
+          delete_code=$(curl -sS -o /tmp/delete.out -w '%{http_code}' -L             -X DELETE             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/statuses/$first_id")
+          set -e
+
+          echo "PATCH_CODE=$patch_code"
+          echo "DELETE_CODE=$delete_code"
+          cat /tmp/patch.out || true
+          cat /tmp/delete.out || true
+
+          test "$patch_code" -ge 400
+          test "$delete_code" -ge 400
+
+          list_after=$(curl --fail-with-body -sS -L             -H "Accept: application/vnd.github+json"             -H "Authorization: Bearer $GH_TOKEN"             -H "X-GitHub-Api-Version: 2022-11-28"             "https://api.github.com/repos/$REPO/commits/$HEAD_SHA/statuses?per_page=100")
+
+          count_after=$(printf '%s' "$list_after" | jq --arg context "$context" '[.[] | select(.context==$context)] | length')
+          states_after=$(printf '%s' "$list_after" | jq -r --arg context "$context" '[.[] | select(.context==$context) | .state] | join(",")')
+          echo "COUNT_AFTER=$count_after"
+          echo "STATES_AFTER=$states_after"
+          test "$count_after" -eq 2


### PR DESCRIPTION
Governance substrate experiment only. DO NOT MERGE. Probes whether commit statuses behave as append-only durable authority anchors distinct from mutable Check Runs.