### PR TITLE
Add read-only physical capability preflight contract

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
@@ -1,0 +1,131 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksPhysicalCapabilityContract = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  var FORBIDDEN_AUTHORITY_METHODS = [
+    'takeoff', 'land', 'move', 'vertical', 'turn', 'wait', 'setSpeed',
+    'setLight', 'arm', 'disarm', 'startMotors', 'stopMotors', 'setpoint',
+    'sendSetpoint', 'thrust'
+  ];
+
+  function fail(message) {
+    throw new Error('physical capability contract: ' + message);
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function requireString(value, path) {
+    if (typeof value !== 'string' || value.trim() === '')
+      fail(path + ' must be a non-empty string');
+  }
+
+  function normalizeStringArray(value, path) {
+    if (!Array.isArray(value))
+      fail(path + ' must be an array');
+    var seen = Object.create(null);
+    return value.map(function(item, index) {
+      requireString(item, path + '[' + index + ']');
+      if (seen[item])
+        fail(path + ' contains duplicate value: ' + item);
+      seen[item] = true;
+      return item;
+    });
+  }
+
+  function normalizeDescriptor(value) {
+    if (!isObject(value))
+      fail('descriptor must be an object');
+    if (value.transport !== 'crazyradio')
+      fail('unsupported transport: ' + String(value.transport));
+    if (value.connected !== true)
+      fail('Crazyflie connection is not established');
+
+    requireString(value.device, 'device');
+    if (value.device !== 'crazyflie-2.1')
+      fail('unsupported device: ' + value.device);
+
+    var hardware = normalizeStringArray(value.hardware, 'hardware');
+    if (hardware.indexOf('crazyflie-2.1') < 0)
+      fail('hardware must include crazyflie-2.1');
+
+    if (!isObject(value.capabilities))
+      fail('capabilities must be an object');
+
+    var descriptor = {
+      transport: 'crazyradio',
+      connected: true,
+      device: 'crazyflie-2.1',
+      hardware: hardware,
+      capabilities: {
+        actions: normalizeStringArray(value.capabilities.actions, 'capabilities.actions'),
+        rangeDirections: normalizeStringArray(value.capabilities.rangeDirections, 'capabilities.rangeDirections'),
+        moveDirections: normalizeStringArray(value.capabilities.moveDirections, 'capabilities.moveDirections'),
+        verticalDirections: normalizeStringArray(value.capabilities.verticalDirections, 'capabilities.verticalDirections')
+      }
+    };
+
+    return descriptor;
+  }
+
+  function assertReadOnlyAdapter(adapter) {
+    if (!adapter || typeof adapter.readCapabilities !== 'function')
+      fail('adapter.readCapabilities is required');
+
+    FORBIDDEN_AUTHORITY_METHODS.forEach(function(name) {
+      if (typeof adapter[name] === 'function')
+        fail('read-only adapter exposes forbidden authority method: ' + name);
+    });
+  }
+
+  async function inspect(adapter) {
+    assertReadOnlyAdapter(adapter);
+    return normalizeDescriptor(await adapter.readCapabilities());
+  }
+
+  function requireSubset(requiredValues, availableValues, messagePrefix) {
+    var available = new Set(availableValues || []);
+    (requiredValues || []).forEach(function(value) {
+      if (!available.has(value))
+        fail(messagePrefix + value);
+    });
+  }
+
+  function preflight(profile, facts, descriptorValue) {
+    if (!profile || !Array.isArray(profile.hardware))
+      fail('profile hardware requirements unavailable');
+    if (!facts || !facts.statements || !facts.ranges ||
+        !facts.moveDirections || !facts.verticalDirections)
+      fail('AST capability facts unavailable');
+
+    var descriptor = normalizeDescriptor(descriptorValue);
+    requireSubset(profile.hardware, descriptor.hardware, 'required hardware unavailable: ');
+
+    var actions = descriptor.capabilities.actions;
+    facts.statements.forEach(function(kind) {
+      if (['takeoff', 'move', 'vertical', 'turn', 'wait', 'set_speed', 'set_light', 'land'].indexOf(kind) >= 0 &&
+          actions.indexOf(kind) < 0)
+        fail('physical action capability unavailable: ' + kind);
+    });
+    requireSubset(Array.from(facts.ranges), descriptor.capabilities.rangeDirections,
+      'physical range capability unavailable: ');
+    requireSubset(Array.from(facts.moveDirections), descriptor.capabilities.moveDirections,
+      'physical move direction unavailable: ');
+    requireSubset(Array.from(facts.verticalDirections), descriptor.capabilities.verticalDirections,
+      'physical vertical direction unavailable: ');
+
+    return true;
+  }
+
+  return {
+    normalizeDescriptor: normalizeDescriptor,
+    inspect: inspect,
+    preflight: preflight,
+    FORBIDDEN_AUTHORITY_METHODS: FORBIDDEN_AUTHORITY_METHODS.slice()
+  };
+});

--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
@@ -11,6 +11,8 @@
     'setLight', 'arm', 'disarm', 'startMotors', 'stopMotors', 'setpoint',
     'sendSetpoint', 'thrust'
   ];
+  var ACTION_KINDS = ['takeoff', 'move', 'vertical', 'turn', 'wait', 'set_speed', 'set_light', 'land'];
+  var EXACT_AIRFRAME = 'crazyflie-2.1';
 
   function fail(message) {
     throw new Error('physical capability contract: ' + message);
@@ -38,6 +40,24 @@
     });
   }
 
+  function normalizeIdentity(value) {
+    if (!isObject(value))
+      fail('identity must be an object');
+    if (value.family !== 'crazyflie')
+      fail('unsupported device family: ' + String(value.family));
+    if (value.modelEvidence !== 'unproven' && value.modelEvidence !== 'verified')
+      fail('identity.modelEvidence must be unproven or verified');
+
+    if (value.modelEvidence === 'unproven') {
+      if (value.model !== null)
+        fail('unproven exact model must be null');
+      return {family: 'crazyflie', model: null, modelEvidence: 'unproven'};
+    }
+
+    requireString(value.model, 'identity.model');
+    return {family: 'crazyflie', model: value.model, modelEvidence: 'verified'};
+  }
+
   function normalizeDescriptor(value) {
     if (!isObject(value))
       fail('descriptor must be an object');
@@ -45,22 +65,22 @@
       fail('unsupported transport: ' + String(value.transport));
     if (value.connected !== true)
       fail('Crazyflie connection is not established');
+    if (value.executionAuthority !== false)
+      fail('read-only descriptor must declare executionAuthority=false');
 
-    requireString(value.device, 'device');
-    if (value.device !== 'crazyflie-2.1')
-      fail('unsupported device: ' + value.device);
-
+    var identity = normalizeIdentity(value.identity);
     var hardware = normalizeStringArray(value.hardware, 'hardware');
-    if (hardware.indexOf('crazyflie-2.1') < 0)
-      fail('hardware must include crazyflie-2.1');
+    if (hardware.indexOf(EXACT_AIRFRAME) >= 0)
+      fail('exact airframe identity must not be encoded as generic hardware evidence');
 
     if (!isObject(value.capabilities))
       fail('capabilities must be an object');
 
-    var descriptor = {
+    return {
       transport: 'crazyradio',
       connected: true,
-      device: 'crazyflie-2.1',
+      executionAuthority: false,
+      identity: identity,
       hardware: hardware,
       capabilities: {
         actions: normalizeStringArray(value.capabilities.actions, 'capabilities.actions'),
@@ -69,8 +89,6 @@
         verticalDirections: normalizeStringArray(value.capabilities.verticalDirections, 'capabilities.verticalDirections')
       }
     };
-
-    return descriptor;
   }
 
   function assertReadOnlyAdapter(adapter) {
@@ -96,6 +114,19 @@
     });
   }
 
+  function requireHardware(profile, descriptor) {
+    profile.hardware.forEach(function(requirement) {
+      if (requirement === EXACT_AIRFRAME) {
+        if (descriptor.identity.modelEvidence !== 'verified' ||
+            descriptor.identity.model !== EXACT_AIRFRAME)
+          fail('exact physical model evidence unavailable: ' + EXACT_AIRFRAME);
+        return;
+      }
+      if (descriptor.hardware.indexOf(requirement) < 0)
+        fail('required hardware unavailable: ' + requirement);
+    });
+  }
+
   function preflight(profile, facts, descriptorValue) {
     if (!profile || !Array.isArray(profile.hardware))
       fail('profile hardware requirements unavailable');
@@ -104,12 +135,11 @@
       fail('AST capability facts unavailable');
 
     var descriptor = normalizeDescriptor(descriptorValue);
-    requireSubset(profile.hardware, descriptor.hardware, 'required hardware unavailable: ');
+    requireHardware(profile, descriptor);
 
     var actions = descriptor.capabilities.actions;
     facts.statements.forEach(function(kind) {
-      if (['takeoff', 'move', 'vertical', 'turn', 'wait', 'set_speed', 'set_light', 'land'].indexOf(kind) >= 0 &&
-          actions.indexOf(kind) < 0)
+      if (ACTION_KINDS.indexOf(kind) >= 0 && actions.indexOf(kind) < 0)
         fail('physical action capability unavailable: ' + kind);
     });
     requireSubset(Array.from(facts.ranges), descriptor.capabilities.rangeDirections,

--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -37,6 +37,10 @@ def main():
     if variable_test.returncode:
         print('FAIL Runtime v2 variables/memory contract',file=sys.stderr);print(variable_test.stdout,file=sys.stderr);print(variable_test.stderr,file=sys.stderr);return variable_test.returncode
     print(variable_test.stdout.strip())
+    physical_capability_test=subprocess.run(['node','tools/ci/test_physical_capability_contract.js'],text=True,capture_output=True)
+    if physical_capability_test.returncode:
+        print('FAIL read-only physical capability contract',file=sys.stderr);print(physical_capability_test.stdout,file=sys.stderr);print(physical_capability_test.stderr,file=sys.stderr);return physical_capability_test.returncode
+    print(physical_capability_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_capability_contract.js
+++ b/tools/ci/test_physical_capability_contract.js
@@ -20,8 +20,13 @@ const facts = {
 const descriptor = {
   transport: 'crazyradio',
   connected: true,
-  device: 'crazyflie-2.1',
-  hardware: ['crazyflie-2.1','flow-deck-v2','multi-ranger-deck'],
+  executionAuthority: false,
+  identity: {
+    family: 'crazyflie',
+    model: 'crazyflie-2.1',
+    modelEvidence: 'verified'
+  },
+  hardware: ['flow-deck-v2','multi-ranger-deck'],
   capabilities: {
     actions: ['takeoff','move','land'],
     rangeDirections: ['front'],
@@ -42,8 +47,35 @@ const descriptor = {
   assert.deepStrictEqual(observed, descriptor);
   assert.strictEqual(PhysicalCapabilities.preflight(profile, facts, observed), true);
 
+  const unprovenModel = JSON.parse(JSON.stringify(descriptor));
+  unprovenModel.identity.model = null;
+  unprovenModel.identity.modelEvidence = 'unproven';
+  const observedUnproven = await PhysicalCapabilities.inspect({
+    async readCapabilities() { return unprovenModel; }
+  });
+  assert.strictEqual(observedUnproven.identity.model, null);
+  assert.strictEqual(observedUnproven.identity.modelEvidence, 'unproven');
+  assert.throws(
+    () => PhysicalCapabilities.preflight(profile, facts, observedUnproven),
+    /exact physical model evidence unavailable: crazyflie-2.1/
+  );
+
+  const claimedUnprovenModel = JSON.parse(JSON.stringify(unprovenModel));
+  claimedUnprovenModel.identity.model = 'crazyflie-2.1';
+  assert.throws(
+    () => PhysicalCapabilities.normalizeDescriptor(claimedUnprovenModel),
+    /unproven exact model must be null/
+  );
+
+  const encodedAirframe = JSON.parse(JSON.stringify(descriptor));
+  encodedAirframe.hardware.push('crazyflie-2.1');
+  assert.throws(
+    () => PhysicalCapabilities.normalizeDescriptor(encodedAirframe),
+    /exact airframe identity must not be encoded as generic hardware evidence/
+  );
+
   const missingDeck = JSON.parse(JSON.stringify(descriptor));
-  missingDeck.hardware = ['crazyflie-2.1','flow-deck-v2'];
+  missingDeck.hardware = ['flow-deck-v2'];
   assert.throws(
     () => PhysicalCapabilities.preflight(profile, facts, missingDeck),
     /required hardware unavailable: multi-ranger-deck/
@@ -64,6 +96,15 @@ const descriptor = {
     /forbidden authority method: takeoff/
   );
 
+  const unauthorized = JSON.parse(JSON.stringify(descriptor));
+  unauthorized.executionAuthority = true;
+  await assert.rejects(
+    () => PhysicalCapabilities.inspect({
+      async readCapabilities() { return unauthorized; }
+    }),
+    /executionAuthority=false/
+  );
+
   const disconnected = JSON.parse(JSON.stringify(descriptor));
   disconnected.connected = false;
   await assert.rejects(
@@ -82,7 +123,7 @@ const descriptor = {
     /unsupported transport/
   );
 
-  console.log('PASS read-only physical capability handshake fails closed without motor authority');
+  console.log('PASS read-only physical capability handshake separates evidence from execution authority');
 })().catch(error => {
   console.error(error);
   process.exit(1);

--- a/tools/ci/test_physical_capability_contract.js
+++ b/tools/ci/test_physical_capability_contract.js
@@ -1,0 +1,89 @@
+'use strict';
+const assert = require('assert');
+const PhysicalCapabilities = require('../../plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js');
+const Profiles = require('../../plugins/robot_windows/blockly/webeeblocks/activity_profiles.js');
+const Activities = require('../../plugins/robot_windows/blockly/webeeblocks/activities.js');
+
+const profile = Profiles.resolveById(
+  Activities.DOCUMENT,
+  'progression-simple-decision-v1',
+  Activities.BLOCK_CATALOG
+);
+
+const facts = {
+  statements: new Set(['takeoff','move','if','land']),
+  ranges: new Set(['front']),
+  moveDirections: new Set(['forward','left']),
+  verticalDirections: new Set()
+};
+
+const descriptor = {
+  transport: 'crazyradio',
+  connected: true,
+  device: 'crazyflie-2.1',
+  hardware: ['crazyflie-2.1','flow-deck-v2','multi-ranger-deck'],
+  capabilities: {
+    actions: ['takeoff','move','land'],
+    rangeDirections: ['front'],
+    moveDirections: ['forward','left'],
+    verticalDirections: []
+  }
+};
+
+(async function() {
+  let reads = 0;
+  const observed = await PhysicalCapabilities.inspect({
+    async readCapabilities() {
+      reads += 1;
+      return descriptor;
+    }
+  });
+  assert.strictEqual(reads, 1);
+  assert.deepStrictEqual(observed, descriptor);
+  assert.strictEqual(PhysicalCapabilities.preflight(profile, facts, observed), true);
+
+  const missingDeck = JSON.parse(JSON.stringify(descriptor));
+  missingDeck.hardware = ['crazyflie-2.1','flow-deck-v2'];
+  assert.throws(
+    () => PhysicalCapabilities.preflight(profile, facts, missingDeck),
+    /required hardware unavailable: multi-ranger-deck/
+  );
+
+  const missingRange = JSON.parse(JSON.stringify(descriptor));
+  missingRange.capabilities.rangeDirections = [];
+  assert.throws(
+    () => PhysicalCapabilities.preflight(profile, facts, missingRange),
+    /physical range capability unavailable: front/
+  );
+
+  await assert.rejects(
+    () => PhysicalCapabilities.inspect({
+      async readCapabilities() { return descriptor; },
+      takeoff() {}
+    }),
+    /forbidden authority method: takeoff/
+  );
+
+  const disconnected = JSON.parse(JSON.stringify(descriptor));
+  disconnected.connected = false;
+  await assert.rejects(
+    () => PhysicalCapabilities.inspect({
+      async readCapabilities() { return disconnected; }
+    }),
+    /connection is not established/
+  );
+
+  const wrongTransport = JSON.parse(JSON.stringify(descriptor));
+  wrongTransport.transport = 'unknown';
+  await assert.rejects(
+    () => PhysicalCapabilities.inspect({
+      async readCapabilities() { return wrongTransport; }
+    }),
+    /unsupported transport/
+  );
+
+  console.log('PASS read-only physical capability handshake fails closed without motor authority');
+})().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Scope

Advances #157 toward the physical-backend boundary with a deliberately non-motorized P0a contract.

This candidate:
- adds a read-only physical capability descriptor/inspection contract for the reference Crazyflie path;
- requires an established Crazyradio/Crazyflie identity and explicit reference hardware declarations;
- checks activity hardware requirements plus the already-generic action/range/move/vertical capability facts before any future physical execution layer;
- fails closed on missing decks, missing generic capabilities, disconnected/unknown transport, duplicate/malformed descriptor values, or an adapter interface exposing flight/action authority;
- adds a deterministic machine oracle to the existing Runtime v2 core gate.

The slice exposes no physical execution backend, takeoff/thrust/setpoint/arming path, and does not claim that cflib/Crazyradio transport has been product-proven. The actual host-library adapter and any indispensable read-only real-hardware evidence remain subsequent bounded work. No #70 estimator behavior, student vocabulary, final-flight logic, or checkpoint mechanism changes.

Refs #157.