### PR TITLE
Add read-only Crazyradio capability probe

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -41,6 +41,10 @@ def main():
     if physical_capability_test.returncode:
         print('FAIL read-only physical capability contract',file=sys.stderr);print(physical_capability_test.stdout,file=sys.stderr);print(physical_capability_test.stderr,file=sys.stderr);return physical_capability_test.returncode
     print(physical_capability_test.stdout.strip())
+    physical_probe_test=subprocess.run([sys.executable,'tools/ci/test_physical_capability_probe.py'],text=True,capture_output=True)
+    if physical_probe_test.returncode:
+        print('FAIL read-only Crazyradio capability evidence',file=sys.stderr);print(physical_probe_test.stdout,file=sys.stderr);print(physical_probe_test.stderr,file=sys.stderr);return physical_probe_test.returncode
+    print(physical_probe_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_capability_probe.py
+++ b/tools/ci/test_physical_capability_probe.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PROBE_PATH = ROOT / "tools" / "physical" / "probe_reference_hardware.py"
+CONTRACT_PATH = ROOT / "plugins" / "robot_windows" / "blockly" / "webeeblocks" / "physical_capability_contract.js"
+
+spec = importlib.util.spec_from_file_location("probe_reference_hardware", PROBE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load physical capability probe")
+probe = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(probe)
+
+BASE_VALUES = {
+    "firmware.revision0": "305419896",
+    "firmware.revision1": "2596069104",
+    "firmware.modified": "0",
+    "deck.bcFlow2": "1",
+    "deck.bcMultiranger": "1",
+    "deck.bcColorLedBot": "1",
+    "deckTest.bcColorLedBot": "0",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_probe_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except probe.ProbeError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected ProbeError containing {pattern!r}")
+
+
+def main() -> int:
+    descriptor = probe.build_descriptor("11", BASE_VALUES)
+
+    require(descriptor["transport"] == "crazyradio", "transport")
+    require(descriptor["connected"] is True, "connected")
+    require(descriptor["executionAuthority"] is False, "execution authority")
+    require(
+        descriptor["identity"]
+        == {"family": "crazyflie", "model": None, "modelEvidence": "unproven"},
+        "exact airframe must remain unproven",
+    )
+    require(
+        descriptor["hardware"]
+        == ["flow-deck-v2", "multi-ranger-deck", "color-led-deck"],
+        "reference deck evidence",
+    )
+    require(
+        descriptor["capabilities"]["rangeDirections"]
+        == ["front", "back", "left", "right", "up"],
+        "Multi-ranger directions",
+    )
+    require(
+        descriptor["capabilities"]["moveDirections"]
+        == ["forward", "back", "left", "right"],
+        "Flow movement directions",
+    )
+    require(
+        descriptor["capabilities"]["verticalDirections"] == ["up", "down"],
+        "Flow vertical directions",
+    )
+    require("set_light" in descriptor["capabilities"]["actions"], "healthy Color LED action fact")
+    require(
+        descriptor["evidence"]["decks"]["colorLedBottom"]
+        == {"present": True, "selfTestMask": 0, "healthy": True},
+        "Color LED self-test evidence",
+    )
+
+    color_failed = dict(BASE_VALUES)
+    color_failed["deckTest.bcColorLedBot"] = "4"
+    failed_descriptor = probe.build_descriptor(11, color_failed)
+    require("color-led-deck" not in failed_descriptor["hardware"], "failed LED deck must not be advertised")
+    require("set_light" not in failed_descriptor["capabilities"]["actions"], "failed LED action must not be advertised")
+    require(
+        failed_descriptor["evidence"]["decks"]["colorLedBottom"]["selfTestMask"] == 4,
+        "failed LED self-test mask preserved",
+    )
+
+    no_flow = dict(BASE_VALUES)
+    no_flow["deck.bcFlow2"] = "0"
+    no_flow_descriptor = probe.build_descriptor(11, no_flow)
+    require(no_flow_descriptor["capabilities"]["moveDirections"] == [], "movement must fail closed without Flow")
+    require(no_flow_descriptor["capabilities"]["verticalDirections"] == [], "vertical must fail closed without Flow")
+    require("takeoff" not in no_flow_descriptor["capabilities"]["actions"], "flight actions require Flow evidence")
+
+    no_multiranger = dict(BASE_VALUES)
+    no_multiranger["deck.bcMultiranger"] = "0"
+    no_multiranger_descriptor = probe.build_descriptor(11, no_multiranger)
+    require(no_multiranger_descriptor["capabilities"]["rangeDirections"] == [], "range must fail closed without Multi-ranger")
+
+    expect_probe_error(
+        lambda: probe.build_descriptor("not-an-int", BASE_VALUES),
+        "protocolVersion is not an integer",
+    )
+    expect_probe_error(
+        lambda: probe._read_required_parameters(
+            lambda name: (_ for _ in ()).throw(KeyError(name))
+        ),
+        "required read-only parameter unavailable",
+    )
+    expect_probe_error(
+        lambda: probe.probe_live("usb://not-crazyradio"),
+        "explicit Crazyradio radio:// URI",
+    )
+
+    # Prove that the live-probe descriptor is accepted by the integrated P0a
+    # structural normalizer while still remaining unusable for an exact 2.1
+    # profile until distinct model evidence exists.
+    node_script = (
+        "const c=require(" + json.dumps(str(CONTRACT_PATH)) + ");"
+        "let s='';process.stdin.on('data',d=>s+=d);"
+        "process.stdin.on('end',()=>process.stdout.write(JSON.stringify(c.normalizeDescriptor(JSON.parse(s)))));"
+    )
+    normalized = subprocess.run(
+        ["node", "-e", node_script],
+        input=json.dumps(descriptor),
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+        check=False,
+    )
+    require(normalized.returncode == 0, f"JS descriptor normalization failed: {normalized.stderr}")
+    normalized_descriptor = json.loads(normalized.stdout)
+    require(normalized_descriptor["executionAuthority"] is False, "JS keeps non-authority invariant")
+    require(normalized_descriptor["identity"]["modelEvidence"] == "unproven", "JS keeps identity boundary")
+    require("evidence" not in normalized_descriptor, "P0a normalizer exposes only decision fields")
+
+    source = PROBE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        ".set_value(",
+        "scan_interfaces",
+        "commander.",
+        "supervisor.",
+        "send_arming_request",
+        "send_setpoint",
+        "send_hover_setpoint",
+        "send_velocity_world_setpoint",
+    ):
+        require(forbidden not in source, f"read-only probe contains forbidden authority surface: {forbidden}")
+
+    print("PASS cflib probe maps read-only platform/deck evidence without execution authority")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_capability_probe.py
+++ b/tools/ci/test_physical_capability_probe.py
@@ -21,6 +21,7 @@ BASE_VALUES = {
     "firmware.revision0": "305419896",
     "firmware.revision1": "2596069104",
     "firmware.modified": "0",
+    "system.selftestPassed": "1",
     "deck.bcFlow2": "1",
     "deck.bcMultiranger": "1",
     "deck.bcColorLedBot": "1",
@@ -87,6 +88,50 @@ def main() -> int:
     require(
         failed_descriptor["evidence"]["decks"]["colorLedBottom"]["selfTestMask"] == 4,
         "failed LED self-test mask preserved",
+    )
+
+    selftest_failed = dict(BASE_VALUES)
+    selftest_failed["system.selftestPassed"] = "0"
+    selftest_failed_descriptor = probe.build_descriptor(11, selftest_failed)
+    require(
+        "flow-deck-v2" not in selftest_failed_descriptor["hardware"],
+        "Flow deck must not be advertised when boot self-test failed",
+    )
+    require(
+        "multi-ranger-deck" not in selftest_failed_descriptor["hardware"],
+        "Multi-ranger must not be advertised when boot self-test failed",
+    )
+    require(
+        selftest_failed_descriptor["capabilities"]["moveDirections"] == [],
+        "movement must fail closed when boot self-test failed",
+    )
+    require(
+        selftest_failed_descriptor["capabilities"]["verticalDirections"] == [],
+        "vertical movement must fail closed when boot self-test failed",
+    )
+    require(
+        selftest_failed_descriptor["capabilities"]["rangeDirections"] == [],
+        "range must fail closed when boot self-test failed",
+    )
+    require(
+        "set_light" in selftest_failed_descriptor["capabilities"]["actions"],
+        "Color LED keeps its own explicit deck self-test evidence",
+    )
+    require(
+        selftest_failed_descriptor["evidence"]["systemSelfTestPassed"] is False,
+        "failed boot self-test evidence must be preserved",
+    )
+    require(
+        selftest_failed_descriptor["evidence"]["decks"]["flowDeckV2"] is True
+        and selftest_failed_descriptor["evidence"]["decks"]["multiRanger"] is True,
+        "deck presence evidence must remain distinct from health",
+    )
+
+    malformed_selftest = dict(BASE_VALUES)
+    malformed_selftest["system.selftestPassed"] = "not-an-int"
+    expect_probe_error(
+        lambda: probe.build_descriptor(11, malformed_selftest),
+        "system.selftestPassed is not an integer",
     )
 
     no_flow = dict(BASE_VALUES)

--- a/tools/physical/probe_reference_hardware.py
+++ b/tools/physical/probe_reference_hardware.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Read-only Crazyradio/Crazyflie capability probe for WebeeBlocks P0b.
+
+This tool deliberately exposes no flight, arming, setpoint or parameter-write
+operation. It requires an explicit Crazyradio URI and reports only observed
+platform/deck evidence plus conservative hardware-compatible capability facts.
+
+Exact Crazyflie 2.1 identity is intentionally left unproven: the supported
+cflib platform handshake establishes the Crazyflie family, not the exact
+airframe model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import sys
+from typing import Callable, Mapping
+
+PARAMETERS = (
+    "firmware.revision0",
+    "firmware.revision1",
+    "firmware.modified",
+    "deck.bcFlow2",
+    "deck.bcMultiranger",
+    "deck.bcColorLedBot",
+    "deckTest.bcColorLedBot",
+)
+
+FLOW_ACTIONS = (
+    "takeoff",
+    "move",
+    "vertical",
+    "turn",
+    "wait",
+    "set_speed",
+    "land",
+)
+MOVE_DIRECTIONS = ("forward", "back", "left", "right")
+VERTICAL_DIRECTIONS = ("up", "down")
+MULTIRANGER_DIRECTIONS = ("front", "back", "left", "right", "up")
+
+
+class ProbeError(RuntimeError):
+    """Fail-closed error for unavailable or malformed physical evidence."""
+
+
+def _parse_uint(value: object, name: str) -> int:
+    text = str(value).strip()
+    try:
+        parsed = int(text, 0)
+    except (TypeError, ValueError) as exc:
+        raise ProbeError(f"{name} is not an integer parameter value: {text!r}") from exc
+    if parsed < 0:
+        raise ProbeError(f"{name} must be non-negative")
+    return parsed
+
+
+def _read_required_parameters(get_value: Callable[[str], object]) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for name in PARAMETERS:
+        try:
+            value = get_value(name)
+        except Exception as exc:
+            raise ProbeError(f"required read-only parameter unavailable: {name}") from exc
+        if value is None:
+            raise ProbeError(f"required read-only parameter unavailable: {name}")
+        values[name] = value
+    return values
+
+
+def build_descriptor(protocol_version: object, values: Mapping[str, object]) -> dict[str, object]:
+    """Build the P0 capability descriptor from already-read evidence only."""
+    protocol = _parse_uint(protocol_version, "protocolVersion")
+    parsed = {name: _parse_uint(values[name], name) for name in PARAMETERS}
+
+    flow_present = parsed["deck.bcFlow2"] != 0
+    multiranger_present = parsed["deck.bcMultiranger"] != 0
+    color_present = parsed["deck.bcColorLedBot"] != 0
+    color_test_mask = parsed["deckTest.bcColorLedBot"]
+    color_healthy = color_present and color_test_mask == 0
+
+    hardware: list[str] = []
+    actions: list[str] = []
+    move_directions: list[str] = []
+    vertical_directions: list[str] = []
+    range_directions: list[str] = []
+
+    # WebeeBlocks physical movement semantics require the Flow Deck path.
+    # This is hardware compatibility evidence only; executionAuthority stays false.
+    if flow_present:
+        hardware.append("flow-deck-v2")
+        actions.extend(FLOW_ACTIONS)
+        move_directions.extend(MOVE_DIRECTIONS)
+        vertical_directions.extend(VERTICAL_DIRECTIONS)
+
+    if multiranger_present:
+        hardware.append("multi-ranger-deck")
+        range_directions.extend(MULTIRANGER_DIRECTIONS)
+
+    if color_healthy:
+        hardware.append("color-led-deck")
+        actions.append("set_light")
+
+    return {
+        "transport": "crazyradio",
+        "connected": True,
+        "executionAuthority": False,
+        "identity": {
+            "family": "crazyflie",
+            "model": None,
+            "modelEvidence": "unproven",
+        },
+        "hardware": hardware,
+        "capabilities": {
+            "actions": actions,
+            "rangeDirections": range_directions,
+            "moveDirections": move_directions,
+            "verticalDirections": vertical_directions,
+        },
+        "evidence": {
+            "source": "cflib-platform-and-read-only-parameters",
+            "protocolVersion": protocol,
+            "firmware": {
+                "revision0": parsed["firmware.revision0"],
+                "revision1": parsed["firmware.revision1"],
+                "modified": parsed["firmware.modified"] != 0,
+            },
+            "decks": {
+                "flowDeckV2": flow_present,
+                "multiRanger": multiranger_present,
+                "colorLedBottom": {
+                    "present": color_present,
+                    "selfTestMask": color_test_mask,
+                    "healthy": color_healthy,
+                },
+            },
+            "exactAirframeModel": "unproven",
+        },
+    }
+
+
+def probe_live(uri: str) -> dict[str, object]:
+    """Connect to one explicitly named Crazyradio URI and read evidence only."""
+    if not uri.startswith("radio://"):
+        raise ProbeError("P0b requires an explicit Crazyradio radio:// URI")
+
+    try:
+        import cflib.crtp
+        from cflib.crazyflie import Crazyflie
+        from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+    except ImportError as exc:
+        raise ProbeError("cflib is required for the live read-only probe") from exc
+
+    cflib.crtp.init_drivers()
+    try:
+        cflib_version = importlib.metadata.version("cflib")
+    except importlib.metadata.PackageNotFoundError:
+        cflib_version = "unknown"
+
+    try:
+        with SyncCrazyflie(uri, cf=Crazyflie()) as scf:
+            scf.wait_for_params()
+            protocol_version = scf.cf.platform.get_protocol_version()
+            values = _read_required_parameters(scf.cf.param.get_value)
+    except ProbeError:
+        raise
+    except Exception as exc:
+        raise ProbeError(f"Crazyradio/Crazyflie read-only probe failed: {exc}") from exc
+
+    descriptor = build_descriptor(protocol_version, values)
+    descriptor["evidence"]["cflibVersion"] = cflib_version
+    return descriptor
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only WebeeBlocks Crazyradio/Crazyflie capability probe"
+    )
+    parser.add_argument(
+        "--uri",
+        required=True,
+        help="Exact Crazyradio URI, for example radio://0/80/2M/E7E7E7E7E7",
+    )
+    parser.add_argument("--pretty", action="store_true", help="pretty-print JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        descriptor = probe_live(args.uri)
+    except ProbeError as exc:
+        print(f"PROBE_FAILED: {exc}", file=sys.stderr)
+        return 2
+
+    json.dump(
+        descriptor,
+        sys.stdout,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=2 if args.pretty else None,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/probe_reference_hardware.py
+++ b/tools/physical/probe_reference_hardware.py
@@ -22,6 +22,7 @@ PARAMETERS = (
     "firmware.revision0",
     "firmware.revision1",
     "firmware.modified",
+    "system.selftestPassed",
     "deck.bcFlow2",
     "deck.bcMultiranger",
     "deck.bcColorLedBot",
@@ -75,8 +76,11 @@ def build_descriptor(protocol_version: object, values: Mapping[str, object]) -> 
     protocol = _parse_uint(protocol_version, "protocolVersion")
     parsed = {name: _parse_uint(values[name], name) for name in PARAMETERS}
 
+    system_selftest_passed = parsed["system.selftestPassed"] == 1
     flow_present = parsed["deck.bcFlow2"] != 0
     multiranger_present = parsed["deck.bcMultiranger"] != 0
+    flow_healthy = flow_present and system_selftest_passed
+    multiranger_healthy = multiranger_present and system_selftest_passed
     color_present = parsed["deck.bcColorLedBot"] != 0
     color_test_mask = parsed["deckTest.bcColorLedBot"]
     color_healthy = color_present and color_test_mask == 0
@@ -89,13 +93,13 @@ def build_descriptor(protocol_version: object, values: Mapping[str, object]) -> 
 
     # WebeeBlocks physical movement semantics require the Flow Deck path.
     # This is hardware compatibility evidence only; executionAuthority stays false.
-    if flow_present:
+    if flow_healthy:
         hardware.append("flow-deck-v2")
         actions.extend(FLOW_ACTIONS)
         move_directions.extend(MOVE_DIRECTIONS)
         vertical_directions.extend(VERTICAL_DIRECTIONS)
 
-    if multiranger_present:
+    if multiranger_healthy:
         hardware.append("multi-ranger-deck")
         range_directions.extend(MULTIRANGER_DIRECTIONS)
 
@@ -122,6 +126,7 @@ def build_descriptor(protocol_version: object, values: Mapping[str, object]) -> 
         "evidence": {
             "source": "cflib-platform-and-read-only-parameters",
             "protocolVersion": protocol,
+            "systemSelfTestPassed": system_selftest_passed,
             "firmware": {
                 "revision0": parsed["firmware.revision0"],
                 "revision1": parsed["firmware.revision1"],


### PR DESCRIPTION
## Scope

Advances #157 P0b after integrated P0a (#192) with the actual supported-host-library read-only evidence path.

This candidate:
- requires an explicit `radio://` Crazyradio URI and performs no automatic interface scan;
- connects through cflib, waits for the parameter TOC/values, then queries firmware revision and reference-deck presence/self-test parameters without exposing a WebeeBlocks write/command API;
- maps observed Flow Deck V2, Multi-ranger and bottom Color LED evidence into the integrated generic physical capability descriptor;
- preserves the exact-airframe boundary from P0a: Crazyflie-family connectivity is observed while exact `crazyflie-2.1` identity remains `unproven`;
- preserves `executionAuthority:false` and exposes no WebeeBlocks parameter-write, commander/supervisor, arming, setpoint, thrust or motor API;
- fails closed on missing/malformed required read-only evidence and does not advertise failed/missing deck capabilities;
- adds a deterministic CI oracle using synthetic read-only values and cross-checks the result against the integrated P0a JavaScript normalizer without requiring cflib or hardware in CI.


**cflib transport side-effect boundary:** the normal `SyncCrazyflie` close path emits cflib's safety-zero shutdown setpoint before closing the link. Therefore `read-only` here is deliberately scoped to capability-evidence access and the WebeeBlocks adapter API; it does **not** claim that cflib emits no command packet at transport level. That library shutdown effect is not exposed as, or treated as, WebeeBlocks execution authority.
This slice does not create a physical execution backend or authorize flight. Exact Crazyflie 2.1 model proof and any indispensable real-hardware acceptance remain later bounded evidence. No TEST_REQUIRED is introduced here because the machine-only read-only path can be established without a human result.

Refs #157.