### PR TITLE
Harden V4 CI evidence and critical-effect reconstruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ a Controller execution is never project state.
   else is running.
 - Before every durable effect, reconstruct shared GitHub state. If the useful
   equivalent effect already exists, do nothing.
+- An unknown critical precondition forbids the effect. An unknown outcome never
+  proves failure or non-occurrence and permits neither a blind retry nor
+  dependent cleanup. Preserve consequential uncertainty in the relevant existing
+  GitHub artifact when possible; do not turn it into a global lock. Independent
+  work may continue under the existing trunk-health rule.
 
 After every push, Draft/Ready transition, settled CI, review, merge, Git race or
 human result, reconstruct GitHub before deciding again.
@@ -106,6 +111,21 @@ make it unsuitable as the base for subsequent development.
 - Integration must be conditional on the exact validated PR HEAD and must use
   that SHA as `expected_head_sha`. If the PR HEAD moves before the merge effect,
   the merge must fail/no-op and the Controller reconstructs current GitHub state.
+- Immediately before a normal merge, reconstruct current main, PR HEAD/Ready
+  state, target repository/branch, CI/review/findings/checkpoints and applicable
+  main protections. The PR must target this repository's main, with observed
+  base SHA equal to observed main; this equality does not prove strict-base
+  freshness. Use the native conditional squash merge without intervening work;
+  do not switch implicitly to async, stack or queue integration. After a known
+  interruption, reconstruct again before acting.
+- After every merge attempt, including an ambiguous transport failure,
+  reconstruct PR and main. Before claiming the exact candidate integrated,
+  establish the merged PR's association with that source HEAD and the merge
+  commit's presence in current main history. `merged=true` alone is insufficient.
+  A non-merged observation after timeout does not prove the request failed.
+  These observations are not a multi-object CAS: concurrent retarget, late
+  refutation or a suspended old process can still race. A crash before durable
+  observation can lose the fact that a request may have been sent.
 - Integration is serialized. If another merge moves the base and updating a PR
   creates a new HEAD, obtain fresh CI and fresh independent review.
 - A late NO_GO on an already merged candidate becomes durable trunk-health

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,9 +176,17 @@ affect a later decision.
 
 ## Controller loop
 
+At launch, load the complete current-main contract, product vision and roadmap.
+Within the same execution, already loaded complete Git content may be reused
+only after its exact blob identity is revalidated against newly resolved main.
+Missing content, lost context or uncertain identity requires a fresh read.
+Relevant mutable GitHub facts must still be reconstructed; conversation memory
+does not establish current project state.
+
 At launch and after every durable transition:
-1. resolve exact main, reread this contract/product vision/roadmap and rebuild
-   relevant PRs, exact HEADs, CI, reviews, issues and evidence;
+1. resolve exact main, load or revalidate this contract/product vision/roadmap
+   under the rule above and rebuild relevant PRs, exact HEADs, CI, reviews,
+   issues and evidence;
 2. if main is known unhealthy, contribute to restoration first unless a credible
    repair path is durably engaged and another independent action is more useful;
 3. prefer a useful action that reduces remaining engaged work when it is a strong
@@ -213,10 +221,34 @@ independent useful work when available.
 
 ## CI and evidence
 
+- Evaluate candidates under the contract currently integrated on main. Proposed
+  authority changes do not authorize themselves. The existing independent review
+  examines changes to `AGENTS.md`, `.github/workflows/**` (including additions,
+  deletions, renames and both `.yml`/`.yaml`), `.github/actions/**`,
+  `tools/ci/select_ci.py`, `tools/ci/check_ci_gate.py`,
+  `tools/ci/test_controller_contract.py` and `tools/ci/test_workflow_contract.py`
+  against the existing obligations. Changes to other scripts, tests,
+  configuration or dependencies producing the evidence require the same scrutiny
+  of their affected obligations; this list is not an exhaustive trust boundary.
+- Technical changes preserving the authorized obligations may use the existing
+  independent review without a new human approval. Changes to obligations,
+  permissions, trust or human boundaries require applicable governance
+  authorization; an explicit owner instruction may already provide it.
+- Required CI evidence identifies the canonical `.github/workflows/ci.yml`
+  pull_request workflow in the expected repository, its association with the PR,
+  exact candidate HEAD, newest relevant run and effective current attempt.
+  Select the newest relevant run before examining its conclusion: an older
+  success cannot replace a newer pending, failed, cancelled or ambiguous run.
+  Require a completed successful run and its successful final `CI Gate` job;
+  a homonymous check or `CI Gate (Draft)` is not sufficient evidence. If identity,
+  completeness or rerun provenance is unknown, do not infer a positive result.
+  See docs/DEVELOPMENT.md for the native GitHub observations.
 - CI proves only the automated properties its oracles exercise.
 - A red result should strongly refute an automated property; a green result
   should strongly establish that scoped property, not full product acceptance.
 - Unsupported required evidence is never fabricated into a pass.
+- Missing or malformed CI selection never exempts a suite. An unselected suite
+  requires explicit `"false"` selection and an observed `skipped` result.
 - Network availability is not an acceptance oracle.
 - There is no Candidate Evidence pipeline. Automated evidence required for PR
   integration belongs in CI Gate; real-world evidence belongs at the human

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,6 +63,57 @@ health is restored. Other independent machine work may continue. A late
 refutation of an already merged SHA is diagnosed against current main before a
 fix-forward or narrow revert.
 
+### Normal merge and result
+
+Use the existing synchronous merge API for an independent PR targeting main:
+
+1. Reconstruct exact main B and PR N: open, Ready, validated HEAD H, base repository
+   `djibian/webeeblocks`, `base.ref=main`, `base.sha=B`. Check the canonical CI,
+   independent GO, applicable findings/checkpoints and trunk health. Observe the
+   applicable protections below; an inaccessible ruleset is not an absent rule.
+   `base.sha=B` checks two observations agree, not that H contains B. Strict-base
+   protection remains necessary; Git ancestry may help diagnose a stale branch.
+2. Without intervening work, call `PUT /repos/djibian/webeeblocks/pulls/N/merge`
+   with `sha=H` (the tool's `expected_head_sha`) and `merge_method=squash`.
+   Never retry this write automatically on a transport error. A 409 requires
+   reconstruction, not substitution of a newer H under the old GO. Do not switch
+   implicitly to an async API, auto-merge, stacked PRs or a queue.
+3. After success or error, read PR N and current main M. To claim H integrated,
+   establish that N is merged, its source HEAD is H in the available evidence,
+   and `merge_commit_sha=S` is an ancestor of M. Use exact Git objects with
+   `git merge-base --is-ancestor S M`, or a GitHub compare result establishing S
+   as the merge-base of `S...M`; S=M also passes. An equality of trees or a live
+   branch pointer alone does not establish the historical source HEAD.
+
+| Observation | Permitted conclusion |
+|---|---|
+| Merged N, source H established, S in main history | H's integration is confirmed; reconstruct cleanup eligibility separately |
+| Merged N and S in main, but source H not established | PR integration observed; this attempt's exact-subject claim is UNKNOWN |
+| PR not merged after timeout | UNKNOWN; the earlier request may still take effect |
+| Merged PR, but S not established in main | No confirmed normal integration; diagnose target and observation consistency |
+| Documented rejection, with no earlier ambiguous send for the known attempt | That request was refused; diagnose before a new request |
+| Missing or inconsistent required evidence | UNKNOWN; no success claim, blind retry or dependent cleanup |
+
+GitHub's merge condition binds HEAD, not base, reviews, checks and rulesets
+atomically. Main membership proves integration history, not current product health
+or absence of an earlier retarget race. An unseen old process is not fenced by a
+rule to reconstruct after interruption. Concurrent Controllers can recognize the
+same existing merge without owning the PR or promising exactly one request.
+
+Preserve consequential uncertainty in the existing PR: operation, exact HEAD/ref,
+observed response/timeout and missing confirmation. A factual comment suffices;
+no intent log or special state format is introduced. A crash before that comment
+can lose the fact that a request may have been sent: **UNRESOLVED**. A delayed
+request is not proven absent by waiting. UNKNOWN blocks the dependent effect,
+not all independent machine work or all other merges; the existing main-health
+rule still applies. No machine-lifecycle notification is added.
+
+For branch cleanup, retain the existing exact-tip conditional deletion rule.
+After response loss, an absent ref proves only its observed absence; a different
+tip must not be deleted; the same tip still requires reconstructing usefulness
+and dependencies before another attempt. Tip CAS does not fence a concurrently
+created dependent PR. A GET followed by unconditional REST DELETE is not CAS.
+
 ## CI topology
 
 .github/workflows/ci.yml is the sole PR CI entry point and targets main. It
@@ -154,8 +205,50 @@ merges, Controller startup/termination/blocking and relaunch are silent.
 
 ## Repository protections
 
-V4 requires main protected by PR + required CI Gate + up-to-date candidate, with
-destructive force-push/deletion disabled. These administration settings are
-outside Git and must be restored explicitly in a rollback.
+For this installation, observe active protections applying to main: PR required,
+squash only, `CI Gate` required from GitHub Actions, strict up-to-date checking,
+force-push/deletion blocked, no bypass actor. Native approving-review count is
+zero: the exact-HEAD independent GO is a Controller obligation, not a GitHub
+approval from another account. Read all applicable rulesets/branch protections;
+a rule's display name alone is not proof of enforcement. Administrative changes
+can still race those reads.
+
+These settings live outside Git. A code/docs revert does not change them, and
+this hardening adds no administrative setting to restore. If a separate change
+alters protections, its rollback must restore those settings explicitly.
 
 A future merge queue is optional only if integration contention becomes real.
+
+## Install or restore this V4 on another repository
+
+1. Adapt AGENTS.md, PRODUCT_VISION.md and ROADMAP.md to the product and explicitly
+   name its trusted decision principal. Preserve stateless executions, independent
+   review, exact HEADs, small PRs and the human boundary. Do not copy live issues,
+   workflow IDs or another repository's owner as authority.
+2. Supply product-appropriate deterministic suites behind one canonical PR CI
+   entry point and a Ready-only `CI Gate`; Draft has a distinct check name.
+   Adapt the existing selector/gate interface and workflow-inventory tests
+   together if suite names change. This repository's Runtime/Webots suites are
+   product-specific, not generic V4 infrastructure.
+3. Configure and read back the main protections above, with the installation's
+   actual App identity. Verify that the Controller's authorized tools can read
+   PRs, reviews, full relevant runs/attempts/jobs and protections, and can perform
+   exact-HEAD merges and exact-tip ref deletion. Do not add a service or credential
+   merely to conceal missing observations. Explicit owner override is outside
+   the normal guarantee.
+4. Enable a human-checkpoint profile only once its deterministic preparation,
+   artifact digest, single unresolved TEST_REQUIRED and notification provenance
+   are implemented. Preserve product-specific physical/publication authority.
+5. Qualify the installation with disposable branches/PRs: Draft cannot emit the
+   required context; new HEAD invalidates old CI/GO; wrong merge SHA and wrong
+   deletion tip are refused; stale base is blocked; a homonymous workflow is not
+   decision evidence; missing CI inputs fail while legitimate skips pass.
+   Examine timeout, retarget and late-refutation scenarios as limits, not claimed
+   atomic guarantees. Run the contract tests, then obtain independent review.
+
+On this repository, the minimal upgrade changes six existing files and adds no
+workflow, stored state, service or permission. Revert the relevant code/text/test
+change through the existing PR process to roll it back; preserve useful evidence
+already recorded. Prefer repairing a legitimate incompatibility over restoring
+the CI oracle's implicit exemptions. Contract-string tests guard wording only;
+they cannot prove that a Controller follows these operational rules.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,15 +28,22 @@ relevant issue/PR/review/evidence. Session presence, ownership, handoffs,
 heartbeats, relaunch state and agent pools do not exist.
 
 Durability does not imply trust. Decision facts are authoritative only when their
-provenance satisfies the V4 trust contract: `CI Gate` must come from the expected
-GitHub Actions context; Controller GO/NO_GO/UNPROVEN and human PASS/FAIL/NOT_NEEDED
+provenance satisfies the V4 trust contract: `CI Gate` must be identified through
+the canonical workflow/run/attempt below, not just a context name or App;
+Controller GO/NO_GO/UNPROVEN and human PASS/FAIL/NOT_NEEDED
 must come from repository owner `djibian` and bind the exact applicable SHA or
 request. External comments/reviews are evidence to inspect, not decision authority.
+
+Resolve main before decisions. Complete immutable contract/vision/roadmap content
+already available in the same execution may be reused only when its Git blob is
+identical at newly resolved main. Reconstruct relevant mutable PRs, reviews,
+checks, refs, issues and protections. Lost context requires a fresh read; a local
+recollection is not proof of object identity.
 
 ## Draft / Ready
 
 - Draft means the change may still be mutated.
-- Ready means the exact HEAD is frozen for decision CI/review.
+- Ready offers the exact HEAD as stable for decision CI/review; it is not a lock.
 - Draft runs may perform policy checks, but only a Ready candidate may publish
   the required `CI Gate` check context.
 - Mutating a Ready PR requires returning it to Draft first.
@@ -68,6 +75,55 @@ not automatically a release/promotion run.
 There is no Candidate Evidence workflow. Deterministic evidence required to
 integrate a PR belongs in CI Gate.
 
+`check_ci_gate.py` requires explicit string selections `"true"`/`"false"` for
+both suites and observed results for `select`, `runtime` and `webots`. A selected
+suite must succeed; an unselected suite must be skipped. Missing/malformed or
+duplicate JSON input fails the gate. Documentation-only selection remains valid.
+The topology contract inventories both `.yml` and `.yaml` workflow files.
+
+### Authority changes
+
+Evaluate a candidate under AGENTS.md on current main, including when the PR
+proposes changing that file. Review workflow additions/deletions/renames, local
+actions, selectors, gates and contract tests against the existing obligations.
+Also inspect changed assertions, configuration and dependencies used by the CI;
+the named paths in AGENTS.md are review triggers, not a complete dependency list.
+
+A technical repair or new test preserving those obligations may use the normal
+independent review. That review examines the counterexample and a healthy control;
+the candidate's own green CI alone cannot justify changing its oracle. Changing
+obligations, trust, permissions or human boundaries requires the applicable
+governance authorization, which an explicit owner request may already supply.
+Ordinary product PRs and technical test extensions need no additional human
+decision or second review. These are Controller obligations, not server access
+controls against an actor that ignores the contract.
+
+### Identify decision CI
+
+Use native GitHub reads, not a new check or stored eligibility record:
+
+1. Read PR N and exact HEAD H. List runs for H and `event=pull_request`, following
+   pagination as needed to establish the complete relevant set. Identify the
+   approved `.github/workflows/ci.yml` workflow in this repository by workflow ID
+   and path, and establish its association with N and H. Do not trust a job's
+   freely chosen name as workflow identity. An installation's workflow ID is
+   repository-specific; it must not be copied to a new repository.
+2. Among those runs, choose the greatest `run_number`, then server ID if tied,
+   before filtering on conclusion. Read that run R and current `run_attempt` A.
+   Require `status=completed` and `conclusion=success`.
+3. Read the jobs of R's effective current attempt and require its final `CI Gate`
+   job to have succeeded. `CI Gate (Draft)` is insufficient. Recheck R if these
+   reads may have crossed a rerun; a changed attempt requires reconstruction.
+   Partial reruns may inherit jobs: do not invent their provenance or require a
+   full rerun when native evidence already establishes the effective result.
+
+The REST surfaces are `GET pulls/N`, `GET actions/runs?head_sha=H&event=pull_request`,
+`GET actions/runs/R` and `GET actions/runs/R/attempts/A/jobs`, under
+`/repos/djibian/webeeblocks`. A newer pending/failed/cancelled run cannot be replaced
+with an older success. Missing association, pagination or attempt evidence means
+UNKNOWN, not permission to fall back to a homonymous green check. Read metadata
+for a healthy run; logs are for diagnosis. No historical negative run poisons H.
+
 ## Real-world checkpoint pipeline
 
 Controllers never notify ntfy directly. A legitimate need is materialized by a
@@ -81,9 +137,11 @@ Runtime + Webots evidence, requires the relevant built artifact, records
 provenance/digest, serializes the publication step, refuses a second open human
 test, then creates one durable [TEST_REQUIRED] issue and sends ntfy.
 
-The only enabled profile at V4 cut-over is `windows-low-end`, backed by the
-`WebeeBlocks-Windows-R2025a` artifact. Unknown profiles fail closed until their
-deterministic preparation is explicitly implemented.
+The enabled profiles are `windows-low-end`, backed by the
+`WebeeBlocks-Windows-R2025a` artifact, and `s3-props-off`, backed by
+`experimental-s3-surface-offset-2026-08` and restricted to purpose `checkpoint`.
+Unknown profiles fail closed until their deterministic preparation is explicitly
+implemented. A props-off checkpoint never authorizes motorized flight.
 
 There is no human-test queue. Other needs remain silent in their original GitHub
 context until the open request resolves. TEST_REQUIRED resolves as PASS, FAIL or

--- a/tools/ci/check_ci_gate.py
+++ b/tools/ci/check_ci_gate.py
@@ -8,23 +8,50 @@ import os
 import sys
 
 
-def main() -> int:
-    selection = json.loads(os.environ.get("CI_SELECTION", "{}"))
-    needs = json.loads(os.environ.get("CI_NEEDS", "{}"))
-
+def evaluate_gate(selection: object, needs: object) -> list[str]:
+    if not isinstance(selection, dict) or set(selection) != {"runtime", "webots"}:
+        return ["invalid CI evidence: selection must name runtime and webots"]
     failures: list[str] = []
-    if needs.get("select", {}).get("result") != "success":
-        failures.append("selection job did not succeed")
+    for suite, selected in selection.items():
+        if not isinstance(selected, str) or selected not in ("true", "false"):
+            failures.append(f"invalid CI evidence: selection for {suite} is {selected!r}")
+    if not isinstance(needs, dict) or set(needs) != {"select", "runtime", "webots"}:
+        return failures + ["invalid CI evidence: needs must name select, runtime and webots"]
+    for job, evidence in needs.items():
+        if not isinstance(evidence, dict) or not isinstance(evidence.get("result"), str):
+            failures.append(f"invalid CI evidence: missing result for {job}")
+    if failures:
+        return failures
 
+    if needs["select"]["result"] != "success":
+        failures.append("selection job did not succeed")
     for suite in ("runtime", "webots"):
-        selected = selection.get(suite) == "true"
-        result = needs.get(suite, {}).get("result")
-        if selected and result != "success":
-            failures.append(f"selected {suite} suite result is {result!r}")
-        if not selected and result not in ("skipped", None):
-            failures.append(f"unselected {suite} suite unexpectedly returned {result!r}")
+        expected = "success" if selection[suite] == "true" else "skipped"
+        result = needs[suite]["result"]
+        if result != expected:
+            failures.append(f"{suite}: expected {expected}, observed {result!r}")
+    return failures
+
+
+def unique_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def main() -> int:
+    try:
+        selection = json.loads(os.environ["CI_SELECTION"], object_pairs_hook=unique_keys)
+        needs = json.loads(os.environ["CI_NEEDS"], object_pairs_hook=unique_keys)
+    except (KeyError, ValueError) as error:
+        print(f"CI Gate failure: invalid CI evidence: {error}", file=sys.stderr)
+        return 1
 
     print(json.dumps({"selection": selection, "results": needs}, indent=2))
+    failures = evaluate_gate(selection, needs)
     if failures:
         for failure in failures:
             print(f"CI Gate failure: {failure}", file=sys.stderr)
@@ -34,4 +61,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tools/ci/test_ci_gate.py
+++ b/tools/ci/test_ci_gate.py
@@ -2,6 +2,8 @@
 
 import contextlib
 import io
+import itertools
+import json
 import os
 import unittest
 from unittest.mock import patch
@@ -10,10 +12,11 @@ import check_ci_gate
 
 
 class GateTests(unittest.TestCase):
-    def run_gate(self, selection: str, needs: str) -> int:
+    def run_gate(self, selection: str | None, needs: str | None) -> int:
         with patch.dict(
             os.environ,
-            {"CI_SELECTION": selection, "CI_NEEDS": needs},
+            {key: value for key, value in
+             (("CI_SELECTION", selection), ("CI_NEEDS", needs)) if value is not None},
             clear=True,
         ), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             return check_ci_gate.main()
@@ -34,10 +37,84 @@ class GateTests(unittest.TestCase):
 
     def test_selector_failure_fails_closed(self) -> None:
         result = self.run_gate(
-            '{}',
+            '{"runtime":"false","webots":"false"}',
             '{"select":{"result":"failure"},"runtime":{"result":"skipped"},"webots":{"result":"skipped"}}',
         )
         self.assertEqual(result, 1)
+
+    def test_all_selection_and_job_result_combinations(self) -> None:
+        successes = 0
+        for flags in itertools.product(("true", "false"), repeat=2):
+            selection = dict(zip(("runtime", "webots"), flags))
+            for results in itertools.product(
+                ("success", "failure", "cancelled", "skipped"), repeat=3
+            ):
+                needs = dict(zip(
+                    ("select", "runtime", "webots"),
+                    ({"result": result} for result in results),
+                ))
+                expected = ("success",) + tuple(
+                    "success" if flag == "true" else "skipped" for flag in flags
+                )
+                with self.subTest(selection=selection, results=results):
+                    result = self.run_gate(json.dumps(selection), json.dumps(needs))
+                    self.assertEqual(result, 0 if results == expected else 1)
+                    successes += result == 0
+        # Includes documentation-only and either suite selected independently.
+        self.assertEqual(successes, 4)
+
+    def test_invalid_selection_never_exempts_suites(self) -> None:
+        needs = '{"select":{"result":"success"},"runtime":{"result":"skipped"},"webots":{"result":"skipped"}}'
+        cases = [None, [], {}, {"runtime": "false"},
+                 {"runtime": "false", "webots": "false", "other": "false"}]
+        for suite in ("runtime", "webots"):
+            for invalid in ("", "tru", "False", False, True, None, 0, []):
+                cases.append({"runtime": "false", "webots": "false", suite: invalid})
+        for selection in cases:
+            with self.subTest(selection=selection):
+                self.assertEqual(self.run_gate(json.dumps(selection), needs), 1)
+
+    def test_missing_or_invalid_job_evidence_fails_closed(self) -> None:
+        selection = '{"runtime":"false","webots":"false"}'
+        valid = {"select": {"result": "success"},
+                 "runtime": {"result": "skipped"}, "webots": {"result": "skipped"}}
+        cases = [None, [], {}, {**valid, "other": {"result": "success"}}]
+        for job in valid:
+            cases.append({key: value for key, value in valid.items() if key != job})
+            for invalid in (None, [], {}, {"result": None}, {"result": False}):
+                cases.append({**valid, job: invalid})
+            for result in ("", "neutral", "timed_out", "action_required", "unknown"):
+                cases.append({**valid, job: {"result": result}})
+        for needs in cases:
+            with self.subTest(needs=needs):
+                self.assertEqual(self.run_gate(selection, json.dumps(needs)), 1)
+
+    def test_nested_job_metadata_does_not_replace_result(self) -> None:
+        self.assertEqual(self.run_gate(
+            '{"runtime":"false","webots":"false"}',
+            '{"select":{"result":"success","outputs":{}},"runtime":{"result":"skipped"},"webots":{"result":"skipped"}}',
+        ), 0)
+
+    def test_absent_malformed_or_duplicate_json_is_a_controlled_failure(self) -> None:
+        selection = '{"runtime":"false","webots":"false"}'
+        needs = '{"select":{"result":"success"},"runtime":{"result":"skipped"},"webots":{"result":"skipped"}}'
+        cases = [(invalid, needs) for invalid in (None, "", "{")]
+        cases += [(selection, invalid) for invalid in (None, "", "{")]
+        cases += [
+            ('{"runtime":"true","runtime":"false","webots":"false"}', needs),
+            (selection, needs.replace('"result":"skipped"',
+                                      '"result":"failure","result":"skipped"', 1)),
+        ]
+        for selected, observed in cases:
+            with self.subTest(selection=selected, needs=observed):
+                environment = {key: value for key, value in
+                               (("CI_SELECTION", selected), ("CI_NEEDS", observed))
+                               if value is not None}
+                error = io.StringIO()
+                with patch.dict(os.environ, environment, clear=True), \
+                        contextlib.redirect_stderr(error):
+                    self.assertEqual(check_ci_gate.main(), 1)
+                self.assertIn("invalid CI evidence", error.getvalue())
 
 
 if __name__ == "__main__":

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed static contract for V4 multi-Controller governance."""
+"""Guard V4 contract wording; these tests do not prove Controller behavior."""
 
 from pathlib import Path
 import unittest
@@ -37,6 +37,41 @@ class ContractTests(unittest.TestCase):
         self.assertIn("External comments or reviews remain evidence to inspect", self.contract)
         self.assertIn("Durability does not imply trust", self.development)
         self.assertIn("github-actions[bot]", self.notifications)
+
+    def test_current_main_governs_authority_changes(self):
+        for required in (
+            "contract currently integrated on main",
+            "Proposed authority changes do not authorize themselves",
+            "`.github/workflows/**`", "both `.yml`/`.yaml`", "`.github/actions/**`",
+            "`tools/ci/select_ci.py`", "`tools/ci/check_ci_gate.py`",
+            "`tools/ci/test_controller_contract.py`", "`tools/ci/test_workflow_contract.py`",
+            "this list is not an exhaustive trust boundary",
+            "Technical changes preserving the authorized obligations",
+            "independent review without a new human approval",
+            "require applicable governance authorization",
+        ):
+            self.assertIn(required, self.contract)
+
+    def test_canonical_ci_identity_and_latest_attempt(self):
+        for required in (
+            "canonical `.github/workflows/ci.yml`", "association with the PR",
+            "exact candidate HEAD", "effective current attempt",
+            "Select the newest relevant run before examining its conclusion",
+            "an older success cannot replace a newer pending, failed, cancelled or ambiguous run",
+            "a homonymous check or `CI Gate (Draft)` is not sufficient evidence",
+            "Missing or malformed CI selection never exempts a suite",
+        ):
+            self.assertIn(required, self.contract)
+
+    def test_immutable_context_reuse_keeps_live_reconstruction(self):
+        for required in (
+            "load the complete current-main contract, product vision and roadmap",
+            "Within the same execution, already loaded complete Git content",
+            "exact blob identity is revalidated against newly resolved main",
+            "Missing content, lost context or uncertain identity requires a fresh read",
+            "Relevant mutable GitHub facts must still be reconstructed",
+        ):
+            self.assertIn(required, self.contract)
 
     def test_transient_branch_cleanup_requires_durable_authority_and_atomic_ref_safety(self):
         self.assertIn("Short-lived branches are transient project references", self.contract)

--- a/tools/ci/test_controller_contract.py
+++ b/tools/ci/test_controller_contract.py
@@ -73,6 +73,32 @@ class ContractTests(unittest.TestCase):
         ):
             self.assertIn(required, self.contract)
 
+    def test_critical_effect_unknown_is_not_failure(self):
+        for required in (
+            "An unknown critical precondition forbids the effect",
+            "An unknown outcome never proves failure or non-occurrence",
+            "neither a blind retry nor dependent cleanup",
+            "Preserve consequential uncertainty in the relevant existing GitHub artifact",
+            "do not turn it into a global lock",
+            "A non-merged observation after timeout does not prove the request failed",
+            "A crash before durable observation can lose the fact that a request may have been sent",
+        ):
+            self.assertIn(required, self.contract)
+
+    def test_merge_confirmation_requires_exact_subject_and_main_presence(self):
+        for required in (
+            "target this repository's main",
+            "this equality does not prove strict-base freshness",
+            "native conditional squash merge without intervening work",
+            "do not switch implicitly to async, stack or queue integration",
+            "After every merge attempt, including an ambiguous transport failure",
+            "merged PR's association with that source HEAD",
+            "merge commit's presence in current main history",
+            "`merged=true` alone is insufficient",
+            "These observations are not a multi-object CAS",
+        ):
+            self.assertIn(required, self.contract)
+
     def test_transient_branch_cleanup_requires_durable_authority_and_atomic_ref_safety(self):
         self.assertIn("Short-lived branches are transient project references", self.contract)
         self.assertIn("durable applicable project evidence under the existing provenance and authority rules", self.contract)

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -3,7 +3,9 @@
 
 from pathlib import Path
 import re
+import tempfile
 import unittest
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -33,10 +35,46 @@ def job_ids(text: str) -> set[str]:
     jobs = text.split("\njobs:\n", 1)[1]
     return set(re.findall(r"^  ([A-Za-z0-9_-]+):\s*$", jobs, re.MULTILINE))
 
+def workflow_files() -> list[Path]:
+    return sorted(
+        path for path in WORKFLOWS.iterdir()
+        if path.is_file() and path.suffix in {".yml", ".yaml"}
+    )
+
 class WorkflowTests(unittest.TestCase):
     def test_only_v4_workflows_exist(self):
-        names = {path.name for path in WORKFLOWS.glob("*.yml")}
+        names = {path.name for path in workflow_files()}
         self.assertEqual(names, set(EXPECTED))
+
+    def test_inventory_rejects_extra_or_missing_workflows(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            for name in EXPECTED:
+                (directory / name).touch()
+            with patch(f"{__name__}.WORKFLOWS", directory):
+                self.test_only_v4_workflows_exist()
+                for suffix in (".yml", ".yaml"):
+                    with self.subTest(suffix=suffix):
+                        extra = directory / f"unexpected{suffix}"
+                        extra.touch()
+                        with self.assertRaises(AssertionError):
+                            self.test_only_v4_workflows_exist()
+                        extra.unlink()
+                (directory / "ci.yml").unlink()
+                with self.assertRaises(AssertionError):
+                    self.test_only_v4_workflows_exist()
+
+    def test_push_trigger_check_covers_both_yaml_extensions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            with patch(f"{__name__}.WORKFLOWS", directory):
+                for suffix in (".yml", ".yaml"):
+                    with self.subTest(suffix=suffix):
+                        workflow = directory / f"unexpected{suffix}"
+                        workflow.write_text("on:\n  push:\n", encoding="utf-8")
+                        with self.assertRaises(AssertionError):
+                            self.test_no_post_merge_push_trigger()
+                        workflow.unlink()
 
     def test_job_sets(self):
         for name, expected in EXPECTED.items():
@@ -242,7 +280,7 @@ class WorkflowTests(unittest.TestCase):
         )
 
     def test_no_post_merge_push_trigger(self):
-        for path in WORKFLOWS.glob("*.yml"):
+        for path in workflow_files():
             self.assertNotIn("  push:\n", path.read_text(encoding="utf-8"), path.name)
 
 if __name__ == "__main__":


### PR DESCRIPTION
At `main@9aa955a13c24431463b36dedb9de6147bc89fdd7`, the CI aggregator accepts missing/empty/misspelled selection as an exemption when both suites are skipped. The workflow inventory also ignores executable `.yaml` files. Both counterexamples were reproduced locally against that exact base.

This implements the owner's requested minimal V4 hardening in six existing files, organized as three commits:

1. Require explicit valid CI selection and job results, reject ambiguous duplicate JSON keys, and inventory both YAML extensions. Legitimate documentation-only selection remains green.
2. Evaluate governance changes under current main; identify decision CI by canonical workflow, exact PR/HEAD and the newest run/current attempt. Preserve independent technical review without adding routine human approval. Permit reuse of complete immutable Git text only after exact blob revalidation.
3. Specify final reconstruction, conditional merge and confirmed exact-subject/main postconditions. An unknown outcome permits no blind retry or dependent cleanup. Document installation on a new repository, rollback and remaining races; correct the stale checkpoint-profile documentation.

The production change is confined to the existing CI aggregator. Workflows, rulesets, credentials, task selection, independent review and the human notification mechanism retain their existing topology. There is no V5 activation, new check, service, ledger or persistent execution state.

**Author verification**

- Canonical GitHub CI on `1445517088deaea1620ed1a297d563ff48d3da37`: [run 34140220967, attempt 1](https://github.com/djibian/webeeblocks/actions/runs/34140220967), **33/33 jobs successful**, including [CI Gate](https://github.com/djibian/webeeblocks/actions/runs/34140220967/job/101801396412). Workflow `.github/workflows/ci.yml`, ID `346601041`, event `pull_request`, associated with PR #195.
- All eight Python contract/test suites invoked by the existing CI selection job pass locally: **71 tests**.
- The gate test exercises **256 selection/result combinations**, retaining the four legitimate successes, including documentation-only and either suite independently selected.
- Missing/malformed selections and results, invalid JSON, duplicate keys, unexpected `.yml`/`.yaml`, a missing workflow and push-trigger coverage have executable regression fixtures.
- `git diff --check` passes. The unchanged selector requests both full suites for this governance change.
- GitHub trees for the three published commits match the locally tested trees exactly; final tree: `c6479555f05c0c1c5394cb307f0b9fb0550423f8`.

**Review boundary**

The new contract-string tests guard wording; they do not prove Controller behavior. Review must independently examine the oracle changes against the previous obligations and assess newest-run selection, changed-authority review, exact immutable-text reuse and unknown-result handling.

This does **not** claim atomic base/review/ruleset binding, monotone durability of mutable reviews, or recovery of a request sent before a crash and before any durable observation. The guide explicitly retains those limits. A technical test extension is not automatically a human-governance checkpoint.

The current execution authored these changes and cannot provide their independent GO under current-main AGENTS.md. Integration still requires canonical exact-HEAD CI and an independent GO from another execution.

Rollback uses the existing PR process: revert the relevant code/text/tests; no data migration or protection change is required. Preserve already recorded evidence.