### PR TITLE
Prepare reference hardware capability checkpoint

### DIFF
--- a/.github/workflows/human-checkpoint.yml
+++ b/.github/workflows/human-checkpoint.yml
@@ -62,10 +62,12 @@ jobs:
           PROFILES = {
               'windows-low-end': 'WebeeBlocks-Windows-R2025a',
               's3-props-off': 'experimental-s3-surface-offset-2026-08',
+              'physical-capabilities-readonly': 'WebeeBlocks-Physical-Capability-Probe',
           }
           PURPOSES = {
               'windows-low-end': {'checkpoint', 'release'},
               's3-props-off': {'checkpoint'},
+              'physical-capabilities-readonly': {'checkpoint'},
           }
 
           def get_commit(sha):
@@ -142,13 +144,53 @@ jobs:
     with:
       target_sha: ${{ needs.validate.outputs.target_sha }}
 
+  physical:
+    name: Prepare physical capability probe
+    needs: validate
+    if: needs.validate.outputs.test_profile == 'physical-capabilities-readonly'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.target_sha }}
+
+      - name: Validate physical capability probe
+        run: |
+          set -euo pipefail
+          python3 tools/ci/test_physical_capability_probe.py
+          node tools/ci/test_physical_capability_contract.js
+
+      - name: Package exact non-authority probe
+        run: |
+          set -euo pipefail
+          bundle=ci-artifacts/physical-capability-probe
+          mkdir -p "$bundle"
+          cp tools/physical/probe_reference_hardware.py "$bundle/"
+          cp tools/physical/reference_probe_requirements.txt "$bundle/"
+          cp tools/physical/run_reference_probe.sh "$bundle/"
+          chmod +x "$bundle/run_reference_probe.sh"
+          (
+            cd "$bundle"
+            sha256sum probe_reference_hardware.py reference_probe_requirements.txt run_reference_probe.sh > SHA256SUMS
+          )
+
+      - name: Upload physical capability probe
+        uses: actions/upload-artifact@v4
+        with:
+          name: WebeeBlocks-Physical-Capability-Probe
+          path: ci-artifacts/physical-capability-probe/
+          if-no-files-found: error
+
   publish:
     name: Publish one TEST_REQUIRED
-    needs: [validate, runtime, webots]
+    needs: [validate, runtime, webots, physical]
     if: >-
+      always() &&
       needs.validate.outputs.target_sha != '' &&
       needs.runtime.result == 'success' &&
-      needs.webots.result == 'success'
+      needs.webots.result == 'success' &&
+      (needs.validate.outputs.test_profile != 'physical-capabilities-readonly' ||
+       needs.physical.result == 'success')
     runs-on: ubuntu-22.04
     concurrency:
       group: webeeblocks-human-test-open

--- a/.github/workflows/human-checkpoint.yml
+++ b/.github/workflows/human-checkpoint.yml
@@ -197,6 +197,11 @@ jobs:
           )
           grep -Fq 'cflib_commit=45fdb784c9d13074c42835f3b5ac1d12133bf873' "$bundle/PROVENANCE.txt"
 
+          ambient="$RUNNER_TEMP/ambient-cflib"
+          mkdir -p "$ambient/cflib"
+          printf '%s\n' 'raise RuntimeError("ambient cflib must never be imported")' > "$ambient/cflib/__init__.py"
+          PYTHONPATH="$ambient" "$bundle/run_reference_probe.sh" --verify-environment
+
       - name: Upload physical capability probe
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/human-checkpoint.yml
+++ b/.github/workflows/human-checkpoint.yml
@@ -164,15 +164,38 @@ jobs:
         run: |
           set -euo pipefail
           bundle=ci-artifacts/physical-capability-probe
-          mkdir -p "$bundle"
+          wheelhouse="$bundle/wheels"
+          mkdir -p "$wheelhouse"
           cp tools/physical/probe_reference_hardware.py "$bundle/"
           cp tools/physical/reference_probe_requirements.txt "$bundle/"
           cp tools/physical/run_reference_probe.sh "$bundle/"
           chmod +x "$bundle/run_reference_probe.sh"
+
+          python3 -m pip wheel --disable-pip-version-check \
+            --wheel-dir "$wheelhouse" \
+            -r tools/physical/reference_probe_requirements.txt
+
+          shopt -s nullglob
+          cflib_wheels=("$wheelhouse"/cflib-*.whl)
+          shopt -u nullglob
+          if [ "${#cflib_wheels[@]}" -ne 1 ] || [ ! -f "${cflib_wheels[0]}" ]; then
+            echo "Expected exactly one cflib wheel from the pinned source commit" >&2
+            exit 1
+          fi
+
+          printf '%s\n' \
+            'cflib_source=https://github.com/bitcraze/crazyflie-lib-python.git' \
+            'cflib_commit=45fdb784c9d13074c42835f3b5ac1d12133bf873' \
+            "cflib_wheel=$(basename "${cflib_wheels[0]}")" \
+            > "$bundle/PROVENANCE.txt"
+
           (
             cd "$bundle"
-            sha256sum probe_reference_hardware.py reference_probe_requirements.txt run_reference_probe.sh > SHA256SUMS
+            find . -type f ! -name SHA256SUMS -print0 |
+              sort -z |
+              xargs -0 sha256sum > SHA256SUMS
           )
+          grep -Fq 'cflib_commit=45fdb784c9d13074c42835f3b5ac1d12133bf873' "$bundle/PROVENANCE.txt"
 
       - name: Upload physical capability probe
         uses: actions/upload-artifact@v4

--- a/docs/CONTROLLER_NOTIFICATIONS.md
+++ b/docs/CONTROLLER_NOTIFICATIONS.md
@@ -24,7 +24,8 @@ TEST_REQUIRED only after the exact target, full evidence, required artifact,
 provenance/digest and procedure are ready. Enabled profiles are:
 
 - `windows-low-end` — checkpoint or release acceptance of the Windows classroom artifact;
-- `s3-props-off` — checkpoint-only, props-removed #70 S3 physical evidence using the exact deterministically built experimental `cf2.bin` artifact.
+- `s3-props-off` — checkpoint-only, props-removed #70 S3 physical evidence using the exact deterministically built experimental `cf2.bin` artifact;
+- `physical-capabilities-readonly` — checkpoint-only observation of the reference Crazyflie 2.1 + Flow Deck V2 + Multi-ranger + bottom Color LED capability descriptor using the exact packaged non-authority probe. This profile grants no WebeeBlocks execution authority and does not claim transport-level read-only behavior because cflib's normal close path may emit its safety-zero commander setpoint.
 
 Any unknown profile is rejected until its preparation is implemented explicitly.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -189,8 +189,13 @@ provenance/digest, serializes the publication step, refuses a second open human
 test, then creates one durable [TEST_REQUIRED] issue and sends ntfy.
 
 The enabled profiles are `windows-low-end`, backed by the
-`WebeeBlocks-Windows-R2025a` artifact, and `s3-props-off`, backed by
-`experimental-s3-surface-offset-2026-08` and restricted to purpose `checkpoint`.
+`WebeeBlocks-Windows-R2025a` artifact; `s3-props-off`, backed by
+`experimental-s3-surface-offset-2026-08` and restricted to purpose `checkpoint`;
+and `physical-capabilities-readonly`, backed by the exact
+`WebeeBlocks-Physical-Capability-Probe` bundle and restricted to purpose
+`checkpoint`. The physical-capability profile validates only the WebeeBlocks
+non-authority capability/API surface; cflib's normal close path may still emit its
+safety-zero commander setpoint, so it does not authorize motorized flight.
 Unknown profiles fail closed until their deterministic preparation is explicitly
 implemented. A props-off checkpoint never authorizes motorized flight.
 

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -11,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 EXPECTED = {
-    "human-checkpoint.yml": {"validate", "runtime", "webots", "publish"},
+    "human-checkpoint.yml": {"validate", "runtime", "webots", "physical", "publish"},
     "ci.yml": {"select", "runtime", "webots", "gate"},
     "ci-runtime.yml": {
         "runtime-v2-core", "runtime-v2-windows-assets", "runtime-v2-windows-release",
@@ -116,6 +116,12 @@ class WorkflowTests(unittest.TestCase):
             "'windows-low-end': 'WebeeBlocks-Windows-R2025a',",
             "'s3-props-off': 'experimental-s3-surface-offset-2026-08',",
             "'s3-props-off': {'checkpoint'},",
+            "'physical-capabilities-readonly': 'WebeeBlocks-Physical-Capability-Probe',",
+            "'physical-capabilities-readonly': {'checkpoint'},",
+            "needs.validate.outputs.test_profile == 'physical-capabilities-readonly'",
+            "python3 tools/ci/test_physical_capability_probe.py",
+            "node tools/ci/test_physical_capability_contract.js",
+            "name: WebeeBlocks-Physical-Capability-Probe",
             "Purpose {purpose} is not allowed for profile {profile}",
             "Unknown test profile; add deterministic preparation before enabling it",
             "Required artifact is missing a valid sha256 digest",

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -285,6 +285,16 @@ class WorkflowTests(unittest.TestCase):
             restart,
         )
 
+    def test_physical_checkpoint_cflib_is_exact_commit(self):
+        requirements = (
+            ROOT / "tools" / "physical" / "reference_probe_requirements.txt"
+        ).read_text(encoding="utf-8").strip()
+        self.assertEqual(
+            requirements,
+            "cflib @ git+https://github.com/bitcraze/crazyflie-lib-python.git@"
+            "45fdb784c9d13074c42835f3b5ac1d12133bf873",
+        )
+
     def test_no_post_merge_push_trigger(self):
         for path in workflow_files():
             self.assertNotIn("  push:\n", path.read_text(encoding="utf-8"), path.name)

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -301,6 +301,7 @@ class WorkflowTests(unittest.TestCase):
             "-r tools/physical/reference_probe_requirements.txt",
             "cflib_commit=45fdb784c9d13074c42835f3b5ac1d12133bf873",
             "find . -type f ! -name SHA256SUMS -print0",
+            'PYTHONPATH="$ambient" "$bundle/run_reference_probe.sh" --verify-environment',
         ):
             self.assertIn(required, workflow)
 
@@ -316,6 +317,8 @@ class WorkflowTests(unittest.TestCase):
             "PYTHONNOUSERSITE=1",
             'python3 -S "$HERE/probe_reference_hardware.py"',
             "FAIL: exact packaged cflib wheel is missing or ambiguous",
+            "--verify-environment",
+            "PASS: packaged cflib isolation verified without hardware",
         ):
             self.assertIn(required, runner)
         self.assertNotIn(

--- a/tools/ci/test_workflow_contract.py
+++ b/tools/ci/test_workflow_contract.py
@@ -295,6 +295,34 @@ class WorkflowTests(unittest.TestCase):
             "45fdb784c9d13074c42835f3b5ac1d12133bf873",
         )
 
+        workflow = (WORKFLOWS / "human-checkpoint.yml").read_text(encoding="utf-8")
+        for required in (
+            "python3 -m pip wheel --disable-pip-version-check",
+            "-r tools/physical/reference_probe_requirements.txt",
+            "cflib_commit=45fdb784c9d13074c42835f3b5ac1d12133bf873",
+            "find . -type f ! -name SHA256SUMS -print0",
+        ):
+            self.assertIn(required, workflow)
+
+        runner = (
+            ROOT / "tools" / "physical" / "run_reference_probe.sh"
+        ).read_text(encoding="utf-8")
+        for required in (
+            'sha256sum -c SHA256SUMS',
+            "--no-index",
+            '--find-links "$HERE/wheels"',
+            "--ignore-installed",
+            '--target "$ISOLATED_SITE"',
+            "PYTHONNOUSERSITE=1",
+            'python3 -S "$HERE/probe_reference_hardware.py"',
+            "FAIL: exact packaged cflib wheel is missing or ambiguous",
+        ):
+            self.assertIn(required, runner)
+        self.assertNotIn(
+            'python3 "$HERE/probe_reference_hardware.py"',
+            runner,
+        )
+
     def test_no_post_merge_push_trigger(self):
         for path in workflow_files():
             self.assertNotIn("  push:\n", path.read_text(encoding="utf-8"), path.name)

--- a/tools/physical/reference_probe_requirements.txt
+++ b/tools/physical/reference_probe_requirements.txt
@@ -1,0 +1,1 @@
+cflib @ https://github.com/bitcraze/crazyflie-lib-python/archive/45fdb784c9d13074c42835f3b5ac1d12133bf873.zip

--- a/tools/physical/reference_probe_requirements.txt
+++ b/tools/physical/reference_probe_requirements.txt
@@ -1,1 +1,1 @@
-cflib @ https://github.com/bitcraze/crazyflie-lib-python/archive/45fdb784c9d13074c42835f3b5ac1d12133bf873.zip
+cflib @ git+https://github.com/bitcraze/crazyflie-lib-python.git@45fdb784c9d13074c42835f3b5ac1d12133bf873

--- a/tools/physical/run_reference_probe.sh
+++ b/tools/physical/run_reference_probe.sh
@@ -17,10 +17,57 @@ esac
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 OUT="$HERE/physical-capability-descriptor.json"
+ISOLATED_SITE=''
+cleanup() {
+  if [ -n "$ISOLATED_SITE" ]; then
+    rm -rf "$(dirname "$ISOLATED_SITE")"
+  fi
+}
+trap cleanup EXIT
 
-python3 "$HERE/probe_reference_hardware.py" --uri "$URI" --pretty | tee "$OUT"
+cd "$HERE"
+test -s SHA256SUMS
+sha256sum -c SHA256SUMS
+test -s PROVENANCE.txt
+grep -Fxq 'cflib_source=https://github.com/bitcraze/crazyflie-lib-python.git' PROVENANCE.txt
+grep -Fxq 'cflib_commit=45fdb784c9d13074c42835f3b5ac1d12133bf873' PROVENANCE.txt
 
-python3 - "$OUT" <<'PY'
+shopt -s nullglob
+CFLIB_WHEELS=("$HERE"/wheels/cflib-*.whl)
+shopt -u nullglob
+if [ "${#CFLIB_WHEELS[@]}" -ne 1 ] || [ ! -f "${CFLIB_WHEELS[0]}" ]; then
+  echo "FAIL: exact packaged cflib wheel is missing or ambiguous" >&2
+  exit 2
+fi
+
+ISOLATED_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/webeeblocks-physical-probe.XXXXXX")"
+ISOLATED_SITE="$ISOLATED_ROOT/site"
+mkdir -p "$ISOLATED_SITE"
+
+python3 -m pip install --disable-pip-version-check \
+  --no-index \
+  --find-links "$HERE/wheels" \
+  --ignore-installed \
+  --target "$ISOLATED_SITE" \
+  "${CFLIB_WHEELS[0]}"
+
+PYTHONPATH="$ISOLATED_SITE" PYTHONNOUSERSITE=1 python3 -S - "$ISOLATED_SITE" <<'PY'
+import pathlib
+import sys
+import cflib
+
+site = pathlib.Path(sys.argv[1]).resolve()
+module = pathlib.Path(cflib.__file__).resolve()
+if site not in module.parents:
+    raise SystemExit(f"FAIL: cflib escaped isolated bundle: {module}")
+print(f"Using packaged cflib: {module}")
+PY
+
+PYTHONPATH="$ISOLATED_SITE" PYTHONNOUSERSITE=1 \
+  python3 -S "$HERE/probe_reference_hardware.py" --uri "$URI" --pretty |
+  tee "$OUT"
+
+PYTHONPATH="$ISOLATED_SITE" PYTHONNOUSERSITE=1 python3 -S - "$OUT" <<'PY'
 import json
 import sys
 from pathlib import Path

--- a/tools/physical/run_reference_probe.sh
+++ b/tools/physical/run_reference_probe.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 radio://<dongle>/<channel>/<rate>/<address>" >&2
+  exit 2
+fi
+
+URI="$1"
+case "$URI" in
+  radio://*) ;;
+  *)
+    echo "Exact Crazyradio radio:// URI required" >&2
+    exit 2
+    ;;
+esac
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="$HERE/physical-capability-descriptor.json"
+
+python3 "$HERE/probe_reference_hardware.py" --uri "$URI" --pretty | tee "$OUT"
+
+python3 - "$OUT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+descriptor = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected_hardware = {"flow-deck-v2", "multi-ranger-deck", "color-led-deck"}
+
+if descriptor.get("executionAuthority") is not False:
+    raise SystemExit("FAIL: executionAuthority must remain false")
+identity = descriptor.get("identity") or {}
+if identity != {
+    "family": "crazyflie",
+    "model": "crazyflie-2.1",
+    "modelEvidence": "verified",
+}:
+    raise SystemExit(f"FAIL: exact Crazyflie 2.1 identity not verified: {identity!r}")
+hardware = set(descriptor.get("hardware") or [])
+missing = expected_hardware - hardware
+if missing:
+    raise SystemExit(f"FAIL: required reference hardware not healthy/present: {sorted(missing)!r}")
+
+capabilities = descriptor.get("capabilities") or {}
+required_actions = {"takeoff", "move", "vertical", "turn", "wait", "set_speed", "set_light", "land"}
+missing_actions = required_actions - set(capabilities.get("actions") or [])
+if missing_actions:
+    raise SystemExit(f"FAIL: required action capability evidence missing: {sorted(missing_actions)!r}")
+if set(capabilities.get("rangeDirections") or []) != {"front", "back", "left", "right", "up"}:
+    raise SystemExit(f"FAIL: unexpected Multi-ranger directions: {capabilities.get('rangeDirections')!r}")
+if set(capabilities.get("moveDirections") or []) != {"forward", "back", "left", "right"}:
+    raise SystemExit(f"FAIL: unexpected move directions: {capabilities.get('moveDirections')!r}")
+if set(capabilities.get("verticalDirections") or []) != {"up", "down"}:
+    raise SystemExit(f"FAIL: unexpected vertical directions: {capabilities.get('verticalDirections')!r}")
+
+print("PASS: exact reference hardware capability descriptor observed with executionAuthority=false")
+PY

--- a/tools/physical/run_reference_probe.sh
+++ b/tools/physical/run_reference_probe.sh
@@ -2,15 +2,16 @@
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 radio://<dongle>/<channel>/<rate>/<address>" >&2
+  echo "Usage: $0 --verify-environment | radio://<dongle>/<channel>/<rate>/<address>" >&2
   exit 2
 fi
 
-URI="$1"
-case "$URI" in
+MODE="$1"
+case "$MODE" in
+  --verify-environment) ;;
   radio://*) ;;
   *)
-    echo "Exact Crazyradio radio:// URI required" >&2
+    echo "Exact Crazyradio radio:// URI or --verify-environment required" >&2
     exit 2
     ;;
 esac
@@ -63,8 +64,13 @@ if site not in module.parents:
 print(f"Using packaged cflib: {module}")
 PY
 
+if [ "$MODE" = "--verify-environment" ]; then
+  echo "PASS: packaged cflib isolation verified without hardware"
+  exit 0
+fi
+
 PYTHONPATH="$ISOLATED_SITE" PYTHONNOUSERSITE=1 \
-  python3 -S "$HERE/probe_reference_hardware.py" --uri "$URI" --pretty |
+  python3 -S "$HERE/probe_reference_hardware.py" --uri "$MODE" --pretty |
   tee "$OUT"
 
 PYTHONPATH="$ISOLATED_SITE" PYTHONNOUSERSITE=1 python3 -S - "$OUT" <<'PY'


### PR DESCRIPTION
## Scope

Prepares a deterministic, checkpoint-only real reference-hardware capability observation path for #157 without requesting a second human test while #180 remains open.

- adds `physical-capabilities-readonly` to the trusted checkpoint profile allowlist;
- packages the exact WebeeBlocks non-authority probe, a pinned cflib source dependency and a one-command fail-closed reference-stack verifier;
- runs the existing physical capability probe/contract oracles before producing the checkpoint artifact;
- preserves the cflib safety-zero close-path qualification and grants no WebeeBlocks execution authority;
- extends the workflow contract and checkpoint documentation.

No CHECKPOINT_REQUEST is created by this PR. The existing single human-test slot remains authoritative.

Refs #157.