### PR TITLE
Replay frozen C10 Qt crash boundary

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1194,7 +1194,22 @@ jobs:
 
           controller="$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2"
           test -x "$controller"
-          LD_LIBRARY_PATH="$diagnostic_webots/lib/webots" ldd "$controller" |
+          real_controller="$controller.real"
+          mv "$controller" "$real_controller"
+          cat > "$controller" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          real="${BASH_SOURCE[0]}.real"
+          "$real" "$@" &
+          pid=$!
+          printf 'WEBEEBLOCKS_C10_PROCESS pid=%s\n' "$pid" >&2
+          wait "$pid"
+          code=$?
+          printf 'WEBEEBLOCKS_C10_PROCESS_EXIT pid=%s code=%s\n' "$pid" "$code" >&2
+          exit "$code"
+          SH
+          chmod +x "$controller"
+          LD_LIBRARY_PATH="$diagnostic_webots/lib/webots" ldd "$real_controller" |
             tee "$artifact_dir/ldd.log"
           qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/ldd.log")"
           test "$(printf '%s\n' "$qt_lines" | wc -l)" -eq 3
@@ -1230,8 +1245,29 @@ jobs:
               capture {print}
             ' "$log" > "$artifact_dir/causal-backtrace.txt"
             test -s "$artifact_dir/causal-backtrace.txt"
-            grep -Eq 'libQt6(Core|Gui|Widgets)|libqxcb|QApplication|QtFileDialogProvider'               "$artifact_dir/causal-backtrace.txt"
-            printf '%s\n' 'DIAGNOSTIC_RESULT=C10_FATAL_SIGNAL_WITH_USABLE_QT_FRAME' |
+            grep -Eq 'libQt6(Core|Gui|Widgets)|libqxcb|QApplication|QtFileDialogProvider' \
+              "$artifact_dir/causal-backtrace.txt"
+
+            signal="$(sed -n 's/.*WEBEEBLOCKS_C10_FATAL signal=\(SIG[A-Z0-9]*\).*/\1/p' "$log" | tail -n 1)"
+            process_pid="$(sed -n 's/.*WEBEEBLOCKS_C10_PROCESS pid=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
+            exit_pid="$(sed -n 's/.*WEBEEBLOCKS_C10_PROCESS_EXIT pid=\([0-9][0-9]*\) code=.*/\1/p' "$log" | tail -n 1)"
+            exit_code="$(sed -n 's/.*WEBEEBLOCKS_C10_PROCESS_EXIT pid=[0-9][0-9]* code=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
+            test -n "$process_pid"
+            test "$exit_pid" = "$process_pid"
+            case "$signal" in
+              SIGSEGV) expected_exit=139 ;;
+              SIGABRT) expected_exit=134 ;;
+              SIGBUS) expected_exit=135 ;;
+              SIGILL) expected_exit=132 ;;
+              SIGFPE) expected_exit=136 ;;
+              *) echo "Unsupported captured signal: $signal" >&2; exit 1 ;;
+            esac
+            test "$exit_code" = "$expected_exit"
+            printf 'controller_pid=%s\nsignal=%s\ncontroller_exit=%s\n' \
+              "$process_pid" "$signal" "$exit_code" |
+              tee "$artifact_dir/controller-exit.txt"
+
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C10_FATAL_SIGNAL_EXIT_WITH_USABLE_QT_FRAME' |
               tee "$artifact_dir/result.txt"
             exit 0
           fi

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1144,8 +1144,8 @@ jobs:
             sigemptyset(&action.sa_mask);
             action.sa_flags = SA_RESETHAND;
 
-            const int signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE};
-            for (const int signal_number : signals) {
+            const int fatal_signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE};
+            for (const int signal_number : fatal_signals) {
               if (sigaction(signal_number, &action, nullptr) != 0)
                 return false;
             }

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -2161,9 +2161,34 @@ jobs:
           if missing:
               raise SystemExit('Pinned Webots R2025a checkout is missing required PROTOs: ' + ', '.join(missing))
 
+          # RotationalMotor's default sound is a webots:// resource that Webots
+          # may resolve through raw.githubusercontent.com even when the pinned
+          # projects tree is mounted locally. The historical light-sensor
+          # behavior does not depend on audio, so override only the two Pioneer
+          # wheel motor sounds in the pinned CI copy before running --network none.
+          pioneer = projects / 'robots/adept/pioneer3/protos/Pioneer3dx.proto'
+          pioneer_original = pioneer.read_text(encoding='utf-8')
+          seams = (
+              'RotationalMotor {\n            name "left wheel"\n            maxVelocity 12.3',
+              'RotationalMotor {\n            name "right wheel"\n            maxVelocity 12.3',
+          )
+          pioneer_offline = pioneer_original
+          for seam in seams:
+              if pioneer_offline.count(seam) != 1:
+                  raise SystemExit(f'Pinned Pioneer3dx motor seam changed: {seam!r}')
+              pioneer_offline = pioneer_offline.replace(
+                  seam,
+                  seam + '\n            sound ""',
+                  1,
+              )
+          if pioneer_offline.count('sound ""') != pioneer_original.count('sound ""') + 2:
+              raise SystemExit('Expected exactly two Pioneer motor sound overrides.')
+          pioneer.write_text(pioneer_offline, encoding='utf-8')
+
           target.write_text(localized, encoding='utf-8')
           print(f'PASS: localized exactly {replacements} Webots R2025a EXTERNPROTO references without changing world semantics.')
           print('PASS: all seven required PROTOs exist in the pinned Cyberbotics R2025a checkout.')
+          print('PASS: disabled only the two non-semantic Pioneer wheel sounds for deterministic offline execution.')
           PY
 
       - name: Execute historical light sensor program offline

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,6 +1055,199 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
+      - name: Run frozen C10 Firefox Qt signal diagnostic
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c10-signal-frame' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/firefox-c10-signal-frame
+          mkdir -p "$artifact_dir"
+
+          c10_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+          c10_file_broker_blob=241e6e6aaec32ceaeaa2693fad337a774757b895
+          c10_makefile_blob=ef44dd5caf4ed3c0e77875cec26da511071649f5
+          c10_runtime_ini_blob=27cbdb180b6f1aa4ed6a871bd9cb3ed147b29b6a
+          historical="$RUNNER_TEMP/webeeblocks-c10"
+
+          git init -q "$historical"
+          git -C "$historical" remote add origin https://github.com/djibian/webeeblocks.git
+          git -C "$historical" fetch --depth=1 origin "$c10_sha"
+          git -C "$historical" checkout -q --detach FETCH_HEAD
+          test "$(git -C "$historical" rev-parse HEAD)" = "$c10_sha"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/file_broker.cpp)" = "$c10_file_broker_blob"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/Makefile)" = "$c10_makefile_blob"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/runtime.ini)" = "$c10_runtime_ini_blob"
+
+          python3 - "$historical/controllers/crazyflie_runtime_v2/file_broker.cpp" <<'PY'
+          from pathlib import Path
+          import sys
+
+          path = Path(sys.argv[1])
+          source = path.read_text(encoding="utf-8")
+
+          include_old = """#ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          #include <csignal>
+          #include <unistd.h>
+          #endif"""
+          include_new = """#ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          #include <csignal>
+          #include <execinfo.h>
+          #include <unistd.h>
+          #endif"""
+          if source.count(include_old) != 1:
+              raise SystemExit("frozen C10 diagnostic include seam changed")
+          source = source.replace(include_old, include_new, 1)
+
+          anchor = 'constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1";\n'
+          instrumentation = r'''
+          #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          void write_diagnostic_marker(const char *message) {
+            ::write(STDERR_FILENO, message, std::strlen(message));
+          }
+
+          void fatal_signal_handler(int signal_number) {
+            switch (signal_number) {
+              case SIGSEGV:
+                write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL signal=SIGSEGV\n");
+                break;
+              case SIGABRT:
+                write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL signal=SIGABRT\n");
+                break;
+              case SIGBUS:
+                write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL signal=SIGBUS\n");
+                break;
+              case SIGILL:
+                write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL signal=SIGILL\n");
+                break;
+              case SIGFPE:
+                write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL signal=SIGFPE\n");
+                break;
+              default:
+                write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL signal=UNKNOWN\n");
+                break;
+            }
+
+            void *frames[64];
+            const int count = ::backtrace(frames, 64);
+            write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL_BACKTRACE_BEGIN\n");
+            ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+            write_diagnostic_marker("WEBEEBLOCKS_C10_FATAL_BACKTRACE_END\n");
+            _exit(128 + signal_number);
+          }
+
+          bool install_fatal_handlers() {
+            void *warmup[1];
+            (void)::backtrace(warmup, 1);
+
+            struct sigaction action {};
+            action.sa_handler = fatal_signal_handler;
+            sigemptyset(&action.sa_mask);
+            action.sa_flags = SA_RESETHAND;
+
+            const int signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE};
+            for (const int signal_number : signals) {
+              if (sigaction(signal_number, &action, nullptr) != 0)
+                return false;
+            }
+            return true;
+          }
+          #endif
+          '''
+          if source.count(anchor) != 1:
+              raise SystemExit("frozen C10 namespace seam changed")
+          source = source.replace(anchor, anchor + instrumentation, 1)
+
+          stop = "    ::raise(SIGSTOP);"
+          replacement = """    if (!install_fatal_handlers())
+                throw std::runtime_error("diagnostic signal handler installation failed");
+              std::fprintf(stderr, "WEBEEBLOCKS_FILE_BROKER_V1 SIGNAL_HANDLERS_ACTIVE\\n");
+              std::fflush(stderr);"""
+          if source.count(stop) != 1:
+              raise SystemExit("frozen C10 SIGSTOP seam changed")
+          source = source.replace(stop, replacement, 1)
+
+          path.write_text(source, encoding="utf-8")
+          PY
+
+          git -C "$historical" diff -- controllers/crazyflie_runtime_v2/file_broker.cpp |
+            tee "$artifact_dir/c10-instrumentation.patch"
+          test -s "$artifact_dir/c10-instrumentation.patch"
+
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          recipe_url="https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh"
+          recipe_blob=4593476be2c985580a0e1738671f4b5bae81f669
+          curl --fail --location --retry 3 --output "$recipe" "$recipe_url"
+          test "$(git hash-object "$recipe")" = "$recipe_blob"
+          sudo env CI=true bash "$recipe"
+
+          archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+          archive_url="https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2"
+          archive_sha=c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38
+          curl --fail --location --retry 3 --output "$archive" "$archive_url"
+          echo "$archive_sha  $archive" | sha256sum --check
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+          diagnostic_webots="$RUNNER_TEMP/webots"
+          test -x "$diagnostic_webots/webots"
+
+          WEBOTS_HOME="$diagnostic_webots"             make -C "$historical/controllers/crazyflie_runtime_v2" clean
+          WEBOTS_HOME="$diagnostic_webots"             make -C "$historical/controllers/crazyflie_runtime_v2"               WEBEEBLOCKS_NATIVE_FILE_BROKER=1               WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC=1               VERBOSE=1               2>&1 | tee "$artifact_dir/build.log"
+
+          controller="$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2"
+          test -x "$controller"
+          LD_LIBRARY_PATH="$diagnostic_webots/lib/webots" ldd "$controller" |
+            tee "$artifact_dir/ldd.log"
+          qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/ldd.log")"
+          test "$(printf '%s\n' "$qt_lines" | wc -l)" -eq 3
+          if printf '%s\n' "$qt_lines" | grep -vF "$diagnostic_webots/lib/webots/"; then
+            echo "Qt resolved outside the official Webots desktop SDK" >&2
+            exit 1
+          fi
+
+          log="$artifact_dir/webots.log"
+          set +e
+          env             QT_PLUGIN_PATH="$diagnostic_webots/lib/webots/qt/plugins"             QT_DEBUG_PLUGINS=1             LIBGL_ALWAYS_SOFTWARE=true             WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true             timeout -k 5s 45s xvfb-run -a "$diagnostic_webots/webots"               --stdout --stderr --batch --mode=realtime               "$historical/worlds/crazyflie_runtime_v2.wbt"               > "$log" 2>&1
+          webots_code=$?
+          set -e
+          printf 'c10_sha=%s\nwebots_exit=%s\n' "$c10_sha" "$webots_code" |
+            tee "$artifact_dir/run.txt"
+          cat "$log"
+
+          grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 DIAGNOSTIC_RENDEZVOUS' "$log"
+          grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 SIGNAL_HANDLERS_ACTIVE' "$log"
+
+          if grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$log"; then
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C10_NO_CRASH_THROUGH_QFILEDIALOG' |
+              tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+
+          if grep -Eq 'WEBEEBLOCKS_C10_FATAL signal=SIG(SEGV|ABRT|BUS|ILL|FPE)' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C10_FATAL_BACKTRACE_BEGIN' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C10_FATAL_BACKTRACE_END' "$log"; then
+            awk '
+              /WEBEEBLOCKS_C10_FATAL_BACKTRACE_BEGIN/ {capture=1; next}
+              /WEBEEBLOCKS_C10_FATAL_BACKTRACE_END/ {capture=0}
+              capture {print}
+            ' "$log" > "$artifact_dir/causal-backtrace.txt"
+            test -s "$artifact_dir/causal-backtrace.txt"
+            grep -Eq 'libQt6(Core|Gui|Widgets)|libqxcb|QApplication|QtFileDialogProvider'               "$artifact_dir/causal-backtrace.txt"
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C10_FATAL_SIGNAL_WITH_USABLE_QT_FRAME' |
+              tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+
+          printf '%s\n' 'DIAGNOSTIC_RESULT=C10_QT_OUTCOME_UNPROVEN' |
+            tee "$artifact_dir/result.txt"
+          exit 1
+
+      - name: Upload frozen C10 Firefox Qt signal diagnostic
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c10-signal-frame' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-c10-signal-frame-r2025a
+          path: ci-artifacts/firefox-c10-signal-frame/
+          if-no-files-found: error
+
       - name: Upload runtime WWI diagnostics
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Scope

Bounded #87 research successor to the abandoned #198 candidate.

This Draft changes only the already-authorized `.github/workflows/ci-webots.yml` surface and is intended to capture discriminating evidence, not to integrate product behavior.

- replays frozen C10 source at `fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c`;
- verifies exact historical `file_broker.cpp`, Makefile and `runtime.ini` blob identities before instrumentation;
- preserves the R2025a/Xvfb/Webots-bundled-Qt environment and does not alter QPA/DISPLAY;
- installs no debugger or new diagnostic dependency;
- replaces only C10's deliberate `SIGSTOP` rendezvous with in-process fatal-signal capture immediately before `QApplication`;
- accepts a fatal result only when a non-empty captured backtrace contains a Qt/QPA-attributable frame;
- also treats successful traversal through historical `QFileDialog` construction as discriminating evidence that the frozen crash no longer reproduces;
- fails closed for any other outcome.

The step is explicitly limited to this research branch and must not be interpreted as a production workflow addition. No Firefox file operation or product semantic is implemented.

This follows the authoritative repair boundary from `NO_GO 21be76a58d27a70f7325f74c4e45f8df07a7a8d8` and the durable P12 evidence on #87.

Refs #87.