### PR TITLE
Discover deterministic physical probe dependency closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,58 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+      - name: Discover exact physical-probe wheel closure
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/physical-probe-lock-discovery' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/physical-probe-lock-discovery"
+          wheels="$root/wheels"
+          site="$root/site"
+          source="$root/cflib-source"
+          rm -rf "$root"
+          mkdir -p "$wheels" "$site"
+
+          python3 -m pip download --disable-pip-version-check --only-binary=:all: --no-deps \
+            --dest "$wheels" \
+            pyusb==1.2.1 \
+            libusb-package==1.0.26.3 \
+            numpy==2.2.6
+
+          echo "WEBEEBLOCKS_PHYSICAL_LOCK_FILES_BEGIN"
+          (
+            cd "$wheels"
+            sha256sum *
+          )
+          echo "WEBEEBLOCKS_PHYSICAL_LOCK_FILES_END"
+
+          python3 -m pip install --disable-pip-version-check --no-index \
+            --find-links "$wheels" --no-deps --target "$site" \
+            pyusb==1.2.1 libusb-package==1.0.26.3 numpy==2.2.6
+
+          git init -q "$source"
+          git -C "$source" remote add origin https://github.com/bitcraze/crazyflie-lib-python.git
+          git -C "$source" fetch --depth=1 origin 45fdb784c9d13074c42835f3b5ac1d12133bf873
+          git -C "$source" checkout -q --detach FETCH_HEAD
+          test "$(git -C "$source" rev-parse HEAD)" = "45fdb784c9d13074c42835f3b5ac1d12133bf873"
+          test "$(git -C "$source" rev-parse HEAD^{tree})" = "a78cf78d2b4aba51a0fa2b03de0260664b523401"
+
+          PYTHONPATH="$source:$site" PYTHONNOUSERSITE=1 python3 -S - <<'PY'
+          import pathlib
+          import cflib
+          import cflib.crtp
+          import libusb_package
+          import numpy
+          import usb
+          from cflib.crazyflie import Crazyflie
+          from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+
+          root = pathlib.Path(cflib.__file__).resolve()
+          print(f"WEBEEBLOCKS_PHYSICAL_LOCK_CFLIB={root}")
+          print(f"WEBEEBLOCKS_PHYSICAL_LOCK_NUMPY={numpy.__version__}")
+          print("WEBEEBLOCKS_PHYSICAL_LOCK_IMPORT_PASS")
+          PY
+
       - name: Verify selector and repository contracts
         run: |
           python3 tools/ci/test_select_ci.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
             --dest "$wheels" \
             pyusb==1.2.1 \
             libusb-package==1.0.26.3 \
+            importlib-resources==6.5.2 \
             numpy==2.2.6
 
           echo "WEBEEBLOCKS_PHYSICAL_LOCK_FILES_BEGIN"
@@ -56,7 +57,7 @@ jobs:
 
           python3 -m pip install --disable-pip-version-check --no-index \
             --find-links "$wheels" --no-deps --target "$site" \
-            pyusb==1.2.1 libusb-package==1.0.26.3 numpy==2.2.6
+            pyusb==1.2.1 libusb-package==1.0.26.3 importlib-resources==6.5.2 numpy==2.2.6
 
           git init -q "$source"
           git -C "$source" remote add origin https://github.com/bitcraze/crazyflie-lib-python.git
@@ -69,6 +70,7 @@ jobs:
           import pathlib
           import cflib
           import cflib.crtp
+          import importlib_resources
           import libusb_package
           import numpy
           import usb


### PR DESCRIPTION
## Scope

Bounded #157 research-only lock discovery after the authoritative late refutation of merged #199 and integrated fix-forward #201.

This Draft does not enable a checkpoint profile and cannot publish TEST_REQUIRED. It adds one branch-gated discovery step to the existing V4 CI Gate only to identify the exact Linux/Python wheel files needed by the already-integrated non-authority Crazyflie capability probe.

The step:
- fetches exact cflib commit `45fdb784c9d13074c42835f3b5ac1d12133bf873` and verifies tree `a78cf78d2b4aba51a0fa2b03de0260664b523401`;
- downloads exact candidate runtime wheels for the actual probe import path, without dependency resolution;
- emits SHA256 for every candidate wheel;
- installs only those local wheels into an isolated target;
- imports exact cflib source plus Crazyradio/Crazyflie/SyncCrazyflie under `python3 -S` and `PYTHONNOUSERSITE=1`.

The sole useful output is a reproducible lock input for a later real candidate. This workflow instrumentation must not be merged. No hardware is contacted, no checkpoint is requested, and `executionAuthority:false` remains unchanged.

Refs #157.