### PR TITLE
Record restored physical checkpoint preparation in roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -187,8 +187,8 @@ props-off S3-A/S3-B/S3-C checkpoint; no motorized flight follows automatically.
   capability-probe runtime closure proven on #157; this preserves
   `executionAuthority:false` and the cflib safety-zero close-path qualification
 - this is checkpoint support, not evidence that a particular classroom device
-  has already been observed; TEST_REQUIRED #180 currently occupies the single
-  human-test slot, so no second #157 checkpoint is published while it remains open
+  has already been observed; human checkpoint publication remains serialized by
+  the governance contract
 - remaining boundary: real-hardware observation, then physical execution
   continuity/safety, remain unproven and belong behind the physical
   capability/safety gate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -181,10 +181,16 @@ props-off S3-A/S3-B/S3-C checkpoint; no motorized flight follows automatically.
   `executionAuthority:false` and exposing no WebeeBlocks motor/arming command
   API; the normal cflib close path still emits its safety-zero commander
   setpoint, so transport-level packet emission is not claimed read-only
-- this is a mechanism proof, not evidence that a particular classroom device
-  has already been observed
-- remaining boundary: real-hardware observation and physical execution
-  continuity/safety remain unproven and belong behind the physical
+- deterministic checkpoint preparation: integrated #207 restores the
+  checkpoint-only `physical-capabilities-readonly` profile using the exact
+  cflib source boundary and the four-wheel Ubuntu 22.04 / CPython 3.10
+  capability-probe runtime closure proven on #157; this preserves
+  `executionAuthority:false` and the cflib safety-zero close-path qualification
+- this is checkpoint support, not evidence that a particular classroom device
+  has already been observed; TEST_REQUIRED #180 currently occupies the single
+  human-test slot, so no second #157 checkpoint is published while it remains open
+- remaining boundary: real-hardware observation, then physical execution
+  continuity/safety, remain unproven and belong behind the physical
   capability/safety gate
 - reopen simulation vocabulary only for a demonstrated pedagogical need or new
   contradictory evidence.


### PR DESCRIPTION
## Scope

Small #157 roadmap maintenance after integrated #207.

This updates only the C1b roadmap fragment that became stale when deterministic `physical-capabilities-readonly` checkpoint preparation was restored on main. It records the exact bounded consequence without changing product authority:

- #207 restored checkpoint-only deterministic preparation on the durable #157 cflib/four-wheel probe-runtime evidence boundary;
- `executionAuthority:false` and the cflib safety-zero close-path qualification remain explicit;
- checkpoint support is not real-hardware product proof;
- open TEST_REQUIRED #180 still occupies the single human-test slot, so no #157 checkpoint is published yet;
- real-hardware observation and later physical execution continuity/safety remain unproven.

No workflow state, ownership, queue or new dependency is encoded.

Refs #157.