### PR TITLE
Classify frozen controller image without Webots launcher

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,6 +1055,275 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
+      - name: Run frozen C10 direct-controller QApplication discriminator
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c16-direct-controller' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/firefox-c16-direct-controller
+          mkdir -p "$artifact_dir"
+
+          c10_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+          historical="$RUNNER_TEMP/webeeblocks-c16-c10"
+          git init -q "$historical"
+          git -C "$historical" remote add origin https://github.com/djibian/webeeblocks.git
+          git -C "$historical" fetch --depth=1 origin "$c10_sha"
+          git -C "$historical" checkout -q --detach FETCH_HEAD
+          test "$(git -C "$historical" rev-parse HEAD)" = "$c10_sha"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c)" = "ab88eb98247e79f322b960bf0791f0ebf4fc4db6"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/file_broker.cpp)" = "241e6e6aaec32ceaeaa2693fad337a774757b895"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/Makefile)" = "ef44dd5caf4ed3c0e77875cec26da511071649f5"
+          test "$(git -C "$historical" hash-object controllers/crazyflie_runtime_v2/runtime.ini)" = "27cbdb180b6f1aa4ed6a871bd9cb3ed147b29b6a"
+
+          python3 - "$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c" "$historical/controllers/crazyflie_runtime_v2/file_broker.cpp" <<'PY'
+          from pathlib import Path
+          import sys
+
+          main_path = Path(sys.argv[1])
+          broker_path = Path(sys.argv[2])
+          main = main_path.read_text(encoding="utf-8")
+          broker = broker_path.read_text(encoding="utf-8")
+
+          include_seam = """#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+          #include "file_broker_c.h"
+          #endif"""
+          include_replacement = """#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
+          #include "file_broker_c.h"
+          #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          int wb_file_broker_c16_direct_qapplication(void);
+          #endif
+          #endif"""
+          if main.count(include_seam) != 1:
+              raise SystemExit("frozen C10 main include seam changed")
+          main = main.replace(include_seam, include_replacement, 1)
+
+          main_seam = """int main(void) {
+            wb_robot_init();"""
+          main_replacement = """int main(void) {
+          #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+            return wb_file_broker_c16_direct_qapplication();
+          #endif
+            wb_robot_init();"""
+          if main.count(main_seam) != 1:
+              raise SystemExit("frozen C10 main entry seam changed")
+          main = main.replace(main_seam, main_replacement, 1)
+
+          include_old = """#ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          #include <csignal>
+          #include <unistd.h>
+          #endif"""
+          include_new = """#ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          #include <csignal>
+          #include <execinfo.h>
+          #include <unistd.h>
+          #endif"""
+          if broker.count(include_old) != 1:
+              raise SystemExit("frozen C10 broker include seam changed")
+          broker = broker.replace(include_old, include_new, 1)
+
+          anchor = 'constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1";\n'
+          instrumentation = r'''
+          #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          void c16_marker(const char *message) {
+            ::write(STDERR_FILENO, message, std::strlen(message));
+          }
+
+          void c16_fatal_handler(int signal_number) {
+            switch (signal_number) {
+              case SIGSEGV: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGSEGV\n"); break;
+              case SIGABRT: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGABRT\n"); break;
+              case SIGBUS: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGBUS\n"); break;
+              case SIGILL: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGILL\n"); break;
+              case SIGFPE: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGFPE\n"); break;
+              default: c16_marker("WEBEEBLOCKS_C16_FATAL signal=UNKNOWN\n"); break;
+            }
+            void *frames[64];
+            const int count = ::backtrace(frames, 64);
+            c16_marker("WEBEEBLOCKS_C16_BACKTRACE_BEGIN\n");
+            ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+            c16_marker("WEBEEBLOCKS_C16_BACKTRACE_END\n");
+            _exit(128 + signal_number);
+          }
+
+          bool c16_install_handlers() {
+            void *warmup[1];
+            (void)::backtrace(warmup, 1);
+            struct sigaction action {};
+            action.sa_handler = c16_fatal_handler;
+            sigemptyset(&action.sa_mask);
+            action.sa_flags = SA_RESETHAND;
+            const int fatal_signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE};
+            for (const int signal_number : fatal_signals)
+              if (sigaction(signal_number, &action, nullptr) != 0)
+                return false;
+            return true;
+          }
+          #endif
+          '''
+          if broker.count(anchor) != 1:
+              raise SystemExit("frozen C10 broker namespace seam changed")
+          broker = broker.replace(anchor, anchor + instrumentation, 1)
+
+          helper = r'''
+          #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
+          extern "C" int wb_file_broker_c16_direct_qapplication(void) {
+            if (!c16_install_handlers()) {
+              c16_marker("WEBEEBLOCKS_C16 HANDLER_INSTALL_FAILED\n");
+              return 120;
+            }
+            c16_marker("WEBEEBLOCKS_C16 DIRECT_PROCESS\n");
+            int argc = 1;
+            char program_name[] = "webeeblocks-file-broker";
+            char *argv[] = {program_name, nullptr};
+            c16_marker("WEBEEBLOCKS_C16 BEFORE_QAPPLICATION\n");
+            {
+              QApplication application(argc, argv);
+              c16_marker("WEBEEBLOCKS_C16 QAPPLICATION_OK\n");
+            }
+            c16_marker("WEBEEBLOCKS_C16 QAPPLICATION_DESTROYED\n");
+            return 0;
+          }
+          #endif
+
+          '''
+          export_seam = 'extern "C" WbFileBroker *wb_file_broker_create_qt(void) {\n'
+          if broker.count(export_seam) != 1:
+              raise SystemExit("frozen C10 broker export seam changed")
+          broker = broker.replace(export_seam, helper + export_seam, 1)
+
+          main_path.write_text(main, encoding="utf-8")
+          broker_path.write_text(broker, encoding="utf-8")
+          PY
+
+          git -C "$historical" diff -- controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c controllers/crazyflie_runtime_v2/file_broker.cpp |
+            tee "$artifact_dir/c16-instrumentation.patch"
+          test -s "$artifact_dir/c16-instrumentation.patch"
+          grep -Fq 'return wb_file_broker_c16_direct_qapplication();' "$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c"
+          grep -Fq 'WEBEEBLOCKS_C16 DIRECT_PROCESS' "$historical/controllers/crazyflie_runtime_v2/file_broker.cpp"
+
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          recipe_url="https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh"
+          recipe_blob=4593476be2c985580a0e1738671f4b5bae81f669
+          curl --fail --location --retry 3 --output "$recipe" "$recipe_url"
+          test "$(git hash-object "$recipe")" = "$recipe_blob"
+          sudo env CI=true bash "$recipe"
+
+          archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+          archive_url="https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2"
+          archive_sha=c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38
+          curl --fail --location --retry 3 --output "$archive" "$archive_url"
+          echo "$archive_sha  $archive" | sha256sum --check
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+          diagnostic_webots="$RUNNER_TEMP/webots"
+          test -x "$diagnostic_webots/webots"
+
+          WEBOTS_HOME="$diagnostic_webots" make -C "$historical/controllers/crazyflie_runtime_v2" clean
+          WEBOTS_HOME="$diagnostic_webots" \
+            make -C "$historical/controllers/crazyflie_runtime_v2" \
+              WEBEEBLOCKS_NATIVE_FILE_BROKER=1 \
+              WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC=1 \
+              VERBOSE=1 2>&1 | tee "$artifact_dir/build.log"
+
+          controller="$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2"
+          test -x "$controller"
+          LD_LIBRARY_PATH="$diagnostic_webots/lib/controller:$diagnostic_webots/lib/webots" \
+            ldd "$controller" | tee "$artifact_dir/ldd.log"
+          qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/ldd.log")"
+          test "$(printf '%s\n' "$qt_lines" | wc -l)" -eq 3
+          if printf '%s\n' "$qt_lines" | grep -vF "$diagnostic_webots/lib/webots/"; then
+            echo "C16 Qt resolved outside the official Webots desktop SDK" >&2
+            exit 1
+          fi
+          grep -Fq "$diagnostic_webots/lib/controller/libController.so" "$artifact_dir/ldd.log"
+
+          wrapper="$RUNNER_TEMP/webeeblocks-c16-direct-wrapper.sh"
+          cat > "$wrapper" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          real="$1"
+          "$real" &
+          pid=$!
+          printf 'WEBEEBLOCKS_C16_PROCESS pid=%s\n' "$pid" >&2
+          wait "$pid"
+          code=$?
+          printf 'WEBEEBLOCKS_C16_PROCESS_EXIT pid=%s code=%s\n' "$pid" "$code" >&2
+          exit "$code"
+          SH
+          chmod +x "$wrapper"
+
+          log="$artifact_dir/direct.log"
+          set +e
+          env \
+            QT_PLUGIN_PATH="$diagnostic_webots/lib/webots/qt/plugins" \
+            QT_DEBUG_PLUGINS=1 \
+            LD_LIBRARY_PATH="$diagnostic_webots/lib/controller:$diagnostic_webots/lib/webots" \
+            LIBGL_ALWAYS_SOFTWARE=true \
+            timeout -k 2s 20s xvfb-run -a "$wrapper" "$controller" > "$log" 2>&1
+          outer_code=$?
+          set -e
+          printf 'c10_sha=%s\nouter_exit=%s\n' "$c10_sha" "$outer_code" | tee "$artifact_dir/run.txt"
+          cat "$log"
+
+          grep -Fq 'WEBEEBLOCKS_C16 DIRECT_PROCESS' "$log"
+          grep -Fq 'WEBEEBLOCKS_C16 BEFORE_QAPPLICATION' "$log"
+          process_pid="$(sed -n 's/.*WEBEEBLOCKS_C16_PROCESS pid=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
+          exit_pid="$(sed -n 's/.*WEBEEBLOCKS_C16_PROCESS_EXIT pid=\([0-9][0-9]*\) code=.*/\1/p' "$log" | tail -n 1)"
+          exit_code="$(sed -n 's/.*WEBEEBLOCKS_C16_PROCESS_EXIT pid=[0-9][0-9]* code=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
+          test -n "$process_pid"
+          test "$exit_pid" = "$process_pid"
+
+          if grep -Fq 'WEBEEBLOCKS_C16 QAPPLICATION_OK' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C16 QAPPLICATION_DESTROYED' "$log"; then
+            test "$exit_code" = 0
+            printf 'controller_pid=%s\ncontroller_exit=%s\n' "$process_pid" "$exit_code" |
+              tee "$artifact_dir/controller-exit.txt"
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_CONTROLLER_QAPPLICATION_OK' |
+              tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+
+          if grep -Eq 'WEBEEBLOCKS_C16_FATAL signal=SIG(SEGV|ABRT|BUS|ILL|FPE)' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C16_BACKTRACE_BEGIN' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C16_BACKTRACE_END' "$log"; then
+            awk '
+              /WEBEEBLOCKS_C16_BACKTRACE_BEGIN/ {capture=1; next}
+              /WEBEEBLOCKS_C16_BACKTRACE_END/ {capture=0}
+              capture {print}
+            ' "$log" > "$artifact_dir/causal-backtrace.txt"
+            test -s "$artifact_dir/causal-backtrace.txt"
+            grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication' \
+              "$artifact_dir/causal-backtrace.txt"
+            signal="$(sed -n 's/.*WEBEEBLOCKS_C16_FATAL signal=\(SIG[A-Z0-9]*\).*/\1/p' "$log" | tail -n 1)"
+            case "$signal" in
+              SIGSEGV) expected_exit=139 ;;
+              SIGABRT) expected_exit=134 ;;
+              SIGBUS) expected_exit=135 ;;
+              SIGILL) expected_exit=132 ;;
+              SIGFPE) expected_exit=136 ;;
+              *) exit 1 ;;
+            esac
+            test "$exit_code" = "$expected_exit"
+            printf 'controller_pid=%s\nsignal=%s\ncontroller_exit=%s\n' \
+              "$process_pid" "$signal" "$exit_code" |
+              tee "$artifact_dir/controller-exit.txt"
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_CONTROLLER_FATAL_SIGNAL_EXIT_WITH_USABLE_QT_FRAME' |
+              tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+
+          printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_CONTROLLER_QT_OUTCOME_UNPROVEN' |
+            tee "$artifact_dir/result.txt"
+          exit 1
+
+      - name: Upload frozen C10 direct-controller QApplication discriminator
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c16-direct-controller' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-c16-direct-controller-r2025a
+          path: ci-artifacts/firefox-c16-direct-controller/
+          if-no-files-found: error
+
+
       - name: Upload runtime WWI diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,7 +1055,7 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
-      - name: Run frozen C10 direct-controller QApplication discriminator
+      - name: Run frozen C10 direct-launch C15-binary discriminator
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c16-direct-controller' }}
         shell: bash
         run: |
@@ -1064,7 +1064,7 @@ jobs:
           mkdir -p "$artifact_dir"
 
           c10_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
-          historical="$RUNNER_TEMP/webeeblocks-c16-c10"
+          historical="$RUNNER_TEMP/webeeblocks-c15-c10"
           git init -q "$historical"
           git -C "$historical" remote add origin https://github.com/djibian/webeeblocks.git
           git -C "$historical" fetch --depth=1 origin "$c10_sha"
@@ -1090,7 +1090,7 @@ jobs:
           include_replacement = """#ifdef WEBEEBLOCKS_NATIVE_FILE_BROKER
           #include "file_broker_c.h"
           #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
-          int wb_file_broker_c16_direct_qapplication(void);
+          int wb_file_broker_c15_pre_wb_init(void);
           #endif
           #endif"""
           if main.count(include_seam) != 1:
@@ -1101,7 +1101,7 @@ jobs:
             wb_robot_init();"""
           main_replacement = """int main(void) {
           #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
-            return wb_file_broker_c16_direct_qapplication();
+            return wb_file_broker_c15_pre_wb_init();
           #endif
             wb_robot_init();"""
           if main.count(main_seam) != 1:
@@ -1124,32 +1124,32 @@ jobs:
           anchor = 'constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1";\n'
           instrumentation = r'''
           #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
-          void c16_marker(const char *message) {
+          void c15_marker(const char *message) {
             ::write(STDERR_FILENO, message, std::strlen(message));
           }
 
-          void c16_fatal_handler(int signal_number) {
+          void c15_fatal_handler(int signal_number) {
             switch (signal_number) {
-              case SIGSEGV: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGSEGV\n"); break;
-              case SIGABRT: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGABRT\n"); break;
-              case SIGBUS: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGBUS\n"); break;
-              case SIGILL: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGILL\n"); break;
-              case SIGFPE: c16_marker("WEBEEBLOCKS_C16_FATAL signal=SIGFPE\n"); break;
-              default: c16_marker("WEBEEBLOCKS_C16_FATAL signal=UNKNOWN\n"); break;
+              case SIGSEGV: c15_marker("WEBEEBLOCKS_C15_FATAL signal=SIGSEGV\n"); break;
+              case SIGABRT: c15_marker("WEBEEBLOCKS_C15_FATAL signal=SIGABRT\n"); break;
+              case SIGBUS: c15_marker("WEBEEBLOCKS_C15_FATAL signal=SIGBUS\n"); break;
+              case SIGILL: c15_marker("WEBEEBLOCKS_C15_FATAL signal=SIGILL\n"); break;
+              case SIGFPE: c15_marker("WEBEEBLOCKS_C15_FATAL signal=SIGFPE\n"); break;
+              default: c15_marker("WEBEEBLOCKS_C15_FATAL signal=UNKNOWN\n"); break;
             }
             void *frames[64];
             const int count = ::backtrace(frames, 64);
-            c16_marker("WEBEEBLOCKS_C16_BACKTRACE_BEGIN\n");
+            c15_marker("WEBEEBLOCKS_C15_BACKTRACE_BEGIN\n");
             ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
-            c16_marker("WEBEEBLOCKS_C16_BACKTRACE_END\n");
+            c15_marker("WEBEEBLOCKS_C15_BACKTRACE_END\n");
             _exit(128 + signal_number);
           }
 
-          bool c16_install_handlers() {
+          bool c15_install_handlers() {
             void *warmup[1];
             (void)::backtrace(warmup, 1);
             struct sigaction action {};
-            action.sa_handler = c16_fatal_handler;
+            action.sa_handler = c15_fatal_handler;
             sigemptyset(&action.sa_mask);
             action.sa_flags = SA_RESETHAND;
             const int fatal_signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE};
@@ -1166,21 +1166,21 @@ jobs:
 
           helper = r'''
           #ifdef WEBEEBLOCKS_QT_CRASH_DIAGNOSTIC
-          extern "C" int wb_file_broker_c16_direct_qapplication(void) {
-            if (!c16_install_handlers()) {
-              c16_marker("WEBEEBLOCKS_C16 HANDLER_INSTALL_FAILED\n");
+          extern "C" int wb_file_broker_c15_pre_wb_init(void) {
+            if (!c15_install_handlers()) {
+              c15_marker("WEBEEBLOCKS_C15 HANDLER_INSTALL_FAILED\n");
               return 120;
             }
-            c16_marker("WEBEEBLOCKS_C16 DIRECT_PROCESS\n");
+            c15_marker("WEBEEBLOCKS_C15 PRE_WB_ROBOT_INIT\n");
             int argc = 1;
             char program_name[] = "webeeblocks-file-broker";
             char *argv[] = {program_name, nullptr};
-            c16_marker("WEBEEBLOCKS_C16 BEFORE_QAPPLICATION\n");
+            c15_marker("WEBEEBLOCKS_C15 BEFORE_QAPPLICATION\n");
             {
               QApplication application(argc, argv);
-              c16_marker("WEBEEBLOCKS_C16 QAPPLICATION_OK\n");
+              c15_marker("WEBEEBLOCKS_C15 QAPPLICATION_OK\n");
             }
-            c16_marker("WEBEEBLOCKS_C16 QAPPLICATION_DESTROYED\n");
+            c15_marker("WEBEEBLOCKS_C15 QAPPLICATION_DESTROYED\n");
             return 0;
           }
           #endif
@@ -1196,10 +1196,11 @@ jobs:
           PY
 
           git -C "$historical" diff -- controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c controllers/crazyflie_runtime_v2/file_broker.cpp |
-            tee "$artifact_dir/c16-instrumentation.patch"
-          test -s "$artifact_dir/c16-instrumentation.patch"
-          grep -Fq 'return wb_file_broker_c16_direct_qapplication();' "$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c"
-          grep -Fq 'WEBEEBLOCKS_C16 DIRECT_PROCESS' "$historical/controllers/crazyflie_runtime_v2/file_broker.cpp"
+            tee "$artifact_dir/c15-instrumentation.patch"
+          test -s "$artifact_dir/c15-instrumentation.patch"
+          grep -Fq 'return wb_file_broker_c15_pre_wb_init();' "$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2.c"
+          grep -Fq 'WEBEEBLOCKS_C15 PRE_WB_ROBOT_INIT' "$historical/controllers/crazyflie_runtime_v2/file_broker.cpp"
+          grep -Fq 'WEBEEBLOCKS_C15 QAPPLICATION_DESTROYED' "$historical/controllers/crazyflie_runtime_v2/file_broker.cpp"
 
           recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
           recipe_url="https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh"
@@ -1226,30 +1227,31 @@ jobs:
 
           controller="$historical/controllers/crazyflie_runtime_v2/crazyflie_runtime_v2"
           test -x "$controller"
+          real_controller="$controller.real"
+          mv "$controller" "$real_controller"
+          cat > "$controller" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          real="${BASH_SOURCE[0]}.real"
+          "$real" "$@" &
+          pid=$!
+          printf 'WEBEEBLOCKS_C15_PROCESS pid=%s\n' "$pid" >&2
+          wait "$pid"
+          code=$?
+          printf 'WEBEEBLOCKS_C15_PROCESS_EXIT pid=%s code=%s\n' "$pid" "$code" >&2
+          exit "$code"
+          SH
+          chmod +x "$controller"
+
           LD_LIBRARY_PATH="$diagnostic_webots/lib/controller:$diagnostic_webots/lib/webots" \
-            ldd "$controller" | tee "$artifact_dir/ldd.log"
+            ldd "$real_controller" | tee "$artifact_dir/ldd.log"
           qt_lines="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/ldd.log")"
           test "$(printf '%s\n' "$qt_lines" | wc -l)" -eq 3
           if printf '%s\n' "$qt_lines" | grep -vF "$diagnostic_webots/lib/webots/"; then
-            echo "C16 Qt resolved outside the official Webots desktop SDK" >&2
+            echo "C15 Qt resolved outside the official Webots desktop SDK" >&2
             exit 1
           fi
           grep -Fq "$diagnostic_webots/lib/controller/libController.so" "$artifact_dir/ldd.log"
-
-          wrapper="$RUNNER_TEMP/webeeblocks-c16-direct-wrapper.sh"
-          cat > "$wrapper" <<'SH'
-          #!/usr/bin/env bash
-          set +e
-          real="$1"
-          "$real" &
-          pid=$!
-          printf 'WEBEEBLOCKS_C16_PROCESS pid=%s\n' "$pid" >&2
-          wait "$pid"
-          code=$?
-          printf 'WEBEEBLOCKS_C16_PROCESS_EXIT pid=%s code=%s\n' "$pid" "$code" >&2
-          exit "$code"
-          SH
-          chmod +x "$wrapper"
 
           log="$artifact_dir/direct.log"
           set +e
@@ -1258,42 +1260,44 @@ jobs:
             QT_DEBUG_PLUGINS=1 \
             LD_LIBRARY_PATH="$diagnostic_webots/lib/controller:$diagnostic_webots/lib/webots" \
             LIBGL_ALWAYS_SOFTWARE=true \
-            timeout -k 2s 20s xvfb-run -a "$wrapper" "$controller" > "$log" 2>&1
+            WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true \
+            timeout -k 2s 20s xvfb-run -a "$controller" > "$log" 2>&1
           outer_code=$?
           set -e
-          printf 'c10_sha=%s\nouter_exit=%s\n' "$c10_sha" "$outer_code" | tee "$artifact_dir/run.txt"
+          printf 'c10_sha=%s\nouter_exit=%s\n' "$c10_sha" "$outer_code" |
+            tee "$artifact_dir/run.txt"
           cat "$log"
 
-          grep -Fq 'WEBEEBLOCKS_C16 DIRECT_PROCESS' "$log"
-          grep -Fq 'WEBEEBLOCKS_C16 BEFORE_QAPPLICATION' "$log"
-          process_pid="$(sed -n 's/.*WEBEEBLOCKS_C16_PROCESS pid=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
-          exit_pid="$(sed -n 's/.*WEBEEBLOCKS_C16_PROCESS_EXIT pid=\([0-9][0-9]*\) code=.*/\1/p' "$log" | tail -n 1)"
-          exit_code="$(sed -n 's/.*WEBEEBLOCKS_C16_PROCESS_EXIT pid=[0-9][0-9]* code=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
+          grep -Fq 'WEBEEBLOCKS_C15 PRE_WB_ROBOT_INIT' "$log"
+          grep -Fq 'WEBEEBLOCKS_C15 BEFORE_QAPPLICATION' "$log"
+          process_pid="$(sed -n 's/.*WEBEEBLOCKS_C15_PROCESS pid=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
+          exit_pid="$(sed -n 's/.*WEBEEBLOCKS_C15_PROCESS_EXIT pid=\([0-9][0-9]*\) code=.*/\1/p' "$log" | tail -n 1)"
+          exit_code="$(sed -n 's/.*WEBEEBLOCKS_C15_PROCESS_EXIT pid=[0-9][0-9]* code=\([0-9][0-9]*\).*/\1/p' "$log" | tail -n 1)"
           test -n "$process_pid"
           test "$exit_pid" = "$process_pid"
 
-          if grep -Fq 'WEBEEBLOCKS_C16 QAPPLICATION_OK' "$log" &&
-             grep -Fq 'WEBEEBLOCKS_C16 QAPPLICATION_DESTROYED' "$log"; then
+          if grep -Fq 'WEBEEBLOCKS_C15 QAPPLICATION_OK' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C15 QAPPLICATION_DESTROYED' "$log"; then
             test "$exit_code" = 0
             printf 'controller_pid=%s\ncontroller_exit=%s\n' "$process_pid" "$exit_code" |
               tee "$artifact_dir/controller-exit.txt"
-            printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_CONTROLLER_QAPPLICATION_OK' |
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_EXACT_C15_BINARY_QAPPLICATION_OK' |
               tee "$artifact_dir/result.txt"
             exit 0
           fi
 
-          if grep -Eq 'WEBEEBLOCKS_C16_FATAL signal=SIG(SEGV|ABRT|BUS|ILL|FPE)' "$log" &&
-             grep -Fq 'WEBEEBLOCKS_C16_BACKTRACE_BEGIN' "$log" &&
-             grep -Fq 'WEBEEBLOCKS_C16_BACKTRACE_END' "$log"; then
+          if grep -Eq 'WEBEEBLOCKS_C15_FATAL signal=SIG(SEGV|ABRT|BUS|ILL|FPE)' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C15_BACKTRACE_BEGIN' "$log" &&
+             grep -Fq 'WEBEEBLOCKS_C15_BACKTRACE_END' "$log"; then
             awk '
-              /WEBEEBLOCKS_C16_BACKTRACE_BEGIN/ {capture=1; next}
-              /WEBEEBLOCKS_C16_BACKTRACE_END/ {capture=0}
+              /WEBEEBLOCKS_C15_BACKTRACE_BEGIN/ {capture=1; next}
+              /WEBEEBLOCKS_C15_BACKTRACE_END/ {capture=0}
               capture {print}
             ' "$log" > "$artifact_dir/causal-backtrace.txt"
             test -s "$artifact_dir/causal-backtrace.txt"
             grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication' \
               "$artifact_dir/causal-backtrace.txt"
-            signal="$(sed -n 's/.*WEBEEBLOCKS_C16_FATAL signal=\(SIG[A-Z0-9]*\).*/\1/p' "$log" | tail -n 1)"
+            signal="$(sed -n 's/.*WEBEEBLOCKS_C15_FATAL signal=\(SIG[A-Z0-9]*\).*/\1/p' "$log" | tail -n 1)"
             case "$signal" in
               SIGSEGV) expected_exit=139 ;;
               SIGABRT) expected_exit=134 ;;
@@ -1306,12 +1310,12 @@ jobs:
             printf 'controller_pid=%s\nsignal=%s\ncontroller_exit=%s\n' \
               "$process_pid" "$signal" "$exit_code" |
               tee "$artifact_dir/controller-exit.txt"
-            printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_CONTROLLER_FATAL_SIGNAL_EXIT_WITH_USABLE_QT_FRAME' |
+            printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_EXACT_C15_BINARY_FATAL_SIGNAL_EXIT_WITH_USABLE_QT_FRAME' |
               tee "$artifact_dir/result.txt"
             exit 0
           fi
 
-          printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_CONTROLLER_QT_OUTCOME_UNPROVEN' |
+          printf '%s\n' 'DIAGNOSTIC_RESULT=C16_DIRECT_EXACT_C15_BINARY_QT_OUTCOME_UNPROVEN' |
             tee "$artifact_dir/result.txt"
           exit 1
 


### PR DESCRIPTION
## Scope

Bounded #87 C16 research implementing the pre-registered discriminator on issue #87.

C14 standalone Qt succeeds. C15 proves the normally Webots-launched frozen C10 controller SIGSEGVs in Qt/XCB even before wb_robot_init(). This candidate asks whether the **same frozen controller executable/linkage** is sufficient without Webots launching the process.

It replays exact frozen C10 source/blob identities and uses the C15 diagnostic ordering and Qt-side inputs, but runs the built controller binary directly under Xvfb instead of launching Webots. It preserves:
- exact pinned R2025a desktop archive/runtime recipe;
- Webots-bundled Qt/XCB libraries/plugins and linked libController.so;
- QT_DEBUG_PLUGINS=1, software rendering, program name webeeblocks-file-broker and unchanged QPA/DISPLAY;
- no wb_robot_init(), QFileDialog, debugger or product file operation;
- exact child PID/terminal status plus fail-closed fatal-signal/backtrace oracle.

Discriminator:
- direct controller succeeds -> frozen binary/linkage is insufficient; Webots launcher-provided process/environment context is required;
- direct controller reproduces SIGSEGV/139 in the Qt/XCB frame class -> Webots launcher is not required; isolate binary/linkage loading next;
- every other outcome is UNPROVEN.

Research-only: preserve result on #87 and close without merge.

Refs #87.