### PR TITLE
Isolate retained broker sections from C19

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,6 +1055,189 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
+      - name: Run C20 broker dead-section discriminator
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c20-broker-gc' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/firefox-c20-broker-gc
+          mkdir -p "$artifact_dir"
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          curl --fail --location --retry 3 --output "$recipe" \
+            https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh
+          test "$(git hash-object "$recipe")" = 4593476be2c985580a0e1738671f4b5bae81f669
+          sudo env CI=true bash "$recipe"
+          archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+          curl --fail --location --retry 3 --output "$archive" \
+            https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
+          echo "c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38  $archive" | sha256sum --check
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+          webots="$RUNNER_TEMP/webots"
+
+          frozen_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+          frozen="$RUNNER_TEMP/c20-frozen-broker"
+          mkdir -p "$frozen"
+          for file in file_broker.cpp file_broker.hpp file_broker_c.h; do
+            curl --fail --location --retry 3 --output "$frozen/$file" \
+              "https://raw.githubusercontent.com/djibian/webeeblocks/$frozen_sha/controllers/crazyflie_runtime_v2/$file"
+          done
+          test "$(git hash-object "$frozen/file_broker.cpp")" = 241e6e6aaec32ceaeaa2693fad337a774757b895
+          test "$(git hash-object "$frozen/file_broker.hpp")" = 9e50d286344f680cb0cc254f4d68f4434a9e409a
+          test "$(git hash-object "$frozen/file_broker_c.h")" = d51074ba660b131f3c9df67d0ceef404c204f079
+          git hash-object "$frozen"/file_broker.* | tee "$artifact_dir/frozen-source-blobs.txt"
+
+          source="$RUNNER_TEMP/c20-control.cpp"
+          baseline="$RUNNER_TEMP/c20-baseline"
+          full="$RUNNER_TEMP/c20-full"
+          gc="$RUNNER_TEMP/c20-gc"
+          staged="$RUNNER_TEMP/c20-control"
+          cat > "$source" <<'CPP'
+          #include <QtWidgets/QApplication>
+          #include <csignal>
+          #include <cstring>
+          #include <execinfo.h>
+          #include <unistd.h>
+          static void marker(const char *m) { ::write(STDERR_FILENO, m, std::strlen(m)); }
+          static void fatal_handler(int s) {
+            if (s == SIGSEGV) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV\n");
+            else if (s == SIGABRT) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGABRT\n");
+            else if (s == SIGBUS) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGBUS\n");
+            else if (s == SIGILL) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGILL\n");
+            else if (s == SIGFPE) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGFPE\n");
+            else marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=UNKNOWN\n");
+            void *frames[64];
+            int count = ::backtrace(frames, 64);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN\n");
+            ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END\n");
+            _exit(128 + s);
+          }
+          int main(int argc, char **argv) {
+            void *warmup[1]; (void)::backtrace(warmup, 1);
+            struct sigaction action {};
+            action.sa_handler = fatal_handler; sigemptyset(&action.sa_mask);
+            action.sa_flags = SA_RESETHAND;
+            for (int s : {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE})
+              if (sigaction(s, &action, nullptr) != 0) return 120;
+            marker("WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION\n");
+            QApplication app(argc, argv);
+            marker("WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK\n");
+            return 0;
+          }
+          CPP
+          common=(-std=c++17 -g -O0
+            -isystem "$webots/include/qt/QtCore"
+            -isystem "$webots/include/qt/QtGui"
+            -isystem "$webots/include/qt/QtWidgets"
+            -L"$webots/lib/webots" -L"$webots/lib/controller"
+            -Wl,-rpath-link,"$webots/lib/webots" -Wl,-rpath-link,"$webots/lib/controller")
+          libs=(-lQt6Widgets -lQt6Gui -lQt6Core -Wl,--no-as-needed -lController -Wl,--as-needed)
+          g++ "${common[@]}" "$source" -o "$baseline" "${libs[@]}"
+          g++ "${common[@]}" -I"$frozen" "$source" "$frozen/file_broker.cpp" -o "$full" "${libs[@]}"
+          g++ "${common[@]}" -Wl,--gc-sections -I"$frozen" "$source" "$frozen/file_broker.cpp" -o "$gc" "${libs[@]}"
+          sha256sum "$baseline" "$full" "$gc" | tee "$artifact_dir/binary-sha256.txt"
+          ! cmp -s "$baseline" "$full"
+          ! cmp -s "$full" "$gc"
+
+          ! nm -C "$baseline" | grep -Fq 'webeeblocks::createQtFileDialogProvider()'
+          nm -C "$full" > "$artifact_dir/full-nm.txt"
+          grep -F 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/full-nm.txt" | tee "$artifact_dir/full-broker-symbol.txt"
+          strings "$full" | grep -F 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' | tee "$artifact_dir/full-broker-marker.txt"
+          nm -C "$gc" > "$artifact_dir/gc-nm.txt"
+          ! grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/gc-nm.txt"
+          ! strings "$gc" | grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED'
+
+          for arm in baseline full gc; do
+            binary="$baseline"; [ "$arm" = full ] && binary="$full"; [ "$arm" = gc ] && binary="$gc"
+            readelf -d "$binary" > "$artifact_dir/$arm-readelf-dynamic.txt"
+            readelf -rW "$binary" > "$artifact_dir/$arm-readelf-relocs.txt"
+            readelf -SW "$binary" > "$artifact_dir/$arm-readelf-sections.txt"
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" ldd "$binary" > "$artifact_dir/$arm-ldd.txt"
+            grep -F "libController.so => $webots/lib/controller/libController.so" "$artifact_dir/$arm-ldd.txt"
+            qt="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/$arm-ldd.txt")"
+            test "$(printf '%s\n' "$qt" | wc -l)" -eq 3
+            ! printf '%s\n' "$qt" | grep -vF "$webots/lib/webots/"
+          done
+
+          session="$RUNNER_TEMP/c20-session.sh"
+          cat > "$session" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          run_one() {
+            tag="$1"; binary="$2"; log="$artifact_dir/$tag.log"
+            cp "$binary" "$staged"
+            env -u QT_DEBUG_PLUGINS "$staged" > "$log" 2>&1 &
+            pid=$!; wait "$pid"; code=$?
+            printf 'WEBEEBLOCKS_C20_PROCESS tag=%s pid=%s argc=1 argv0=%s debug=0 display=%s\n' \
+              "$tag" "$pid" "$staged" "${DISPLAY:-}" >> "$log"
+            printf 'WEBEEBLOCKS_C20_PROCESS_EXIT tag=%s pid=%s code=%s\n' "$tag" "$pid" "$code" >> "$log"
+          }
+          run_one baseline "$baseline"
+          run_one full "$full"
+          run_one gc "$gc"
+          SH
+          chmod +x "$session"
+          set +e
+          env artifact_dir="$artifact_dir" staged="$staged" baseline="$baseline" full="$full" gc="$gc" \
+            QT_PLUGIN_PATH="$webots/lib/webots/qt/plugins" \
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+            LIBGL_ALWAYS_SOFTWARE=true timeout -k 2s 45s xvfb-run -a "$session"
+          outer=$?
+          set -e
+          test "$outer" = 0
+          for tag in baseline full gc; do
+            log="$artifact_dir/$tag.log"; cat "$log"
+            pid="$(sed -n "s/.*WEBEEBLOCKS_C20_PROCESS tag=$tag pid=\([0-9][0-9]*\).*/\1/p" "$log" | tail -1)"
+            exit_pid="$(sed -n "s/.*WEBEEBLOCKS_C20_PROCESS_EXIT tag=$tag pid=\([0-9][0-9]*\) code=.*/\1/p" "$log" | tail -1)"
+            test -n "$pid"; test "$pid" = "$exit_pid"
+            grep -Eq "WEBEEBLOCKS_C20_PROCESS tag=$tag .* argc=1 .* debug=0 display=:[0-9]+" "$log"
+            grep -Fq 'WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION' "$log"
+          done
+
+          baseline_log="$artifact_dir/baseline.log"
+          full_log="$artifact_dir/full.log"
+          gc_log="$artifact_dir/gc.log"
+          exit_code() { sed -n "s/.*tag=$1 pid=[0-9][0-9]* code=\([0-9][0-9]*\).*/\1/p" "$artifact_dir/$1.log" | tail -1; }
+          baseline_exit="$(exit_code baseline)"
+          full_exit="$(exit_code full)"
+          gc_exit="$(exit_code gc)"
+
+          grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$baseline_log"
+          test "$baseline_exit" = 0
+          ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=' "$baseline_log"
+
+          if ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV' "$full_log" || [ "$full_exit" != 139 ]; then
+            echo DIAGNOSTIC_RESULT=C20_C19_WITNESS_NOT_REPRODUCED_UNPROVEN | tee "$artifact_dir/result.txt"
+            exit 1
+          fi
+          sed -n '/BACKTRACE_BEGIN/,/BACKTRACE_END/p' "$full_log" > "$artifact_dir/full-causal-backtrace.txt"
+          grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication' "$artifact_dir/full-causal-backtrace.txt"
+          ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$full_log"
+          ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$full_log"
+
+          if grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$gc_log"; then
+            test "$gc_exit" = 0
+            ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=' "$gc_log"
+            echo DIAGNOSTIC_RESULT=C20_RETAINED_BROKER_SECTIONS_NECESSARY | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV' "$gc_log" && [ "$gc_exit" = 139 ]; then
+            sed -n '/BACKTRACE_BEGIN/,/BACKTRACE_END/p' "$gc_log" > "$artifact_dir/gc-causal-backtrace.txt"
+            grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication' "$artifact_dir/gc-causal-backtrace.txt"
+            echo DIAGNOSTIC_RESULT=C20_GC_ELISION_INSUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          echo DIAGNOSTIC_RESULT=C20_OUTCOME_UNPROVEN | tee "$artifact_dir/result.txt"
+          exit 1
+
+      - name: Upload C20 broker dead-section discriminator
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c20-broker-gc' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-c20-broker-gc-r2025a
+          path: ci-artifacts/firefox-c20-broker-gc/
+          if-no-files-found: error
+
       - name: Upload runtime WWI diagnostics
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Scope

Bounded #87 C20 research after the settled C19 result.

C19 proved that adding the exact frozen C10 `file_broker.cpp` translation unit to the successful C17-style standalone `QApplication` + exact `libController.so` control is sufficient to reproduce the historical Qt/XCB SIGSEGV/139 even though no broker/provider code runs.

C20 isolates whether the **retained broker code/data sections and their load-time relocations** are necessary for that effect. It preserves the pinned Webots R2025a/Xvfb/Qt/Controller boundary and the exact frozen broker source blobs, then runs three same-path arms in one Xvfb session:

- baseline: C17-style standalone control;
- full: exact C19-style broker translation unit retained;
- gc: the same full build with only linker dead-section collection (`--gc-sections`) added.

The oracle requires the full arm to reproduce the exact C19 SIGSEGV/139 Qt/XCB witness before interpreting the gc arm, and requires the gc image to contain neither `webeeblocks::createQtFileDialogProvider()` nor the broker runtime marker.

Pre-registered discriminator:
1. baseline succeeds, full reproduces exact SIGSEGV/139, gc reaches `QAPPLICATION_OK`/0 -> retained broker sections/relocations are necessary; next isolate the smallest retained section/symbol group without invoking broker behavior;
2. baseline succeeds, full reproduces exact SIGSEGV/139, gc still reproduces the same Qt/XCB SIGSEGV despite broker symbol/marker elimination -> dead-section elision is insufficient; inspect residual ELF/layout/load metadata before source-level behavior;
3. C19 witness not reproduced, gc residue remains, or any other outcome -> UNPROVEN.

Research-only. Do not change QPA/DISPLAY or invoke `QFileDialog`. Preserve the exact settled result on #87 and close without merge.

Refs #87.