### PR TITLE
Isolate retained broker sections from C20 crash

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,6 +1055,232 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
+
+      - name: Run C21 retained broker section discriminator
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c21-broker-gc' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/firefox-c21-broker-gc
+          mkdir -p "$artifact_dir"
+
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          curl --fail --location --retry 3 --output "$recipe" \
+            https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh
+          test "$(git hash-object "$recipe")" = 4593476be2c985580a0e1738671f4b5bae81f669
+          sudo env CI=true bash "$recipe"
+
+          archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+          curl --fail --location --retry 3 --output "$archive" \
+            https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
+          echo "c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38  $archive" | sha256sum --check
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+          webots="$RUNNER_TEMP/webots"
+
+          frozen_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+          frozen="$RUNNER_TEMP/c21-frozen-broker"
+          mkdir -p "$frozen"
+          for file in file_broker.cpp file_broker.hpp file_broker_c.h; do
+            curl --fail --location --retry 3 --output "$frozen/$file" \
+              "https://raw.githubusercontent.com/djibian/webeeblocks/$frozen_sha/controllers/crazyflie_runtime_v2/$file"
+          done
+          test "$(git hash-object "$frozen/file_broker.cpp")" = 241e6e6aaec32ceaeaa2693fad337a774757b895
+          test "$(git hash-object "$frozen/file_broker.hpp")" = 9e50d286344f680cb0cc254f4d68f4434a9e409a
+          test "$(git hash-object "$frozen/file_broker_c.h")" = d51074ba660b131f3c9df67d0ceef404c204f079
+          git hash-object "$frozen"/file_broker.* | tee "$artifact_dir/frozen-source-blobs.txt"
+
+          source="$RUNNER_TEMP/c21-control.cpp"
+          control_obj="$RUNNER_TEMP/c21-control.o"
+          broker_obj="$RUNNER_TEMP/c21-broker.o"
+          arm_a="$RUNNER_TEMP/c21-arm-a"
+          arm_b="$RUNNER_TEMP/c21-arm-b"
+          arm_c="$RUNNER_TEMP/c21-arm-c"
+          staged="$RUNNER_TEMP/c21-control"
+
+          cat > "$source" <<'CPP'
+          #include <QtWidgets/QApplication>
+          #include <csignal>
+          #include <cstring>
+          #include <execinfo.h>
+          #include <unistd.h>
+          static void marker(const char *m) { ::write(STDERR_FILENO, m, std::strlen(m)); }
+          static void fatal_handler(int s) {
+            if (s == SIGSEGV) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV\n");
+            else if (s == SIGABRT) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGABRT\n");
+            else if (s == SIGBUS) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGBUS\n");
+            else if (s == SIGILL) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGILL\n");
+            else if (s == SIGFPE) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGFPE\n");
+            else marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=UNKNOWN\n");
+            void *frames[64];
+            int count = ::backtrace(frames, 64);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN\n");
+            ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END\n");
+            _exit(128 + s);
+          }
+          int main(int argc, char **argv) {
+            void *warmup[1]; (void)::backtrace(warmup, 1);
+            struct sigaction action {};
+            action.sa_handler = fatal_handler; sigemptyset(&action.sa_mask);
+            action.sa_flags = SA_RESETHAND;
+            for (int s : {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE})
+              if (sigaction(s, &action, nullptr) != 0) return 120;
+            marker("WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION\n");
+            QApplication app(argc, argv);
+            marker("WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK\n");
+            return 0;
+          }
+          CPP
+
+          common=(-std=c++17 -g -O0
+            -isystem "$webots/include/qt/QtCore"
+            -isystem "$webots/include/qt/QtGui"
+            -isystem "$webots/include/qt/QtWidgets"
+            -L"$webots/lib/webots" -L"$webots/lib/controller"
+            -Wl,-rpath-link,"$webots/lib/webots" -Wl,-rpath-link,"$webots/lib/controller")
+          libs=(-lQt6Widgets -lQt6Gui -lQt6Core -Wl,--no-as-needed -lController -Wl,--as-needed)
+
+          g++ "${common[@]}" -ffunction-sections -fdata-sections -c "$source" -o "$control_obj"
+          g++ "${common[@]}" -ffunction-sections -fdata-sections -I"$frozen" \
+            -c "$frozen/file_broker.cpp" -o "$broker_obj"
+
+          g++ "${common[@]}" "$control_obj" -o "$arm_a" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" -o "$arm_b" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,-Map,"$artifact_dir/arm-c-link.map" \
+            -o "$arm_c" "${libs[@]}"
+
+          sha256sum "$control_obj" "$broker_obj" "$arm_a" "$arm_b" "$arm_c" \
+            | tee "$artifact_dir/sha256.txt"
+          ! cmp -s "$arm_a" "$arm_b"
+          ! cmp -s "$arm_b" "$arm_c"
+
+          nm -C "$arm_a" > "$artifact_dir/arm-a-nm.txt"
+          nm -C "$arm_b" > "$artifact_dir/arm-b-nm.txt"
+          nm -C "$arm_c" > "$artifact_dir/arm-c-nm.txt"
+          strings "$arm_a" > "$artifact_dir/arm-a-strings.txt"
+          strings "$arm_b" > "$artifact_dir/arm-b-strings.txt"
+          strings "$arm_c" > "$artifact_dir/arm-c-strings.txt"
+
+          ! grep -Eq 'createQtFileDialogProvider|wb_file_broker_create_qt|QtFileDialogProvider' "$artifact_dir/arm-a-nm.txt"
+          grep -Eq 'createQtFileDialogProvider|wb_file_broker_create_qt|QtFileDialogProvider' "$artifact_dir/arm-b-nm.txt"
+          grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$artifact_dir/arm-b-strings.txt"
+          ! grep -Eq 'createQtFileDialogProvider|wb_file_broker_create_qt|QtFileDialogProvider' "$artifact_dir/arm-c-nm.txt"
+          ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$artifact_dir/arm-c-strings.txt"
+          echo BROKER_UNUSED_PROVIDER_SECTIONS_REMOVED=1 | tee "$artifact_dir/gc-proof.txt"
+
+          for arm in a b c; do
+            binary="$arm_a"
+            [ "$arm" = b ] && binary="$arm_b"
+            [ "$arm" = c ] && binary="$arm_c"
+            readelf -d "$binary" > "$artifact_dir/arm-$arm-readelf.txt"
+            sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p' \
+              "$artifact_dir/arm-$arm-readelf.txt" > "$artifact_dir/arm-$arm-needed.txt"
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+              ldd "$binary" > "$artifact_dir/arm-$arm-ldd.txt"
+            grep -F "libController.so => $webots/lib/controller/libController.so" \
+              "$artifact_dir/arm-$arm-ldd.txt"
+            qt="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/arm-$arm-ldd.txt")"
+            test "$(printf '%s\n' "$qt" | wc -l)" -eq 3
+            ! printf '%s\n' "$qt" | grep -vF "$webots/lib/webots/"
+          done
+          diff -u "$artifact_dir/arm-b-needed.txt" "$artifact_dir/arm-c-needed.txt" \
+            > "$artifact_dir/arm-b-vs-c-needed.diff" || true
+          cat "$artifact_dir/arm-b-vs-c-needed.diff"
+
+          session="$RUNNER_TEMP/c21-session.sh"
+          cat > "$session" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          run_one() {
+            tag="$1"
+            binary="$2"
+            log="$artifact_dir/$tag.log"
+            cp "$binary" "$staged"
+            env -u QT_DEBUG_PLUGINS "$staged" > "$log" 2>&1 &
+            pid=$!
+            wait "$pid"
+            code=$?
+            printf 'WEBEEBLOCKS_C21_PROCESS tag=%s pid=%s argc=1 argv0=%s debug=0 display=%s\n' \
+              "$tag" "$pid" "$staged" "${DISPLAY:-}" >> "$log"
+            printf 'WEBEEBLOCKS_C21_PROCESS_EXIT tag=%s pid=%s code=%s\n' \
+              "$tag" "$pid" "$code" >> "$log"
+          }
+          run_one arm-a "$arm_a"
+          run_one arm-c "$arm_c"
+          run_one arm-b "$arm_b"
+          SH
+          chmod +x "$session"
+
+          set +e
+          env artifact_dir="$artifact_dir" staged="$staged" \
+            arm_a="$arm_a" arm_b="$arm_b" arm_c="$arm_c" \
+            QT_PLUGIN_PATH="$webots/lib/webots/qt/plugins" \
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+            LIBGL_ALWAYS_SOFTWARE=true timeout -k 2s 45s xvfb-run -a "$session"
+          outer=$?
+          set -e
+          test "$outer" = 0
+
+          check_common() {
+            log="$1"; tag="$2"
+            cat "$log"
+            pid="$(sed -n "s/.*WEBEEBLOCKS_C21_PROCESS tag=$tag pid=\([0-9][0-9]*\).*/\1/p" "$log" | tail -1)"
+            exit_pid="$(sed -n "s/.*WEBEEBLOCKS_C21_PROCESS_EXIT tag=$tag pid=\([0-9][0-9]*\) code=.*/\1/p" "$log" | tail -1)"
+            test -n "$pid" && test "$pid" = "$exit_pid" &&
+              grep -Eq "WEBEEBLOCKS_C21_PROCESS tag=$tag .* argc=1 .* debug=0 display=:[0-9]+" "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION' "$log"
+          }
+
+          check_success() {
+            log="$1"; tag="$2"
+            check_common "$log" "$tag" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$log" &&
+              grep -Eq "WEBEEBLOCKS_C21_PROCESS_EXIT tag=$tag pid=[0-9]+ code=0" "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=' "$log"
+          }
+
+          check_crash() {
+            log="$1"; tag="$2"
+            check_common "$log" "$tag" &&
+              ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END' "$log" &&
+              grep -Eq "WEBEEBLOCKS_C21_PROCESS_EXIT tag=$tag pid=[0-9]+ code=139" "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$log" &&
+              sed -n '/BACKTRACE_BEGIN/,/BACKTRACE_END/p' "$log" |
+                grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication'
+          }
+
+          a_log="$artifact_dir/arm-a.log"
+          b_log="$artifact_dir/arm-b.log"
+          c_log="$artifact_dir/arm-c.log"
+
+          if ! check_success "$a_log" arm-a || ! check_crash "$b_log" arm-b; then
+            echo DIAGNOSTIC_RESULT=C21_CONTROL_OUTCOME_UNPROVEN | tee "$artifact_dir/result.txt"
+            exit 1
+          fi
+          if check_success "$c_log" arm-c; then
+            echo DIAGNOSTIC_RESULT=C21_DEAD_SECTIONS_NECESSARY | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if check_crash "$c_log" arm-c; then
+            echo DIAGNOSTIC_RESULT=C21_SURVIVES_GC | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          echo DIAGNOSTIC_RESULT=C21_GC_OUTCOME_UNPROVEN | tee "$artifact_dir/result.txt"
+          exit 1
+
+      - name: Upload C21 retained broker section discriminator
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c21-broker-gc' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-c21-broker-gc-r2025a
+          path: ci-artifacts/firefox-c21-broker-gc/
+          if-no-files-found: error
+
       - name: Upload runtime WWI diagnostics
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Scope

Bounded #87 C21 research after the settled C20 reproducibility result.

C20 established on exact candidate `f6a7bb7fa7db44c081bbd007b1dc0cd0af328776` that the C19 broker-object association reproduces in both fresh Xvfb session orders while the standalone baseline remains successful. C21 now executes the pre-registered next discriminator from #87: whether otherwise-unreferenced code/data retained from the exact frozen C10 broker translation unit is necessary for the Qt/XCB crash class.

The candidate preserves the exact C20/C19 standalone `QApplication` source and pinned Webots R2025a runtime/Qt/XCB closure, exact forced `libController.so`, same staged executable path/argv, software rendering and unchanged QPA/DISPLAY. It fetches the exact frozen broker sources from `fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c` and verifies the three proven blob identities.

The control source and broker translation unit are each compiled once with `-ffunction-sections -fdata-sections`, then linked as:
- A: sectioned standalone control only, normal link;
- B: exact control + exact broker object, normal link;
- C: exact same objects and library order as B, changing only `--gc-sections` plus output-only link-map evidence.

Before execution classification, B must retain the broker provider symbol class and frozen `QT_APP_INITIALIZED` marker, while C must prove those provider symbols/marker absent after dead-section collection. A/C/B then run from the same staged path in one fresh Xvfb session, with B last so its intended crash cannot perturb C.

Pre-registered discriminator:
- A succeeds, B reproduces exact Qt/XCB `SIGSEGV`/139, C succeeds after proven dead-section elimination -> `C21_DEAD_SECTIONS_NECESSARY`;
- A succeeds, B reproduces exact crash, C still reproduces it after proven provider-symbol/marker elimination -> `C21_SURVIVES_GC`;
- failed controls/removal proof, different fatal class or any other outcome -> UNPROVEN.

No Controller API, `wb_robot_init()`, broker/provider construction, `QFileDialog`, debugger, QPA/DISPLAY change or product file operation. Research-only. Preserve the exact settled result on #87 and close without merge.

Refs #87.