### PR TITLE
Stabilize student UI tooltip hover oracle

### DIFF
--- a/experiments/runtime-v2-student-ui/probe.py
+++ b/experiments/runtime-v2-student-ui/probe.py
@@ -344,8 +344,23 @@ def main():
         if expected not in menu_text:
             raise RuntimeError('real direction dropdown lacks '+expected+': '+menu_text)
     c.screenshot(screenshot.with_name('direction-menu-1366x768.png'))
-    c.key('Escape'); time.sleep(.2)
-    c.hover(rendered['repeatRect'])
+    c.key('Escape')
+    blocking_overlay=[]
+    overlay_end=time.time()+2.0
+    while time.time()<overlay_end:
+        blocking_overlay=[
+            entry for entry in c.eval(VISIBLE_OVERLAY)
+            if 'tooltip' not in entry['className'].lower() and entry['text'].strip()
+        ]
+        if not blocking_overlay: break
+        time.sleep(.05)
+    if blocking_overlay:
+        raise RuntimeError('direction dropdown overlay did not close before tooltip hover: '+json.dumps(blocking_overlay,ensure_ascii=False))
+    # Re-hit-test after the dropdown has actually closed. A stale pre-menu
+    # coordinate can remain under the transient widget overlay, causing the
+    # synthetic mouse move to be consumed without ever entering the real block.
+    repeat_after_close=c.eval(RENDER_LOCALE)
+    c.hover(repeat_after_close['repeatRect'])
     tooltip=[]
     end=time.time()+5.0
     while time.time()<end:

--- a/experiments/runtime-v2-student-ui/probe.py
+++ b/experiments/runtime-v2-student-ui/probe.py
@@ -150,6 +150,23 @@ RENDER_LOCALE=r'''(() => {
  };
 })()'''
 
+REPEAT_HOVER_RECT=r'''(() => {
+ const repeat=workspace.getBlocksByType('controls_repeat_ext',false)[0];
+ if(!repeat)throw new Error('rendered repeat block missing for hover');
+ const repeatRoot=repeat.getSvgRoot();
+ if(!repeatRoot)throw new Error('rendered repeat SVG root missing for hover');
+ const rb=repeatRoot.getBoundingClientRect();
+ for(let y=Math.ceil(rb.top)+2;y<Math.floor(rb.bottom);y+=4){
+   for(let x=Math.ceil(rb.left)+2;x<Math.floor(rb.right);x+=4){
+     const hit=document.elementFromPoint(x,y);
+     if(hit&&repeatRoot.contains(hit)){
+       return {x:x-1,y:y-1,width:2,height:2,hitTag:hit.tagName,hitClass:String(hit.getAttribute&&hit.getAttribute('class')||'')};
+     }
+   }
+ }
+ throw new Error('no real hit-tested hover point on existing repeat block');
+})()'''
+
 VISIBLE_OVERLAY=r'''(() => {
  const visible=el=>{if(!el)return false;const r=el.getBoundingClientRect(),s=getComputedStyle(el);return s.display!=='none'&&s.visibility!=='hidden'&&r.width>0&&r.height>0;};
  const nodes=[...document.querySelectorAll('.blocklyDropDownDiv,.blocklyWidgetDiv,[role="menu"],[role="listbox"],.blocklyTooltipDiv')].filter(visible);
@@ -359,8 +376,8 @@ def main():
     # Re-hit-test after the dropdown has actually closed. A stale pre-menu
     # coordinate can remain under the transient widget overlay, causing the
     # synthetic mouse move to be consumed without ever entering the real block.
-    repeat_after_close=c.eval(RENDER_LOCALE)
-    c.hover(repeat_after_close['repeatRect'])
+    repeat_after_close=c.eval(REPEAT_HOVER_RECT)
+    c.hover(repeat_after_close)
     tooltip=[]
     end=time.time()+5.0
     while time.time()<end:


### PR DESCRIPTION
## Problem

Canonical C21 run `34186940578` exposed a recurrent false-negative in the unchanged `Runtime suite / student-ui` oracle. Attempt 1 (`101937095661`) and failed-jobs attempt 2 (`101937941390`) both reached the real Blockly UI but failed at the same boundary: the repeat-block tooltip never became observable after `Escape` closed the preceding real direction dropdown. The exact same unchanged student-UI suite passed moments earlier on canonical C20 run `34185240716` (`101932174289`), and the C21 change itself is confined to a branch-gated Webots workflow step.

The failure mechanism is a UI-event race in the probe: it waited a fixed 200 ms after closing the dropdown, then hovered a hit-tested repeat-block coordinate captured *before* the dropdown had opened. If the transient Blockly widget overlay still owns that coordinate when the synthetic mouse move occurs, the overlay can consume the entry event; once it disappears, the pointer is already stationary over the block and no real block hover is generated.

## Fix

Preserve the existing tooltip product oracle and its 5 s observation bound. Change only the interaction preparation:
- after `Escape`, poll the existing real-overlay observation until the non-tooltip dropdown/widget overlay is actually closed, failing explicitly if it does not close within 2 s;
- re-evaluate the existing real rendered-block hit test after closure;
- hover that fresh repeat-block point;
- keep the same requirement that a non-empty, non-English real tooltip becomes visible within the original 5 s bound.

This does not weaken the product property, extend its tooltip timeout, fabricate a tooltip, or bypass real Blockly/Webots interaction. It removes a stale-coordinate/transient-overlay race in the evidence harness.

Refs #218.