### PR TITLE
C23 split provider root below C wrapper

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,6 +1055,268 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
+
+      - name: Run C23 provider internal-factory discriminator
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c23-provider-factory-root' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/firefox-c23-provider-factory-root
+          mkdir -p "$artifact_dir"
+
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          curl --fail --location --retry 3 --output "$recipe" \
+            https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh
+          test "$(git hash-object "$recipe")" = 4593476be2c985580a0e1738671f4b5bae81f669
+          sudo env CI=true bash "$recipe"
+
+          archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+          curl --fail --location --retry 3 --output "$archive" \
+            https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
+          echo "c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38  $archive" | sha256sum --check
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+          webots="$RUNNER_TEMP/webots"
+
+          frozen_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+          frozen="$RUNNER_TEMP/c23-frozen-broker"
+          mkdir -p "$frozen"
+          for file in file_broker.cpp file_broker.hpp file_broker_c.h; do
+            curl --fail --location --retry 3 --output "$frozen/$file" \
+              "https://raw.githubusercontent.com/djibian/webeeblocks/$frozen_sha/controllers/crazyflie_runtime_v2/$file"
+          done
+          test "$(git hash-object "$frozen/file_broker.cpp")" = 241e6e6aaec32ceaeaa2693fad337a774757b895
+          test "$(git hash-object "$frozen/file_broker.hpp")" = 9e50d286344f680cb0cc254f4d68f4434a9e409a
+          test "$(git hash-object "$frozen/file_broker_c.h")" = d51074ba660b131f3c9df67d0ceef404c204f079
+          git hash-object "$frozen"/file_broker.* | tee "$artifact_dir/frozen-source-blobs.txt"
+
+          source="$RUNNER_TEMP/c23-control.cpp"
+          control_obj="$RUNNER_TEMP/c23-control.o"
+          broker_obj="$RUNNER_TEMP/c23-broker.o"
+          arm_a="$RUNNER_TEMP/c23-arm-a"
+          arm_b="$RUNNER_TEMP/c23-arm-b"
+          arm_c="$RUNNER_TEMP/c23-arm-c"
+          arm_d="$RUNNER_TEMP/c23-arm-d-provider-c-root"
+          arm_f="$RUNNER_TEMP/c23-arm-f-internal-factory"
+          staged="$RUNNER_TEMP/c23-control"
+
+          cat > "$source" <<'CPP'
+          #include <QtWidgets/QApplication>
+          #include <csignal>
+          #include <cstring>
+          #include <execinfo.h>
+          #include <unistd.h>
+          static void marker(const char *m) { ::write(STDERR_FILENO, m, std::strlen(m)); }
+          static void fatal_handler(int s) {
+            if (s == SIGSEGV) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV\n");
+            else if (s == SIGABRT) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGABRT\n");
+            else if (s == SIGBUS) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGBUS\n");
+            else if (s == SIGILL) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGILL\n");
+            else if (s == SIGFPE) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGFPE\n");
+            else marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=UNKNOWN\n");
+            void *frames[64];
+            int count = ::backtrace(frames, 64);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN\n");
+            ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END\n");
+            _exit(128 + s);
+          }
+          int main(int argc, char **argv) {
+            void *warmup[1]; (void)::backtrace(warmup, 1);
+            struct sigaction action {};
+            action.sa_handler = fatal_handler; sigemptyset(&action.sa_mask);
+            action.sa_flags = SA_RESETHAND;
+            for (int s : {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE})
+              if (sigaction(s, &action, nullptr) != 0) return 120;
+            marker("WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION\n");
+            QApplication app(argc, argv);
+            marker("WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK\n");
+            return 0;
+          }
+          CPP
+
+          common=(-std=c++17 -g -O0
+            -isystem "$webots/include/qt/QtCore"
+            -isystem "$webots/include/qt/QtGui"
+            -isystem "$webots/include/qt/QtWidgets"
+            -L"$webots/lib/webots" -L"$webots/lib/controller"
+            -Wl,-rpath-link,"$webots/lib/webots" -Wl,-rpath-link,"$webots/lib/controller")
+          libs=(-lQt6Widgets -lQt6Gui -lQt6Core -Wl,--no-as-needed -lController -Wl,--as-needed)
+
+          g++ "${common[@]}" -ffunction-sections -fdata-sections -c "$source" -o "$control_obj"
+          g++ "${common[@]}" -ffunction-sections -fdata-sections -I"$frozen" \
+            -c "$frozen/file_broker.cpp" -o "$broker_obj"
+
+          g++ "${common[@]}" "$control_obj" -o "$arm_a" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" -o "$arm_b" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,-Map,"$artifact_dir/arm-c-link.map" \
+            -o "$arm_c" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,--undefined=wb_file_broker_create_qt \
+            -Wl,-Map,"$artifact_dir/arm-d-provider-c-root-link.map" \
+            -o "$arm_d" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,--undefined=_ZN11webeeblocks26createQtFileDialogProviderEv \
+            -Wl,-Map,"$artifact_dir/arm-f-internal-factory-link.map" \
+            -o "$arm_f" "${libs[@]}"
+
+          sha256sum "$control_obj" "$broker_obj" "$arm_a" "$arm_b" "$arm_c" "$arm_d" "$arm_f" \
+            | tee "$artifact_dir/sha256.txt"
+          ! cmp -s "$arm_c" "$arm_d"
+          ! cmp -s "$arm_c" "$arm_f"
+          ! cmp -s "$arm_d" "$arm_f"
+
+          for arm in a b c d f; do
+            binary_var="arm_$arm"
+            binary="${!binary_var}"
+            nm -C "$binary" > "$artifact_dir/arm-$arm-nm.txt"
+            strings "$binary" > "$artifact_dir/arm-$arm-strings.txt"
+            readelf -SW "$binary" > "$artifact_dir/arm-$arm-sections.txt"
+            readelf -rW "$binary" > "$artifact_dir/arm-$arm-relocations.txt"
+            readelf -d "$binary" > "$artifact_dir/arm-$arm-readelf.txt"
+            sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p' \
+              "$artifact_dir/arm-$arm-readelf.txt" > "$artifact_dir/arm-$arm-needed.txt"
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+              ldd "$binary" > "$artifact_dir/arm-$arm-ldd.txt"
+            grep -F "libController.so => $webots/lib/controller/libController.so" \
+              "$artifact_dir/arm-$arm-ldd.txt"
+            qt="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/arm-$arm-ldd.txt")"
+            test "$(printf '%s\n' "$qt" | wc -l)" -eq 3
+            ! printf '%s\n' "$qt" | grep -vF "$webots/lib/webots/"
+          done
+
+          # Re-prove the C21/C22 section-retention identities.
+          ! grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-c-nm.txt"
+          ! grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-c-nm.txt"
+          grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-d-nm.txt"
+          grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-d-nm.txt"
+
+          # F must retain only the internal factory root depth, not the broader C wrapper.
+          ! grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-f-nm.txt"
+          ! grep -Fq 'wb_file_broker_handle_message' "$artifact_dir/arm-f-nm.txt"
+          grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-f-nm.txt"
+
+          # Full-retention positive control.
+          grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-b-nm.txt"
+          grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-b-nm.txt"
+          grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$artifact_dir/arm-b-strings.txt"
+
+          for arm in c d f; do
+            diff -u "$artifact_dir/arm-b-needed.txt" "$artifact_dir/arm-$arm-needed.txt" \
+              > "$artifact_dir/arm-b-vs-$arm-needed.diff" || true
+          done
+          diff -u "$artifact_dir/arm-d-nm.txt" "$artifact_dir/arm-f-nm.txt" \
+            > "$artifact_dir/arm-d-vs-f-nm.diff" || true
+          diff -u "$artifact_dir/arm-d-relocations.txt" "$artifact_dir/arm-f-relocations.txt" \
+            > "$artifact_dir/arm-d-vs-f-relocations.diff" || true
+          echo C23_ROOT_DEPTH_PROVEN=1 | tee "$artifact_dir/root-proof.txt"
+
+          session="$RUNNER_TEMP/c23-session.sh"
+          cat > "$session" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          run_one() {
+            tag="$1"; binary="$2"; log="$artifact_dir/$tag.log"
+            cp "$binary" "$staged"
+            env -u QT_DEBUG_PLUGINS "$staged" > "$log" 2>&1 &
+            pid=$!
+            wait "$pid"
+            code=$?
+            printf 'WEBEEBLOCKS_C23_PROCESS tag=%s pid=%s argc=1 argv0=%s debug=0 display=%s\n' \
+              "$tag" "$pid" "$staged" "${DISPLAY:-}" >> "$log"
+            printf 'WEBEEBLOCKS_C23_PROCESS_EXIT tag=%s pid=%s code=%s\n' \
+              "$tag" "$pid" "$code" >> "$log"
+          }
+          run_one arm-a "$arm_a"
+          run_one arm-c "$arm_c"
+          run_one arm-f "$arm_f"
+          run_one arm-d "$arm_d"
+          run_one arm-b "$arm_b"
+          SH
+          chmod +x "$session"
+
+          set +e
+          env artifact_dir="$artifact_dir" staged="$staged" \
+            arm_a="$arm_a" arm_b="$arm_b" arm_c="$arm_c" arm_d="$arm_d" arm_f="$arm_f" \
+            QT_PLUGIN_PATH="$webots/lib/webots/qt/plugins" \
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+            LIBGL_ALWAYS_SOFTWARE=true timeout -k 2s 60s xvfb-run -a "$session"
+          outer=$?
+          set -e
+          test "$outer" = 0
+
+          check_common() {
+            log="$1"; tag="$2"
+            cat "$log"
+            pid="$(sed -n "s/.*WEBEEBLOCKS_C23_PROCESS tag=$tag pid=\([0-9][0-9]*\).*/\1/p" "$log" | tail -1)"
+            exit_pid="$(sed -n "s/.*WEBEEBLOCKS_C23_PROCESS_EXIT tag=$tag pid=\([0-9][0-9]*\) code=.*/\1/p" "$log" | tail -1)"
+            test -n "$pid" && test "$pid" = "$exit_pid" &&
+              grep -Eq "WEBEEBLOCKS_C23_PROCESS tag=$tag .* argc=1 .* debug=0 display=:[0-9]+" "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION' "$log"
+          }
+
+          check_no_broker_runtime() {
+            log="$1"
+            ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$log"
+          }
+
+          check_success() {
+            log="$1"; tag="$2"
+            check_common "$log" "$tag" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$log" &&
+              grep -Eq "WEBEEBLOCKS_C23_PROCESS_EXIT tag=$tag pid=[0-9]+ code=0" "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=' "$log" &&
+              check_no_broker_runtime "$log"
+          }
+
+          check_crash() {
+            log="$1"; tag="$2"
+            check_common "$log" "$tag" &&
+              ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END' "$log" &&
+              grep -Eq "WEBEEBLOCKS_C23_PROCESS_EXIT tag=$tag pid=[0-9]+ code=139" "$log" &&
+              check_no_broker_runtime "$log" &&
+              sed -n '/BACKTRACE_BEGIN/,/BACKTRACE_END/p' "$log" |
+                grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication'
+          }
+
+          a_log="$artifact_dir/arm-a.log"
+          b_log="$artifact_dir/arm-b.log"
+          c_log="$artifact_dir/arm-c.log"
+          d_log="$artifact_dir/arm-d.log"
+          f_log="$artifact_dir/arm-f.log"
+
+          if ! check_success "$a_log" arm-a ||
+             ! check_crash "$b_log" arm-b ||
+             ! check_success "$c_log" arm-c ||
+             ! check_crash "$d_log" arm-d; then
+            echo DIAGNOSTIC_RESULT=C23_C21_C22_CONTROLS_UNPROVEN | tee "$artifact_dir/result.txt"
+            exit 1
+          fi
+
+          if check_crash "$f_log" arm-f; then
+            echo DIAGNOSTIC_RESULT=C23_INTERNAL_FACTORY_SUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if check_success "$f_log" arm-f; then
+            echo DIAGNOSTIC_RESULT=C23_C_WRAPPER_REMAINDER_NECESSARY | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+
+          echo DIAGNOSTIC_RESULT=C23_INTERNAL_FACTORY_OUTCOME_UNPROVEN | tee "$artifact_dir/result.txt"
+          exit 1
+
+      - name: Upload C23 provider internal-factory discriminator
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c23-provider-factory-root' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-c23-provider-factory-root-r2025a
+          path: ci-artifacts/firefox-c23-provider-factory-root/
+          if-no-files-found: error
+
       - name: Upload runtime WWI diagnostics
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Scope

Bounded #87 C23 research after C22 proved that the provider-construction C root is sufficient under the sectionized C21 closure.

C23 preserves the exact C21/C22 sectionized objects/runtime boundary and splits that provider root one level deeper without invoking any broker/factory function:
- A: sectioned standalone control only;
- B: exact control + broker object, normal link (full-retention crash control);
- C: exact B objects/library order with `--gc-sections` (C21 success control);
- D: exact C link plus only `--undefined=wb_file_broker_create_qt` (C22 provider-root crash control);
- F: exact C link plus only `--undefined=_ZN11webeeblocks26createQtFileDialogProviderEv`.

The build oracle proves F retains `webeeblocks::createQtFileDialogProvider()` while neither `wb_file_broker_create_qt` nor the message C root is retained. It preserves per-arm symbols, sections, relocations, dynamic dependencies, linker maps and exact hashes, including D-vs-F symbol/relocation deltas. A/C/F/D/B execute from the same staged path in one fresh Xvfb session, with broader intentional crash controls last.

Pre-registered result on #87:
- F reproduces the exact Qt/XCB SIGSEGV/139 while A/B/C/D preserve the settled controls => `C23_INTERNAL_FACTORY_SUFFICIENT`;
- F succeeds while D still reproduces the exact crash => `C23_C_WRAPPER_REMAINDER_NECESSARY`;
- failed controls/root identity or any other outcome => UNPROVEN.

Pinned Webots R2025a Qt/XCB, exact `libController.so`, exact frozen broker blobs, software rendering, staged path/argv and QPA/DISPLAY remain fixed. No Controller API, `wb_robot_init()`, broker/factory invocation, `QFileDialog`, debugger or product file operation.

Research-only. Preserve the exact settled result on #87 and close without merge.

Refs #87.