### PR TITLE
C24 split provider factory by Qt copy-relocation subroot

### DIFF
--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1093,7 +1093,7 @@ jobs:
           control_obj="$RUNNER_TEMP/c24-control.o"
           broker_obj="$RUNNER_TEMP/c24-broker.o"
           arm_a="$RUNNER_TEMP/c24-arm-a-gc"
-          arm_b="$RUNNER_TEMP/c24-arm-b-provider-root"
+          arm_b="$RUNNER_TEMP/c24-arm-b-internal-factory"
           arm_f="$RUNNER_TEMP/c24-arm-f-qcore-self"
           arm_g="$RUNNER_TEMP/c24-arm-g-qapp-metaobject"
           arm_h="$RUNNER_TEMP/c24-arm-h-both-copy-subroots"
@@ -1150,8 +1150,8 @@ jobs:
             -Wl,--gc-sections -Wl,-Map,"$artifact_dir/arm-a-link.map" \
             -o "$arm_a" "${libs[@]}"
           g++ "${common[@]}" "$control_obj" "$broker_obj" \
-            -Wl,--gc-sections -Wl,--undefined=wb_file_broker_create_qt \
-            -Wl,-Map,"$artifact_dir/arm-b-provider-root-link.map" \
+            -Wl,--gc-sections -Wl,--undefined=_ZN11webeeblocks26createQtFileDialogProviderEv \
+            -Wl,-Map,"$artifact_dir/arm-b-internal-factory-link.map" \
             -o "$arm_b" "${libs[@]}"
           g++ "${common[@]}" "$control_obj" "$broker_obj" \
             -Wl,--gc-sections -Wl,--undefined=_ZN16QCoreApplication8instanceEv \
@@ -1222,8 +1222,9 @@ jobs:
           ! has_qcore_copy a
           ! has_meta_copy a
 
-          # B: settled C22 provider-root positive control; both subroots and COPY relocations survive.
-          grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-b-nm.txt"
+          # B: settled C23 internal-factory positive control; the outer C wrapper stays absent.
+          ! grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-b-nm.txt"
+          ! grep -Fq 'wb_file_broker_handle_message' "$artifact_dir/arm-b-nm.txt"
           grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-b-nm.txt"
           has_qcore_root b
           has_meta_root b
@@ -1338,7 +1339,7 @@ jobs:
           h_log="$artifact_dir/arm-h.log"
 
           if ! check_success "$a_log" arm-a || ! check_crash "$b_log" arm-b; then
-            echo DIAGNOSTIC_RESULT=C24_C22_CONTROLS_UNPROVEN | tee "$artifact_dir/result.txt"
+            echo DIAGNOSTIC_RESULT=C24_C23_CONTROLS_UNPROVEN | tee "$artifact_dir/result.txt"
             exit 1
           fi
 

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1055,6 +1055,339 @@ jobs:
           print('PASS: Blockly Submit -> one WWI mission -> validation -> shared STOP executor -> L course; persistent runtime rearmed afterwards.')
           PY
 
+
+      - name: Run C24 Qt copy-relocation subroot discriminator
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c24-copy-relocation-subroots' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir=ci-artifacts/firefox-c24-copy-relocation-subroots
+          mkdir -p "$artifact_dir"
+
+          recipe="$RUNNER_TEMP/linux_runtime_dependencies-R2025a.sh"
+          curl --fail --location --retry 3 --output "$recipe" \
+            https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh
+          test "$(git hash-object "$recipe")" = 4593476be2c985580a0e1738671f4b5bae81f669
+          sudo env CI=true bash "$recipe"
+
+          archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+          curl --fail --location --retry 3 --output "$archive" \
+            https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
+          echo "c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38  $archive" | sha256sum --check
+          tar -xjf "$archive" -C "$RUNNER_TEMP"
+          webots="$RUNNER_TEMP/webots"
+
+          frozen_sha=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+          frozen="$RUNNER_TEMP/c24-frozen-broker"
+          mkdir -p "$frozen"
+          for file in file_broker.cpp file_broker.hpp file_broker_c.h; do
+            curl --fail --location --retry 3 --output "$frozen/$file" \
+              "https://raw.githubusercontent.com/djibian/webeeblocks/$frozen_sha/controllers/crazyflie_runtime_v2/$file"
+          done
+          test "$(git hash-object "$frozen/file_broker.cpp")" = 241e6e6aaec32ceaeaa2693fad337a774757b895
+          test "$(git hash-object "$frozen/file_broker.hpp")" = 9e50d286344f680cb0cc254f4d68f4434a9e409a
+          test "$(git hash-object "$frozen/file_broker_c.h")" = d51074ba660b131f3c9df67d0ceef404c204f079
+          git hash-object "$frozen"/file_broker.* | tee "$artifact_dir/frozen-source-blobs.txt"
+
+          source="$RUNNER_TEMP/c24-control.cpp"
+          control_obj="$RUNNER_TEMP/c24-control.o"
+          broker_obj="$RUNNER_TEMP/c24-broker.o"
+          arm_a="$RUNNER_TEMP/c24-arm-a-gc"
+          arm_b="$RUNNER_TEMP/c24-arm-b-provider-root"
+          arm_f="$RUNNER_TEMP/c24-arm-f-qcore-self"
+          arm_g="$RUNNER_TEMP/c24-arm-g-qapp-metaobject"
+          arm_h="$RUNNER_TEMP/c24-arm-h-both-copy-subroots"
+          staged="$RUNNER_TEMP/c24-control"
+
+          cat > "$source" <<'CPP'
+          #include <QtWidgets/QApplication>
+          #include <csignal>
+          #include <cstring>
+          #include <execinfo.h>
+          #include <unistd.h>
+          static void marker(const char *m) { ::write(STDERR_FILENO, m, std::strlen(m)); }
+          static void fatal_handler(int s) {
+            if (s == SIGSEGV) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV\n");
+            else if (s == SIGABRT) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGABRT\n");
+            else if (s == SIGBUS) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGBUS\n");
+            else if (s == SIGILL) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGILL\n");
+            else if (s == SIGFPE) marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGFPE\n");
+            else marker("WEBEEBLOCKS_QT_CONTROL_FATAL signal=UNKNOWN\n");
+            void *frames[64];
+            int count = ::backtrace(frames, 64);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN\n");
+            ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+            marker("WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END\n");
+            _exit(128 + s);
+          }
+          int main(int argc, char **argv) {
+            void *warmup[1]; (void)::backtrace(warmup, 1);
+            struct sigaction action {};
+            action.sa_handler = fatal_handler; sigemptyset(&action.sa_mask);
+            action.sa_flags = SA_RESETHAND;
+            for (int s : {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE})
+              if (sigaction(s, &action, nullptr) != 0) return 120;
+            marker("WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION\n");
+            QApplication app(argc, argv);
+            marker("WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK\n");
+            return 0;
+          }
+          CPP
+
+          common=(-std=c++17 -g -O0
+            -isystem "$webots/include/qt/QtCore"
+            -isystem "$webots/include/qt/QtGui"
+            -isystem "$webots/include/qt/QtWidgets"
+            -L"$webots/lib/webots" -L"$webots/lib/controller"
+            -Wl,-rpath-link,"$webots/lib/webots" -Wl,-rpath-link,"$webots/lib/controller")
+          libs=(-lQt6Widgets -lQt6Gui -lQt6Core -Wl,--no-as-needed -lController -Wl,--as-needed)
+
+          g++ "${common[@]}" -ffunction-sections -fdata-sections -c "$source" -o "$control_obj"
+          g++ "${common[@]}" -ffunction-sections -fdata-sections -I"$frozen" \
+            -c "$frozen/file_broker.cpp" -o "$broker_obj"
+
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,-Map,"$artifact_dir/arm-a-link.map" \
+            -o "$arm_a" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,--undefined=wb_file_broker_create_qt \
+            -Wl,-Map,"$artifact_dir/arm-b-provider-root-link.map" \
+            -o "$arm_b" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,--undefined=_ZN16QCoreApplication8instanceEv \
+            -Wl,-Map,"$artifact_dir/arm-f-qcore-self-link.map" \
+            -o "$arm_f" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections -Wl,--undefined=_Z12qobject_castIP12QApplicationET_P7QObject \
+            -Wl,-Map,"$artifact_dir/arm-g-qapp-metaobject-link.map" \
+            -o "$arm_g" "${libs[@]}"
+          g++ "${common[@]}" "$control_obj" "$broker_obj" \
+            -Wl,--gc-sections \
+            -Wl,--undefined=_ZN16QCoreApplication8instanceEv \
+            -Wl,--undefined=_Z12qobject_castIP12QApplicationET_P7QObject \
+            -Wl,-Map,"$artifact_dir/arm-h-both-copy-subroots-link.map" \
+            -o "$arm_h" "${libs[@]}"
+
+          sha256sum "$control_obj" "$broker_obj" "$arm_a" "$arm_b" "$arm_f" "$arm_g" "$arm_h" \
+            | tee "$artifact_dir/sha256.txt"
+          ! cmp -s "$arm_a" "$arm_b"
+          ! cmp -s "$arm_a" "$arm_f"
+          ! cmp -s "$arm_a" "$arm_g"
+          ! cmp -s "$arm_f" "$arm_g"
+          ! cmp -s "$arm_h" "$arm_f"
+          ! cmp -s "$arm_h" "$arm_g"
+
+          for arm in a b f g h; do
+            binary_var="arm_$arm"
+            binary="${!binary_var}"
+            nm -C "$binary" > "$artifact_dir/arm-$arm-nm.txt"
+            strings "$binary" > "$artifact_dir/arm-$arm-strings.txt"
+            readelf -SW "$binary" > "$artifact_dir/arm-$arm-sections.txt"
+            readelf -rW "$binary" > "$artifact_dir/arm-$arm-relocations.txt"
+            readelf -rW --demangle "$binary" > "$artifact_dir/arm-$arm-relocations-demangled.txt"
+            readelf -d "$binary" > "$artifact_dir/arm-$arm-readelf.txt"
+            sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p' \
+              "$artifact_dir/arm-$arm-readelf.txt" > "$artifact_dir/arm-$arm-needed.txt"
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+              ldd "$binary" > "$artifact_dir/arm-$arm-ldd.txt"
+            grep -F "libController.so => $webots/lib/controller/libController.so" \
+              "$artifact_dir/arm-$arm-ldd.txt"
+            qt="$(grep 'libQt6\(Core\|Gui\|Widgets\)' "$artifact_dir/arm-$arm-ldd.txt")"
+            test "$(printf '%s\n' "$qt" | wc -l)" -eq 3
+            ! printf '%s\n' "$qt" | grep -vF "$webots/lib/webots/"
+          done
+
+          has_qcore_root() {
+            grep -Fq 'QCoreApplication::instance()' "$artifact_dir/arm-$1-nm.txt"
+          }
+          has_meta_root() {
+            grep -Fq 'qobject_cast<QApplication*>' "$artifact_dir/arm-$1-nm.txt"
+          }
+          has_qcore_copy() {
+            grep -Eq 'R_X86_64_COPY.*QCoreApplication::self' "$artifact_dir/arm-$1-relocations-demangled.txt"
+          }
+          has_meta_copy() {
+            grep -Eq 'R_X86_64_COPY.*QApplication::staticMetaObject' "$artifact_dir/arm-$1-relocations-demangled.txt"
+          }
+          no_provider_roots() {
+            arm="$1"
+            ! grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-$arm-nm.txt" &&
+              ! grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-$arm-nm.txt"
+          }
+
+          # A: ordinary C21 GC success control; neither smaller provider subroot survives.
+          no_provider_roots a
+          ! has_qcore_root a
+          ! has_meta_root a
+          ! has_qcore_copy a
+          ! has_meta_copy a
+
+          # B: settled C22 provider-root positive control; both subroots and COPY relocations survive.
+          grep -Fq 'wb_file_broker_create_qt' "$artifact_dir/arm-b-nm.txt"
+          grep -Fq 'webeeblocks::createQtFileDialogProvider()' "$artifact_dir/arm-b-nm.txt"
+          has_qcore_root b
+          has_meta_root b
+          has_qcore_copy b
+          has_meta_copy b
+
+          # F: retain only QCoreApplication::instance/self copy-relocation subroot.
+          no_provider_roots f
+          has_qcore_root f
+          ! has_meta_root f
+          has_qcore_copy f
+          ! has_meta_copy f
+
+          # G: retain only qobject_cast/QApplication::staticMetaObject subroot.
+          no_provider_roots g
+          ! has_qcore_root g
+          has_meta_root g
+          ! has_qcore_copy g
+          has_meta_copy g
+
+          # H: retain both smaller copy-relocation subroots without provider factory/C wrapper.
+          no_provider_roots h
+          has_qcore_root h
+          has_meta_root h
+          has_qcore_copy h
+          has_meta_copy h
+
+          for arm in f g h; do
+            diff -u "$artifact_dir/arm-a-needed.txt" "$artifact_dir/arm-$arm-needed.txt" \
+              > "$artifact_dir/arm-a-vs-$arm-needed.diff" || true
+            diff -u "$artifact_dir/arm-b-needed.txt" "$artifact_dir/arm-$arm-needed.txt" \
+              > "$artifact_dir/arm-b-vs-$arm-needed.diff" || true
+          done
+          echo C24_COPY_SUBROOTS_CHARACTERIZED=1 | tee "$artifact_dir/root-proof.txt"
+
+          session="$RUNNER_TEMP/c24-session.sh"
+          cat > "$session" <<'SH'
+          #!/usr/bin/env bash
+          set +e
+          run_one() {
+            tag="$1"; binary="$2"; log="$artifact_dir/$tag.log"
+            cp "$binary" "$staged"
+            env -u QT_DEBUG_PLUGINS "$staged" > "$log" 2>&1 &
+            pid=$!
+            wait "$pid"
+            code=$?
+            printf 'WEBEEBLOCKS_C24_PROCESS tag=%s pid=%s argc=1 argv0=%s debug=0 display=%s\n' \
+              "$tag" "$pid" "$staged" "${DISPLAY:-}" >> "$log"
+            printf 'WEBEEBLOCKS_C24_PROCESS_EXIT tag=%s pid=%s code=%s\n' \
+              "$tag" "$pid" "$code" >> "$log"
+          }
+          run_one arm-a "$arm_a"
+          run_one arm-f "$arm_f"
+          run_one arm-g "$arm_g"
+          run_one arm-h "$arm_h"
+          run_one arm-b "$arm_b"
+          SH
+          chmod +x "$session"
+
+          set +e
+          env artifact_dir="$artifact_dir" staged="$staged" \
+            arm_a="$arm_a" arm_b="$arm_b" arm_f="$arm_f" arm_g="$arm_g" arm_h="$arm_h" \
+            QT_PLUGIN_PATH="$webots/lib/webots/qt/plugins" \
+            LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" \
+            LIBGL_ALWAYS_SOFTWARE=true timeout -k 2s 60s xvfb-run -a "$session"
+          outer=$?
+          set -e
+          test "$outer" = 0
+
+          check_common() {
+            log="$1"; tag="$2"
+            cat "$log"
+            pid="$(sed -n "s/.*WEBEEBLOCKS_C24_PROCESS tag=$tag pid=\([0-9][0-9]*\).*/\1/p" "$log" | tail -1)"
+            exit_pid="$(sed -n "s/.*WEBEEBLOCKS_C24_PROCESS_EXIT tag=$tag pid=\([0-9][0-9]*\) code=.*/\1/p" "$log" | tail -1)"
+            test -n "$pid" && test "$pid" = "$exit_pid" &&
+              grep -Eq "WEBEEBLOCKS_C24_PROCESS tag=$tag .* argc=1 .* debug=0 display=:[0-9]+" "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL BEFORE_QAPPLICATION' "$log"
+          }
+
+          check_no_broker_runtime() {
+            log="$1"
+            ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED' "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED' "$log"
+          }
+
+          check_success() {
+            log="$1"; tag="$2"
+            check_common "$log" "$tag" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$log" &&
+              grep -Eq "WEBEEBLOCKS_C24_PROCESS_EXIT tag=$tag pid=[0-9]+ code=0" "$log" &&
+              ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=' "$log" &&
+              check_no_broker_runtime "$log"
+          }
+
+          check_crash() {
+            log="$1"; tag="$2"
+            check_common "$log" "$tag" &&
+              ! grep -Fq 'WEBEEBLOCKS_QT_CONTROL QAPPLICATION_OK' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_FATAL signal=SIGSEGV' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_BACKTRACE_BEGIN' "$log" &&
+              grep -Fq 'WEBEEBLOCKS_QT_CONTROL_BACKTRACE_END' "$log" &&
+              grep -Eq "WEBEEBLOCKS_C24_PROCESS_EXIT tag=$tag pid=[0-9]+ code=139" "$log" &&
+              check_no_broker_runtime "$log" &&
+              sed -n '/BACKTRACE_BEGIN/,/BACKTRACE_END/p' "$log" |
+                grep -Eq 'libQt6(Core|Gui|Widgets)|libQt6XcbQpa|libqxcb|QApplication|QGuiApplication'
+          }
+
+          a_log="$artifact_dir/arm-a.log"
+          b_log="$artifact_dir/arm-b.log"
+          f_log="$artifact_dir/arm-f.log"
+          g_log="$artifact_dir/arm-g.log"
+          h_log="$artifact_dir/arm-h.log"
+
+          if ! check_success "$a_log" arm-a || ! check_crash "$b_log" arm-b; then
+            echo DIAGNOSTIC_RESULT=C24_C22_CONTROLS_UNPROVEN | tee "$artifact_dir/result.txt"
+            exit 1
+          fi
+
+          outcome() {
+            log="$1"; tag="$2"
+            if check_success "$log" "$tag"; then printf success
+            elif check_crash "$log" "$tag"; then printf crash
+            else printf unproven
+            fi
+          }
+
+          f_outcome="$(outcome "$f_log" arm-f)"
+          g_outcome="$(outcome "$g_log" arm-g)"
+          h_outcome="$(outcome "$h_log" arm-h)"
+          printf 'C24_SUBROOT_OUTCOMES qcore=%s metaobject=%s combined=%s\n' \
+            "$f_outcome" "$g_outcome" "$h_outcome" | tee "$artifact_dir/subroot-outcomes.txt"
+
+          if [ "$f_outcome" = crash ] && [ "$g_outcome" = success ]; then
+            echo DIAGNOSTIC_RESULT=C24_QCORE_SELF_SUBROOT_SUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if [ "$g_outcome" = crash ] && [ "$f_outcome" = success ]; then
+            echo DIAGNOSTIC_RESULT=C24_QAPPLICATION_METAOBJECT_SUBROOT_SUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if [ "$f_outcome" = crash ] && [ "$g_outcome" = crash ]; then
+            echo DIAGNOSTIC_RESULT=C24_BOTH_SUBROOTS_INDEPENDENTLY_SUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if [ "$f_outcome" = success ] && [ "$g_outcome" = success ] && [ "$h_outcome" = crash ]; then
+            echo DIAGNOSTIC_RESULT=C24_COMBINED_COPY_SUBROOTS_SUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+          if [ "$f_outcome" = success ] && [ "$g_outcome" = success ] && [ "$h_outcome" = success ]; then
+            echo DIAGNOSTIC_RESULT=C24_COPY_SUBROOTS_INSUFFICIENT | tee "$artifact_dir/result.txt"
+            exit 0
+          fi
+
+          echo DIAGNOSTIC_RESULT=C24_COPY_SUBROOT_OUTCOME_UNPROVEN | tee "$artifact_dir/result.txt"
+          exit 1
+
+      - name: Upload C24 Qt copy-relocation subroot discriminator
+        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'research/firefox-c24-copy-relocation-subroots' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-c24-copy-relocation-subroots-r2025a
+          path: ci-artifacts/firefox-c24-copy-relocation-subroots/
+          if-no-files-found: error
+
       - name: Upload runtime WWI diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-webots.yml
+++ b/.github/workflows/ci-webots.yml
@@ -1345,8 +1345,10 @@ jobs:
 
           outcome() {
             log="$1"; tag="$2"
-            if check_success "$log" "$tag"; then printf success
-            elif check_crash "$log" "$tag"; then printf crash
+            # Classification runs inside command substitution. Keep diagnostic
+            # log replay on stderr so the captured value is exactly one token.
+            if check_success "$log" "$tag" >&2; then printf success
+            elif check_crash "$log" "$tag" >&2; then printf crash
             else printf unproven
             fi
           }


### PR DESCRIPTION
## Scope

Bounded #87 C24 research after C23 proved the internal provider factory family is sufficient under the sectionized closure and preserved both smaller Qt COPY-relocation subroots.

C24 executes the aligned activation from #87 without invoking any broker/provider function. One sectionized standalone control object and one exact frozen broker object are reused across all arms:
- A: ordinary `--gc-sections` success control;
- B: A plus only `--undefined=_ZN11webeeblocks26createQtFileDialogProviderEv` (settled C23 internal-factory crash control; outer C wrapper absent);
- F: A plus only `--undefined=_ZN16QCoreApplication8instanceEv`;
- G: A plus only `--undefined=_Z12qobject_castIP12QApplicationET_P7QObject`;
- H: A plus both F and G roots.

The static oracle proves B retains the internal factory and both COPY-relocation subroots while `wb_file_broker_create_qt` remains absent. F retains `QCoreApplication::instance()` and only the `QCoreApplication::self` COPY relocation; G retains the `qobject_cast<QApplication*>` subroot and only the `QApplication::staticMetaObject` COPY relocation; H retains both; A retains neither. F/G/H must not retain the broader provider C root or internal factory. Symbols, sections, raw/demangled relocations, linker maps, dynamic dependencies and exact hashes are preserved.

A/F/G/H/B execute from the same staged path in one fresh Xvfb session, with the intentional internal-factory crash control last.

Pre-registered result on #87:
- F crash / G success => `C24_QCORE_SELF_SUBROOT_SUFFICIENT`;
- G crash / F success => `C24_QAPPLICATION_METAOBJECT_SUBROOT_SUFFICIENT`;
- F and G both crash => `C24_BOTH_SUBROOTS_INDEPENDENTLY_SUFFICIENT`;
- F/G success and H crash => `C24_COMBINED_COPY_SUBROOTS_SUFFICIENT`;
- F/G/H all success => `C24_COPY_SUBROOTS_INSUFFICIENT`;
- failed A/B controls or relocation characterization, different fatal class, or any other outcome => UNPROVEN.

Pinned Webots R2025a bundled Qt/XCB, exact `libController.so`, exact frozen broker blobs, software rendering, staged path/argv and QPA/DISPLAY remain fixed. No Controller API, `wb_robot_init()`, broker/provider invocation, `QFileDialog`, debugger or product file operation.

This exact HEAD resolves the prior NO_GO on `8abed03c4a81af39eaf073841db5b78ab0fab1df` by replacing only the broader provider-C-root B control with the required C23 internal-factory control and aligning its static proof/prose.

This exact HEAD also repairs the fail-closed outcome harness exposed by the first repaired Ready run: F/G/H classification executes inside shell command substitution, so diagnostic log replay is redirected to stderr and the captured classifier value remains exactly `success`, `crash`, or `unproven`. The tested arm binaries, order and pre-registered oracle are unchanged.

Research-only. Preserve the exact settled result on #87 and close without merge.

Refs #87.