### PR TITLE
Split S3 vertical-veto diagnostics without retuning

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/S3_VETO_DISCRIMINATOR.md
+++ b/experiments/crazyflie-ukf-surface-range/S3_VETO_DISCRIMINATOR.md
@@ -1,0 +1,48 @@
+# S3 veto discriminator — props-off, reason split only
+
+## Purpose
+
+Checkpoint #180 refuted the S3 terrain classifier because `surfReason=3` (`VERTICAL_VETO`) dominated the terrain SUSPECT interval even though the local-range candidate reached the expected surface-step magnitude. The existing reason code aggregates two already-present cues:
+
+`abs(vz) >= 0.08 m/s || abs(surfaceBaroDelta) >= 0.08 m`.
+
+The retained archive cannot currently be consumed through the available machine path. This discriminator therefore changes **observability only** so that one later props-off trace can identify which existing cue vetoes terrain.
+
+## Exact instrumentation change
+
+Apply the existing `apply_surface_offset_s3.py` first to the exact Crazyflie firmware 2026.08 source boundary, then apply `apply_surface_offset_s3_veto_discriminator.py`.
+
+The overlay preserves the exact commit predicate and every existing numerical constant. It only emits distinct `sensorFilter.surfReason` values:
+
+- `6` — `VZ_VETO`: `abs(vz) >= 0.08 m/s` only;
+- `7` — `BARO_VETO`: `abs(surfaceBaroDelta) >= 0.08 m` only;
+- `8` — `BOTH_VETO`: both predicates true.
+
+Legacy reason `3` remains defined for provenance but is no longer emitted by the split instrumentation. Existing reason codes `0`, `1`, `2`, `4`, and `5` retain their meanings.
+
+## Frozen boundaries
+
+Do not change `qualityGateTof=20`, `baroNoise=6.25`, `surfaceOffsetS3=1`, `S3_VZ_VERTICAL_VETO_MPS=0.08`, `S3_BARO_VERTICAL_VETO_M=0.08`, any settle/persistence/window constant, estimator state dimension, local-range Flow path, controller, Runtime v2, or deck cue set. Do not add `rangeUp`. Props remain removed. No motorized test follows automatically.
+
+## Smallest physical discriminator
+
+Only after the globally serialized human-checkpoint slot is free, repeat the already established props-off geometry with the instrumented reason codes:
+
+1. stationary calibration >=10 s;
+2. S3-A: fixed-world-height floor -> raised platform -> floor;
+3. S3-B: flat-floor true vertical motion;
+4. S3-C: slow flat-floor true vertical motion.
+
+Keep the existing 20 ms logging surface, including `stateEstimate.vz`, `sensorFilter.surfBaroD`, `surfState`, `surfReason`, `surfCand`, `surfOffset`, raw/local range, ToF diagnostics and the existing provenance/configuration evidence.
+
+## Pre-registered decision table
+
+- Terrain S3-A dominated by `VZ_VETO`, while S3-B/S3-C also require VZ veto: the current UKF vertical-velocity estimate is not a discriminating terrain cue at the commit boundary. Do not tune its threshold from the outcome; redesign the classifier evidence before another terrain candidate.
+- Terrain S3-A dominated by `BARO_VETO`, while S3-B/S3-C correctly require barometer veto: the raw-relative-barometer delta is not discriminating enough in the present temporal alignment. Do not tune its threshold from the outcome; redesign timing/evidence semantics before another candidate.
+- Terrain S3-A dominated by `BOTH_VETO`: both current cues confound the terrain transition; no threshold sweep is justified.
+- S3-A reaches commit eligibility without any of `6/7/8` yet still does not commit: investigate the next existing commit predicate from the same trace before changing estimator structure.
+- Any S3-B/S3-C false terrain commit remains an immediate refutation.
+
+## Status
+
+`Lab only`. This branch is experimental evidence preparation and is not a product Runtime change. It does not authorize flight or a checkpoint while another `TEST_REQUIRED` is open.

--- a/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_veto_discriminator.py
+++ b/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_veto_discriminator.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Split the #70 S3 vertical-veto reason without changing veto semantics.
+
+This is a Lab-only instrumentation overlay for the already reconstructed
+``apply_surface_offset_s3.py`` candidate. Run that applicator first on the exact
+Crazyflie firmware 2026.08 checkout, then run this script.
+
+The only behavioral change is observability: the existing boolean
+
+    abs(stateNav[5]) >= 0.08 || abs(surfaceBaroDelta) >= 0.08
+
+still gates commit exactly as before, but ``surfReason`` distinguishes velocity,
+barometer, and simultaneous vetoes. No threshold, persistence window, estimator
+state, Flow path, ToF/barometer weighting, controller, or motor authority changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+
+EXPECTED_COMMIT = "54f31e243a0b28b67efef5ba20dbb6d9890a5478"
+TARGET = Path("src/modules/src/estimator/estimator_ukf.c")
+
+ENUM_OLD = """  S3_REASON_NONE = 0,
+  S3_REASON_TOF_REJECT = 1,
+  S3_REASON_WAIT = 2,
+  S3_REASON_VERTICAL_VETO = 3,
+  S3_REASON_COMMIT = 4,
+  S3_REASON_CANDIDATE_REJECT = 5,
+};"""
+
+ENUM_NEW = """  S3_REASON_NONE = 0,
+  S3_REASON_TOF_REJECT = 1,
+  S3_REASON_WAIT = 2,
+  S3_REASON_VERTICAL_VETO = 3, // legacy aggregate; retained but no longer emitted
+  S3_REASON_COMMIT = 4,
+  S3_REASON_CANDIDATE_REJECT = 5,
+  S3_REASON_VZ_VETO = 6,
+  S3_REASON_BARO_VETO = 7,
+  S3_REASON_BOTH_VETO = 8,
+};"""
+
+VETO_OLD = """              const bool verticalVeto = fabsf(stateNav[5]) >= S3_VZ_VERTICAL_VETO_MPS ||
+                fabsf(surfaceBaroDelta) >= S3_BARO_VERTICAL_VETO_M;
+"""
+
+VETO_NEW = """              const bool vzVerticalVeto = fabsf(stateNav[5]) >= S3_VZ_VERTICAL_VETO_MPS;
+              const bool baroVerticalVeto = fabsf(surfaceBaroDelta) >= S3_BARO_VERTICAL_VETO_M;
+              const bool verticalVeto = vzVerticalVeto || baroVerticalVeto;
+"""
+
+REASON_OLD = """              if (verticalVeto)
+              {
+                surfaceDetectorReason = S3_REASON_VERTICAL_VETO;
+              }
+"""
+
+REASON_NEW = """              if (verticalVeto)
+              {
+                if (vzVerticalVeto && baroVerticalVeto)
+                {
+                  surfaceDetectorReason = S3_REASON_BOTH_VETO;
+                }
+                else if (vzVerticalVeto)
+                {
+                  surfaceDetectorReason = S3_REASON_VZ_VETO;
+                }
+                else
+                {
+                  surfaceDetectorReason = S3_REASON_BARO_VETO;
+                }
+              }
+"""
+
+
+def git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def require_exact_context(text: str) -> None:
+    if git("rev-parse", "HEAD") != EXPECTED_COMMIT:
+        raise SystemExit("wrong upstream commit; no file written")
+    if "WebeeBlocks #70 S3 Lab prototype" not in text:
+        raise SystemExit("S3 base applicator has not been applied; no file written")
+    for label, old, new in (
+        ("reason enum", ENUM_OLD, ENUM_NEW),
+        ("vertical-veto expression", VETO_OLD, VETO_NEW),
+        ("vertical-veto reason", REASON_OLD, REASON_NEW),
+    ):
+        old_count = text.count(old)
+        new_count = text.count(new)
+        if old_count == 1 and new_count == 0:
+            continue
+        if old_count == 0 and new_count == 1:
+            continue
+        raise SystemExit(
+            f"{label}: expected exactly one old or one new marker, "
+            f"found old={old_count}, new={new_count}; no file written"
+        )
+
+
+def transform(text: str) -> str:
+    require_exact_context(text)
+    if text.count(ENUM_NEW) == 1:
+        if text.count(VETO_NEW) == 1 and text.count(REASON_NEW) == 1:
+            return text
+        raise SystemExit("partial discriminator application detected; no file written")
+    text = text.replace(ENUM_OLD, ENUM_NEW, 1)
+    text = text.replace(VETO_OLD, VETO_NEW, 1)
+    text = text.replace(REASON_OLD, REASON_NEW, 1)
+    require_exact_context(text)
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify that the exact S3 context is transformable/already transformed",
+    )
+    args = parser.parse_args()
+
+    if not TARGET.is_file():
+        raise SystemExit(f"missing target: {TARGET}")
+    original = TARGET.read_text(encoding="utf-8")
+    transformed = transform(original)
+    if args.check:
+        state = "already applied" if transformed == original else "applicable"
+        print(f"S3 veto discriminator: {state}")
+        return
+    if transformed == original:
+        print("S3 veto discriminator already applied; no file written")
+        return
+    TARGET.write_text(transformed, encoding="utf-8")
+    print("Applied S3 veto discriminator: VZ/BARO/BOTH reason codes only")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lab-only #70 evidence preparation after physical checkpoint #180 refuted the scalar S3 classifier.

The retained attachment is not consumable through the available machine path, so this implements the already documented smallest fallback discriminator: preserve the exact existing vertical-veto boolean and every threshold/persistence constant, but split `surfReason` into VZ-only, barometer-only, and both-veto codes. A pre-registered props-off decision table is included.

No Runtime v2 change, no estimator-structure change, no `rangeUp`, no threshold/barometer/ToF retuning, no motor authority, and no checkpoint request while #226 remains open.

Research/Lab candidate only; it does not authorize merge into product behavior or motorized testing.