### PR TITLE
Use one primary Run/Stop execution control

### DIFF
--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -33,8 +33,7 @@
       <button id="projectSave" type="button">Enregistrer</button>
       <button id="projectSaveAs" type="button">Enregistrer sous</button>
       <button id="resetSimulation" type="button" hidden disabled>Réinitialiser</button>
-      <button id="stopSimulation" type="button" hidden disabled>Arrêter le vol</button>
-      <button id="submit" disabled>Lancer le vol</button>
+      <button id="submit" type="button" aria-label="Lancer le vol" disabled>Lancer le vol</button>
     </div>
   </header>
   <section id="statusPanel" aria-live="polite">

--- a/plugins/robot_windows/blockly_v2/classroom_fixes.js
+++ b/plugins/robot_windows/blockly_v2/classroom_fixes.js
@@ -28,14 +28,14 @@
 
   window.addEventListener('load', function() {
     var submit = document.getElementById('submit');
-    if (!submit || typeof window.runProgram !== 'function') return;
+    if (!submit || typeof window.activatePrimaryExecution !== 'function') return;
 
     submit.onclick = function() {
-      if (window.workspace && typeof workspace.getTopBlocks === 'function' && workspace.getTopBlocks(false).length === 0) {
+      if (!window.runtimeRunning && window.workspace && typeof workspace.getTopBlocks === 'function' && workspace.getTopBlocks(false).length === 0) {
         setRuntimeStatus('À COMPLÉTER', 'Ajoutez au moins une instruction avant de lancer le vol');
         return;
       }
-      return runProgram();
+      return activatePrimaryExecution();
     };
   });
 })();

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -49,7 +49,7 @@ function updateRuntimeActions() {
   var primaryIsStop = runtimeRunning === true;
   var primaryLabel = primaryIsStop ? 'Arrêter le vol' : 'Lancer le vol';
   submit.textContent = primaryLabel;
-  submit.setAttribute('aria-label', primaryLabel);
+  if (typeof submit.setAttribute === 'function') submit.setAttribute('aria-label', primaryLabel);
   submit.disabled = primaryIsStop
     ? (!stopSupported || !ready || runtimeStopPending || runtimeStopRequested)
     : (!ready || runtimeTerminal || runtimeResetPending || runtimeStopPending);

--- a/plugins/robot_windows/blockly_v2/main.js
+++ b/plugins/robot_windows/blockly_v2/main.js
@@ -45,11 +45,17 @@ function updateRuntimeActions() {
   var submit = document.getElementById('submit');
   var reset = document.getElementById('resetSimulation');
   var stop = document.getElementById('stopSimulation');
-  submit.disabled = !ready || runtimeRunning || runtimeTerminal || runtimeResetPending || runtimeStopPending;
+  var stopSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationStop === true);
+  var primaryIsStop = runtimeRunning === true;
+  var primaryLabel = primaryIsStop ? 'Arrêter le vol' : 'Lancer le vol';
+  submit.textContent = primaryLabel;
+  submit.setAttribute('aria-label', primaryLabel);
+  submit.disabled = primaryIsStop
+    ? (!stopSupported || !ready || runtimeStopPending || runtimeStopRequested)
+    : (!ready || runtimeTerminal || runtimeResetPending || runtimeStopPending);
   if (stop) {
-    var stopSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationStop === true);
-    stop.hidden = !stopSupported || !runtimeRunning || runtimeStopRequested;
-    stop.disabled = !stopSupported || !ready || !runtimeRunning || runtimeStopPending || runtimeStopRequested;
+    stop.hidden = true;
+    stop.disabled = true;
   }
   if (reset) {
     var resetSupported = !!(runtimeBackend && runtimeBackend.capabilities && runtimeBackend.capabilities.simulationReset === true);
@@ -306,6 +312,10 @@ async function runProgram() {
   }
 }
 
+function activatePrimaryExecution() {
+  return runtimeRunning ? stopSimulation() : runProgram();
+}
+
 function isPureVisualWorkspaceMove(event) {
   return !!(event && event.type === Blockly.Events.BLOCK_MOVE &&
     event.oldParentId == null && event.newParentId == null);
@@ -328,7 +338,8 @@ function wireWorkspaceControls() {
     workspace.setScale(WEBEEBLOCKS_WORKSPACE_SCALE); if (typeof workspace.scrollCenter === 'function') workspace.scrollCenter();
   });
   document.getElementById('resetSimulation').addEventListener('click', resetSimulation);
-  document.getElementById('stopSimulation').addEventListener('click', stopSimulation);
+  var legacyStop = document.getElementById('stopSimulation');
+  if (legacyStop) legacyStop.addEventListener('click', stopSimulation);
 }
 
 window.onload = async function() {
@@ -361,4 +372,4 @@ window.onload = async function() {
   } catch (error) { setRuntimeFailure(error); }
 };
 
-document.getElementById('submit').onclick = runProgram;
+document.getElementById('submit').onclick = activatePrimaryExecution;


### PR DESCRIPTION
Implements the bounded student-UI decision in #228.

- removes the separate visible `Arrêter le vol` button;
- keeps one primary execution control and switches its label, accessible name, enabled state, and click action from `Lancer le vol` to the existing stop path while `runtimeRunning` is active;
- keeps the same stop action available while step execution is paused;
- preserves the established `USER_STOPPED`, terminal/reset, backend, AST/interpreter, and project-file semantics;
- keeps the empty-workspace guard for starting a run without intercepting an active stop.

Closes #228