### PR TITLE
Add backend-neutral basic arithmetic semantics

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/interpreter.js
+++ b/plugins/robot_windows/blockly/webeeblocks/interpreter.js
@@ -11,8 +11,11 @@
   var VERTICAL_DIRECTIONS=['up','down'];
   var LIGHT_COLORS=['off','red','green','blue','yellow','white'];
   var COMPARE_OPS=['LT','LTE','GT','GTE','EQ','NEQ'];
+  var ARITHMETIC_OPS=['ADD','MINUS','MULTIPLY','DIVIDE'];
   function fail(message){throw new Error('runtime v2: '+message);}
+  function studentFail(message,detail){var error=new Error('runtime v2: '+message);error.code='PROGRAM_INVALID';error.studentDetail=detail;throw error;}
   function finite(value,name){var n=Number(value);if(!Number.isFinite(n))fail(name+' must be finite');return n;}
+  function numeric(value,name){if(typeof value!=='number'||!Number.isFinite(value))studentFail(name+' must be a finite number','Vérifiez les valeurs utilisées dans le calcul.');return value;}
   function requireMethod(backend,name){if(!backend||typeof backend[name]!=='function')fail('backend is missing '+name+'()');return backend[name].bind(backend);}
   async function hook(options,name,payload){var hooks=options&&options.hooks;if(hooks&&typeof hooks[name]==='function')await hooks[name](payload);}
   function variableRef(variable){if(!variable||typeof variable.id!=='string'||!variable.id||typeof variable.name!=='string'||!variable.name.trim())fail('invalid variable reference');return{id:variable.id,name:variable.name};}
@@ -29,6 +32,7 @@
       case 'number':finite(expression.value,'number');return;
       case 'range':if(SENSOR_DIRECTIONS.indexOf(String(expression.direction))<0||expression.unit!=='m')fail('unsupported range expression');return;
       case 'variable_get':{var ref=rememberVariable(variables,expression.variable);if(!assigned.has(ref.id))fail('variable read before assignment: '+ref.name);return;}
+      case 'arithmetic':if(ARITHMETIC_OPS.indexOf(String(expression.op))<0)fail('unsupported arithmetic operation '+expression.op);validateExpression(expression.left,depth+1,assigned,variables);validateExpression(expression.right,depth+1,assigned,variables);return;
       case 'compare':if(COMPARE_OPS.indexOf(String(expression.op))<0)fail('unsupported comparison '+expression.op);validateExpression(expression.left,depth+1,assigned,variables);validateExpression(expression.right,depth+1,assigned,variables);return;
       case 'logic':if(expression.op!=='AND'&&expression.op!=='OR')fail('unsupported logic operation '+expression.op);validateExpression(expression.left,depth+1,assigned,variables);validateExpression(expression.right,depth+1,assigned,variables);return;
       default:fail('unsupported expression kind '+expression.kind);
@@ -87,6 +91,19 @@
         var value=finite(await requireMethod(backend,'readRange')(String(expression.direction)),'range('+expression.direction+')');
         await hook(options,'onSensor',{node:expression,path:(path||[]).slice(),role:'expression',variables:snapshot(env),direction:String(expression.direction),value:value});
         return value;
+      }
+      case 'arithmetic':{
+        var arithmeticLeft=numeric(await evaluate(expression.left,backend,budget,depth+1,options,(path||[]).concat('left'),env),'left arithmetic operand');
+        var arithmeticRight=numeric(await evaluate(expression.right,backend,budget,depth+1,options,(path||[]).concat('right'),env),'right arithmetic operand');
+        await hook(options,'beforeStep',context(expression,path,'expression',env));
+        if(expression.op==='DIVIDE'&&arithmeticRight===0)studentFail('division by zero','Une division par zéro est impossible. Modifiez le diviseur.');
+        var arithmeticResult;
+        if(expression.op==='ADD')arithmeticResult=arithmeticLeft+arithmeticRight;
+        else if(expression.op==='MINUS')arithmeticResult=arithmeticLeft-arithmeticRight;
+        else if(expression.op==='MULTIPLY')arithmeticResult=arithmeticLeft*arithmeticRight;
+        else arithmeticResult=arithmeticLeft/arithmeticRight;
+        if(!Number.isFinite(arithmeticResult))studentFail('arithmetic result must be finite','Le calcul produit une valeur invalide. Vérifiez les nombres utilisés.');
+        return arithmeticResult;
       }
       case 'compare':{
         var left=await evaluate(expression.left,backend,budget,depth+1,options,(path||[]).concat('left'),env);

--- a/plugins/robot_windows/blockly/webeeblocks/semantic_ast.js
+++ b/plugins/robot_windows/blockly/webeeblocks/semantic_ast.js
@@ -9,6 +9,7 @@
   var LIMITS = Object.freeze({height_m:{min:0.2,max:1.5},distance_m:{min:0.1,max:2.0},vertical_m:{min:0.1,max:0.8},wait_s:{min:0.1,max:5.0},speed_m_s:{min:0.1,max:0.6},repeat:{min:1,max:20}});
   var SENSOR_DIRECTIONS = Object.freeze(['front','back','left','right','up']);
   var LIGHT_COLORS = Object.freeze(['off','red','green','blue','yellow','white']);
+  var ARITHMETIC_OPS = Object.freeze(['ADD','MINUS','MULTIPLY','DIVIDE']);
   function fail(message){throw new Error('semantic AST: '+message);}
   function studentFail(message,detail){var error=new Error('semantic AST: '+message);error.code='PROGRAM_INVALID';error.studentDetail=detail;throw error;}
   function finite(value,name){var n=Number(value);if(!Number.isFinite(n))fail(name+' must be finite');return n;}
@@ -32,6 +33,7 @@
     switch(block.type){
       case 'webeeblocks_v2_range':{var direction=String(field(block,'DIRECTION'));if(SENSOR_DIRECTIONS.indexOf(direction)<0)fail('unsupported range direction: '+direction);return{kind:'range',direction:direction,unit:'m'};}
       case 'math_number':return{kind:'number',value:finite(field(block,'NUM'),'number')};
+      case 'math_arithmetic':{var arithmetic=String(field(block,'OP'));if(ARITHMETIC_OPS.indexOf(arithmetic)<0)fail('unsupported arithmetic operation: '+arithmetic);return{kind:'arithmetic',op:arithmetic,left:valueChild(block,'A'),right:valueChild(block,'B')};}
       case 'variables_get':return{kind:'variable_get',variable:variableReference(block)};
       case 'logic_compare':{var compare=String(field(block,'OP'));if(['LT','LTE','GT','GTE','EQ','NEQ'].indexOf(compare)<0)fail('unsupported comparison: '+compare);return{kind:'compare',op:compare,left:valueChild(block,'A'),right:valueChild(block,'B')};}
       case 'logic_operation':{var logic=String(field(block,'OP'));if(logic!=='AND'&&logic!=='OR')fail('unsupported logic operation: '+logic);return{kind:'logic',op:logic,left:valueChild(block,'A'),right:valueChild(block,'B')};}
@@ -84,5 +86,5 @@
     var program=compileSequence(tops[0]);validateFlightBoundaries(program);return{version:1,semantics:'webeeblocks-ast-v1',program:program};
   }
 
-  return{LIMITS:LIMITS,SENSOR_DIRECTIONS:SENSOR_DIRECTIONS,LIGHT_COLORS:LIGHT_COLORS,compileExpression:compileExpression,compileStatement:compileStatement,compileSequence:compileSequence,compileWorkspace:compileWorkspace,validateFlightBoundaries:validateFlightBoundaries};
+  return{LIMITS:LIMITS,SENSOR_DIRECTIONS:SENSOR_DIRECTIONS,LIGHT_COLORS:LIGHT_COLORS,ARITHMETIC_OPS:ARITHMETIC_OPS,compileExpression:compileExpression,compileStatement:compileStatement,compileSequence:compileSequence,compileWorkspace:compileWorkspace,validateFlightBoundaries:validateFlightBoundaries};
 });

--- a/tools/ci/test_runtime_v2_variables.js
+++ b/tools/ci/test_runtime_v2_variables.js
@@ -53,6 +53,14 @@ function backend(log){return{capabilities:{actions:['takeoff','move','land'],ran
 async function execute(ast,hooks){const log=[];const result=await Interpreter.run(ast,backend(log),{hooks:hooks||{}});return{log,result};}
 function memoryTransport(){const state={text:null,writes:0};const handle={name:'memoire.wbb'};return{state,nativeFileSystemAccess:true,async open(){return{handle,name:handle.name,text:state.text,mode:'test'};},async saveAs(name,text){state.text=text;state.writes++;return{handle,name,mode:'test'};},async save(target,name,text){assert.strictEqual(target,handle);state.text=text;state.writes++;return{handle,name,mode:'test'};}};}
 async function roundTrip(workspace, expectedAst){const p={value:profile()},transport=memoryTransport();const manager=ProjectFiles.createManager({Blockly,profiles:Profiles,activitiesDocument:Activities.DOCUMENT,blockCatalog:Activities.BLOCK_CATALOG,semanticAst:SemanticAst,activityContract:ActivityContract,workspace,getProfile:()=>p.value,setProfile:value=>{p.value=value;},transport});await manager.saveAs('memoire');const bytes=transport.state.text;assert(bytes.includes('distance mémorisée'),'serialized project lost variable name');workspace.clear();transport.state.text=bytes;await manager.open();assert.deepStrictEqual(compile(workspace),expectedAst,'project Save/Open changed variable AST identity or semantics');}
+function arithmeticBlock(workspace,op,leftValue,rightValue){
+  const arithmetic=workspace.newBlock('math_arithmetic');
+  const left=workspace.newBlock('math_number');
+  const right=workspace.newBlock('math_number');
+  arithmetic.setFieldValue(op,'OP');left.setFieldValue(String(leftValue),'NUM');right.setFieldValue(String(rightValue),'NUM');
+  arithmetic.getInput('A').connection.connect(left.outputConnection);arithmetic.getInput('B').connection.connect(right.outputConnection);
+  return arithmetic;
+}
 
 (async function(){
   const p4=Profiles.resolveById(Activities.DOCUMENT,'progression-combined-decisions-v1',Activities.BLOCK_CATALOG),p5=profile();
@@ -80,5 +88,26 @@ async function roundTrip(workspace, expectedAst){const p={value:profile()},trans
   let backendActions=0;await assert.rejects(Interpreter.run({version:1,semantics:'webeeblocks-ast-v1',program:[{kind:'takeoff',height_m:0.8},{kind:'if',condition:{kind:'variable_get',variable:{id:'x',name:'x'}},then:[],else:[]},{kind:'land'}]},{async takeoff(){backendActions++;},async land(){backendActions++;}}),/read before assignment/);assert.strictEqual(backendActions,0,'uninitialized variable was not rejected before backend action');
   await assert.rejects(Interpreter.run(ast,backend([]),{maxSteps:1}),/execution budget exceeded/);
   await roundTrip(workspace,ast);
-  console.log('PASS variables-memory: Blockly model -> stable AST -> fail-closed interpreter -> execution observer -> project round-trip');
+
+  const arithmeticWorkspace=new Blockly.Workspace();
+  const compiledArithmetic=SemanticAst.compileExpression(arithmeticBlock(arithmeticWorkspace,'MULTIPLY',3,4));
+  assert.deepStrictEqual(compiledArithmetic,{kind:'arithmetic',op:'MULTIPLY',left:{kind:'number',value:3},right:{kind:'number',value:4}},'standard Blockly arithmetic did not compile to backend-neutral AST');
+  assert.deepStrictEqual(SemanticAst.ARITHMETIC_OPS,['ADD','MINUS','MULTIPLY','DIVIDE']);
+  const arithmeticCases=[['ADD',7,5,12],['MINUS',7,5,2],['MULTIPLY',7,5,35],['DIVIDE',10,4,2.5]];
+  for(const [op,left,right,expected] of arithmeticCases){
+    const value=await Interpreter.evaluate({kind:'arithmetic',op,left:{kind:'number',value:left},right:{kind:'number',value:right}},{},{remaining:20},0,{},['arithmetic']);
+    assert.strictEqual(value,expected,op+' arithmetic result mismatch');
+  }
+  const nestedValue=await Interpreter.evaluate({kind:'arithmetic',op:'MULTIPLY',left:{kind:'arithmetic',op:'ADD',left:{kind:'range',direction:'front',unit:'m'},right:{kind:'number',value:0.1}},right:{kind:'number',value:2}},{async readRange(){return 0.4;}},{remaining:30},0,{},['nested']);
+  assert.strictEqual(nestedValue,1,'nested sensor arithmetic did not compose');
+  const arithmeticProgram={version:1,semantics:'webeeblocks-ast-v1',program:[{kind:'takeoff',height_m:0.8},{kind:'set_variable',variable:{id:'x',name:'x'},value:{kind:'arithmetic',op:'ADD',left:{kind:'number',value:2},right:{kind:'number',value:3}}},{kind:'set_variable',variable:{id:'y',name:'y'},value:{kind:'arithmetic',op:'MULTIPLY',left:{kind:'variable_get',variable:{id:'x',name:'x'}},right:{kind:'number',value:4}}},{kind:'land'}]};
+  const arithmeticRun=await Interpreter.run(arithmeticProgram,{async takeoff(){},async land(){}},{maxSteps:50});
+  assert.deepStrictEqual(arithmeticRun.variables,{x:5,y:20},'arithmetic did not compose with variable assignment/read');
+  await assert.rejects(
+    Interpreter.evaluate({kind:'arithmetic',op:'DIVIDE',left:{kind:'number',value:1},right:{kind:'number',value:0}},{},{remaining:20},0,{},['divide']),
+    error=>error&&error.code==='PROGRAM_INVALID'&&/division by zero/.test(error.message)&&/division par zéro/.test(error.studentDetail),
+    'division by zero must fail with a correctable student outcome'
+  );
+  arithmeticWorkspace.dispose();
+  console.log('PASS variables-memory: Blockly model -> stable AST -> fail-closed interpreter -> execution observer -> project round-trip -> finite basic arithmetic');
 })().catch(error=>{console.error(error);process.exit(1);});


### PR DESCRIPTION
Advances the arithmetic foundation of #227 without changing toolbox exposure yet.

- compiles standard Blockly `math_arithmetic` into backend-neutral AST for exactly `+ - * /`;
- evaluates arithmetic in the shared interpreter, including nesting with range expressions and variable reads;
- rejects division by zero and non-finite arithmetic with `PROGRAM_INVALID` student-correctable outcomes;
- extends the existing variables/memory harness to prove standard Blockly compilation, all four operations, nested sensor arithmetic, variable composition, and fail-closed division.

This deliberately leaves the dedicated Variables toolbox/category and profile-controlled UI exposure to the remaining #227 product slice.