### PR TITLE
Bind physical preflight to exact AST capabilities

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
@@ -114,17 +114,12 @@
     });
   }
 
-  function requireHardware(profile, descriptor) {
-    profile.hardware.forEach(function(requirement) {
-      if (requirement === EXACT_AIRFRAME) {
-        if (descriptor.identity.modelEvidence !== 'verified' ||
-            descriptor.identity.model !== EXACT_AIRFRAME)
-          fail('exact physical model evidence unavailable: ' + EXACT_AIRFRAME);
-        return;
-      }
-      if (descriptor.hardware.indexOf(requirement) < 0)
-        fail('required hardware unavailable: ' + requirement);
-    });
+  function requireExactAirframe(profile, descriptor) {
+    if (profile.hardware.indexOf(EXACT_AIRFRAME) < 0)
+      fail('profile exact physical model requirement unavailable: ' + EXACT_AIRFRAME);
+    if (descriptor.identity.modelEvidence !== 'verified' ||
+        descriptor.identity.model !== EXACT_AIRFRAME)
+      fail('exact physical model evidence unavailable: ' + EXACT_AIRFRAME);
   }
 
   function preflight(profile, facts, descriptorValue) {
@@ -135,7 +130,7 @@
       fail('AST capability facts unavailable');
 
     var descriptor = normalizeDescriptor(descriptorValue);
-    requireHardware(profile, descriptor);
+    requireExactAirframe(profile, descriptor);
 
     var actions = descriptor.capabilities.actions;
     facts.statements.forEach(function(kind) {

--- a/tools/ci/test_physical_capability_contract.js
+++ b/tools/ci/test_physical_capability_contract.js
@@ -9,6 +9,11 @@ const profile = Profiles.resolveById(
   'progression-simple-decision-v1',
   Activities.BLOCK_CATALOG
 );
+const broadProfile = Profiles.resolveById(
+  Activities.DOCUMENT,
+  'progression-autonomous-strategy-v1',
+  Activities.BLOCK_CATALOG
+);
 
 const facts = {
   statements: new Set(['takeoff','move','if','land']),
@@ -74,11 +79,41 @@ const descriptor = {
     /exact airframe identity must not be encoded as generic hardware evidence/
   );
 
-  const missingDeck = JSON.parse(JSON.stringify(descriptor));
-  missingDeck.hardware = ['flow-deck-v2'];
+  const missingUnusedDeck = JSON.parse(JSON.stringify(descriptor));
+  missingUnusedDeck.hardware = ['flow-deck-v2'];
+  assert.strictEqual(
+    PhysicalCapabilities.preflight(profile, facts, missingUnusedDeck),
+    true,
+    'an unused optional deck must not block when the exact required capabilities are available'
+  );
+
+  const minimalFacts = {
+    statements: new Set(['takeoff','land']),
+    ranges: new Set(),
+    moveDirections: new Set(),
+    verticalDirections: new Set()
+  };
+  const minimalDescriptor = JSON.parse(JSON.stringify(descriptor));
+  minimalDescriptor.hardware = ['flow-deck-v2'];
+  minimalDescriptor.capabilities.actions = ['takeoff','land'];
+  minimalDescriptor.capabilities.rangeDirections = [];
+  minimalDescriptor.capabilities.moveDirections = [];
+  assert.strictEqual(
+    PhysicalCapabilities.preflight(broadProfile, minimalFacts, minimalDescriptor),
+    true,
+    'broad profile optional decks must not become global prerequisites for a smaller AST'
+  );
+
+  const requiredLightFacts = {
+    statements: new Set(['takeoff','set_light','land']),
+    ranges: new Set(),
+    moveDirections: new Set(),
+    verticalDirections: new Set()
+  };
   assert.throws(
-    () => PhysicalCapabilities.preflight(profile, facts, missingDeck),
-    /required hardware unavailable: multi-ranger-deck/
+    () => PhysicalCapabilities.preflight(broadProfile, requiredLightFacts, minimalDescriptor),
+    /physical action capability unavailable: set_light/,
+    'a capability actually required by the AST must still fail closed'
   );
 
   const missingRange = JSON.parse(JSON.stringify(descriptor));
@@ -123,7 +158,7 @@ const descriptor = {
     /unsupported transport/
   );
 
-  console.log('PASS read-only physical capability handshake separates evidence from execution authority');
+  console.log('PASS live physical capability preflight binds exact AST needs without granting execution authority');
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
Implements the live physical capability-preflight decision recorded on #157 (human product decision comment 5588080013).

- keeps verified exact Crazyflie 2.1 identity mandatory for physical execution;
- continues to observe the connected hardware/deck descriptor without turning every profile-listed optional deck into a global prerequisite;
- gates physical compatibility on the capabilities actually required by the exact submitted AST: action kinds, range directions, move directions and vertical directions;
- keeps fail-closed behavior when a required capability is unavailable, including a required `set_light` capability;
- preserves the read-only capability-inspection boundary and `executionAuthority:false` safeguards;
- adds regression coverage proving that an unused optional deck does not block a compatible AST while a truly required capability still fails closed.

Refs #157