### PR TITLE
Expose applied Color LED observer state

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/execution_observer.js
+++ b/plugins/robot_windows/blockly/webeeblocks/execution_observer.js
@@ -69,11 +69,13 @@
     this.waiter = null;
     this.credit = 0;
     this.sensorValues = Object.create(null);
+    this.lightColor = 'off';
     var self = this;
     this.hooks = {
       onNode: function(context) { return self._onNode(context); },
       beforeStep: function(context) { return self._beforeStep(context); },
       onSensor: function(context) { return self._onSensor(context); },
+      onLight: function(context) { return self._onLight(context); },
       onVariables: function(context) { return self._onVariables(context); }
     };
   }
@@ -97,6 +99,7 @@
     this.continuous = !this.enabled;
     this.credit = 0;
     this.sensorValues = Object.create(null);
+    this.lightColor = 'off';
     if (typeof this.callbacks.onBegin === 'function')
       this.callbacks.onBegin({enabled: this.enabled});
     return this.hooks;
@@ -144,6 +147,17 @@
     });
     if (typeof this.callbacks.onSensor === 'function')
       this.callbacks.onSensor(detail);
+  };
+
+  Controller.prototype._onLight = async function(context) {
+    if (!this.enabled || !context || typeof context.color !== 'string') return;
+    this.lightColor = String(context.color);
+    var detail = Object.assign({}, context, {
+      blockId: this._blockId(context.path),
+      color: this.lightColor
+    });
+    if (typeof this.callbacks.onLight === 'function')
+      this.callbacks.onLight(detail);
   };
 
   Controller.prototype._onVariables = async function(context) {

--- a/plugins/robot_windows/blockly/webeeblocks/interpreter.js
+++ b/plugins/robot_windows/blockly/webeeblocks/interpreter.js
@@ -132,7 +132,7 @@
         case 'turn':await hook(options,'beforeStep',current);await requireMethod(backend,'turn')(Number(statement.angle_deg));break;
         case 'wait':await hook(options,'beforeStep',current);await requireMethod(backend,'wait')(Number(statement.seconds));break;
         case 'set_speed':await hook(options,'beforeStep',current);await requireMethod(backend,'setSpeed')(Number(statement.speed_m_s));break;
-        case 'set_light':await hook(options,'beforeStep',current);await requireMethod(backend,'setLight')(String(statement.color));break;
+        case 'set_light':{var lightColor=String(statement.color);await hook(options,'beforeStep',current);await requireMethod(backend,'setLight')(lightColor);await hook(options,'onLight',{node:statement,path:path.slice(),role:'statement',variables:snapshot(env),color:lightColor});break;}
         case 'set_variable':{
           var ref=variableRef(statement.variable),stored=await evaluate(statement.value,backend,budget,depth+1,options,path.concat('value'),env);
           await hook(options,'beforeStep',context(statement,path,'statement',env));env.values[ref.id]=stored;env.names[ref.id]=ref.name;

--- a/tools/ci/runtime_v2_core_harness.html
+++ b/tools/ci/runtime_v2_core_harness.html
@@ -11,6 +11,7 @@
 <script src="../../plugins/robot_windows/blockly/webeeblocks/activities.js"></script>
 <script src="../../plugins/robot_windows/blockly/webeeblocks/semantic_ast.js"></script>
 <script src="../../plugins/robot_windows/blockly/webeeblocks/interpreter.js"></script>
+<script src="../../plugins/robot_windows/blockly/webeeblocks/execution_observer.js"></script>
 <script src="../../plugins/robot_windows/blockly/webeeblocks/activity_contract.js"></script>
 </head>
 <body>
@@ -145,8 +146,43 @@
     ]};
     assert(JSON.stringify(WebeeBlocksSemanticAst.compileWorkspace(lightWorkspace)) === JSON.stringify(expectedLight), 'light AST differs');
     trace = [];
-    await WebeeBlocksActivityContract.execute(profile, lightWorkspace, WebeeBlocksSemanticAst, WebeeBlocksInterpreter, backendFor(capabilities), {maxSteps: 20});
-    assert(JSON.stringify(trace) === JSON.stringify([['takeoff',0.5],['set_light','blue'],['set_light','off'],['land']]), 'light interpreter trace differs: ' + JSON.stringify(trace));
+    var observedLight = [];
+    var lightObserver = WebeeBlocksExecutionObserver.create(lightWorkspace, {
+      onLight: function(detail) {
+        observedLight.push({color: detail.color, blockId: detail.blockId});
+        trace.push(['observed_light', detail.color]);
+      }
+    });
+    var lightHooks = lightObserver.begin(true);
+    lightObserver.continueRun();
+    await WebeeBlocksActivityContract.execute(profile, lightWorkspace, WebeeBlocksSemanticAst, WebeeBlocksInterpreter, backendFor(capabilities), {maxSteps: 20, hooks: lightHooks});
+    lightObserver.finish();
+    assert(JSON.stringify(trace) === JSON.stringify([['takeoff',0.5],['set_light','blue'],['observed_light','blue'],['set_light','off'],['observed_light','off'],['land']]), 'light interpreter/observer trace differs: ' + JSON.stringify(trace));
+    assert(JSON.stringify(observedLight) === JSON.stringify([
+      {color:'blue', blockId:lightBlue.id},
+      {color:'off', blockId:lightOff.id}
+    ]), 'applied light state did not map to the exact Blockly actions: ' + JSON.stringify(observedLight));
+
+    trace = [];
+    observedLight = [];
+    var failedLightObserver = WebeeBlocksExecutionObserver.create(lightWorkspace, {
+      onLight: function(detail) { observedLight.push(detail.color); }
+    });
+    var failedLightHooks = failedLightObserver.begin(true);
+    failedLightObserver.continueRun();
+    var failedLightBackend = backendFor(capabilities);
+    failedLightBackend.setLight = async function(color) {
+      trace.push(['set_light_failed', color]);
+      throw new Error('synthetic light backend failure');
+    };
+    await expectReject(
+      WebeeBlocksActivityContract.execute(profile, lightWorkspace, WebeeBlocksSemanticAst, WebeeBlocksInterpreter, failedLightBackend, {maxSteps:20, hooks:failedLightHooks}),
+      /synthetic light backend failure/,
+      'failed light backend'
+    );
+    failedLightObserver.finish();
+    assert(JSON.stringify(trace) === JSON.stringify([['takeoff',0.5],['set_light_failed','blue']]), 'failed light backend trace differs: ' + JSON.stringify(trace));
+    assert(observedLight.length === 0, 'failed light backend was incorrectly reported as an applied LED state');
 
     var missingLightAction = clone(capabilities);
     missingLightAction.actions = capabilities.actions.filter(function(kind) { return kind !== 'set_light'; });


### PR DESCRIPTION
Adds the backend-confirmed Color LED execution-observer transport needed by the 2026-09-08 #157 product decision.

- emits `onLight` only after the backend `setLight` promise has resolved successfully;
- maps the applied light event back to the exact Blockly action through the existing execution observer;
- proves blue → off ordering and proves a rejected backend action never becomes observed LED state;
- keeps the AST, backend-neutral light intent and WWI command semantics unchanged.

This is the transport/core slice only. Student-visible French LED state/reset rendering remains a separate follow-up surface slice. Ready for exact-head full CI and independent review.

Refs #157