### PR TITLE
Bind physical preflight to the exact checked AST

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -56,12 +56,14 @@ modeling deck electronics or photometric fidelity.
 The substantive remaining #157 boundary is physical-backend continuity/proof.
 The integrated physical preflight core now derives required actions, range
 sensors and movement/vertical capabilities from the exact submitted
-backend-neutral AST and keeps optional deck requirements intent-dependent. This
-is not execution authority: fresh connected-hardware acquisition, binding the
-preflighted AST to any later authorization/submission, and the real-Crazyflie
-student execution path remain unproven. Do not turn source availability, Lab
-firmware experiments, preflight compatibility, or simulation coverage into a
-real-hardware support claim.
+backend-neutral AST, keeps optional deck requirements intent-dependent, and
+produces a canonical non-authority AST binding that later code can verify before
+authorization/submission. This still is not execution authority: fresh
+connected-hardware acquisition, reconnect invalidation/session freshness, the
+future authorization consumer, and the real-Crazyflie student execution path
+remain unproven. Do not turn source availability, Lab firmware experiments,
+preflight compatibility, or simulation coverage into a real-hardware support
+claim.
 
 This inventory should be updated only when integrated product evidence changes a
 row; live PR/CI/review state remains on GitHub rather than in this document.

--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
@@ -23,6 +23,36 @@
     return value !== null && typeof value === 'object' && !Array.isArray(value);
   }
 
+  function canonicalJson(value, path, depth) {
+    path = path || 'value';
+    depth = depth || 0;
+    if (depth > 100)
+      fail(path + ' nesting is too deep');
+    if (value === null || typeof value === 'string' || typeof value === 'boolean')
+      return JSON.stringify(value);
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value))
+        fail(path + ' contains a non-finite number');
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value))
+      return '[' + value.map(function(item, index) {
+        return canonicalJson(item, path + '[' + index + ']', depth + 1);
+      }).join(',') + ']';
+    if (isObject(value)) {
+      return '{' + Object.keys(value).sort().map(function(key) {
+        return JSON.stringify(key) + ':' + canonicalJson(value[key], path + '.' + key, depth + 1);
+      }).join(',') + '}';
+    }
+    fail(path + ' contains a non-JSON value');
+  }
+
+  function bindAst(ast) {
+    if (!isObject(ast) || ast.version !== 1 || ast.semantics !== 'webeeblocks-ast-v1')
+      fail('unsupported or malformed backend-neutral AST');
+    return canonicalJson(ast, 'AST', 0);
+  }
+
   function requireString(value, path) {
     if (typeof value !== 'string' || value.trim() === '')
       fail(path + ' must be a non-empty string');
@@ -256,6 +286,7 @@
       fail('profile hardware requirements unavailable');
     var descriptor = normalizeDescriptor(descriptorValue);
     var facts = deriveFacts(ast);
+    var astBinding = bindAst(ast);
     try {
       requireExactAirframe(profile, descriptor);
       requireUnconditionalHardware(profile, descriptor);
@@ -276,9 +307,19 @@
     return {
       compatible: true,
       executionAuthority: false,
+      astBinding: astBinding,
       facts: facts,
       descriptor: descriptor
     };
+  }
+
+  function assertPreflightAst(preflightResult, ast) {
+    if (!isObject(preflightResult) || preflightResult.compatible !== true ||
+        preflightResult.executionAuthority !== false || typeof preflightResult.astBinding !== 'string')
+      fail('valid non-authority physical preflight result required');
+    if (bindAst(ast) !== preflightResult.astBinding)
+      fail('submitted AST differs from preflighted AST');
+    return true;
   }
 
   return {
@@ -286,7 +327,9 @@
     inspect: inspect,
     preflight: preflight,
     deriveFacts: deriveFacts,
+    bindAst: bindAst,
     preflightAst: preflightAst,
+    assertPreflightAst: assertPreflightAst,
     FORBIDDEN_AUTHORITY_METHODS: FORBIDDEN_AUTHORITY_METHODS.slice()
   };
 });

--- a/tools/ci/test_physical_capability_contract.js
+++ b/tools/ci/test_physical_capability_contract.js
@@ -197,6 +197,34 @@ const descriptor = {
   const compatible = PhysicalCapabilities.preflightAst(reactiveProfile, noOptionalDeckIntent, flowOnly);
   assert.strictEqual(compatible.compatible, true, 'unused optional decks must not reject physical compatibility');
   assert.strictEqual(compatible.executionAuthority, false, 'capability preflight must never grant execution authority');
+  assert.strictEqual(typeof compatible.astBinding, 'string', 'successful preflight must bind the exact AST');
+  assert.strictEqual(
+    PhysicalCapabilities.assertPreflightAst(compatible, JSON.parse(JSON.stringify(noOptionalDeckIntent))),
+    true,
+    'an unchanged preflighted AST must remain eligible for later authorization/submission binding'
+  );
+  const reorderedEnvelope = {
+    semantics: noOptionalDeckIntent.semantics,
+    program: JSON.parse(JSON.stringify(noOptionalDeckIntent.program)),
+    version: noOptionalDeckIntent.version
+  };
+  assert.strictEqual(
+    PhysicalCapabilities.assertPreflightAst(compatible, reorderedEnvelope),
+    true,
+    'AST binding must be canonical rather than object-key-order dependent'
+  );
+  const changedAfterPreflight = JSON.parse(JSON.stringify(noOptionalDeckIntent));
+  changedAfterPreflight.program[1].distance_m = 0.3;
+  assert.throws(
+    () => PhysicalCapabilities.assertPreflightAst(compatible, changedAfterPreflight),
+    /submitted AST differs from preflighted AST/,
+    'a later workspace/program change must invalidate the prior preflight binding'
+  );
+  assert.throws(
+    () => PhysicalCapabilities.assertPreflightAst({compatible: true, executionAuthority: false}, noOptionalDeckIntent),
+    /valid non-authority physical preflight result required/,
+    'authorization/submission code must not accept an unbound or fabricated preflight shape'
+  );
 
   const lightIntent = ast([
     {kind: 'takeoff', height_m: 0.8},
@@ -254,7 +282,7 @@ const descriptor = {
     'unknown AST capabilities must fail closed rather than be ignored'
   );
 
-  console.log('PASS live physical capability preflight derives exact AST needs without granting execution authority');
+  console.log('PASS live physical capability preflight derives exact AST needs and binds the checked AST without granting execution authority');
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
Implements the next non-authority #157 physical-preflight boundary from the 2026-09-08 human decision.

- canonicalizes the exact backend-neutral AST used by successful physical capability preflight and records that binding in the returned non-authority preflight result;
- adds an explicit fail-closed verifier for later authorization/submission code, rejecting any program/workspace change after preflight;
- keeps object-key ordering irrelevant while preserving exact JSON AST content, so serialization order does not create false invalidation;
- preserves `executionAuthority:false` and introduces no motor, arming, teacher-authorization or physical backend execution surface;
- updates the capability matrix narrowly: AST binding is now represented, while fresh connected-hardware acquisition/reconnect freshness, future authorization consumption and real execution remain explicitly unproven.

This does not solve reconnect/session freshness and does not activate #72. It only closes the exact-AST binding gap already recorded in the integrated capability matrix.

Refs #157