### PR TITLE
Re-read connected capabilities for each physical preflight

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -58,12 +58,15 @@ The integrated physical preflight core now derives required actions, range
 sensors and movement/vertical capabilities from the exact submitted
 backend-neutral AST, keeps optional deck requirements intent-dependent, and
 produces a canonical non-authority AST binding that later code can verify before
-authorization/submission. This still is not execution authority: fresh
-connected-hardware acquisition, reconnect invalidation/session freshness, the
-future authorization consumer, and the real-Crazyflie student execution path
-remain unproven. Do not turn source availability, Lab firmware experiments,
-preflight compatibility, or simulation coverage into a real-hardware support
-claim.
+authorization/submission. A connected-preflight entry point now acquires and
+normalizes the live descriptor from the read-only adapter on every invocation
+before performing those exact-AST checks, so an earlier cached capability
+descriptor is not reused across later submissions. This still is not execution
+authority: reconnect invalidation/session freshness between a completed
+preflight and a future authorization consumer, that authorization consumer
+itself, and the real-Crazyflie student execution path remain unproven. Do not
+turn source availability, Lab firmware experiments, preflight compatibility, or
+simulation coverage into a real-hardware support claim.
 
 This inventory should be updated only when integrated product evidence changes a
 row; live PR/CI/review state remains on GitHub rather than in this document.

--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
@@ -137,6 +137,11 @@
     return normalizeDescriptor(await adapter.readCapabilities());
   }
 
+  async function preflightConnected(profile, ast, adapter) {
+    var descriptor = await inspect(adapter);
+    return preflightAst(profile, ast, descriptor);
+  }
+
   function requireSubset(requiredValues, availableValues, messagePrefix) {
     var available = new Set(availableValues || []);
     (requiredValues || []).forEach(function(value) {
@@ -329,6 +334,7 @@
     deriveFacts: deriveFacts,
     bindAst: bindAst,
     preflightAst: preflightAst,
+    preflightConnected: preflightConnected,
     assertPreflightAst: assertPreflightAst,
     FORBIDDEN_AUTHORITY_METHODS: FORBIDDEN_AUTHORITY_METHODS.slice()
   };

--- a/tools/ci/test_physical_capability_contract.js
+++ b/tools/ci/test_physical_capability_contract.js
@@ -226,6 +226,42 @@ const descriptor = {
     'authorization/submission code must not accept an unbound or fabricated preflight shape'
   );
 
+  let freshReads = 0;
+  let currentLiveDescriptor = JSON.parse(JSON.stringify(flowOnly));
+  currentLiveDescriptor.hardware = ['flow-deck-v2','color-led-deck'];
+  currentLiveDescriptor.capabilities.actions = ['takeoff','move','set_light','land'];
+  const connectedLightIntent = ast([
+    {kind: 'takeoff', height_m: 0.8},
+    {kind: 'set_light', color: 'red'},
+    {kind: 'land'}
+  ]);
+  const connectedAdapter = {
+    async readCapabilities() {
+      freshReads += 1;
+      return JSON.parse(JSON.stringify(currentLiveDescriptor));
+    }
+  };
+  const freshCompatible = await PhysicalCapabilities.preflightConnected(
+    reactiveProfile, connectedLightIntent, connectedAdapter
+  );
+  assert.strictEqual(freshReads, 1, 'connected preflight must read the live descriptor');
+  assert.strictEqual(freshCompatible.compatible, true);
+  assert.strictEqual(freshCompatible.executionAuthority, false);
+  assert.strictEqual(
+    PhysicalCapabilities.assertPreflightAst(freshCompatible, connectedLightIntent),
+    true,
+    'fresh connected preflight must preserve the exact checked AST binding'
+  );
+
+  currentLiveDescriptor = JSON.parse(JSON.stringify(flowOnly));
+  await assert.rejects(
+    () => PhysicalCapabilities.preflightConnected(reactiveProfile, connectedLightIntent, connectedAdapter),
+    error => error && error.code === 'PHYSICAL_CAPABILITY_MISMATCH' &&
+      /physical action capability unavailable: set_light/.test(error.message),
+    'a later connected preflight must re-read hardware instead of reusing a cached descriptor'
+  );
+  assert.strictEqual(freshReads, 2, 'every connected preflight invocation must acquire a fresh descriptor');
+
   const lightIntent = ast([
     {kind: 'takeoff', height_m: 0.8},
     {kind: 'set_light', color: 'red'},
@@ -282,7 +318,7 @@ const descriptor = {
     'unknown AST capabilities must fail closed rather than be ignored'
   );
 
-  console.log('PASS live physical capability preflight derives exact AST needs and binds the checked AST without granting execution authority');
+  console.log('PASS live physical capability preflight derives exact AST needs, re-reads connected hardware and binds the checked AST without granting execution authority');
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
Implements the next bounded non-authority #157 physical-preflight slice from the 2026-09-08 human decision.

- adds `preflightConnected(profile, ast, adapter)`, which acquires and normalizes the connected read-only capability descriptor on every invocation before exact-AST capability checks;
- proves a later invocation does not reuse an earlier cached descriptor: when the Color LED capability disappears, the same `set_light` AST fails closed on the next connected preflight;
- preserves the exact AST binding introduced by #241 and `executionAuthority:false`;
- introduces no motor, arming, teacher-authorization or physical execution surface;
- records the remaining boundary accurately: reconnect/session invalidation after a completed preflight and the future authorization consumer remain unproven.

Refs #157.