### PR TITLE
Invalidate physical preflight after reconnect

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -59,14 +59,17 @@ sensors and movement/vertical capabilities from the exact submitted
 backend-neutral AST, keeps optional deck requirements intent-dependent, and
 produces a canonical non-authority AST binding that later code can verify before
 authorization/submission. A connected-preflight entry point now acquires and
-normalizes the live descriptor from the read-only adapter on every invocation
-before performing those exact-AST checks, so an earlier cached capability
-descriptor is not reused across later submissions. This still is not execution
-authority: reconnect invalidation/session freshness between a completed
-preflight and a future authorization consumer, that authorization consumer
-itself, and the real-Crazyflie student execution path remain unproven. Do not
-turn source availability, Lab firmware experiments, preflight compatibility, or
-simulation coverage into a real-hardware support claim.
+normalizes the live descriptor from the read-only adapter on every invocation,
+brackets that acquisition with an opaque adapter-provided connection epoch, and
+binds the successful result to that epoch. The connected assertion fails closed
+if the epoch changes before a later consumer checks the preflight, and a
+connection change during descriptor acquisition invalidates the attempt. This
+still is not execution authority: a real physical adapter must provide a
+trustworthy epoch that changes on reconnect, the future authorization/submission
+consumer must perform the check immediately before its effect, and the
+real-Crazyflie student execution path remains unproven. Do not turn source
+availability, Lab firmware experiments, preflight compatibility, or simulation
+coverage into a real-hardware support claim.
 
 This inventory should be updated only when integrated product evidence changes a
 row; live PR/CI/review state remains on GitHub rather than in this document.

--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_contract.js
@@ -58,6 +58,11 @@
       fail(path + ' must be a non-empty string');
   }
 
+  function normalizeConnectionEpoch(value) {
+    requireString(value, 'connection epoch');
+    return String(value);
+  }
+
   function normalizeStringArray(value, path) {
     if (!Array.isArray(value))
       fail(path + ' must be an array');
@@ -132,14 +137,27 @@
     });
   }
 
+  function assertConnectedAdapter(adapter) {
+    assertReadOnlyAdapter(adapter);
+    if (typeof adapter.readConnectionEpoch !== 'function')
+      fail('adapter.readConnectionEpoch is required for connected preflight');
+  }
+
   async function inspect(adapter) {
     assertReadOnlyAdapter(adapter);
     return normalizeDescriptor(await adapter.readCapabilities());
   }
 
   async function preflightConnected(profile, ast, adapter) {
-    var descriptor = await inspect(adapter);
-    return preflightAst(profile, ast, descriptor);
+    assertConnectedAdapter(adapter);
+    var beforeEpoch = normalizeConnectionEpoch(await adapter.readConnectionEpoch());
+    var descriptor = normalizeDescriptor(await adapter.readCapabilities());
+    var afterEpoch = normalizeConnectionEpoch(await adapter.readConnectionEpoch());
+    if (beforeEpoch !== afterEpoch)
+      fail('Crazyflie connection changed during physical preflight');
+    var result = preflightAst(profile, ast, descriptor);
+    result.connectionEpoch = afterEpoch;
+    return result;
   }
 
   function requireSubset(requiredValues, availableValues, messagePrefix) {
@@ -327,6 +345,17 @@
     return true;
   }
 
+  async function assertPreflightConnected(preflightResult, ast, adapter) {
+    assertPreflightAst(preflightResult, ast);
+    if (typeof preflightResult.connectionEpoch !== 'string')
+      fail('session-bound physical preflight result required');
+    assertConnectedAdapter(adapter);
+    var currentEpoch = normalizeConnectionEpoch(await adapter.readConnectionEpoch());
+    if (currentEpoch !== preflightResult.connectionEpoch)
+      fail('Crazyflie connection changed since physical preflight');
+    return true;
+  }
+
   return {
     normalizeDescriptor: normalizeDescriptor,
     inspect: inspect,
@@ -336,6 +365,7 @@
     preflightAst: preflightAst,
     preflightConnected: preflightConnected,
     assertPreflightAst: assertPreflightAst,
+    assertPreflightConnected: assertPreflightConnected,
     FORBIDDEN_AUTHORITY_METHODS: FORBIDDEN_AUTHORITY_METHODS.slice()
   };
 });

--- a/tools/ci/test_physical_capability_contract.js
+++ b/tools/ci/test_physical_capability_contract.js
@@ -227,6 +227,8 @@ const descriptor = {
   );
 
   let freshReads = 0;
+  let epochReads = 0;
+  let currentConnectionEpoch = 'connection-1';
   let currentLiveDescriptor = JSON.parse(JSON.stringify(flowOnly));
   currentLiveDescriptor.hardware = ['flow-deck-v2','color-led-deck'];
   currentLiveDescriptor.capabilities.actions = ['takeoff','move','set_light','land'];
@@ -236,6 +238,10 @@ const descriptor = {
     {kind: 'land'}
   ]);
   const connectedAdapter = {
+    async readConnectionEpoch() {
+      epochReads += 1;
+      return currentConnectionEpoch;
+    },
     async readCapabilities() {
       freshReads += 1;
       return JSON.parse(JSON.stringify(currentLiveDescriptor));
@@ -245,12 +251,55 @@ const descriptor = {
     reactiveProfile, connectedLightIntent, connectedAdapter
   );
   assert.strictEqual(freshReads, 1, 'connected preflight must read the live descriptor');
+  assert.strictEqual(epochReads, 2, 'connected preflight must bracket capability acquisition with one connection epoch');
   assert.strictEqual(freshCompatible.compatible, true);
   assert.strictEqual(freshCompatible.executionAuthority, false);
+  assert.strictEqual(freshCompatible.connectionEpoch, 'connection-1');
   assert.strictEqual(
-    PhysicalCapabilities.assertPreflightAst(freshCompatible, connectedLightIntent),
+    await PhysicalCapabilities.assertPreflightConnected(freshCompatible, connectedLightIntent, connectedAdapter),
     true,
-    'fresh connected preflight must preserve the exact checked AST binding'
+    'unchanged AST and connection epoch must remain eligible for a later non-authority consumer'
+  );
+  assert.strictEqual(epochReads, 3, 'connected assertion must re-read the current connection epoch');
+
+  currentConnectionEpoch = 'connection-2';
+  await assert.rejects(
+    () => PhysicalCapabilities.assertPreflightConnected(freshCompatible, connectedLightIntent, connectedAdapter),
+    /connection changed since physical preflight/,
+    'a reconnect after successful preflight must invalidate that preflight'
+  );
+
+  await assert.rejects(
+    () => PhysicalCapabilities.assertPreflightConnected(
+      {compatible: true, executionAuthority: false, astBinding: freshCompatible.astBinding},
+      connectedLightIntent,
+      connectedAdapter
+    ),
+    /session-bound physical preflight result required/,
+    'a fabricated preflight without a connection epoch must not satisfy the connected assertion'
+  );
+
+  let unstableEpochReads = 0;
+  await assert.rejects(
+    () => PhysicalCapabilities.preflightConnected(reactiveProfile, connectedLightIntent, {
+      async readConnectionEpoch() {
+        unstableEpochReads += 1;
+        return unstableEpochReads === 1 ? 'connection-a' : 'connection-b';
+      },
+      async readCapabilities() {
+        return JSON.parse(JSON.stringify(currentLiveDescriptor));
+      }
+    }),
+    /connection changed during physical preflight/,
+    'a reconnect during descriptor acquisition must invalidate the preflight attempt'
+  );
+
+  await assert.rejects(
+    () => PhysicalCapabilities.preflightConnected(reactiveProfile, connectedLightIntent, {
+      async readCapabilities() { return JSON.parse(JSON.stringify(currentLiveDescriptor)); }
+    }),
+    /readConnectionEpoch is required/,
+    'connected preflight must fail closed when session freshness cannot be observed'
   );
 
   currentLiveDescriptor = JSON.parse(JSON.stringify(flowOnly));
@@ -318,7 +367,7 @@ const descriptor = {
     'unknown AST capabilities must fail closed rather than be ignored'
   );
 
-  console.log('PASS live physical capability preflight derives exact AST needs, re-reads connected hardware and binds the checked AST without granting execution authority');
+  console.log('PASS live physical capability preflight binds exact AST and connection epoch, re-reads connected hardware and grants no execution authority');
 })().catch(error => {
   console.error(error);
   process.exit(1);


### PR DESCRIPTION
Implements the next bounded non-authority #157 physical-preflight freshness slice from the 2026-09-08 human decision.

- requires connected physical preflight adapters to expose an opaque connection epoch that is stable for one live connection and changes on reconnect;
- brackets capability acquisition with the epoch and fails closed if the connection changes while the descriptor is being read;
- binds a successful exact-AST preflight to that epoch and adds a later connected assertion that rejects a reconnect after preflight;
- preserves the existing fresh descriptor re-read on every connected preflight invocation, exact AST binding, and `executionAuthority:false`;
- introduces no motor, arming, teacher-authorization or physical execution surface;
- records the remaining boundary accurately: a real physical adapter must provide a trustworthy reconnect-sensitive epoch, a future authorization/submission consumer must verify immediately before its effect, and real physical execution remains unproven.

Refs #157.