### PR TITLE
Add reconnect-aware live capability session

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -54,20 +54,25 @@ real `color_led` device and gate that normal-view color visibility without
 modeling deck electronics or photometric fidelity.
 
 The substantive remaining #157 boundary is physical-backend continuity/proof.
-The integrated physical preflight core now derives required actions, range
-sensors and movement/vertical capabilities from the exact submitted
-backend-neutral AST, keeps optional deck requirements intent-dependent, and
-produces a canonical non-authority AST binding that later code can verify before
-authorization/submission. A connected-preflight entry point now acquires and
-normalizes the live descriptor from the read-only adapter on every invocation,
-brackets that acquisition with an opaque adapter-provided connection epoch, and
-binds the successful result to that epoch. The connected assertion fails closed
-if the epoch changes before a later consumer checks the preflight, and a
-connection change during descriptor acquisition invalidates the attempt. This
-still is not execution authority: a real physical adapter must provide a
-trustworthy epoch that changes on reconnect, the future authorization/submission
-consumer must perform the check immediately before its effect, and the
-real-Crazyflie student execution path remains unproven. Do not turn source
+The integrated physical preflight core derives required actions, range sensors
+and movement/vertical capabilities from the exact submitted backend-neutral AST,
+keeps optional deck requirements intent-dependent, and produces a canonical
+non-authority AST binding that later code can verify before
+authorization/submission. The host-side read-only probe now also exposes a
+persistent `ReadOnlyCapabilitySession`: it opens one explicit Crazyradio URI,
+waits for the connected parameter snapshot, creates an opaque epoch only after
+the link is live, invalidates that epoch from cflib's disconnect callback, and
+creates each descriptor read from the current connected evidence instead of
+caching an earlier descriptor object. Reopening therefore rotates the epoch, and
+a disconnect makes both epoch and capability reads fail closed. The session
+exposes no WebeeBlocks movement, light, arming or setpoint method and retains the
+documented cflib safety-zero close-path qualification.
+
+This still is not execution authority or a complete physical backend. The
+Blockly/runtime submission path does not yet consume this host session, and no
+authorization/execution consumer performs the bound AST/session assertion
+immediately before a physical effect. Arming, abort/failsafe behavior and
+real-Crazyflie student execution remain unproven. Do not turn source
 availability, Lab firmware experiments, preflight compatibility, or simulation
 coverage into a real-hardware support claim.
 

--- a/tools/ci/test_physical_capability_probe.py
+++ b/tools/ci/test_physical_capability_probe.py
@@ -122,8 +122,167 @@ def test_device_type_query() -> None:
     require(timeout.removed, "device-type callback cleanup after timeout")
 
 
+
+def test_live_capability_session() -> None:
+    class FakeCaller:
+        def __init__(self) -> None:
+            self.callbacks = []
+
+        def add_callback(self, callback) -> None:
+            self.callbacks.append(callback)
+
+        def remove_callback(self, callback) -> None:
+            self.callbacks.remove(callback)
+
+        def call(self, *args) -> None:
+            for callback in list(self.callbacks):
+                callback(*args)
+
+    class FakeCf:
+        def __init__(self, values, device_type: str) -> None:
+            self.values = dict(values)
+            self.device_type = device_type
+            self.disconnected = FakeCaller()
+
+    class FakeSyncCrazyflie:
+        def __init__(self, uri: str, values, device_type: str) -> None:
+            self.uri = uri
+            self.cf = FakeCf(values, device_type)
+            self.link_open = False
+            self.params_waited = False
+            self.close_count = 0
+
+        def open_link(self) -> None:
+            require(not self.link_open, "fake link must start closed")
+            self.link_open = True
+
+        def wait_for_params(self) -> None:
+            require(self.link_open, "fake params require a live link")
+            self.params_waited = True
+
+        def is_link_open(self) -> bool:
+            return self.link_open
+
+        def close_link(self) -> None:
+            if not self.link_open:
+                return
+            self.link_open = False
+            self.close_count += 1
+            self.cf.disconnected.call(self.uri)
+
+        def lose_link(self) -> None:
+            require(self.link_open, "fake lost-link requires a live link")
+            self.link_open = False
+            self.cf.disconnected.call(self.uri)
+
+    def read_fake_descriptor(cf) -> dict[str, object]:
+        return probe.build_descriptor(11, cf.values, cf.device_type)
+
+    first = FakeSyncCrazyflie(
+        "radio://0/80/2M/E7E7E7E7E7",
+        BASE_VALUES,
+        "Crazyflie 2.1",
+    )
+    second_values = dict(BASE_VALUES)
+    second_values["deck.bcColorLedBot"] = "0"
+    second = FakeSyncCrazyflie(
+        "radio://0/80/2M/E7E7E7E7E7",
+        second_values,
+        "Crazyflie 2.1",
+    )
+    candidates = [first, second]
+    epochs = iter(("session-epoch-one", "session-epoch-two"))
+    driver_inits: list[str] = []
+
+    session = probe.ReadOnlyCapabilitySession(
+        "radio://0/80/2M/E7E7E7E7E7",
+        scf_factory=lambda _uri: candidates.pop(0),
+        driver_init=lambda: driver_inits.append("init"),
+        epoch_factory=lambda: next(epochs),
+        cflib_version_reader=lambda: "test-cflib",
+        descriptor_reader=read_fake_descriptor,
+    )
+
+    session.open()
+    require(first.params_waited, "session must wait for the connected parameter snapshot")
+    require(session.read_connection_epoch() == "session-epoch-one", "first session epoch")
+    observed = session.read_capabilities()
+    require(
+        observed["evidence"]["cflibVersion"] == "test-cflib",
+        "live session must preserve cflib provenance",
+    )
+    require("set_light" in observed["capabilities"]["actions"], "first live descriptor")
+
+    first.cf.values["deck.bcColorLedBot"] = "0"
+    refreshed = session.read_capabilities()
+    require(
+        "set_light" not in refreshed["capabilities"]["actions"],
+        "capability reads must not cache an earlier descriptor",
+    )
+
+    for forbidden in (
+        "takeoff",
+        "land",
+        "move",
+        "vertical",
+        "turn",
+        "set_speed",
+        "set_light",
+        "arm",
+        "disarm",
+    ):
+        require(not hasattr(session, forbidden), f"session exposes forbidden authority method: {forbidden}")
+
+    first.lose_link()
+    expect_probe_error(
+        session.read_connection_epoch,
+        "connection is not established",
+    )
+    expect_probe_error(
+        session.read_capabilities,
+        "connection is not established",
+    )
+
+    session.open()
+    require(session.read_connection_epoch() == "session-epoch-two", "reconnect must rotate epoch")
+    require(driver_inits == ["init"], "Crazyradio drivers initialize once per adapter")
+    second_observed = session.read_capabilities()
+    require(
+        "set_light" not in second_observed["capabilities"]["actions"],
+        "reconnected descriptor must reflect the new live session",
+    )
+    session.close()
+    require(second.close_count == 1, "explicit session close")
+    expect_probe_error(
+        session.read_connection_epoch,
+        "connection is not established",
+    )
+
+    invalid_epoch_link = FakeSyncCrazyflie(
+        "radio://0/80/2M/E7E7E7E7E7",
+        BASE_VALUES,
+        "Crazyflie 2.1",
+    )
+    invalid_epoch = probe.ReadOnlyCapabilitySession(
+        "radio://0/80/2M/E7E7E7E7E7",
+        scf_factory=lambda _uri: invalid_epoch_link,
+        driver_init=lambda: None,
+        epoch_factory=lambda: "",
+        cflib_version_reader=lambda: "test-cflib",
+        descriptor_reader=read_fake_descriptor,
+    )
+    expect_probe_error(
+        invalid_epoch.open,
+        "invalid epoch",
+    )
+    require(
+        invalid_epoch_link.close_count == 1 and not invalid_epoch_link.is_link_open(),
+        "failed session setup must close the live link",
+    )
+
 def main() -> int:
     test_device_type_query()
+    test_live_capability_session()
     descriptor = probe.build_descriptor("11", BASE_VALUES)
 
     require(descriptor["transport"] == "crazyradio", "transport")

--- a/tools/physical/probe_reference_hardware.py
+++ b/tools/physical/probe_reference_hardware.py
@@ -259,6 +259,7 @@ class ReadOnlyCapabilitySession:
         driver_init: Callable[[], None] | None = None,
         epoch_factory: Callable[[], str] | None = None,
         cflib_version_reader: Callable[[], str] | None = None,
+        descriptor_reader: Callable[[object], dict[str, object]] | None = None,
     ) -> None:
         if not uri.startswith("radio://"):
             raise ProbeError("P0b requires an explicit Crazyradio radio:// URI")
@@ -267,6 +268,7 @@ class ReadOnlyCapabilitySession:
         self._driver_init = driver_init
         self._epoch_factory = epoch_factory or (lambda: secrets.token_hex(16))
         self._cflib_version_reader = cflib_version_reader or _installed_cflib_version
+        self._descriptor_reader = descriptor_reader or _read_connected_descriptor
         self._drivers_initialized = False
         self._scf: object | None = None
         self._disconnect_callback: Callable[[str], None] | None = None
@@ -387,7 +389,7 @@ class ReadOnlyCapabilitySession:
         if scf is None:
             raise ProbeError("Crazyflie connection is not established for capability preflight")
         try:
-            descriptor = _read_connected_descriptor(scf.cf)
+            descriptor = self._descriptor_reader(scf.cf)
         except ProbeError:
             raise
         except Exception as exc:

--- a/tools/physical/probe_reference_hardware.py
+++ b/tools/physical/probe_reference_hardware.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 import json
+import secrets
 import sys
-from threading import Event
+from threading import Event, Lock
 from typing import Callable, Mapping
 
 PARAMETERS = (
@@ -220,38 +221,220 @@ def build_descriptor(
     }
 
 
+def _read_connected_descriptor(cf: object) -> dict[str, object]:
+    """Read one truthful capability descriptor from an already-live link."""
+    protocol_version = cf.platform.get_protocol_version()
+    device_type_name = _read_device_type_name(cf)
+    values = _read_required_parameters(cf.param.get_value)
+    return build_descriptor(protocol_version, values, device_type_name)
+
+
+def _installed_cflib_version() -> str:
+    try:
+        return importlib.metadata.version("cflib")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+class ReadOnlyCapabilitySession:
+    """Persistent non-authority capability adapter for one live Crazyflie link.
+
+    The opaque epoch is created only after a successful live connection and is
+    invalidated by the Crazyflie disconnected callback. Reopening creates a new
+    epoch. Capability reads are bracketed by that epoch and never cache the
+    descriptor, so a later preflight observes the current descriptor fields from
+    the same still-live session.
+
+    This adapter deliberately exposes no flight, arming, setpoint or parameter
+    write operation. Closing the underlying cflib link retains cflib's documented
+    safety-zero close-path behavior; that transport qualification is not execution
+    authority.
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        scf_factory: Callable[[str], object] | None = None,
+        driver_init: Callable[[], None] | None = None,
+        epoch_factory: Callable[[], str] | None = None,
+        cflib_version_reader: Callable[[], str] | None = None,
+    ) -> None:
+        if not uri.startswith("radio://"):
+            raise ProbeError("P0b requires an explicit Crazyradio radio:// URI")
+        self._uri = uri
+        self._scf_factory = scf_factory
+        self._driver_init = driver_init
+        self._epoch_factory = epoch_factory or (lambda: secrets.token_hex(16))
+        self._cflib_version_reader = cflib_version_reader or _installed_cflib_version
+        self._drivers_initialized = False
+        self._scf: object | None = None
+        self._disconnect_callback: Callable[[str], None] | None = None
+        self._connection_epoch: str | None = None
+        self._cflib_version = "unknown"
+        self._state_lock = Lock()
+
+    def _initialize_drivers(self) -> None:
+        if self._drivers_initialized:
+            return
+        if self._driver_init is not None:
+            self._driver_init()
+        elif self._scf_factory is None:
+            try:
+                import cflib.crtp
+            except ImportError as exc:
+                raise ProbeError("cflib is required for the live read-only probe") from exc
+            cflib.crtp.init_drivers()
+        self._drivers_initialized = True
+
+    def _new_scf(self) -> object:
+        if self._scf_factory is not None:
+            return self._scf_factory(self._uri)
+        try:
+            from cflib.crazyflie import Crazyflie
+            from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+        except ImportError as exc:
+            raise ProbeError("cflib is required for the live read-only probe") from exc
+        return SyncCrazyflie(self._uri, cf=Crazyflie())
+
+    def _invalidate(self, expected_scf: object) -> None:
+        with self._state_lock:
+            if self._scf is expected_scf:
+                self._connection_epoch = None
+
+    def _discard_stale_session(self) -> None:
+        with self._state_lock:
+            scf = self._scf
+            callback = self._disconnect_callback
+            if scf is None:
+                return
+            if scf.is_link_open():
+                raise ProbeError("read-only capability session is already connected")
+            self._scf = None
+            self._disconnect_callback = None
+            self._connection_epoch = None
+        if callback is not None:
+            try:
+                scf.cf.disconnected.remove_callback(callback)
+            except ValueError:
+                pass
+
+    def open(self) -> None:
+        self._discard_stale_session()
+        self._initialize_drivers()
+        scf = self._new_scf()
+        try:
+            scf.open_link()
+            scf.wait_for_params()
+            if not scf.is_link_open():
+                raise ProbeError("Crazyflie connection closed during session setup")
+            epoch = self._epoch_factory()
+            if not isinstance(epoch, str) or not epoch.strip():
+                raise ProbeError("connection epoch factory returned an invalid epoch")
+            epoch = epoch.strip()
+
+            def disconnected(_uri: str) -> None:
+                self._invalidate(scf)
+
+            with self._state_lock:
+                self._scf = scf
+                self._disconnect_callback = disconnected
+                self._connection_epoch = epoch
+                self._cflib_version = self._cflib_version_reader()
+
+            scf.cf.disconnected.add_callback(disconnected)
+            if not scf.is_link_open():
+                self._invalidate(scf)
+                raise ProbeError("Crazyflie connection closed during session setup")
+        except ProbeError:
+            self._cleanup_failed_open(scf)
+            raise
+        except Exception as exc:
+            self._cleanup_failed_open(scf)
+            raise ProbeError(f"Crazyradio/Crazyflie read-only session failed: {exc}") from exc
+
+    def _cleanup_failed_open(self, scf: object) -> None:
+        with self._state_lock:
+            callback = self._disconnect_callback if self._scf is scf else None
+            if self._scf is scf:
+                self._scf = None
+                self._disconnect_callback = None
+                self._connection_epoch = None
+        if callback is not None:
+            try:
+                scf.cf.disconnected.remove_callback(callback)
+            except ValueError:
+                pass
+        try:
+            if scf.is_link_open():
+                scf.close_link()
+        except Exception:
+            pass
+
+    def read_connection_epoch(self) -> str:
+        with self._state_lock:
+            scf = self._scf
+            epoch = self._connection_epoch
+        if scf is None or epoch is None or not scf.is_link_open():
+            raise ProbeError("Crazyflie connection is not established for capability preflight")
+        return epoch
+
+    def read_capabilities(self) -> dict[str, object]:
+        before = self.read_connection_epoch()
+        with self._state_lock:
+            scf = self._scf
+            cflib_version = self._cflib_version
+        if scf is None:
+            raise ProbeError("Crazyflie connection is not established for capability preflight")
+        try:
+            descriptor = _read_connected_descriptor(scf.cf)
+        except ProbeError:
+            raise
+        except Exception as exc:
+            raise ProbeError(f"Crazyflie capability read failed: {exc}") from exc
+        after = self.read_connection_epoch()
+        if after != before:
+            raise ProbeError("Crazyflie connection changed while capabilities were read")
+        descriptor["evidence"]["cflibVersion"] = cflib_version
+        return descriptor
+
+    def close(self) -> None:
+        with self._state_lock:
+            scf = self._scf
+            callback = self._disconnect_callback
+            self._scf = None
+            self._disconnect_callback = None
+            self._connection_epoch = None
+        if scf is None:
+            return
+        if callback is not None:
+            try:
+                scf.cf.disconnected.remove_callback(callback)
+            except ValueError:
+                pass
+        try:
+            if scf.is_link_open():
+                scf.close_link()
+        except Exception as exc:
+            raise ProbeError(f"Crazyradio/Crazyflie read-only session close failed: {exc}") from exc
+
+    def __enter__(self) -> "ReadOnlyCapabilitySession":
+        self.open()
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb) -> None:
+        self.close()
+
+
 def probe_live(uri: str) -> dict[str, object]:
     """Connect to one explicitly named Crazyradio URI and read evidence only."""
-    if not uri.startswith("radio://"):
-        raise ProbeError("P0b requires an explicit Crazyradio radio:// URI")
-
     try:
-        import cflib.crtp
-        from cflib.crazyflie import Crazyflie
-        from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
-    except ImportError as exc:
-        raise ProbeError("cflib is required for the live read-only probe") from exc
-
-    cflib.crtp.init_drivers()
-    try:
-        cflib_version = importlib.metadata.version("cflib")
-    except importlib.metadata.PackageNotFoundError:
-        cflib_version = "unknown"
-
-    try:
-        with SyncCrazyflie(uri, cf=Crazyflie()) as scf:
-            scf.wait_for_params()
-            protocol_version = scf.cf.platform.get_protocol_version()
-            device_type_name = _read_device_type_name(scf.cf)
-            values = _read_required_parameters(scf.cf.param.get_value)
+        with ReadOnlyCapabilitySession(uri) as session:
+            return session.read_capabilities()
     except ProbeError:
         raise
     except Exception as exc:
         raise ProbeError(f"Crazyradio/Crazyflie read-only probe failed: {exc}") from exc
-
-    descriptor = build_descriptor(protocol_version, values, device_type_name)
-    descriptor["evidence"]["cflibVersion"] = cflib_version
-    return descriptor
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Advances the remaining non-authority #157 live-adapter boundary without introducing physical execution.

- adds a persistent host-side `ReadOnlyCapabilitySession` around one explicit Crazyradio/Crazyflie link;
- creates an opaque connection epoch only after a successful live connection and invalidates it from cflib's disconnect callback; reopening rotates the epoch;
- rebuilds each capability descriptor from the current connected evidence instead of reusing an earlier descriptor object, and brackets the read with the same session epoch;
- keeps the existing exact Crazyflie 2.1 device-type query, deck/self-test capability mapping, `executionAuthority:false`, and explicit Crazyradio URI boundary;
- exposes no WebeeBlocks movement, light, arming, setpoint or parameter-write method; cflib's documented safety-zero close-path qualification remains explicit;
- adds deterministic fake-link coverage for descriptor refresh, disconnect fail-closed behavior, reconnect epoch rotation, cleanup on invalid epoch, and the absence of authority methods;
- updates the capability matrix narrowly: the host live session exists, but Blockly/runtime submission wiring, immediate pre-effect AST/session verification, arming/abort/failsafe and real student execution remain unproven.

This PR does not authorize flight, does not wire a physical execution backend, and does not change #70 or Runtime v2 semantics.

Refs #157.