### PR TITLE
Refresh roadmap after live capability session

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,17 +22,20 @@ interface) are validated baseline, not active priority nodes.
 The #157 simulation-side C1b boundary is now established for every currently
 justified student-facing generic capability. Integrated #193/#196 establish the
 machine-readable read-only capability evidence path and exact Crazyflie 2.1
-identity; #238/#241/#243/#244 then establish intent-dependent exact-AST
-preflight, canonical AST binding, fresh connected-descriptor acquisition on each
-preflight, and reconnect invalidation through an opaque connection epoch. All of
-this remains non-authority with `executionAuthority:false`. The underlying cflib
-SyncCrazyflie close path still emits its documented safety-zero commander
-setpoint, so this is not a claim that the transport emits no command packet. The
-substantive remaining product boundary is a concrete trustworthy live adapter,
-immediate pre-effect consumption of the bound preflight, and safe physical
-execution continuity; do not invent additional simulation vocabulary merely to
-keep #157 active. A new simulation slice needs a concrete pedagogical need or
-contradictory evidence.
+identity; #238/#241/#243/#244 establish intent-dependent exact-AST preflight,
+canonical AST binding, fresh connected-descriptor acquisition on each preflight
+and reconnect invalidation through an opaque connection epoch; #246 now provides
+the concrete host-side non-authority live Crazyradio session that owns that epoch,
+invalidates it on disconnect and rebuilds capability descriptors from the current
+connection. All of this remains non-authority with `executionAuthority:false`.
+The underlying cflib SyncCrazyflie close path still emits its documented
+safety-zero commander setpoint, so this is not a claim that the transport emits no
+command packet. The substantive remaining product boundary is wiring the actual
+physical submission path to this live session, consuming the bound AST/session
+preflight immediately before any separately authorized effect, and then proving
+safe physical execution continuity; do not invent additional simulation
+vocabulary merely to keep #157 active. A new simulation slice needs a concrete
+pedagogical need or contradictory evidence.
 
 Research / later work:
 
@@ -203,10 +206,14 @@ Runtime/controller change is justified by #236 alone.
   the fail-closed read-only descriptor/probe and exact Crazyflie 2.1 identity
   path; #238 derives requirements from the exact submitted AST with optional
   deck capabilities intent-dependent; #241 binds a successful preflight to that
-  canonical AST; #243 re-reads the connected descriptor on every invocation; and
+  canonical AST; #243 re-reads the connected descriptor on every invocation;
   #244 binds the result to an adapter-provided connection epoch so a reconnect
-  during or after preflight invalidates it. These slices preserve
-  `executionAuthority:false` and expose no WebeeBlocks motor/arming command API
+  during or after preflight invalidates it; and #246 provides the concrete
+  host-side `ReadOnlyCapabilitySession` that opens one explicit Crazyradio link,
+  creates/rotates that epoch around live connections, invalidates it on cflib
+  disconnect and reconstructs descriptors from current connected evidence.
+  These slices preserve `executionAuthority:false` and expose no WebeeBlocks
+  motor/arming command API
 - real-device checkpoint #226 was authoritatively closed `NOT_NEEDED` after the
   live-preflight product decision superseded the fixed all-reference-decks gate.
   Its bounded partial observation still established exact Crazyflie 2.1
@@ -215,11 +222,12 @@ Runtime/controller change is justified by #236 alone.
   this is historical capability evidence, not a reusable execution preflight
 - the normal cflib close path still emits its safety-zero commander setpoint, so
   transport-level packet emission is not claimed read-only
-- remaining boundary: a concrete physical adapter must provide a trustworthy
-  reconnect-sensitive epoch and fresh truthful descriptors; a future
-  authorization/submission consumer must re-assert the exact AST and epoch
-  immediately before its effect; arming/abort/failsafe and real student
-  execution continuity remain separately unproven
+- remaining boundary: the product submission path must connect the exact
+  backend-neutral AST to the integrated #246 live session and the existing
+  connected-preflight contract, then re-assert the bound AST and connection epoch
+  immediately before any separately authorized physical effect.
+  Arming/abort/failsafe and real student execution continuity remain separately
+  unproven
 - reopen simulation vocabulary only for a demonstrated pedagogical need or new
   contradictory evidence.
 
@@ -261,15 +269,17 @@ Runtime/controller change is justified by #236 alone.
 - established prerequisite: #193/#196 plus #238/#241/#243/#244 provide the
   non-authority Crazyradio/deck evidence path, exact-airframe proof, exact-AST
   capability derivation/binding, fresh descriptor acquisition and reconnect
-  invalidation. The surface remains read-only with `executionAuthority:false`;
-  the cflib close path retains its safety-zero transport setpoint
+  invalidation; #246 supplies the concrete host-side live session that owns the
+  reconnect-sensitive epoch and current descriptor reads. The surface remains
+  read-only with `executionAuthority:false`; the cflib close path retains its
+  safety-zero transport setpoint
 - bounded real-device evidence from superseded checkpoint #226 confirms the
   available Crazyflie 2.1 + Flow Deck V2 + Multi-ranger observation, but it is
   not a reusable live execution preflight and does not prove an absent Color LED
   capability or any command path
-- depends: a trustworthy real adapter plus immediate pre-effect verification of
-  the bound AST/session, then separately authorized arming/abort/failsafe and
-  physical execution continuity
+- depends: wiring the actual physical submission flow to #246 plus immediate
+  pre-effect verification of the bound AST/session, then separately authorized
+  arming/abort/failsafe and physical execution continuity
 - proof direction: preserve backend-neutral AST continuity while adding only the
   minimum teacher-authorized physical execution authority after the live
   capability and safety gates are independently established


### PR DESCRIPTION
Synchronizes the smallest stale #157/P roadmap fragments after integrated #246.

- records the host-side `ReadOnlyCapabilitySession` as the concrete non-authority live Crazyradio session that owns a reconnect-sensitive epoch and reconstructs capability descriptors from current connected evidence;
- removes the now-obsolete statement that such a concrete live adapter remains to be provided;
- narrows the remaining product boundary to wiring the actual physical submission path to #246 plus the existing exact-AST/connected-preflight contract and re-asserting the bound AST/session immediately before any separately authorized physical effect;
- keeps arming/abort/failsafe and real student execution continuity explicitly unproven;
- preserves `executionAuthority:false`, the cflib safety-zero close-path qualification, #226 as historical evidence only, and all #70 boundaries.

Roadmap-only; no Runtime, workflow, governance or flight authority changes.

Refs #157 and #72.