### PR TITLE
Connect physical preflight to live read-only session

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js
@@ -1,0 +1,60 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksPhysicalCapabilityHttpAdapter = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  function fail(message) {
+    throw new Error('physical capability HTTP adapter: ' + message);
+  }
+
+  function requireText(value, name) {
+    if (typeof value !== 'string' || value.trim() === '')
+      fail(name + ' must be a non-empty string');
+    return value.trim();
+  }
+
+  function create(options) {
+    options = options || {};
+    var baseUrl = requireText(options.baseUrl, 'baseUrl').replace(/\/$/, '');
+    var token = requireText(options.token, 'token');
+    var fetchImpl = options.fetchImpl || (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+    if (typeof fetchImpl !== 'function')
+      fail('fetch implementation is required');
+
+    async function read(path) {
+      var response = await fetchImpl(baseUrl + path, {
+        method: 'GET',
+        headers: {
+          'Authorization': 'Bearer ' + token,
+          'Cache-Control': 'no-store'
+        },
+        cache: 'no-store'
+      });
+      var payload;
+      try {
+        payload = await response.json();
+      } catch (_error) {
+        fail('bridge returned malformed JSON');
+      }
+      if (!response.ok)
+        fail('bridge read failed (' + response.status + '): ' + String(payload && payload.error || 'unknown error'));
+      return payload;
+    }
+
+    var adapter = {
+      async readCapabilities() {
+        return read('/v1/capabilities');
+      },
+      async readConnectionEpoch() {
+        var payload = await read('/v1/connection-epoch');
+        return requireText(payload && payload.connectionEpoch, 'connectionEpoch');
+      }
+    };
+    return Object.freeze(adapter);
+  }
+
+  return {create: create};
+});

--- a/plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js
@@ -1,0 +1,66 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory(
+      require('./physical_capability_contract.js'),
+      require('./semantic_ast.js')
+    );
+  else
+    root.WebeeBlocksPhysicalSubmissionBridge = factory(
+      root.WebeeBlocksPhysicalCapabilityContract,
+      root.WebeeBlocksSemanticAst
+    );
+})(typeof self !== 'undefined' ? self : this, function(PhysicalCapabilities, SemanticAst) {
+  'use strict';
+
+  function fail(message) {
+    throw new Error('physical submission bridge: ' + message);
+  }
+
+  function create(profile, adapter, compileWorkspace) {
+    if (!profile || !Array.isArray(profile.hardware))
+      fail('activity profile is required');
+    if (!PhysicalCapabilities || typeof PhysicalCapabilities.preflightConnected !== 'function' ||
+        typeof PhysicalCapabilities.assertPreflightConnected !== 'function')
+      fail('physical capability contract is unavailable');
+    compileWorkspace = compileWorkspace || (SemanticAst && SemanticAst.compileWorkspace);
+    if (typeof compileWorkspace !== 'function')
+      fail('semantic AST compiler is unavailable');
+
+    var bound = null;
+
+    async function preflightWorkspace(workspace) {
+      var ast = compileWorkspace(workspace);
+      var result = await PhysicalCapabilities.preflightConnected(profile, ast, adapter);
+      bound = {astBinding: result.astBinding, result: result};
+      return result;
+    }
+
+    async function assertCurrentWorkspace(workspace) {
+      if (!bound)
+        fail('physical preflight is required before re-assertion');
+      var ast = compileWorkspace(workspace);
+      if (PhysicalCapabilities.bindAst(ast) !== bound.astBinding)
+        fail('workspace changed since physical preflight');
+      await PhysicalCapabilities.assertPreflightConnected(bound.result, ast, adapter);
+      return {
+        compatible: true,
+        executionAuthority: false,
+        ast: ast,
+        preflight: bound.result
+      };
+    }
+
+    function clear() {
+      bound = null;
+    }
+
+    return Object.freeze({
+      executionAuthority: false,
+      preflightWorkspace: preflightWorkspace,
+      assertCurrentWorkspace: assertCurrentWorkspace,
+      clear: clear
+    });
+  }
+
+  return {create: create};
+});

--- a/plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js
@@ -16,6 +16,15 @@
     throw new Error('physical submission bridge: ' + message);
   }
 
+  function immutableTicket(result) {
+    return Object.freeze({
+      compatible: result.compatible,
+      executionAuthority: result.executionAuthority,
+      astBinding: result.astBinding,
+      connectionEpoch: result.connectionEpoch
+    });
+  }
+
   function create(profile, adapter, compileWorkspace) {
     if (!profile || !Array.isArray(profile.hardware))
       fail('activity profile is required');
@@ -31,7 +40,7 @@
     async function preflightWorkspace(workspace) {
       var ast = compileWorkspace(workspace);
       var result = await PhysicalCapabilities.preflightConnected(profile, ast, adapter);
-      bound = {astBinding: result.astBinding, result: result};
+      bound = immutableTicket(result);
       return result;
     }
 
@@ -41,12 +50,12 @@
       var ast = compileWorkspace(workspace);
       if (PhysicalCapabilities.bindAst(ast) !== bound.astBinding)
         fail('workspace changed since physical preflight');
-      await PhysicalCapabilities.assertPreflightConnected(bound.result, ast, adapter);
+      await PhysicalCapabilities.assertPreflightConnected(bound, ast, adapter);
       return {
         compatible: true,
         executionAuthority: false,
         ast: ast,
-        preflight: bound.result
+        preflight: bound
       };
     }
 

--- a/plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js
@@ -47,15 +47,23 @@
     async function assertCurrentWorkspace(workspace) {
       if (!bound)
         fail('physical preflight is required before re-assertion');
+      var ticket = bound;
       var ast = compileWorkspace(workspace);
-      if (PhysicalCapabilities.bindAst(ast) !== bound.astBinding)
+      if (PhysicalCapabilities.bindAst(ast) !== ticket.astBinding) {
+        bound = null;
         fail('workspace changed since physical preflight');
-      await PhysicalCapabilities.assertPreflightConnected(bound, ast, adapter);
+      }
+      await PhysicalCapabilities.assertPreflightConnected(ticket, ast, adapter);
+      var currentAst = compileWorkspace(workspace);
+      if (PhysicalCapabilities.bindAst(currentAst) !== ticket.astBinding) {
+        bound = null;
+        fail('workspace changed during physical re-assertion');
+      }
       return {
         compatible: true,
         executionAuthority: false,
-        ast: ast,
-        preflight: bound
+        ast: currentAst,
+        preflight: ticket
       };
     }
 

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -64,6 +64,7 @@
     </nav>
   </main>
   <script src="main.js"></script>
+  <script src="physical_preflight_runtime.js"></script>
   <script src="classroom_fixes.js"></script>
   <script src="project_ui.js?rev=20260830-1"></script>
 </body>

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -15,6 +15,9 @@
   <script src="../blockly/webeeblocks/activity_profiles.js"></script>
   <script src="../blockly/webeeblocks/activities.js"></script>
   <script src="../blockly/webeeblocks/semantic_ast.js"></script>
+  <script src="../blockly/webeeblocks/physical_capability_contract.js"></script>
+  <script src="../blockly/webeeblocks/physical_capability_http_adapter.js"></script>
+  <script src="../blockly/webeeblocks/physical_submission_bridge.js"></script>
   <script src="../blockly/webeeblocks/interpreter.js"></script>
   <script src="../blockly/webeeblocks/execution_observer.js"></script>
   <script src="../blockly/webeeblocks/runtime_outcome.js"></script>

--- a/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
+++ b/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
@@ -77,13 +77,36 @@
     requireProductState();
     if (!bridge || boundProfile === null)
       fail('physical preflight is required before re-assertion');
-    if (profileBinding(root.runtimeProfile) !== boundProfile) {
-      bridge.clear();
+    var activeBridge = bridge;
+    var expectedProfileBinding = boundProfile;
+    if (profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+      activeBridge.clear();
       bridge = null;
       boundProfile = null;
       fail('activity profile changed since physical preflight');
     }
-    return bridge.assertCurrentWorkspace(root.workspace);
+    var result;
+    try {
+      result = await activeBridge.assertCurrentWorkspace(root.workspace);
+    } catch (error) {
+      if (bridge === activeBridge &&
+          profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+        activeBridge.clear();
+        bridge = null;
+        boundProfile = null;
+      }
+      throw error;
+    }
+    if (bridge !== activeBridge || boundProfile !== expectedProfileBinding ||
+        profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+      activeBridge.clear();
+      if (bridge === activeBridge) {
+        bridge = null;
+        boundProfile = null;
+      }
+      fail('activity profile changed during physical re-assertion');
+    }
+    return result;
   }
 
   function clear() {

--- a/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
+++ b/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
@@ -7,6 +7,23 @@
 
   var adapter = null;
   var bridge = null;
+  var boundProfile = null;
+
+  function profileBinding(profile) {
+    if (!profile || typeof profile.id !== 'string' || profile.id.trim() === '' ||
+        !Array.isArray(profile.hardware))
+      fail('current activity profile is unavailable');
+    if (profile.physicalHardwareRequired !== undefined &&
+        !Array.isArray(profile.physicalHardwareRequired))
+      fail('current activity physical hardware requirements are malformed');
+    return JSON.stringify({
+      id: profile.id,
+      hardware: profile.hardware.slice(),
+      physicalHardwareRequired: profile.physicalHardwareRequired === undefined
+        ? null
+        : profile.physicalHardwareRequired.slice()
+    });
+  }
 
   function requireProductState() {
     if (!root.WebeeBlocksPhysicalCapabilityHttpAdapter ||
@@ -27,6 +44,7 @@
     if (bridge && typeof bridge.clear === 'function')
       bridge.clear();
     bridge = null;
+    boundProfile = null;
     adapter = root.WebeeBlocksPhysicalCapabilityHttpAdapter.create(options || {});
     return true;
   }
@@ -35,18 +53,36 @@
     requireProductState();
     if (!adapter)
       fail('live capability session is not configured');
-    bridge = root.WebeeBlocksPhysicalSubmissionBridge.create(
-      root.runtimeProfile,
+    var profile = root.runtimeProfile;
+    var expectedProfileBinding = profileBinding(profile);
+    var activeBridge = root.WebeeBlocksPhysicalSubmissionBridge.create(
+      profile,
       adapter,
       root.WebeeBlocksSemanticAst.compileWorkspace
     );
-    return bridge.preflightWorkspace(root.workspace);
+    bridge = activeBridge;
+    boundProfile = null;
+    var result = await activeBridge.preflightWorkspace(root.workspace);
+    if (bridge !== activeBridge || profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+      activeBridge.clear();
+      if (bridge === activeBridge)
+        bridge = null;
+      fail('activity profile changed during physical preflight');
+    }
+    boundProfile = expectedProfileBinding;
+    return result;
   }
 
   async function assertCurrentProgram() {
     requireProductState();
-    if (!bridge)
+    if (!bridge || boundProfile === null)
       fail('physical preflight is required before re-assertion');
+    if (profileBinding(root.runtimeProfile) !== boundProfile) {
+      bridge.clear();
+      bridge = null;
+      boundProfile = null;
+      fail('activity profile changed since physical preflight');
+    }
     return bridge.assertCurrentWorkspace(root.workspace);
   }
 
@@ -54,6 +90,7 @@
     if (bridge && typeof bridge.clear === 'function')
       bridge.clear();
     bridge = null;
+    boundProfile = null;
     adapter = null;
   }
 

--- a/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
+++ b/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
@@ -1,0 +1,67 @@
+(function(root) {
+  'use strict';
+
+  function fail(message) {
+    throw new Error('physical preflight runtime: ' + message);
+  }
+
+  var adapter = null;
+  var bridge = null;
+
+  function requireProductState() {
+    if (!root.WebeeBlocksPhysicalCapabilityHttpAdapter ||
+        typeof root.WebeeBlocksPhysicalCapabilityHttpAdapter.create !== 'function')
+      fail('live capability adapter is unavailable');
+    if (!root.WebeeBlocksPhysicalSubmissionBridge ||
+        typeof root.WebeeBlocksPhysicalSubmissionBridge.create !== 'function')
+      fail('physical submission bridge is unavailable');
+    if (!root.WebeeBlocksSemanticAst || typeof root.WebeeBlocksSemanticAst.compileWorkspace !== 'function')
+      fail('semantic AST compiler is unavailable');
+    if (!root.runtimeProfile || !Array.isArray(root.runtimeProfile.hardware))
+      fail('current activity profile is unavailable');
+    if (!root.workspace)
+      fail('current Blockly workspace is unavailable');
+  }
+
+  function configure(options) {
+    if (bridge && typeof bridge.clear === 'function')
+      bridge.clear();
+    bridge = null;
+    adapter = root.WebeeBlocksPhysicalCapabilityHttpAdapter.create(options || {});
+    return true;
+  }
+
+  async function preflightCurrentProgram() {
+    requireProductState();
+    if (!adapter)
+      fail('live capability session is not configured');
+    bridge = root.WebeeBlocksPhysicalSubmissionBridge.create(
+      root.runtimeProfile,
+      adapter,
+      root.WebeeBlocksSemanticAst.compileWorkspace
+    );
+    return bridge.preflightWorkspace(root.workspace);
+  }
+
+  async function assertCurrentProgram() {
+    requireProductState();
+    if (!bridge)
+      fail('physical preflight is required before re-assertion');
+    return bridge.assertCurrentWorkspace(root.workspace);
+  }
+
+  function clear() {
+    if (bridge && typeof bridge.clear === 'function')
+      bridge.clear();
+    bridge = null;
+    adapter = null;
+  }
+
+  root.WebeeBlocksPhysicalPreflight = Object.freeze({
+    executionAuthority: false,
+    configure: configure,
+    preflightCurrentProgram: preflightCurrentProgram,
+    assertCurrentProgram: assertCurrentProgram,
+    clear: clear
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -49,6 +49,14 @@ def main():
     if physical_probe_test.returncode:
         print('FAIL read-only Crazyradio capability evidence',file=sys.stderr);print(physical_probe_test.stdout,file=sys.stderr);print(physical_probe_test.stderr,file=sys.stderr);return physical_probe_test.returncode
     print(physical_probe_test.stdout.strip())
+    physical_http_test=subprocess.run([sys.executable,'tools/ci/test_physical_capability_http_bridge.py'],text=True,capture_output=True)
+    if physical_http_test.returncode:
+        print('FAIL read-only physical capability HTTP bridge',file=sys.stderr);print(physical_http_test.stdout,file=sys.stderr);print(physical_http_test.stderr,file=sys.stderr);return physical_http_test.returncode
+    print(physical_http_test.stdout.strip())
+    physical_submission_test=subprocess.run(['node','tools/ci/test_physical_submission_bridge.js'],text=True,capture_output=True)
+    if physical_submission_test.returncode:
+        print('FAIL session-bound physical submission bridge',file=sys.stderr);print(physical_submission_test.stdout,file=sys.stderr);print(physical_submission_test.stderr,file=sys.stderr);return physical_submission_test.returncode
+    print(physical_submission_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_capability_http_bridge.py
+++ b/tools/ci/test_physical_capability_http_bridge.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from threading import Thread
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(PHYSICAL))
+BRIDGE_PATH = PHYSICAL / "serve_reference_capabilities.py"
+spec = importlib.util.spec_from_file_location("serve_reference_capabilities", BRIDGE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load capability HTTP bridge")
+bridge_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bridge_module)
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.epoch = "connection-one"
+        self.capability_reads = 0
+        self.epoch_reads = 0
+
+    def read_connection_epoch(self) -> str:
+        self.epoch_reads += 1
+        return self.epoch
+
+    def read_capabilities(self) -> dict[str, object]:
+        self.capability_reads += 1
+        return {
+            "transport": "crazyradio",
+            "connected": True,
+            "executionAuthority": False,
+            "identity": {
+                "family": "crazyflie",
+                "model": "crazyflie-2.1",
+                "modelEvidence": "verified",
+            },
+            "hardware": ["flow-deck-v2"],
+            "capabilities": {
+                "actions": ["takeoff", "move", "land"],
+                "rangeDirections": [],
+                "moveDirections": ["forward"],
+                "verticalDirections": [],
+            },
+        }
+
+
+def request_json(url: str, token: str | None = None, method: str = "GET") -> tuple[int, object]:
+    headers = {} if token is None else {"Authorization": f"Bearer {token}"}
+    request = Request(url, method=method, headers=headers)
+    try:
+        with urlopen(request, timeout=2) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def main() -> int:
+    fake = FakeSession()
+    token = "test-bridge-token"
+    bridge = bridge_module.ReadOnlyCapabilityHttpBridge(fake, token=token)
+    host, port = bridge.address
+    thread = Thread(target=bridge.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://{host}:{port}"
+    try:
+        status, payload = request_json(base + "/v1/connection-epoch", token)
+        assert status == 200 and payload == {"connectionEpoch": "connection-one"}
+        status, payload = request_json(base + "/v1/capabilities", token)
+        assert status == 200
+        assert payload["executionAuthority"] is False
+        assert payload["hardware"] == ["flow-deck-v2"]
+        assert fake.epoch_reads == 1 and fake.capability_reads == 1
+
+        status, payload = request_json(base + "/v1/capabilities")
+        assert status == 401 and payload == {"error": "unauthorized"}
+        assert fake.capability_reads == 1, "unauthorized read must not touch the live session"
+
+        status, payload = request_json(base + "/v1/connection-epoch", token, method="POST")
+        assert status == 405 and payload == {"error": "read-only bridge"}
+        assert fake.epoch_reads == 1, "effect-shaped methods must never reach the live session"
+
+        fake.epoch = "connection-two"
+        status, payload = request_json(base + "/v1/connection-epoch", token)
+        assert status == 200 and payload == {"connectionEpoch": "connection-two"}
+    finally:
+        bridge.shutdown()
+        thread.join(timeout=2)
+
+    try:
+        bridge_module.ReadOnlyCapabilityHttpBridge(fake, host="0.0.0.0")
+    except bridge_module.CapabilityBridgeError as exc:
+        assert "loopback" in str(exc)
+    else:
+        raise AssertionError("non-loopback bind must fail closed")
+
+    forbidden = (
+        "takeoff", "land", "move", "vertical", "turn", "set_light", "arm",
+        "disarm", "setpoint", "send_setpoint", "thrust",
+    )
+    for name in forbidden:
+        assert not hasattr(bridge, name), f"HTTP bridge exposes authority method: {name}"
+
+    print("PASS loopback capability bridge exposes authenticated reads only and no physical authority")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_capability_http_bridge.py
+++ b/tools/ci/test_physical_capability_http_bridge.py
@@ -51,14 +51,18 @@ class FakeSession:
         }
 
 
-def request_json(url: str, token: str | None = None, method: str = "GET") -> tuple[int, object]:
+def request(url: str, token: str | None = None, method: str = "GET") -> tuple[int, object | None, object]:
     headers = {} if token is None else {"Authorization": f"Bearer {token}"}
-    request = Request(url, method=method, headers=headers)
+    req = Request(url, method=method, headers=headers)
     try:
-        with urlopen(request, timeout=2) as response:
-            return response.status, json.loads(response.read().decode("utf-8"))
+        with urlopen(req, timeout=2) as response:
+            raw = response.read()
+            payload = json.loads(raw.decode("utf-8")) if raw else None
+            return response.status, payload, response.headers
     except HTTPError as exc:
-        return exc.code, json.loads(exc.read().decode("utf-8"))
+        raw = exc.read()
+        payload = json.loads(raw.decode("utf-8")) if raw else None
+        return exc.code, payload, exc.headers
 
 
 def main() -> int:
@@ -70,35 +74,46 @@ def main() -> int:
     thread.start()
     base = f"http://{host}:{port}"
     try:
-        status, payload = request_json(base + "/v1/connection-epoch", token)
+        status, payload, headers = request(base + "/v1/connection-epoch", token)
         assert status == 200 and payload == {"connectionEpoch": "connection-one"}
-        status, payload = request_json(base + "/v1/capabilities", token)
+        assert headers["Access-Control-Allow-Origin"] == "*"
+        assert headers["Cache-Control"] == "no-store"
+
+        status, payload, _ = request(base + "/v1/capabilities", token)
         assert status == 200
         assert payload["executionAuthority"] is False
         assert payload["hardware"] == ["flow-deck-v2"]
         assert fake.epoch_reads == 1 and fake.capability_reads == 1
 
-        status, payload = request_json(base + "/v1/capabilities")
+        status, payload, cors = request(base + "/v1/capabilities", method="OPTIONS")
+        assert status == 204 and payload is None
+        assert cors["Access-Control-Allow-Origin"] == "*"
+        assert cors["Access-Control-Allow-Methods"] == "GET, OPTIONS"
+        assert "Authorization" in cors["Access-Control-Allow-Headers"]
+        assert fake.epoch_reads == 1 and fake.capability_reads == 1, "CORS preflight must not touch live session"
+
+        status, payload, _ = request(base + "/v1/capabilities")
         assert status == 401 and payload == {"error": "unauthorized"}
         assert fake.capability_reads == 1, "unauthorized read must not touch the live session"
 
-        status, payload = request_json(base + "/v1/connection-epoch", token, method="POST")
+        status, payload, _ = request(base + "/v1/connection-epoch", token, method="POST")
         assert status == 405 and payload == {"error": "read-only bridge"}
         assert fake.epoch_reads == 1, "effect-shaped methods must never reach the live session"
 
         fake.epoch = "connection-two"
-        status, payload = request_json(base + "/v1/connection-epoch", token)
+        status, payload, _ = request(base + "/v1/connection-epoch", token)
         assert status == 200 and payload == {"connectionEpoch": "connection-two"}
     finally:
         bridge.shutdown()
         thread.join(timeout=2)
 
-    try:
-        bridge_module.ReadOnlyCapabilityHttpBridge(fake, host="0.0.0.0")
-    except bridge_module.CapabilityBridgeError as exc:
-        assert "loopback" in str(exc)
-    else:
-        raise AssertionError("non-loopback bind must fail closed")
+    for forbidden_host in ("0.0.0.0", "::1"):
+        try:
+            bridge_module.ReadOnlyCapabilityHttpBridge(fake, host=forbidden_host)
+        except bridge_module.CapabilityBridgeError as exc:
+            assert "loopback" in str(exc)
+        else:
+            raise AssertionError(f"unsupported bind {forbidden_host} must fail closed")
 
     forbidden = (
         "takeoff", "land", "move", "vertical", "turn", "set_light", "arm",
@@ -107,7 +122,7 @@ def main() -> int:
     for name in forbidden:
         assert not hasattr(bridge, name), f"HTTP bridge exposes authority method: {name}"
 
-    print("PASS loopback capability bridge exposes authenticated reads only and no physical authority")
+    print("PASS loopback capability bridge supports browser reads with authentication and no physical authority")
     return 0
 
 

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const assert = require('assert');
+const HttpAdapter = require('../../plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js');
+const SubmissionBridge = require('../../plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js');
+const Profiles = require('../../plugins/robot_windows/blockly/webeeblocks/activity_profiles.js');
+const Activities = require('../../plugins/robot_windows/blockly/webeeblocks/activities.js');
+
+const profile = Profiles.resolveById(
+  Activities.DOCUMENT,
+  'reactive-obstacle-v2',
+  Activities.BLOCK_CATALOG
+);
+
+const descriptor = {
+  transport: 'crazyradio',
+  connected: true,
+  executionAuthority: false,
+  identity: {family: 'crazyflie', model: 'crazyflie-2.1', modelEvidence: 'verified'},
+  hardware: ['flow-deck-v2'],
+  capabilities: {
+    actions: ['takeoff', 'move', 'land'],
+    rangeDirections: [],
+    moveDirections: ['forward'],
+    verticalDirections: []
+  }
+};
+
+function program(distance) {
+  return {
+    version: 1,
+    semantics: 'webeeblocks-ast-v1',
+    program: [
+      {kind: 'takeoff', height_m: 0.8},
+      {kind: 'move', direction: 'forward', distance_m: distance},
+      {kind: 'land'}
+    ]
+  };
+}
+
+(async function() {
+  let epoch = 'connection-1';
+  let currentAst = program(0.2);
+  let capabilityReads = 0;
+  let epochReads = 0;
+  const token = 'unit-test-secret';
+
+  async function fakeFetch(url, options) {
+    assert.strictEqual(options.method, 'GET');
+    assert.strictEqual(options.headers.Authorization, 'Bearer ' + token);
+    if (url.endsWith('/v1/capabilities')) {
+      capabilityReads += 1;
+      return {ok: true, status: 200, async json() { return JSON.parse(JSON.stringify(descriptor)); }};
+    }
+    if (url.endsWith('/v1/connection-epoch')) {
+      epochReads += 1;
+      return {ok: true, status: 200, async json() { return {connectionEpoch: epoch}; }};
+    }
+    return {ok: false, status: 404, async json() { return {error: 'not-found'}; }};
+  }
+
+  const adapter = HttpAdapter.create({
+    baseUrl: 'http://127.0.0.1:8765/',
+    token: token,
+    fetchImpl: fakeFetch
+  });
+  assert.deepStrictEqual(Object.keys(adapter).sort(), ['readCapabilities', 'readConnectionEpoch']);
+  assert.strictEqual(Object.isFrozen(adapter), true);
+
+  const bridge = SubmissionBridge.create(profile, adapter, () => JSON.parse(JSON.stringify(currentAst)));
+  assert.strictEqual(bridge.executionAuthority, false);
+  for (const forbidden of ['takeoff','land','move','vertical','turn','setLight','arm','setpoint','sendSetpoint','thrust'])
+    assert.strictEqual(typeof bridge[forbidden], 'undefined', 'bridge exposes authority method: ' + forbidden);
+
+  const result = await bridge.preflightWorkspace({});
+  assert.strictEqual(result.compatible, true);
+  assert.strictEqual(result.executionAuthority, false);
+  assert.strictEqual(result.connectionEpoch, 'connection-1');
+  assert.strictEqual(capabilityReads, 1);
+  assert.strictEqual(epochReads, 2, 'preflight must bracket the descriptor with one stable epoch');
+
+  const asserted = await bridge.assertCurrentWorkspace({});
+  assert.strictEqual(asserted.compatible, true);
+  assert.strictEqual(asserted.executionAuthority, false);
+  assert.strictEqual(asserted.preflight.astBinding, result.astBinding);
+  assert.strictEqual(epochReads, 3, 'pre-effect reassertion must re-read the current epoch');
+
+  currentAst = program(0.3);
+  await assert.rejects(
+    () => bridge.assertCurrentWorkspace({}),
+    /workspace changed since physical preflight/,
+    'changed program must invalidate the stored exact-AST binding'
+  );
+
+  currentAst = program(0.2);
+  epoch = 'connection-2';
+  await assert.rejects(
+    () => bridge.assertCurrentWorkspace({}),
+    /connection changed since physical preflight/,
+    'reconnect must invalidate the stored session binding'
+  );
+
+  bridge.clear();
+  await assert.rejects(
+    () => bridge.assertCurrentWorkspace({}),
+    /physical preflight is required/,
+    'cleared binding must fail closed'
+  );
+
+  const failingAdapter = HttpAdapter.create({
+    baseUrl: 'http://127.0.0.1:8765',
+    token: token,
+    fetchImpl: async () => ({ok: false, status: 401, async json() { return {error: 'unauthorized'}; }})
+  });
+  await assert.rejects(
+    () => failingAdapter.readCapabilities(),
+    /bridge read failed \(401\): unauthorized/
+  );
+
+  console.log('PASS non-authority physical submission bridge preserves exact AST and live connection epoch');
+})().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const HttpAdapter = require('../../plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js');
 const SubmissionBridge = require('../../plugins/robot_windows/blockly/webeeblocks/physical_submission_bridge.js');
 const Profiles = require('../../plugins/robot_windows/blockly/webeeblocks/activity_profiles.js');
@@ -79,10 +81,13 @@ function program(distance) {
   assert.strictEqual(capabilityReads, 1);
   assert.strictEqual(epochReads, 2, 'preflight must bracket the descriptor with one stable epoch');
 
+  result.connectionEpoch = 'caller-tampered-epoch';
   const asserted = await bridge.assertCurrentWorkspace({});
   assert.strictEqual(asserted.compatible, true);
   assert.strictEqual(asserted.executionAuthority, false);
-  assert.strictEqual(asserted.preflight.astBinding, result.astBinding);
+  assert.notStrictEqual(asserted.preflight, result, 'internal exact-session ticket must not alias caller-owned result');
+  assert.strictEqual(asserted.preflight.connectionEpoch, 'connection-1');
+  assert.strictEqual(Object.isFrozen(asserted.preflight), true);
   assert.strictEqual(epochReads, 3, 'pre-effect reassertion must re-read the current epoch');
 
   currentAst = program(0.3);
@@ -117,7 +122,47 @@ function program(distance) {
     /bridge read failed \(401\): unauthorized/
   );
 
-  console.log('PASS non-authority physical submission bridge preserves exact AST and live connection epoch');
+  const productHtml = fs.readFileSync(path.join(__dirname, '../../plugins/robot_windows/blockly_v2/blockly_v2.html'), 'utf8');
+  for (const script of [
+    'physical_capability_contract.js',
+    'physical_capability_http_adapter.js',
+    'physical_submission_bridge.js',
+    'physical_preflight_runtime.js'
+  ])
+    assert(productHtml.includes(script), 'student runtime must load ' + script);
+  assert(productHtml.indexOf('main.js') < productHtml.indexOf('physical_preflight_runtime.js'),
+    'physical runtime bridge must bind after main student runtime globals exist');
+
+  global.WebeeBlocksPhysicalCapabilityHttpAdapter = HttpAdapter;
+  global.WebeeBlocksPhysicalSubmissionBridge = SubmissionBridge;
+  global.WebeeBlocksSemanticAst = {compileWorkspace: () => JSON.parse(JSON.stringify(currentAst))};
+  global.runtimeProfile = profile;
+  global.workspace = {};
+  delete require.cache[require.resolve('../../plugins/robot_windows/blockly_v2/physical_preflight_runtime.js')];
+  require('../../plugins/robot_windows/blockly_v2/physical_preflight_runtime.js');
+  const productBridge = global.WebeeBlocksPhysicalPreflight;
+  assert.strictEqual(productBridge.executionAuthority, false);
+  for (const forbidden of ['takeoff','land','move','vertical','turn','setLight','arm','setpoint','sendSetpoint','thrust'])
+    assert.strictEqual(typeof productBridge[forbidden], 'undefined', 'product bridge exposes authority method: ' + forbidden);
+
+  epoch = 'connection-product';
+  currentAst = program(0.2);
+  productBridge.configure({baseUrl: 'http://127.0.0.1:8765', token: token, fetchImpl: fakeFetch});
+  const productPreflight = await productBridge.preflightCurrentProgram();
+  assert.strictEqual(productPreflight.connectionEpoch, 'connection-product');
+  const productAssertion = await productBridge.assertCurrentProgram();
+  assert.strictEqual(productAssertion.executionAuthority, false);
+  assert.strictEqual(productAssertion.preflight.connectionEpoch, 'connection-product');
+
+  currentAst = program(0.4);
+  await assert.rejects(
+    () => productBridge.assertCurrentProgram(),
+    /workspace changed since physical preflight/,
+    'live student workspace mutation must invalidate production physical binding'
+  );
+  productBridge.clear();
+
+  console.log('PASS non-authority physical submission bridge binds the live student AST to one Crazyradio connection epoch');
 })().catch(error => {
   console.error(error);
   process.exit(1);

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -154,6 +154,25 @@ function program(distance) {
   assert.strictEqual(productAssertion.executionAuthority, false);
   assert.strictEqual(productAssertion.preflight.connectionEpoch, 'connection-product');
 
+  const preflightProfile = global.runtimeProfile;
+  global.runtimeProfile = Profiles.resolveById(
+    Activities.DOCUMENT,
+    'progression-precise-movement-v1',
+    Activities.BLOCK_CATALOG
+  );
+  await assert.rejects(
+    () => productBridge.assertCurrentProgram(),
+    /activity profile changed since physical preflight/,
+    'profile change with identical AST and connection epoch must invalidate physical preflight'
+  );
+  global.runtimeProfile = preflightProfile;
+  await assert.rejects(
+    () => productBridge.assertCurrentProgram(),
+    /physical preflight is required/,
+    'profile mismatch must clear the prior physical preflight binding'
+  );
+  await productBridge.preflightCurrentProgram();
+
   currentAst = program(0.4);
   await assert.rejects(
     () => productBridge.assertCurrentProgram(),

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -116,6 +116,12 @@ function program(distance) {
   );
 
   currentAst = program(0.2);
+  await assert.rejects(
+    () => bridge.assertCurrentWorkspace({}),
+    /physical preflight is required/,
+    'workspace mismatch must clear the stored exact-AST binding'
+  );
+  await bridge.preflightWorkspace({});
   epoch = 'connection-2';
   await assert.rejects(
     () => bridge.assertCurrentWorkspace({}),

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -45,7 +45,20 @@ function program(distance) {
   let currentAst = program(0.2);
   let capabilityReads = 0;
   let epochReads = 0;
+  let epochReadHook = null;
   const token = 'unit-test-secret';
+
+  function delayNextEpochRead() {
+    let startedResolve;
+    let releaseResolve;
+    const started = new Promise(resolve => { startedResolve = resolve; });
+    const released = new Promise(resolve => { releaseResolve = resolve; });
+    epochReadHook = async function() {
+      startedResolve();
+      await released;
+    };
+    return {started: started, release: releaseResolve};
+  }
 
   async function fakeFetch(url, options) {
     assert.strictEqual(options.method, 'GET');
@@ -56,6 +69,11 @@ function program(distance) {
     }
     if (url.endsWith('/v1/connection-epoch')) {
       epochReads += 1;
+      if (epochReadHook) {
+        const hook = epochReadHook;
+        epochReadHook = null;
+        await hook();
+      }
       return {ok: true, status: 200, async json() { return {connectionEpoch: epoch}; }};
     }
     return {ok: false, status: 404, async json() { return {error: 'not-found'}; }};
@@ -154,22 +172,44 @@ function program(distance) {
   assert.strictEqual(productAssertion.executionAuthority, false);
   assert.strictEqual(productAssertion.preflight.connectionEpoch, 'connection-product');
 
+  const workspaceDelay = delayNextEpochRead();
+  const pendingWorkspaceAssertion = productBridge.assertCurrentProgram();
+  await workspaceDelay.started;
+  currentAst = program(0.3);
+  workspaceDelay.release();
+  await assert.rejects(
+    pendingWorkspaceAssertion,
+    /workspace changed during physical re-assertion/,
+    'workspace mutation while epoch re-assertion is pending must fail closed'
+  );
+  currentAst = program(0.2);
+  await assert.rejects(
+    () => productBridge.assertCurrentProgram(),
+    /physical preflight is required/,
+    'async workspace mismatch must invalidate the prior physical preflight'
+  );
+  await productBridge.preflightCurrentProgram();
+
   const preflightProfile = global.runtimeProfile;
+  const profileDelay = delayNextEpochRead();
+  const pendingProfileAssertion = productBridge.assertCurrentProgram();
+  await profileDelay.started;
   global.runtimeProfile = Profiles.resolveById(
     Activities.DOCUMENT,
     'progression-precise-movement-v1',
     Activities.BLOCK_CATALOG
   );
+  profileDelay.release();
   await assert.rejects(
-    () => productBridge.assertCurrentProgram(),
-    /activity profile changed since physical preflight/,
-    'profile change with identical AST and connection epoch must invalidate physical preflight'
+    pendingProfileAssertion,
+    /activity profile changed during physical re-assertion/,
+    'profile mutation while epoch re-assertion is pending must fail closed'
   );
   global.runtimeProfile = preflightProfile;
   await assert.rejects(
     () => productBridge.assertCurrentProgram(),
     /physical preflight is required/,
-    'profile mismatch must clear the prior physical preflight binding'
+    'async profile mismatch must invalidate the prior physical preflight'
   );
   await productBridge.preflightCurrentProgram();
 

--- a/tools/physical/serve_reference_capabilities.py
+++ b/tools/physical/serve_reference_capabilities.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Loopback-only, non-authority bridge to one live Crazyflie capability session.
+
+The service intentionally exposes only the two reads required by
+physical_capability_contract.js: the current connection epoch and a fresh
+capability descriptor. It owns no arming, setpoint, movement, light or other
+physical effect API.
+"""
+
+from __future__ import annotations
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import secrets
+from typing import Callable
+
+from probe_reference_hardware import ProbeError, ReadOnlyCapabilitySession
+
+
+class CapabilityBridgeError(RuntimeError):
+    """Fail-closed request/bridge error."""
+
+
+class ReadOnlyCapabilityHttpBridge:
+    def __init__(
+        self,
+        session: ReadOnlyCapabilitySession,
+        *,
+        token: str | None = None,
+        host: str = "127.0.0.1",
+        port: int = 0,
+    ) -> None:
+        if host not in {"127.0.0.1", "::1", "localhost"}:
+            raise CapabilityBridgeError("capability bridge must bind to loopback")
+        self.session = session
+        self.token = token or secrets.token_urlsafe(32)
+        if not isinstance(self.token, str) or not self.token.strip():
+            raise CapabilityBridgeError("capability bridge token must be non-empty")
+        self._server = ThreadingHTTPServer((host, port), self._handler_type())
+
+    def _handler_type(self):
+        bridge = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args) -> None:
+                return
+
+            def _json(self, status: int, payload: object) -> None:
+                data = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(data)
+
+            def _authorized(self) -> bool:
+                return self.headers.get("Authorization") == f"Bearer {bridge.token}"
+
+            def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+                if not self._authorized():
+                    self._json(401, {"error": "unauthorized"})
+                    return
+                try:
+                    if self.path == "/v1/connection-epoch":
+                        self._json(200, {"connectionEpoch": bridge.session.read_connection_epoch()})
+                    elif self.path == "/v1/capabilities":
+                        self._json(200, bridge.session.read_capabilities())
+                    else:
+                        self._json(404, {"error": "not-found"})
+                except ProbeError as exc:
+                    self._json(409, {"error": str(exc)})
+
+            def do_POST(self) -> None:  # noqa: N802 - fail closed on effects
+                self._json(405, {"error": "read-only bridge"})
+
+            def do_PUT(self) -> None:  # noqa: N802
+                self._json(405, {"error": "read-only bridge"})
+
+            def do_DELETE(self) -> None:  # noqa: N802
+                self._json(405, {"error": "read-only bridge"})
+
+        return Handler
+
+    @property
+    def address(self) -> tuple[str, int]:
+        host, port = self._server.server_address[:2]
+        return str(host), int(port)
+
+    def serve_forever(self) -> None:
+        self._server.serve_forever()
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--uri", required=True, help="explicit radio:// Crazyradio URI")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    args = parser.parse_args()
+
+    with ReadOnlyCapabilitySession(args.uri) as session:
+        bridge = ReadOnlyCapabilityHttpBridge(session, host=args.host, port=args.port)
+        host, port = bridge.address
+        print(json.dumps({
+            "baseUrl": f"http://{host}:{port}",
+            "token": bridge.token,
+            "executionAuthority": False,
+        }, separators=(",", ":")), flush=True)
+        try:
+            bridge.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            bridge.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/serve_reference_capabilities.py
+++ b/tools/physical/serve_reference_capabilities.py
@@ -13,7 +13,6 @@ import argparse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import secrets
-from typing import Callable
 
 from probe_reference_hardware import ProbeError, ReadOnlyCapabilitySession
 
@@ -31,8 +30,8 @@ class ReadOnlyCapabilityHttpBridge:
         host: str = "127.0.0.1",
         port: int = 0,
     ) -> None:
-        if host not in {"127.0.0.1", "::1", "localhost"}:
-            raise CapabilityBridgeError("capability bridge must bind to loopback")
+        if host not in {"127.0.0.1", "localhost"}:
+            raise CapabilityBridgeError("capability bridge must bind to IPv4 loopback")
         self.session = session
         self.token = token or secrets.token_urlsafe(32)
         if not isinstance(self.token, str) or not self.token.strip():
@@ -46,17 +45,32 @@ class ReadOnlyCapabilityHttpBridge:
             def log_message(self, _format: str, *_args) -> None:
                 return
 
+            def _cors(self) -> None:
+                # The service is loopback-only and every data read still requires
+                # the unguessable bearer capability. No cookies/credentials are used.
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "Authorization, Cache-Control")
+
             def _json(self, status: int, payload: object) -> None:
                 data = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
                 self.send_response(status)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(data)))
                 self.send_header("Cache-Control", "no-store")
+                self._cors()
                 self.end_headers()
                 self.wfile.write(data)
 
             def _authorized(self) -> bool:
                 return self.headers.get("Authorization") == f"Bearer {bridge.token}"
+
+            def do_OPTIONS(self) -> None:  # noqa: N802 - browser CORS preflight only
+                self.send_response(204)
+                self.send_header("Content-Length", "0")
+                self.send_header("Cache-Control", "no-store")
+                self._cors()
+                self.end_headers()
 
             def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
                 if not self._authorized():


### PR DESCRIPTION
Advances #157 with the smallest non-authority bridge between the backend-neutral physical preflight contract and the integrated live Crazyradio capability session.

- adds a loopback-only authenticated HTTP surface over `ReadOnlyCapabilitySession` exposing only fresh capabilities and the reconnect-sensitive epoch;
- adds a browser-side adapter implementing only `readCapabilities()` / `readConnectionEpoch()` so the existing `preflightConnected(...)` contract can consume the live session without gaining flight authority;
- binds that bridge into the production Blockly v2 runtime so the exact current activity profile/workspace AST can be preflighted and later re-asserted against the same live connection epoch;
- preserves an internal immutable AST/session ticket even if caller-owned preflight data is mutated;
- keeps `executionAuthority:false` throughout and exposes no arming, setpoint, motor, movement or light effect API;
- wires the HTTP/session/product binding tests into the existing Runtime v2 core harness, including reconnect, workspace-mutation, unauthorized-read and no-authority fail-closed checks.

This deliberately stops before the separately authorized physical effect consumer: arming/abort/failsafe and actual real-flight execution remain unproven and out of this slice.

Refs #157.