### PR TITLE
Add pure physical HighLevelCommander semantic adapter

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -57,6 +57,10 @@ def main():
     if physical_submission_test.returncode:
         print('FAIL session-bound physical submission bridge',file=sys.stderr);print(physical_submission_test.stdout,file=sys.stderr);print(physical_submission_test.stderr,file=sys.stderr);return physical_submission_test.returncode
     print(physical_submission_test.stdout.strip())
+    physical_high_level_semantics_test=subprocess.run([sys.executable,'tools/ci/test_physical_high_level_semantics.py'],text=True,capture_output=True)
+    if physical_high_level_semantics_test.returncode:
+        print('FAIL physical HighLevelCommander semantic adapter',file=sys.stderr);print(physical_high_level_semantics_test.stdout,file=sys.stderr);print(physical_high_level_semantics_test.stderr,file=sys.stderr);return physical_high_level_semantics_test.returncode
+    print(physical_high_level_semantics_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_high_level_semantics.py
+++ b/tools/ci/test_physical_high_level_semantics.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-import importlib.util
 import math
 from pathlib import Path
+import sys
 
 
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "tools" / "physical" / "high_level_semantics.py"
-SPEC = importlib.util.spec_from_file_location("webeeblocks_high_level_semantics", MODULE_PATH)
-assert SPEC is not None and SPEC.loader is not None
-semantics = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(semantics)
+sys.path.insert(0, str(MODULE_PATH.parent))
+import high_level_semantics as semantics  # noqa: E402
 
 
 def close(actual: float, expected: float, tolerance: float = 1e-12) -> None:

--- a/tools/ci/test_physical_high_level_semantics.py
+++ b/tools/ci/test_physical_high_level_semantics.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Deterministic parity checks for the pure physical high-level semantic adapter."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "high_level_semantics.py"
+SPEC = importlib.util.spec_from_file_location("webeeblocks_high_level_semantics", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+semantics = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(semantics)
+
+
+def close(actual: float, expected: float, tolerance: float = 1e-12) -> None:
+    assert math.isclose(actual, expected, rel_tol=0.0, abs_tol=tolerance), (actual, expected)
+
+
+def target(direction: str, distance: float, yaw: float, expected: tuple[float, float]) -> None:
+    result = semantics.body_relative_move(direction, distance, yaw)
+    close(result.x_m, expected[0])
+    close(result.y_m, expected[1])
+    close(result.z_m, 0.0)
+    close(result.yaw_rad, 0.0)
+
+
+def expect_error(callable_) -> None:
+    try:
+        callable_()
+    except semantics.HighLevelSemanticError:
+        return
+    raise AssertionError("expected fail-closed HighLevelSemanticError")
+
+
+# Exact parity with crazyflie_runtime_v2.c body/world rotation.
+target("forward", 1.0, 0.0, (1.0, 0.0))
+target("back", 1.0, 0.0, (-1.0, 0.0))
+target("left", 1.0, 0.0, (0.0, 1.0))
+target("right", 1.0, 0.0, (0.0, -1.0))
+target("forward", 1.0, math.pi / 2.0, (0.0, 1.0))
+target("left", 1.0, math.pi / 2.0, (-1.0, 0.0))
+target("right", 0.5, -math.pi / 2.0, (-0.5, 0.0))
+root_half = math.sqrt(0.5)
+target("forward", 2.0, math.pi / 4.0, (2.0 * root_half, 2.0 * root_half))
+
+up = semantics.vertical_move("up", 0.8)
+down = semantics.vertical_move("down", 0.1)
+assert up == semantics.RelativeHighLevelTarget(0.0, 0.0, 0.8, 0.0)
+assert down == semantics.RelativeHighLevelTarget(0.0, 0.0, -0.1, 0.0)
+
+left_turn = semantics.relative_turn(90.0)
+right_turn = semantics.relative_turn(-45.0)
+close(left_turn.yaw_rad, math.pi / 2.0)
+close(right_turn.yaw_rad, -math.pi / 4.0)
+assert left_turn.x_m == left_turn.y_m == left_turn.z_m == 0.0
+
+# Do not silently widen the integrated Runtime v2 generic action envelope.
+for invalid_direction in ("", "rear", "Forward"):
+    expect_error(lambda d=invalid_direction: semantics.body_relative_move(d, 1.0, 0.0))
+for invalid_distance in (0.0, 0.09, 2.01, float("inf"), float("nan")):
+    expect_error(lambda d=invalid_distance: semantics.body_relative_move("forward", d, 0.0))
+for invalid_vertical in (0.09, 0.81, float("nan")):
+    expect_error(lambda d=invalid_vertical: semantics.vertical_move("up", d))
+for invalid_turn in (0.0, 0.9, 180.0, float("inf")):
+    expect_error(lambda a=invalid_turn: semantics.relative_turn(a))
+expect_error(lambda: semantics.body_relative_move("forward", 1.0, float("nan")))
+expect_error(lambda: semantics.vertical_move("sideways", 0.2))
+
+source = MODULE_PATH.read_text(encoding="utf-8")
+assert "import cflib" not in source
+assert "HighLevelCommander(" not in source
+assert "send_packet" not in source
+assert "executionAuthority" not in source
+
+print("PASS pure physical HighLevelCommander geometry preserves Runtime v2 body/world semantics without execution authority")

--- a/tools/physical/high_level_semantics.py
+++ b/tools/physical/high_level_semantics.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Pure WebeeBlocks -> direct HighLevelCommander relative-target semantics.
+
+This module deliberately emits no Crazyflie command and imports no cflib API.
+It only preserves the already-integrated Runtime v2 geometry at the future
+physical-effect boundary.  The caller must supply an accepted current yaw and
+must separately establish teacher authorization, exact bound preflight,
+watchdog/liveness and supervisor completion before any physical effect.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+
+MOVE_DIRECTIONS = ("forward", "back", "left", "right")
+VERTICAL_DIRECTIONS = ("up", "down")
+
+
+class HighLevelSemanticError(ValueError):
+    """Fail-closed error for malformed generic physical action semantics."""
+
+
+@dataclass(frozen=True)
+class RelativeHighLevelTarget:
+    """Relative target consumed later by direct HighLevelCommander.go_to()."""
+
+    x_m: float
+    y_m: float
+    z_m: float
+    yaw_rad: float
+
+
+def _finite(value: object, name: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise HighLevelSemanticError(f"{name} must be finite") from exc
+    if not math.isfinite(number):
+        raise HighLevelSemanticError(f"{name} must be finite")
+    return number
+
+
+def _bounded_positive(value: object, name: str, minimum: float, maximum: float) -> float:
+    number = _finite(value, name)
+    if number < minimum or number > maximum:
+        raise HighLevelSemanticError(
+            f"{name} out of Runtime v2 bounds: {number}"
+        )
+    return number
+
+
+def body_relative_move(
+    direction: str,
+    distance_m: object,
+    accepted_yaw_rad: object,
+) -> RelativeHighLevelTarget:
+    """Map one Runtime v2 body-relative horizontal move to world-frame delta."""
+
+    if direction not in MOVE_DIRECTIONS:
+        raise HighLevelSemanticError(f"unsupported move direction: {direction}")
+    distance = _bounded_positive(distance_m, "distance_m", 0.1, 2.0)
+    yaw = _finite(accepted_yaw_rad, "accepted_yaw_rad")
+    forward_x = math.cos(yaw) * distance
+    forward_y = math.sin(yaw) * distance
+
+    if direction == "forward":
+        dx, dy = forward_x, forward_y
+    elif direction == "back":
+        dx, dy = -forward_x, -forward_y
+    elif direction == "left":
+        dx, dy = -math.sin(yaw) * distance, math.cos(yaw) * distance
+    else:
+        dx, dy = math.sin(yaw) * distance, -math.cos(yaw) * distance
+
+    return RelativeHighLevelTarget(dx, dy, 0.0, 0.0)
+
+
+def vertical_move(direction: str, distance_m: object) -> RelativeHighLevelTarget:
+    """Map Runtime v2 vertical intent to relative world-Z displacement."""
+
+    if direction not in VERTICAL_DIRECTIONS:
+        raise HighLevelSemanticError(f"unsupported vertical direction: {direction}")
+    distance = _bounded_positive(distance_m, "distance_m", 0.1, 0.8)
+    dz = distance if direction == "up" else -distance
+    return RelativeHighLevelTarget(0.0, 0.0, dz, 0.0)
+
+
+def relative_turn(angle_deg: object) -> RelativeHighLevelTarget:
+    """Map signed Runtime v2 yaw intent to relative HighLevelCommander yaw."""
+
+    angle = _finite(angle_deg, "angle_deg")
+    if abs(angle) < 1.0 or abs(angle) > 179.0:
+        raise HighLevelSemanticError(f"angle_deg out of Runtime v2 bounds: {angle}")
+    return RelativeHighLevelTarget(0.0, 0.0, 0.0, math.radians(angle))


### PR DESCRIPTION
Implements the smallest non-authority #157 command-semantics slice selected by the authoritative P1 source finding.

- adds a pure host-side semantic adapter for the existing Runtime v2 `move`, `vertical` and `turn` meanings;
- rotates body-relative horizontal movement into world-frame deltas from an explicitly supplied accepted yaw, exactly matching the current Webots controller geometry;
- maps vertical intent to relative world-Z and signed turns to relative yaw;
- fail-closes outside the already-integrated Runtime v2 bounds and vocabulary;
- adds deterministic parity tests to the existing Runtime v2 core harness.

The new module deliberately imports no cflib API and emits no command. It does not create execution authority, teacher authorization, a duration policy, watchdog/liveness, supervisor completion, arming, landing, or motorized-test capability. Those remain separate safety/effect boundaries. Refs #157 and #72.