### PR TITLE
Add fail-closed fresh supervisor state reader

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -49,6 +49,10 @@ def main():
     if physical_probe_test.returncode:
         print('FAIL read-only Crazyradio capability evidence',file=sys.stderr);print(physical_probe_test.stdout,file=sys.stderr);print(physical_probe_test.stderr,file=sys.stderr);return physical_probe_test.returncode
     print(physical_probe_test.stdout.strip())
+    physical_supervisor_test=subprocess.run([sys.executable,'tools/ci/test_physical_supervisor_state.py'],text=True,capture_output=True)
+    if physical_supervisor_test.returncode:
+        print('FAIL connection-epoch physical supervisor freshness',file=sys.stderr);print(physical_supervisor_test.stdout,file=sys.stderr);print(physical_supervisor_test.stderr,file=sys.stderr);return physical_supervisor_test.returncode
+    print(physical_supervisor_test.stdout.strip())
     physical_http_test=subprocess.run([sys.executable,'tools/ci/test_physical_capability_http_bridge.py'],text=True,capture_output=True)
     if physical_http_test.returncode:
         print('FAIL read-only physical capability HTTP bridge',file=sys.stderr);print(physical_http_test.stdout,file=sys.stderr);print(physical_http_test.stderr,file=sys.stderr);return physical_http_test.returncode

--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -49,6 +49,10 @@ def main():
     if physical_probe_test.returncode:
         print('FAIL read-only Crazyradio capability evidence',file=sys.stderr);print(physical_probe_test.stdout,file=sys.stderr);print(physical_probe_test.stderr,file=sys.stderr);return physical_probe_test.returncode
     print(physical_probe_test.stdout.strip())
+    physical_supervisor_test=subprocess.run([sys.executable,'tools/ci/test_physical_supervisor_state.py'],text=True,capture_output=True)
+    if physical_supervisor_test.returncode:
+        print('FAIL fresh fail-closed physical supervisor state',file=sys.stderr);print(physical_supervisor_test.stdout,file=sys.stderr);print(physical_supervisor_test.stderr,file=sys.stderr);return physical_supervisor_test.returncode
+    print(physical_supervisor_test.stdout.strip())
     physical_http_test=subprocess.run([sys.executable,'tools/ci/test_physical_capability_http_bridge.py'],text=True,capture_output=True)
     if physical_http_test.returncode:
         print('FAIL read-only physical capability HTTP bridge',file=sys.stderr);print(physical_http_test.stdout,file=sys.stderr);print(physical_http_test.stderr,file=sys.stderr);return physical_http_test.returncode

--- a/tools/ci/test_physical_supervisor_state.py
+++ b/tools/ci/test_physical_supervisor_state.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "supervisor_state.py"
+
+spec = importlib.util.spec_from_file_location("webeeblocks_supervisor_state", MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load supervisor-state reader")
+supervisor_state = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(supervisor_state)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except supervisor_state.SupervisorReadError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected SupervisorReadError containing {pattern!r}")
+
+
+class FakeCaller:
+    def __init__(self) -> None:
+        self.callbacks = []
+
+    def add_callback(self, callback) -> None:
+        self.callbacks.append(callback)
+
+    def remove_callback(self, callback) -> None:
+        self.callbacks.remove(callback)
+
+    def call(self, *args) -> None:
+        for callback in list(self.callbacks):
+            callback(*args)
+
+
+class FakePlatform:
+    def __init__(self, protocol_version: int) -> None:
+        self.protocol_version = protocol_version
+
+    def get_protocol_version(self) -> int:
+        return self.protocol_version
+
+
+class FakeCRTPPort:
+    SUPERVISOR = 14
+
+
+class FakeCRTPPacket:
+    def __init__(self) -> None:
+        self.port = None
+        self.channel = None
+        self.data = bytearray()
+
+    def set_header(self, port: int, channel: int) -> None:
+        self.port = port
+        self.channel = channel
+
+
+class FakeCf:
+    def __init__(self, response: bytes | None, protocol_version: int = 12) -> None:
+        self.platform = FakePlatform(protocol_version)
+        self.disconnected = FakeCaller()
+        self.response = response
+        self.callback = None
+        self.callback_port = None
+        self.removed = False
+        self.sent = []
+        self.disconnect_on_send = False
+        self.send_unrelated_first = False
+
+    def add_port_callback(self, port: int, callback) -> None:
+        self.callback_port = port
+        self.callback = callback
+
+    def remove_port_callback(self, port: int, callback) -> None:
+        require(port == self.callback_port, "supervisor callback cleanup port")
+        require(callback is self.callback, "supervisor callback cleanup identity")
+        self.removed = True
+
+    def send_packet(self, packet) -> None:
+        self.sent.append((packet.port, packet.channel, bytes(packet.data)))
+        if self.disconnect_on_send:
+            self.disconnected.call("radio://test")
+            return
+        if self.send_unrelated_first:
+            self.callback(
+                type(
+                    "Packet",
+                    (),
+                    {
+                        "channel": supervisor_state.SUPERVISOR_CH_INFO,
+                        "data": bytearray((0x81, 0x00, 0x00)),
+                    },
+                )()
+            )
+        if self.response is not None:
+            self.callback(
+                type(
+                    "Packet",
+                    (),
+                    {
+                        "channel": supervisor_state.SUPERVISOR_CH_INFO,
+                        "data": bytearray(self.response),
+                    },
+                )()
+            )
+
+
+CRTP_TYPES = (FakeCRTPPacket, FakeCRTPPort)
+
+
+def read(cf: FakeCf, timeout_seconds: float = 0.01):
+    return supervisor_state.read_fresh_supervisor_state(
+        cf,
+        timeout_seconds=timeout_seconds,
+        crtp_types=CRTP_TYPES,
+    )
+
+
+def test_success_and_decode() -> None:
+    bitfield = (
+        (1 << supervisor_state.BIT_CAN_BE_ARMED)
+        | (1 << supervisor_state.BIT_IS_AUTO_ARMED)
+        | (1 << supervisor_state.BIT_CAN_FLY)
+        | (1 << supervisor_state.BIT_HL_TRAJ_FINISHED)
+    )
+    cf = FakeCf(
+        bytes(
+            (
+                supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE,
+                bitfield & 0xFF,
+                (bitfield >> 8) & 0xFF,
+            )
+        )
+    )
+    cf.send_unrelated_first = True
+    state = read(cf)
+    require(
+        cf.sent
+        == [
+            (
+                FakeCRTPPort.SUPERVISOR,
+                supervisor_state.SUPERVISOR_CH_INFO,
+                bytes((supervisor_state.CMD_GET_STATE_BITFIELD,)),
+            )
+        ],
+        "reader must send only one GET_STATE_BITFIELD request",
+    )
+    require(state.protocol_version == 12, "protocol version")
+    require(state.bitfield == bitfield, "bitfield round trip")
+    require(state.can_be_armed, "can-be-armed bit")
+    require(state.is_auto_armed, "auto-armed configuration bit")
+    require(state.can_fly, "can-fly bit")
+    require(state.hl_traj_finished, "trajectory-finished bit")
+    require(not state.is_armed and not state.is_locked and not state.is_crashed, "unset bits")
+    require(cf.removed, "supervisor callback cleanup")
+    require(cf.disconnected.callbacks == [], "disconnect callback cleanup")
+
+
+def test_timeout_never_reuses_previous_state() -> None:
+    finished = 1 << supervisor_state.BIT_HL_TRAJ_FINISHED
+    cf = FakeCf(
+        bytes(
+            (
+                supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE,
+                finished & 0xFF,
+                (finished >> 8) & 0xFF,
+            )
+        )
+    )
+    first = read(cf)
+    require(first.hl_traj_finished, "first fresh state")
+    cf.response = None
+    cf.removed = False
+    expect_error(lambda: read(cf, timeout_seconds=0.001), "timed out")
+    require(cf.removed, "timeout callback cleanup")
+    require(
+        len(cf.sent) == 2,
+        "second read must issue a new request instead of consulting cached state",
+    )
+
+
+def test_malformed_response_fails_closed() -> None:
+    cf = FakeCf(bytes((supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE, 0x01)))
+    expect_error(lambda: read(cf), "malformed supervisor state response")
+    require(cf.removed, "malformed response callback cleanup")
+
+
+def test_disconnect_fails_closed() -> None:
+    cf = FakeCf(None)
+    cf.disconnect_on_send = True
+    expect_error(lambda: read(cf), "disconnected during supervisor state read")
+    require(cf.removed, "disconnect callback cleanup")
+
+
+def test_protocol_boundary() -> None:
+    legacy = FakeCf(None, protocol_version=11)
+    expect_error(lambda: read(legacy), "protocol version 12 or later")
+    require(legacy.sent == [], "legacy protocol must not emit supervisor request")
+    require(legacy.callback is None, "legacy protocol must fail before callback registration")
+
+
+def test_timeout_argument() -> None:
+    cf = FakeCf(None)
+    expect_error(lambda: read(cf, timeout_seconds=0), "timeout must be positive")
+    require(cf.sent == [], "invalid timeout must not emit a request")
+
+
+def main() -> int:
+    test_success_and_decode()
+    test_timeout_never_reuses_previous_state()
+    test_malformed_response_fails_closed()
+    test_disconnect_fails_closed()
+    test_protocol_boundary()
+    test_timeout_argument()
+
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "send_arming_request",
+        "send_emergency_stop",
+        "send_emergency_stop_watchdog",
+        "high_level_commander",
+        "send_setpoint",
+        "send_hover_setpoint",
+        "send_velocity_world_setpoint",
+    ):
+        require(forbidden not in source, f"supervisor reader exposes authority surface: {forbidden}")
+
+    print(
+        "PASS fresh supervisor-state read fails closed on timeout/disconnect without execution authority"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_supervisor_state.py
+++ b/tools/ci/test_physical_supervisor_state.py
@@ -28,6 +28,27 @@ def expect_error(callable_, pattern: str) -> None:
     raise AssertionError(f"expected SupervisorReadError containing {pattern!r}")
 
 
+def frame(bitfield: int) -> bytes:
+    return bytes(
+        (
+            supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE,
+            bitfield & 0xFF,
+            (bitfield >> 8) & 0xFF,
+        )
+    )
+
+
+class EpochSource:
+    def __init__(self, value: str) -> None:
+        self.value = value
+        self.error = None
+
+    def __call__(self) -> str:
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
 class FakeCaller:
     def __init__(self) -> None:
         self.callbacks = []
@@ -71,6 +92,7 @@ class FakeCf:
         self.platform = FakePlatform(protocol_version)
         self.disconnected = FakeCaller()
         self.response = response
+        self.pending_late_response = None
         self.callback = None
         self.callback_port = None
         self.removed = False
@@ -87,6 +109,21 @@ class FakeCf:
         require(port == self.callback_port, "supervisor callback cleanup port")
         require(callback is self.callback, "supervisor callback cleanup identity")
         self.removed = True
+        self.callback = None
+
+    def _emit(self, response: bytes) -> None:
+        if self.callback is None:
+            return
+        self.callback(
+            type(
+                "Packet",
+                (),
+                {
+                    "channel": supervisor_state.SUPERVISOR_CH_INFO,
+                    "data": bytearray(response),
+                },
+            )()
+        )
 
     def send_packet(self, packet) -> None:
         self.sent.append((packet.port, packet.channel, bytes(packet.data)))
@@ -96,36 +133,23 @@ class FakeCf:
         if self.fail_on_send:
             raise RuntimeError("radio send failed")
         if self.send_unrelated_first:
-            self.callback(
-                type(
-                    "Packet",
-                    (),
-                    {
-                        "channel": supervisor_state.SUPERVISOR_CH_INFO,
-                        "data": bytearray((0x81, 0x00, 0x00)),
-                    },
-                )()
-            )
+            self._emit(bytes((0x81, 0x00, 0x00)))
+        if self.pending_late_response is not None:
+            pending = self.pending_late_response
+            self.pending_late_response = None
+            self._emit(pending)
+            return
         if self.response is not None:
-            self.callback(
-                type(
-                    "Packet",
-                    (),
-                    {
-                        "channel": supervisor_state.SUPERVISOR_CH_INFO,
-                        "data": bytearray(self.response),
-                    },
-                )()
-            )
+            self._emit(self.response)
 
 
 CRTP_TYPES = (FakeCRTPPacket, FakeCRTPPort)
 
 
-def read(cf: FakeCf, timeout_seconds: float = 0.01):
-    return supervisor_state.read_fresh_supervisor_state(
+def make_reader(cf: FakeCf, epoch: EpochSource):
+    return supervisor_state.FreshSupervisorStateReader(
         cf,
-        timeout_seconds=timeout_seconds,
+        epoch,
         crtp_types=CRTP_TYPES,
     )
 
@@ -137,17 +161,12 @@ def test_success_and_decode() -> None:
         | (1 << supervisor_state.BIT_CAN_FLY)
         | (1 << supervisor_state.BIT_HL_TRAJ_FINISHED)
     )
-    cf = FakeCf(
-        bytes(
-            (
-                supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE,
-                bitfield & 0xFF,
-                (bitfield >> 8) & 0xFF,
-            )
-        )
-    )
+    cf = FakeCf(frame(bitfield))
     cf.send_unrelated_first = True
-    state = read(cf)
+    epoch = EpochSource("epoch-success")
+    reader = make_reader(cf, epoch)
+    state = reader.read(timeout_seconds=0.01)
+
     require(
         cf.sent
         == [
@@ -162,94 +181,215 @@ def test_success_and_decode() -> None:
     require(state.protocol_version == 12, "protocol version")
     require(state.bitfield == bitfield, "bitfield round trip")
     require(state.can_be_armed, "can-be-armed bit")
-    require(state.is_auto_armed, "auto-armed configuration bit")
+    require(state.is_auto_armed, "auto-armed bit")
     require(state.can_fly, "can-fly bit")
     require(state.hl_traj_finished, "trajectory-finished bit")
-    require(not state.is_armed and not state.is_locked and not state.is_crashed, "unset bits")
+    require(not state.deck_fault and not state.blocking_fault, "healthy state")
+    require(not reader.poisoned, "successful read must not poison epoch")
     require(cf.removed, "supervisor callback cleanup")
     require(cf.disconnected.callbacks == [], "disconnect callback cleanup")
 
 
-def test_timeout_never_reuses_previous_state() -> None:
+def test_deck_fault_is_preserved_and_blocks() -> None:
+    bitfield = (
+        (1 << supervisor_state.BIT_CAN_FLY)
+        | (1 << supervisor_state.BIT_DECK_FAULT)
+    )
+    reader = make_reader(FakeCf(frame(bitfield)), EpochSource("epoch-deck"))
+    state = reader.read(timeout_seconds=0.01)
+    require(state.bitfield == bitfield, "raw deck-fault bitfield")
+    require(state.deck_fault, "deck fault bit must be decoded")
+    require(state.blocking_fault, "deck fault must be evaluated as blocking")
+
+
+def test_timeout_poison_blocks_delayed_reply_until_epoch_rotates() -> None:
     finished = 1 << supervisor_state.BIT_HL_TRAJ_FINISHED
-    cf = FakeCf(
+    cf = FakeCf(frame(finished))
+    epoch = EpochSource("epoch-timeout")
+    reader = make_reader(cf, epoch)
+
+    first = reader.read(timeout_seconds=0.01)
+    require(first.hl_traj_finished, "first fresh state")
+
+    cf.response = None
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.001),
+        "fresh supervisor state request timed out",
+    )
+    require(reader.poisoned, "timeout must poison the connection epoch")
+    sent_after_timeout = len(cf.sent)
+
+    # Model the old untagged reply arriving on the next request. A poisoned
+    # reader must refuse before sending, so that reply can never be accepted.
+    cf.pending_late_response = frame(finished)
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.01),
+        "poisoned until reconnect",
+    )
+    require(
+        len(cf.sent) == sent_after_timeout,
+        "poisoned epoch must not send a retry that could consume a delayed reply",
+    )
+    require(
+        cf.pending_late_response is not None,
+        "delayed reply should remain unconsumed because no retry was emitted",
+    )
+
+    expect_error(
+        lambda: make_reader(cf, epoch),
+        "poisoned until reconnect",
+    )
+
+    reconnected = FakeCf(frame(finished))
+    new_epoch = EpochSource("epoch-timeout-reconnected")
+    recovered = make_reader(reconnected, new_epoch)
+    require(
+        recovered.read(timeout_seconds=0.01).hl_traj_finished,
+        "rotated reconnect epoch must permit a new freshness domain",
+    )
+
+
+def test_malformed_framing_poison() -> None:
+    short_cf = FakeCf(
+        bytes((supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE, 0x01))
+    )
+    short_reader = make_reader(short_cf, EpochSource("epoch-short"))
+    expect_error(
+        lambda: short_reader.read(timeout_seconds=0.01),
+        "malformed supervisor state response",
+    )
+    require(short_reader.poisoned, "short response must poison epoch")
+
+    extended_cf = FakeCf(
         bytes(
             (
                 supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE,
-                finished & 0xFF,
-                (finished >> 8) & 0xFF,
+                0x01,
+                0x00,
+                0x00,
             )
         )
     )
-    first = read(cf)
-    require(first.hl_traj_finished, "first fresh state")
-    cf.response = None
-    cf.removed = False
-    expect_error(lambda: read(cf, timeout_seconds=0.001), "timed out")
-    require(cf.removed, "timeout callback cleanup")
-    require(
-        len(cf.sent) == 2,
-        "second read must issue a new request instead of consulting cached state",
+    extended_reader = make_reader(extended_cf, EpochSource("epoch-extended"))
+    expect_error(
+        lambda: extended_reader.read(timeout_seconds=0.01),
+        "malformed supervisor state response",
     )
+    require(extended_reader.poisoned, "extended response must poison epoch")
 
 
-def test_malformed_response_fails_closed() -> None:
-    cf = FakeCf(bytes((supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE, 0x01)))
-    expect_error(lambda: read(cf), "malformed supervisor state response")
-    require(cf.removed, "malformed response callback cleanup")
+def test_unknown_state_bits_poison() -> None:
+    unknown = 1 << 12
+    reader = make_reader(FakeCf(frame(unknown)), EpochSource("epoch-unknown"))
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.01),
+        "unknown supervisor state bits set",
+    )
+    require(reader.poisoned, "unknown state semantics must poison epoch")
 
 
-def test_disconnect_fails_closed() -> None:
+def test_disconnect_poison() -> None:
     cf = FakeCf(None)
     cf.disconnect_on_send = True
-    expect_error(lambda: read(cf), "disconnected during supervisor state read")
+    reader = make_reader(cf, EpochSource("epoch-disconnect"))
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.01),
+        "disconnected during supervisor state read",
+    )
+    require(reader.poisoned, "disconnect must poison epoch")
     require(cf.removed, "disconnect callback cleanup")
 
 
-def test_request_transport_failure_is_typed_and_cleaned_up() -> None:
+def test_request_transport_failure_poison() -> None:
     cf = FakeCf(None)
     cf.fail_on_send = True
-    expect_error(lambda: read(cf), "fresh supervisor state request failed")
+    reader = make_reader(cf, EpochSource("epoch-send-fail"))
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.01),
+        "fresh supervisor state request failed",
+    )
+    require(reader.poisoned, "ambiguous send failure must poison epoch")
     require(cf.removed, "send-failure callback cleanup")
     require(cf.disconnected.callbacks == [], "send-failure disconnect cleanup")
 
 
-def test_protocol_boundary() -> None:
-    legacy = FakeCf(None, protocol_version=11)
-    expect_error(lambda: read(legacy), "protocol version 12 or later")
-    require(legacy.sent == [], "legacy protocol must not emit supervisor request")
-    require(legacy.callback is None, "legacy protocol must fail before callback registration")
+def test_connection_epoch_change_poison_and_recovery() -> None:
+    cf = FakeCf(frame(0))
+    epoch = EpochSource("epoch-before-change")
+    reader = make_reader(cf, epoch)
+    epoch.value = "epoch-after-change"
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.01),
+        "connection epoch changed",
+    )
+    require(reader.poisoned, "old epoch must be poisoned after rotation")
+    require(cf.sent == [], "epoch mismatch must fail before supervisor request")
+
+    replacement = make_reader(
+        FakeCf(frame(0)),
+        EpochSource("epoch-after-change"),
+    )
+    require(
+        replacement.read(timeout_seconds=0.01).bitfield == 0,
+        "new reconnect epoch must establish a separate freshness domain",
+    )
 
 
-def test_timeout_argument() -> None:
-    cf = FakeCf(None)
-    expect_error(lambda: read(cf, timeout_seconds=0), "timeout must be positive")
+def test_protocol_boundary_poison() -> None:
+    cf = FakeCf(None, protocol_version=11)
+    reader = make_reader(cf, EpochSource("epoch-legacy"))
+    expect_error(
+        lambda: reader.read(timeout_seconds=0.01),
+        "protocol version 12 or later",
+    )
+    require(reader.poisoned, "unsupported supervisor protocol must poison epoch")
+    require(cf.sent == [], "legacy protocol must not emit supervisor request")
+
+
+def test_invalid_timeout_has_no_transport_effect() -> None:
+    cf = FakeCf(frame(0))
+    reader = make_reader(cf, EpochSource("epoch-invalid-timeout"))
+    expect_error(
+        lambda: reader.read(timeout_seconds=0),
+        "timeout must be positive",
+    )
+    require(not reader.poisoned, "invalid local timeout must not poison connection")
     require(cf.sent == [], "invalid timeout must not emit a request")
+    require(
+        reader.read(timeout_seconds=0.01).bitfield == 0,
+        "same epoch remains usable when no ambiguous transport occurred",
+    )
 
 
 def main() -> int:
     test_success_and_decode()
-    test_timeout_never_reuses_previous_state()
-    test_malformed_response_fails_closed()
-    test_disconnect_fails_closed()
-    test_request_transport_failure_is_typed_and_cleaned_up()
-    test_protocol_boundary()
-    test_timeout_argument()
+    test_deck_fault_is_preserved_and_blocks()
+    test_timeout_poison_blocks_delayed_reply_until_epoch_rotates()
+    test_malformed_framing_poison()
+    test_unknown_state_bits_poison()
+    test_disconnect_poison()
+    test_request_transport_failure_poison()
+    test_connection_epoch_change_poison_and_recovery()
+    test_protocol_boundary_poison()
+    test_invalid_timeout_has_no_transport_effect()
 
     source = MODULE_PATH.read_text(encoding="utf-8")
     for forbidden in (
         "send_arming_request",
         "send_emergency_stop",
         "send_emergency_stop_watchdog",
-        "high_level_commander",
+        "HighLevelCommander(",
         "send_setpoint",
         "send_hover_setpoint",
         "send_velocity_world_setpoint",
     ):
-        require(forbidden not in source, f"supervisor reader exposes authority surface: {forbidden}")
+        require(
+            forbidden not in source,
+            f"supervisor reader exposes authority surface: {forbidden}",
+        )
 
     print(
-        "PASS fresh supervisor-state read fails closed on timeout/disconnect without execution authority"
+        "PASS connection-epoch supervisor freshness fails closed without execution authority"
     )
     return 0
 

--- a/tools/ci/test_physical_supervisor_state.py
+++ b/tools/ci/test_physical_supervisor_state.py
@@ -76,6 +76,7 @@ class FakeCf:
         self.removed = False
         self.sent = []
         self.disconnect_on_send = False
+        self.fail_on_send = False
         self.send_unrelated_first = False
 
     def add_port_callback(self, port: int, callback) -> None:
@@ -92,6 +93,8 @@ class FakeCf:
         if self.disconnect_on_send:
             self.disconnected.call("radio://test")
             return
+        if self.fail_on_send:
+            raise RuntimeError("radio send failed")
         if self.send_unrelated_first:
             self.callback(
                 type(
@@ -203,6 +206,14 @@ def test_disconnect_fails_closed() -> None:
     require(cf.removed, "disconnect callback cleanup")
 
 
+def test_request_transport_failure_is_typed_and_cleaned_up() -> None:
+    cf = FakeCf(None)
+    cf.fail_on_send = True
+    expect_error(lambda: read(cf), "fresh supervisor state request failed")
+    require(cf.removed, "send-failure callback cleanup")
+    require(cf.disconnected.callbacks == [], "send-failure disconnect cleanup")
+
+
 def test_protocol_boundary() -> None:
     legacy = FakeCf(None, protocol_version=11)
     expect_error(lambda: read(legacy), "protocol version 12 or later")
@@ -221,6 +232,7 @@ def main() -> int:
     test_timeout_never_reuses_previous_state()
     test_malformed_response_fails_closed()
     test_disconnect_fails_closed()
+    test_request_transport_failure_is_typed_and_cleaned_up()
     test_protocol_boundary()
     test_timeout_argument()
 

--- a/tools/ci/test_physical_supervisor_state.py
+++ b/tools/ci/test_physical_supervisor_state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import threading
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "tools" / "physical" / "supervisor_state.py"
@@ -97,6 +98,8 @@ class FakeCf:
         self.callback_port = None
         self.removed = False
         self.sent = []
+        self.request_sent = threading.Event()
+        self.second_request_sent = threading.Event()
         self.disconnect_on_send = False
         self.fail_on_send = False
         self.send_unrelated_first = False
@@ -127,6 +130,10 @@ class FakeCf:
 
     def send_packet(self, packet) -> None:
         self.sent.append((packet.port, packet.channel, bytes(packet.data)))
+        if len(self.sent) == 1:
+            self.request_sent.set()
+        elif len(self.sent) >= 2:
+            self.second_request_sent.set()
         if self.disconnect_on_send:
             self.disconnected.call("radio://test")
             return
@@ -249,6 +256,52 @@ def test_timeout_poison_blocks_delayed_reply_until_epoch_rotates() -> None:
     )
 
 
+def test_two_readers_share_epoch_guard_and_waiter_fails_after_poison() -> None:
+    cf = FakeCf(None)
+    epoch = EpochSource("epoch-two-readers")
+    first = make_reader(cf, epoch)
+    second = make_reader(cf, epoch)
+    require(
+        first._read_lock is second._read_lock,
+        "readers on one connection epoch must share one serialization guard",
+    )
+
+    errors = []
+
+    def run(reader) -> None:
+        try:
+            reader.read(timeout_seconds=1.0)
+        except supervisor_state.SupervisorReadError as exc:
+            errors.append(str(exc))
+
+    first_thread = threading.Thread(target=run, args=(first,), daemon=True)
+    first_thread.start()
+    require(cf.request_sent.wait(1.0), "first reader must emit one supervisor request")
+
+    second_thread = threading.Thread(target=run, args=(second,), daemon=True)
+    second_thread.start()
+    require(
+        not cf.second_request_sent.wait(0.05),
+        "second reader must not emit a concurrent untagged supervisor request",
+    )
+
+    cf.disconnected.call("radio://test")
+    first_thread.join(1.0)
+    second_thread.join(1.0)
+    require(not first_thread.is_alive(), "first reader must terminate after poison")
+    require(not second_thread.is_alive(), "waiting reader must terminate after poison")
+    require(len(cf.sent) == 1, "waiting reader must fail closed without sending")
+    require(len(errors) == 2, "both readers must fail closed")
+    require(
+        any("disconnected during supervisor state read" in error for error in errors),
+        "first read must establish the poison reason",
+    )
+    require(
+        any("poisoned until reconnect" in error for error in errors),
+        "waiting reader must re-check epoch poison after acquiring the shared guard",
+    )
+
+
 def test_malformed_framing_poison() -> None:
     short_cf = FakeCf(
         bytes((supervisor_state.CMD_GET_STATE_BITFIELD_RESPONSE, 0x01))
@@ -365,6 +418,7 @@ def main() -> int:
     test_success_and_decode()
     test_deck_fault_is_preserved_and_blocks()
     test_timeout_poison_blocks_delayed_reply_until_epoch_rotates()
+    test_two_readers_share_epoch_guard_and_waiter_fails_after_poison()
     test_malformed_framing_poison()
     test_unknown_state_bits_poison()
     test_disconnect_poison()

--- a/tools/physical/supervisor_state.py
+++ b/tools/physical/supervisor_state.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Fresh, fail-closed read-only Crazyflie supervisor-state observation.
+
+This module deliberately exposes no arming, watchdog, setpoint, high-level
+commander or other physical-effect operation. It exists only to obtain one fresh
+supervisor state reply for a future separately authorized physical execution
+consumer.
+
+cflib's Supervisor convenience properties may return a cached bitfield when a
+fresh request times out. That behavior is useful for general UI polling but is
+not a sufficient freshness oracle for WebeeBlocks physical command completion.
+This reader therefore owns one bounded read transaction and raises on timeout or
+disconnect instead of falling back to an earlier value.
+"""
+
+from __future__ import annotations
+
+from threading import Event, Lock
+from typing import NamedTuple
+
+SUPERVISOR_CH_INFO = 0
+CMD_GET_STATE_BITFIELD = 0x0C
+CMD_GET_STATE_BITFIELD_RESPONSE = CMD_GET_STATE_BITFIELD | 0x80
+MIN_SUPERVISOR_PROTOCOL_VERSION = 12
+
+BIT_CAN_BE_ARMED = 0
+BIT_IS_ARMED = 1
+BIT_IS_AUTO_ARMED = 2
+BIT_CAN_FLY = 3
+BIT_IS_FLYING = 4
+BIT_IS_TUMBLED = 5
+BIT_IS_LOCKED = 6
+BIT_IS_CRASHED = 7
+BIT_HL_CONTROL_ACTIVE = 8
+BIT_HL_TRAJ_FINISHED = 9
+BIT_HL_CONTROL_DISABLED = 10
+
+
+class SupervisorReadError(RuntimeError):
+    """Fail-closed error for unavailable or malformed fresh supervisor state."""
+
+
+class SupervisorState(NamedTuple):
+    protocol_version: int
+    bitfield: int
+    can_be_armed: bool
+    is_armed: bool
+    is_auto_armed: bool
+    can_fly: bool
+    is_flying: bool
+    is_tumbled: bool
+    is_locked: bool
+    is_crashed: bool
+    hl_control_active: bool
+    hl_traj_finished: bool
+    hl_control_disabled: bool
+
+
+def _bit(value: int, position: int) -> bool:
+    return bool((value >> position) & 0x01)
+
+
+def decode_supervisor_state(protocol_version: int, bitfield: int) -> SupervisorState:
+    if protocol_version < MIN_SUPERVISOR_PROTOCOL_VERSION:
+        raise SupervisorReadError(
+            "supervisor state requires CRTP protocol version 12 or later"
+        )
+    if bitfield < 0:
+        raise SupervisorReadError("supervisor bitfield must be non-negative")
+    return SupervisorState(
+        protocol_version=protocol_version,
+        bitfield=bitfield,
+        can_be_armed=_bit(bitfield, BIT_CAN_BE_ARMED),
+        is_armed=_bit(bitfield, BIT_IS_ARMED),
+        is_auto_armed=_bit(bitfield, BIT_IS_AUTO_ARMED),
+        can_fly=_bit(bitfield, BIT_CAN_FLY),
+        is_flying=_bit(bitfield, BIT_IS_FLYING),
+        is_tumbled=_bit(bitfield, BIT_IS_TUMBLED),
+        is_locked=_bit(bitfield, BIT_IS_LOCKED),
+        is_crashed=_bit(bitfield, BIT_IS_CRASHED),
+        hl_control_active=_bit(bitfield, BIT_HL_CONTROL_ACTIVE),
+        hl_traj_finished=_bit(bitfield, BIT_HL_TRAJ_FINISHED),
+        hl_control_disabled=_bit(bitfield, BIT_HL_CONTROL_DISABLED),
+    )
+
+
+def _read_protocol_version(cf: object) -> int:
+    try:
+        value = cf.platform.get_protocol_version()
+        protocol_version = int(value)
+    except Exception as exc:
+        raise SupervisorReadError(
+            "Crazyflie protocol version is unavailable for supervisor state"
+        ) from exc
+    if protocol_version < MIN_SUPERVISOR_PROTOCOL_VERSION:
+        raise SupervisorReadError(
+            "supervisor state requires CRTP protocol version 12 or later"
+        )
+    return protocol_version
+
+
+def read_fresh_supervisor_state(
+    cf: object,
+    *,
+    timeout_seconds: float = 0.2,
+    crtp_types: tuple[object, object] | None = None,
+) -> SupervisorState:
+    """Read one fresh supervisor bitfield without any cached fallback.
+
+    The function accepts an already-connected cflib Crazyflie object. It sends
+    only the supervisor GET_STATE_BITFIELD information request, waits for the
+    next matching response while its callback is installed, and fails closed on
+    timeout, disconnect or malformed matching response.
+
+    The supervisor protocol has no transaction identifier, so the future
+    physical-effect session must serialize these reads and must not issue
+    concurrent supervisor-state requests through another path.
+    """
+    if timeout_seconds <= 0:
+        raise SupervisorReadError("supervisor read timeout must be positive")
+
+    protocol_version = _read_protocol_version(cf)
+
+    if crtp_types is None:
+        try:
+            from cflib.crtp.crtpstack import CRTPPacket, CRTPPort
+        except ImportError as exc:
+            raise SupervisorReadError("cflib CRTP packet support is unavailable") from exc
+    else:
+        CRTPPacket, CRTPPort = crtp_types
+
+    done = Event()
+    lock = Lock()
+    result: dict[str, object] = {}
+
+    def finish(*, bitfield: int | None = None, error: Exception | None = None) -> None:
+        with lock:
+            if done.is_set():
+                return
+            if error is not None:
+                result["error"] = error
+            else:
+                result["bitfield"] = bitfield
+            done.set()
+
+    def supervisor_callback(packet: object) -> None:
+        try:
+            if packet.channel != SUPERVISOR_CH_INFO:
+                return
+            data = bytes(packet.data)
+            if not data or data[0] != CMD_GET_STATE_BITFIELD_RESPONSE:
+                return
+            # Current supervisor state uses a uint16 bitfield. Accept additional
+            # future bytes conservatively while requiring all currently defined
+            # bits to be present.
+            if len(data) < 3:
+                finish(error=SupervisorReadError("malformed supervisor state response"))
+                return
+            finish(bitfield=int.from_bytes(data[1:], byteorder="little"))
+        except Exception as exc:
+            finish(error=SupervisorReadError(f"malformed supervisor state response: {exc}"))
+
+    def disconnected(_uri: str) -> None:
+        finish(error=SupervisorReadError("Crazyflie disconnected during supervisor state read"))
+
+    disconnect_callbacks = getattr(cf, "disconnected", None)
+    disconnect_registered = False
+    cf.add_port_callback(CRTPPort.SUPERVISOR, supervisor_callback)
+    try:
+        if (
+            disconnect_callbacks is not None
+            and hasattr(disconnect_callbacks, "add_callback")
+            and hasattr(disconnect_callbacks, "remove_callback")
+        ):
+            disconnect_callbacks.add_callback(disconnected)
+            disconnect_registered = True
+
+        packet = CRTPPacket()
+        packet.set_header(CRTPPort.SUPERVISOR, SUPERVISOR_CH_INFO)
+        packet.data = (CMD_GET_STATE_BITFIELD,)
+        cf.send_packet(packet)
+
+        if not done.wait(timeout_seconds):
+            raise SupervisorReadError("fresh supervisor state request timed out")
+    finally:
+        if disconnect_registered:
+            try:
+                disconnect_callbacks.remove_callback(disconnected)
+            except ValueError:
+                pass
+        cf.remove_port_callback(CRTPPort.SUPERVISOR, supervisor_callback)
+
+    error = result.get("error")
+    if isinstance(error, Exception):
+        raise error
+    bitfield = result.get("bitfield")
+    if not isinstance(bitfield, int):
+        raise SupervisorReadError("fresh supervisor state response is unavailable")
+    return decode_supervisor_state(protocol_version, bitfield)

--- a/tools/physical/supervisor_state.py
+++ b/tools/physical/supervisor_state.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python3
 """Fresh, fail-closed read-only Crazyflie supervisor-state observation.
 
-This module deliberately exposes no arming, watchdog, setpoint, high-level
-commander or other physical-effect operation. It exists only to obtain one fresh
-supervisor state reply for a future separately authorized physical execution
-consumer.
+cflib Supervisor convenience properties may return a cached bitfield when a
+fresh request times out. That behavior is not a sufficient freshness oracle for
+WebeeBlocks physical command completion. This module therefore owns a bounded
+read-only supervisor transaction, binds it to a reconnect-sensitive connection
+epoch and permanently poisons that reader after any ambiguous read failure.
 
-cflib's Supervisor convenience properties may return a cached bitfield when a
-fresh request times out. That behavior is useful for general UI polling but is
-not a sufficient freshness oracle for WebeeBlocks physical command completion.
-This reader therefore owns one bounded read transaction and raises on timeout or
-disconnect instead of falling back to an earlier value.
+The reader deliberately exposes no arming, watchdog keepalive, setpoint,
+high-level commander or other physical-effect operation.
 """
 
 from __future__ import annotations
 
 from threading import Event, Lock
-from typing import NamedTuple
+from typing import Callable, NamedTuple
 
 SUPERVISOR_CH_INFO = 0
 CMD_GET_STATE_BITFIELD = 0x0C
@@ -34,10 +32,12 @@ BIT_IS_CRASHED = 7
 BIT_HL_CONTROL_ACTIVE = 8
 BIT_HL_TRAJ_FINISHED = 9
 BIT_HL_CONTROL_DISABLED = 10
+BIT_DECK_FAULT = 11
+KNOWN_STATE_MASK = (1 << (BIT_DECK_FAULT + 1)) - 1
 
 
 class SupervisorReadError(RuntimeError):
-    """Fail-closed error for unavailable or malformed fresh supervisor state."""
+    """Fail-closed error for unavailable or ambiguous fresh supervisor state."""
 
 
 class SupervisorState(NamedTuple):
@@ -54,6 +54,8 @@ class SupervisorState(NamedTuple):
     hl_control_active: bool
     hl_traj_finished: bool
     hl_control_disabled: bool
+    deck_fault: bool
+    blocking_fault: bool
 
 
 def _bit(value: int, position: int) -> bool:
@@ -67,6 +69,17 @@ def decode_supervisor_state(protocol_version: int, bitfield: int) -> SupervisorS
         )
     if bitfield < 0:
         raise SupervisorReadError("supervisor bitfield must be non-negative")
+    unknown_bits = bitfield & ~KNOWN_STATE_MASK
+    if unknown_bits:
+        raise SupervisorReadError(
+            f"unknown supervisor state bits set: 0x{unknown_bits:x}"
+        )
+
+    is_tumbled = _bit(bitfield, BIT_IS_TUMBLED)
+    is_locked = _bit(bitfield, BIT_IS_LOCKED)
+    is_crashed = _bit(bitfield, BIT_IS_CRASHED)
+    hl_control_disabled = _bit(bitfield, BIT_HL_CONTROL_DISABLED)
+    deck_fault = _bit(bitfield, BIT_DECK_FAULT)
     return SupervisorState(
         protocol_version=protocol_version,
         bitfield=bitfield,
@@ -75,12 +88,20 @@ def decode_supervisor_state(protocol_version: int, bitfield: int) -> SupervisorS
         is_auto_armed=_bit(bitfield, BIT_IS_AUTO_ARMED),
         can_fly=_bit(bitfield, BIT_CAN_FLY),
         is_flying=_bit(bitfield, BIT_IS_FLYING),
-        is_tumbled=_bit(bitfield, BIT_IS_TUMBLED),
-        is_locked=_bit(bitfield, BIT_IS_LOCKED),
-        is_crashed=_bit(bitfield, BIT_IS_CRASHED),
+        is_tumbled=is_tumbled,
+        is_locked=is_locked,
+        is_crashed=is_crashed,
         hl_control_active=_bit(bitfield, BIT_HL_CONTROL_ACTIVE),
         hl_traj_finished=_bit(bitfield, BIT_HL_TRAJ_FINISHED),
-        hl_control_disabled=_bit(bitfield, BIT_HL_CONTROL_DISABLED),
+        hl_control_disabled=hl_control_disabled,
+        deck_fault=deck_fault,
+        blocking_fault=(
+            is_tumbled
+            or is_locked
+            or is_crashed
+            or hl_control_disabled
+            or deck_fault
+        ),
     )
 
 
@@ -99,106 +120,184 @@ def _read_protocol_version(cf: object) -> int:
     return protocol_version
 
 
-def read_fresh_supervisor_state(
-    cf: object,
-    *,
-    timeout_seconds: float = 0.2,
-    crtp_types: tuple[object, object] | None = None,
-) -> SupervisorState:
-    """Read one fresh supervisor bitfield without any cached fallback.
+class FreshSupervisorStateReader:
+    """One connection-bound supervisor freshness domain.
 
-    The function accepts an already-connected cflib Crazyflie object. It sends
-    only the supervisor GET_STATE_BITFIELD information request, waits for the
-    next matching response while its callback is installed, and fails closed on
-    timeout, disconnect or malformed matching response.
-
-    The supervisor protocol has no transaction identifier, so the future
-    physical-effect session must serialize these reads and must not issue
-    concurrent supervisor-state requests through another path.
+    A timeout, disconnect, malformed response, protocol incompatibility or
+    connection-epoch change permanently poisons the instance. Since the
+    supervisor GET_STATE command has no transaction identifier, the caller must
+    reconnect and construct a new reader after poison; retrying on the same
+    connection could misclassify a delayed old reply as fresh evidence.
     """
-    if timeout_seconds <= 0:
-        raise SupervisorReadError("supervisor read timeout must be positive")
 
-    protocol_version = _read_protocol_version(cf)
+    def __init__(
+        self,
+        cf: object,
+        connection_epoch_reader: Callable[[], str],
+        *,
+        crtp_types: tuple[object, object] | None = None,
+    ) -> None:
+        self._cf = cf
+        self._connection_epoch_reader = connection_epoch_reader
+        self._crtp_types = crtp_types
+        self._read_lock = Lock()
+        self._state_lock = Lock()
+        self._poisoned = False
+        self._poison_reason: str | None = None
+        self._bound_connection_epoch = self._read_epoch()
 
-    if crtp_types is None:
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._bound_connection_epoch
+
+    @property
+    def poisoned(self) -> bool:
+        with self._state_lock:
+            return self._poisoned
+
+    def _read_epoch(self) -> str:
+        try:
+            epoch = self._connection_epoch_reader()
+        except Exception as exc:
+            raise SupervisorReadError(
+                "connection epoch is unavailable for supervisor state"
+            ) from exc
+        if not isinstance(epoch, str) or not epoch.strip():
+            raise SupervisorReadError("connection epoch is invalid for supervisor state")
+        return epoch
+
+    def _poison(self, reason: str) -> None:
+        with self._state_lock:
+            if not self._poisoned:
+                self._poisoned = True
+                self._poison_reason = reason
+
+    def _raise_if_poisoned(self) -> None:
+        with self._state_lock:
+            if self._poisoned:
+                raise SupervisorReadError(
+                    "supervisor freshness is poisoned until reconnect: "
+                    + (self._poison_reason or "ambiguous prior read")
+                )
+
+    def _verify_connection_epoch(self) -> None:
+        self._raise_if_poisoned()
+        current_epoch = self._read_epoch()
+        if current_epoch != self._bound_connection_epoch:
+            reason = "connection epoch changed during supervisor freshness domain"
+            self._poison(reason)
+            raise SupervisorReadError(reason)
+
+    def read(self, *, timeout_seconds: float = 0.2) -> SupervisorState:
+        if timeout_seconds <= 0:
+            raise SupervisorReadError("supervisor read timeout must be positive")
+
+        with self._read_lock:
+            self._verify_connection_epoch()
+            try:
+                state = self._read_once(timeout_seconds)
+                self._verify_connection_epoch()
+                return state
+            except SupervisorReadError as exc:
+                self._poison(str(exc))
+                raise
+
+    def _resolve_crtp_types(self) -> tuple[object, object]:
+        if self._crtp_types is not None:
+            return self._crtp_types
         try:
             from cflib.crtp.crtpstack import CRTPPacket, CRTPPort
         except ImportError as exc:
             raise SupervisorReadError("cflib CRTP packet support is unavailable") from exc
-    else:
-        CRTPPacket, CRTPPort = crtp_types
+        return CRTPPacket, CRTPPort
 
-    done = Event()
-    lock = Lock()
-    result: dict[str, object] = {}
+    def _read_once(self, timeout_seconds: float) -> SupervisorState:
+        protocol_version = _read_protocol_version(self._cf)
+        CRTPPacket, CRTPPort = self._resolve_crtp_types()
 
-    def finish(*, bitfield: int | None = None, error: Exception | None = None) -> None:
-        with lock:
-            if done.is_set():
-                return
-            if error is not None:
-                result["error"] = error
-            else:
-                result["bitfield"] = bitfield
-            done.set()
+        done = Event()
+        result_lock = Lock()
+        result: dict[str, object] = {}
 
-    def supervisor_callback(packet: object) -> None:
-        try:
-            if packet.channel != SUPERVISOR_CH_INFO:
-                return
-            data = bytes(packet.data)
-            if not data or data[0] != CMD_GET_STATE_BITFIELD_RESPONSE:
-                return
-            # Current supervisor state uses a uint16 bitfield. Accept additional
-            # future bytes conservatively while requiring all currently defined
-            # bits to be present.
-            if len(data) < 3:
-                finish(error=SupervisorReadError("malformed supervisor state response"))
-                return
-            finish(bitfield=int.from_bytes(data[1:], byteorder="little"))
-        except Exception as exc:
-            finish(error=SupervisorReadError(f"malformed supervisor state response: {exc}"))
+        def finish(
+            *,
+            bitfield: int | None = None,
+            error: SupervisorReadError | None = None,
+        ) -> None:
+            with result_lock:
+                if done.is_set():
+                    return
+                if error is not None:
+                    result["error"] = error
+                else:
+                    result["bitfield"] = bitfield
+                done.set()
 
-    def disconnected(_uri: str) -> None:
-        finish(error=SupervisorReadError("Crazyflie disconnected during supervisor state read"))
-
-    disconnect_callbacks = getattr(cf, "disconnected", None)
-    disconnect_registered = False
-    cf.add_port_callback(CRTPPort.SUPERVISOR, supervisor_callback)
-    try:
-        if (
-            disconnect_callbacks is not None
-            and hasattr(disconnect_callbacks, "add_callback")
-            and hasattr(disconnect_callbacks, "remove_callback")
-        ):
-            disconnect_callbacks.add_callback(disconnected)
-            disconnect_registered = True
-
-        try:
-            packet = CRTPPacket()
-            packet.set_header(CRTPPort.SUPERVISOR, SUPERVISOR_CH_INFO)
-            packet.data = (CMD_GET_STATE_BITFIELD,)
-            cf.send_packet(packet)
-        except Exception as exc:
-            raise SupervisorReadError(
-                f"fresh supervisor state request failed: {exc}"
-            ) from exc
-
-        if not done.wait(timeout_seconds):
-            raise SupervisorReadError("fresh supervisor state request timed out")
-    finally:
-        if disconnect_registered:
+        def supervisor_callback(packet: object) -> None:
             try:
-                disconnect_callbacks.remove_callback(disconnected)
-            except ValueError:
-                pass
-        cf.remove_port_callback(CRTPPort.SUPERVISOR, supervisor_callback)
+                if packet.channel != SUPERVISOR_CH_INFO:
+                    return
+                data = bytes(packet.data)
+                if not data or data[0] != CMD_GET_STATE_BITFIELD_RESPONSE:
+                    return
+                # Pinned 2026.08 firmware responds with one command byte plus a
+                # uint16 supervisor bitfield. Anything else is incompatible.
+                if len(data) != 3:
+                    finish(
+                        error=SupervisorReadError(
+                            "malformed supervisor state response"
+                        )
+                    )
+                    return
+                finish(bitfield=int.from_bytes(data[1:3], byteorder="little"))
+            except Exception as exc:
+                finish(
+                    error=SupervisorReadError(
+                        f"malformed supervisor state response: {exc}"
+                    )
+                )
 
-    error = result.get("error")
-    if isinstance(error, Exception):
-        raise error
-    bitfield = result.get("bitfield")
-    if not isinstance(bitfield, int):
-        raise SupervisorReadError("fresh supervisor state response is unavailable")
-    return decode_supervisor_state(protocol_version, bitfield)
+        def disconnected(_uri: str) -> None:
+            reason = "Crazyflie disconnected during supervisor state read"
+            self._poison(reason)
+            finish(error=SupervisorReadError(reason))
+
+        disconnect_callbacks = getattr(self._cf, "disconnected", None)
+        disconnect_registered = False
+        self._cf.add_port_callback(CRTPPort.SUPERVISOR, supervisor_callback)
+        try:
+            if (
+                disconnect_callbacks is not None
+                and hasattr(disconnect_callbacks, "add_callback")
+                and hasattr(disconnect_callbacks, "remove_callback")
+            ):
+                disconnect_callbacks.add_callback(disconnected)
+                disconnect_registered = True
+
+            try:
+                packet = CRTPPacket()
+                packet.set_header(CRTPPort.SUPERVISOR, SUPERVISOR_CH_INFO)
+                packet.data = (CMD_GET_STATE_BITFIELD,)
+                self._cf.send_packet(packet)
+            except Exception as exc:
+                raise SupervisorReadError(
+                    f"fresh supervisor state request failed: {exc}"
+                ) from exc
+
+            if not done.wait(timeout_seconds):
+                raise SupervisorReadError("fresh supervisor state request timed out")
+        finally:
+            if disconnect_registered:
+                try:
+                    disconnect_callbacks.remove_callback(disconnected)
+                except ValueError:
+                    pass
+            self._cf.remove_port_callback(CRTPPort.SUPERVISOR, supervisor_callback)
+
+        error = result.get("error")
+        if isinstance(error, SupervisorReadError):
+            raise error
+        bitfield = result.get("bitfield")
+        if not isinstance(bitfield, int):
+            raise SupervisorReadError("fresh supervisor state response is unavailable")
+        return decode_supervisor_state(protocol_version, bitfield)

--- a/tools/physical/supervisor_state.py
+++ b/tools/physical/supervisor_state.py
@@ -34,8 +34,9 @@ BIT_HL_CONTROL_DISABLED = 10
 BIT_DECK_FAULT = 11
 KNOWN_STATE_MASK = (1 << (BIT_DECK_FAULT + 1)) - 1
 
-_POISON_LOCK = Lock()
+_EPOCH_STATE_LOCK = Lock()
 _POISONED_EPOCHS: dict[str, str] = {}
+_EPOCH_READ_LOCKS: dict[str, Lock] = {}
 
 
 class SupervisorReadError(RuntimeError):
@@ -65,13 +66,23 @@ def _bit(value: int, position: int) -> bool:
 
 
 def _poison_epoch(epoch: str, reason: str) -> None:
-    with _POISON_LOCK:
+    with _EPOCH_STATE_LOCK:
         _POISONED_EPOCHS.setdefault(epoch, reason)
 
 
 def _poison_reason(epoch: str) -> str | None:
-    with _POISON_LOCK:
+    with _EPOCH_STATE_LOCK:
         return _POISONED_EPOCHS.get(epoch)
+
+
+def _read_lock_for_epoch(epoch: str) -> Lock:
+    """Return the process-wide serialization guard for one connection epoch."""
+    with _EPOCH_STATE_LOCK:
+        lock = _EPOCH_READ_LOCKS.get(epoch)
+        if lock is None:
+            lock = Lock()
+            _EPOCH_READ_LOCKS[epoch] = lock
+        return lock
 
 
 def decode_supervisor_state(protocol_version: int, bitfield: int) -> SupervisorState:
@@ -151,8 +162,8 @@ class FreshSupervisorStateReader:
         self._cf = cf
         self._connection_epoch_reader = connection_epoch_reader
         self._crtp_types = crtp_types
-        self._read_lock = Lock()
         self._bound_connection_epoch = self._read_epoch()
+        self._read_lock = _read_lock_for_epoch(self._bound_connection_epoch)
         self._raise_if_poisoned()
 
     @property

--- a/tools/physical/supervisor_state.py
+++ b/tools/physical/supervisor_state.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """Fresh, fail-closed read-only Crazyflie supervisor-state observation.
 
-cflib Supervisor convenience properties may return a cached bitfield when a
-fresh request times out. That behavior is not a sufficient freshness oracle for
-WebeeBlocks physical command completion. This module therefore owns a bounded
-read-only supervisor transaction, binds it to a reconnect-sensitive connection
-epoch and permanently poisons that reader after any ambiguous read failure.
+cflib Supervisor convenience properties may return cached state when a fresh
+request times out. That behavior is not a sufficient freshness oracle for
+WebeeBlocks command completion. This module binds each read to the live
+connection epoch and permanently poisons that epoch after an ambiguous read.
 
 The reader deliberately exposes no arming, watchdog keepalive, setpoint,
-high-level commander or other physical-effect operation.
+high-level commander or other effect operation.
 """
 
 from __future__ import annotations
@@ -35,6 +34,9 @@ BIT_HL_CONTROL_DISABLED = 10
 BIT_DECK_FAULT = 11
 KNOWN_STATE_MASK = (1 << (BIT_DECK_FAULT + 1)) - 1
 
+_POISON_LOCK = Lock()
+_POISONED_EPOCHS: dict[str, str] = {}
+
 
 class SupervisorReadError(RuntimeError):
     """Fail-closed error for unavailable or ambiguous fresh supervisor state."""
@@ -60,6 +62,16 @@ class SupervisorState(NamedTuple):
 
 def _bit(value: int, position: int) -> bool:
     return bool((value >> position) & 0x01)
+
+
+def _poison_epoch(epoch: str, reason: str) -> None:
+    with _POISON_LOCK:
+        _POISONED_EPOCHS.setdefault(epoch, reason)
+
+
+def _poison_reason(epoch: str) -> str | None:
+    with _POISON_LOCK:
+        return _POISONED_EPOCHS.get(epoch)
 
 
 def decode_supervisor_state(protocol_version: int, bitfield: int) -> SupervisorState:
@@ -121,13 +133,12 @@ def _read_protocol_version(cf: object) -> int:
 
 
 class FreshSupervisorStateReader:
-    """One connection-bound supervisor freshness domain.
+    """One reconnect-sensitive supervisor freshness domain.
 
-    A timeout, disconnect, malformed response, protocol incompatibility or
-    connection-epoch change permanently poisons the instance. Since the
-    supervisor GET_STATE command has no transaction identifier, the caller must
-    reconnect and construct a new reader after poison; retrying on the same
-    connection could misclassify a delayed old reply as fresh evidence.
+    GET_STATE has no transaction identifier. A timeout or malformed transport
+    can leave an old reply in flight, so poison is stored by connection epoch,
+    not merely by reader instance. A new reader on the same epoch is rejected.
+    Recovery requires a reconnect/session replacement that rotates the epoch.
     """
 
     def __init__(
@@ -141,10 +152,8 @@ class FreshSupervisorStateReader:
         self._connection_epoch_reader = connection_epoch_reader
         self._crtp_types = crtp_types
         self._read_lock = Lock()
-        self._state_lock = Lock()
-        self._poisoned = False
-        self._poison_reason: str | None = None
         self._bound_connection_epoch = self._read_epoch()
+        self._raise_if_poisoned()
 
     @property
     def bound_connection_epoch(self) -> str:
@@ -152,8 +161,7 @@ class FreshSupervisorStateReader:
 
     @property
     def poisoned(self) -> bool:
-        with self._state_lock:
-            return self._poisoned
+        return _poison_reason(self._bound_connection_epoch) is not None
 
     def _read_epoch(self) -> str:
         try:
@@ -166,26 +174,19 @@ class FreshSupervisorStateReader:
             raise SupervisorReadError("connection epoch is invalid for supervisor state")
         return epoch
 
-    def _poison(self, reason: str) -> None:
-        with self._state_lock:
-            if not self._poisoned:
-                self._poisoned = True
-                self._poison_reason = reason
-
     def _raise_if_poisoned(self) -> None:
-        with self._state_lock:
-            if self._poisoned:
-                raise SupervisorReadError(
-                    "supervisor freshness is poisoned until reconnect: "
-                    + (self._poison_reason or "ambiguous prior read")
-                )
+        reason = _poison_reason(self._bound_connection_epoch)
+        if reason is not None:
+            raise SupervisorReadError(
+                "supervisor freshness is poisoned until reconnect: " + reason
+            )
 
     def _verify_connection_epoch(self) -> None:
         self._raise_if_poisoned()
         current_epoch = self._read_epoch()
         if current_epoch != self._bound_connection_epoch:
             reason = "connection epoch changed during supervisor freshness domain"
-            self._poison(reason)
+            _poison_epoch(self._bound_connection_epoch, reason)
             raise SupervisorReadError(reason)
 
     def read(self, *, timeout_seconds: float = 0.2) -> SupervisorState:
@@ -199,7 +200,7 @@ class FreshSupervisorStateReader:
                 self._verify_connection_epoch()
                 return state
             except SupervisorReadError as exc:
-                self._poison(str(exc))
+                _poison_epoch(self._bound_connection_epoch, str(exc))
                 raise
 
     def _resolve_crtp_types(self) -> tuple[object, object]:
@@ -240,8 +241,7 @@ class FreshSupervisorStateReader:
                 data = bytes(packet.data)
                 if not data or data[0] != CMD_GET_STATE_BITFIELD_RESPONSE:
                     return
-                # Pinned 2026.08 firmware responds with one command byte plus a
-                # uint16 supervisor bitfield. Anything else is incompatible.
+                # Pinned firmware 2026.08 sends command + uint16 exactly.
                 if len(data) != 3:
                     finish(
                         error=SupervisorReadError(
@@ -259,7 +259,7 @@ class FreshSupervisorStateReader:
 
         def disconnected(_uri: str) -> None:
             reason = "Crazyflie disconnected during supervisor state read"
-            self._poison(reason)
+            _poison_epoch(self._bound_connection_epoch, reason)
             finish(error=SupervisorReadError(reason))
 
         disconnect_callbacks = getattr(self._cf, "disconnected", None)

--- a/tools/physical/supervisor_state.py
+++ b/tools/physical/supervisor_state.py
@@ -175,10 +175,15 @@ def read_fresh_supervisor_state(
             disconnect_callbacks.add_callback(disconnected)
             disconnect_registered = True
 
-        packet = CRTPPacket()
-        packet.set_header(CRTPPort.SUPERVISOR, SUPERVISOR_CH_INFO)
-        packet.data = (CMD_GET_STATE_BITFIELD,)
-        cf.send_packet(packet)
+        try:
+            packet = CRTPPacket()
+            packet.set_header(CRTPPort.SUPERVISOR, SUPERVISOR_CH_INFO)
+            packet.data = (CMD_GET_STATE_BITFIELD,)
+            cf.send_packet(packet)
+        except Exception as exc:
+            raise SupervisorReadError(
+                f"fresh supervisor state request failed: {exc}"
+            ) from exc
 
         if not done.wait(timeout_seconds):
             raise SupervisorReadError("fresh supervisor state request timed out")


### PR DESCRIPTION
Adds the bounded non-authority supervisor observation prerequisite identified on #157.

- reads one fresh CRTP supervisor state reply directly instead of using cflib `Supervisor`'s cached-timeout fallback;
- fails closed on timeout, disconnect, malformed matching response, or unsupported protocol;
- exposes decoded supervisor/high-level trajectory state only, with no arming, watchdog, setpoint, high-level commander, or other effect API;
- proves that a second timed-out read never reuses an earlier `hl_traj_finished` value;
- wires the test into the Runtime v2 core harness.

This does not add execution authority, does not authorize flight, and does not replace the independent emergency-stop watchdog or teacher-authorization boundaries. Refs #157 and #72.