### PR TITLE
Refresh physical roadmap after HighLevel semantics integration

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -82,8 +82,9 @@ assertion: a separately authorized physical effect consumer with explicit teache
 authorization before any flight-capable command/effect, firmware-independent
 arming semantics (stock brushed Crazyflie 2.1 auto-arms when pre-flight checks
 pass), an independent emergency-stop watchdog/liveness guard, controlled normal
-land/disarm behavior and proof of real execution continuity. Integrated #256 now codifies the non-authority semantic transform for the
-future direct cflib HighLevelCommander path: body-relative horizontal movement is
+land/disarm behavior and proof of real execution continuity. Integrated #256
+now codifies the non-authority semantic transform for the future direct cflib
+HighLevelCommander path: body-relative horizontal movement is
 rotated into world-frame displacement from an accepted yaw, vertical intent stays
 relative world-Z and turns stay relative yaw. That adapter imports no cflib API
 and emits no command, so physical execution authority remains unproven. A later

--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -95,7 +95,12 @@ reconnect. Neither slice emits flight authority.
 
 A later effect consumer still must supply the accepted live yaw, consume #257 to
 bound command completion, and establish the independent watchdog before any
-flight-capable effect. The pinned watchdog is one-way after first activation:
+flight-capable effect. For safety decisions, #257 must be the exclusive
+authoritative issuer of supervisor GET_STATE requests on the connection epoch:
+the passive cflib supervisor callback may remain registered, but later
+authority/completion/watchdog code must not invoke cflib `Supervisor` getters in
+parallel or use them as a second oracle because they bypass #257's epoch-wide
+serialization and ambiguity poisoning. The pinned watchdog is one-way after first activation:
 there is no normal disable/reset command and abandoning keepalives eventually
 enters the latching locked/reboot path. Its keepalive also has no application
 reply. The current bounded activation-proof direction is therefore a same-epoch,

--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -82,11 +82,13 @@ assertion: a separately authorized physical effect consumer with explicit teache
 authorization before any flight-capable command/effect, firmware-independent
 arming semantics (stock brushed Crazyflie 2.1 auto-arms when pre-flight checks
 pass), an independent emergency-stop watchdog/liveness guard, controlled normal
-land/disarm behavior and proof of real execution continuity. Current source
-evidence selects direct cflib HighLevelCommander semantics as the closest
-physical primitive substrate; body-relative horizontal movement must be rotated
-into world-frame displacement from the accepted yaw, and normal command
-completion must be bounded by observed supervisor state rather than host-side
+land/disarm behavior and proof of real execution continuity. Integrated #256 now codifies the non-authority semantic transform for the
+future direct cflib HighLevelCommander path: body-relative horizontal movement is
+rotated into world-frame displacement from an accepted yaw, vertical intent stays
+relative world-Z and turns stay relative yaw. That adapter imports no cflib API
+and emits no command, so physical execution authority remains unproven. A later
+effect consumer still must supply the accepted live yaw and bound normal command
+completion by fresh supervisor/high-level trajectory state rather than host-side
 sleep alone. Immediate emergency stop and high-level commander stop remain
 exceptional motor-cut paths, not normal Stop/Land semantics.
 

--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -83,15 +83,27 @@ authorization before any flight-capable command/effect, firmware-independent
 arming semantics (stock brushed Crazyflie 2.1 auto-arms when pre-flight checks
 pass), an independent emergency-stop watchdog/liveness guard, controlled normal
 land/disarm behavior and proof of real execution continuity. Integrated #256
-now codifies the non-authority semantic transform for the future direct cflib
-HighLevelCommander path: body-relative horizontal movement is
-rotated into world-frame displacement from an accepted yaw, vertical intent stays
-relative world-Z and turns stay relative yaw. That adapter imports no cflib API
-and emits no command, so physical execution authority remains unproven. A later
-effect consumer still must supply the accepted live yaw and bound normal command
-completion by fresh supervisor/high-level trajectory state rather than host-side
-sleep alone. Immediate emergency stop and high-level commander stop remain
-exceptional motor-cut paths, not normal Stop/Land semantics.
+codifies the non-authority semantic transform for the future direct cflib
+HighLevelCommander path: body-relative horizontal movement is rotated into
+world-frame displacement from an accepted yaw, vertical intent stays relative
+world-Z and turns stay relative yaw. Integrated #257 separately establishes the
+fresh fail-closed supervisor-state observer needed for later completion/safety
+decisions: it is bound to the reconnect-sensitive connection epoch, serializes
+reads across that epoch, requires exact response framing, preserves the raw
+bitfield including deck fault and poisons ambiguous freshness/transport until
+reconnect. Neither slice emits flight authority.
+
+A later effect consumer still must supply the accepted live yaw, consume #257 to
+bound command completion, and establish the independent watchdog before any
+flight-capable effect. The pinned watchdog is one-way after first activation:
+there is no normal disable/reset command and abandoning keepalives eventually
+enters the latching locked/reboot path. Its keepalive also has no application
+reply. The current bounded activation-proof direction is therefore a same-epoch,
+same-supervisor-port causal fence: enqueue a keepalive and then require a
+successful fresh #257 GET_STATE read, relying on the documented same-port ordering
+before treating watchdog liveness as active. That fence/lifecycle still requires
+its own non-motorized implementation proof. Immediate emergency stop and high-level
+commander stop remain exceptional motor-cut paths, not normal Stop/Land semantics.
 
 Do not turn source availability, Lab firmware experiments, preflight
 compatibility, simulation coverage or this implementation direction into a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,16 +33,19 @@ re-asserting both together with the connection epoch immediately before any late
 separately authorized effect. Integrated #256 additionally establishes the pure
 non-authority physical HighLevelCommander semantic adapter for the already-proven
 Runtime v2 horizontal/body-to-world geometry, relative world-Z and signed relative
-yaw; it imports no cflib command surface and emits no physical effect. All of this
-remains non-authority with `executionAuthority:false`. The underlying cflib
-SyncCrazyflie close path still
+yaw; it imports no cflib command surface and emits no physical effect. Integrated
+#257 further establishes a non-authority fresh supervisor-state observer bound to
+the reconnect-sensitive connection epoch: reads are serialized across that epoch,
+exact-framed, preserve the raw bitfield including deck fault, and poison ambiguous
+freshness/transport until reconnect. All of this remains non-authority with
+`executionAuthority:false`. The underlying cflib SyncCrazyflie close path still
 emits its documented safety-zero commander setpoint, so this is not a claim that
 the transport emits no command packet. The substantive remaining product boundary
-now starts after that validated pre-effect assertion: a separately authorized
-physical effect consumer plus explicit teacher authorization before any
-flight-capable command/effect, firmware-independent arming semantics, an
-independent emergency-stop watchdog/liveness guard, controlled normal
-land/disarm behavior and proof of safe real execution continuity. Stock brushed
+now starts after those validated pre-effect/safety observations: a separately
+authorized physical effect consumer plus explicit teacher authorization before any
+flight-capable command/effect, firmware-independent arming semantics, a causally
+activated and continuously maintained emergency-stop watchdog/liveness guard,
+controlled normal land/disarm behavior and proof of safe real execution continuity. Stock brushed
 Crazyflie 2.1 auto-arms when pre-flight checks pass, so teacher authorization
 must not be modeled as merely approving a host arming packet. Do not invent
 additional simulation vocabulary
@@ -229,9 +232,13 @@ Runtime/controller change is justified by #236 alone.
   re-asserting them with the same connection epoch immediately before any later
   separately authorized effect. Integrated #256 then codifies the physical
   body-relative horizontal -> world-frame transform plus relative world-Z/yaw as
-  a pure semantic adapter, without importing cflib or emitting any command. These
-  slices preserve `executionAuthority:false` and expose no WebeeBlocks
-  motor/arming command API
+  a pure semantic adapter, without importing cflib or emitting any command.
+  Integrated #257 adds the fresh fail-closed supervisor-state observer: one
+  reconnect-sensitive epoch serializes all reads, exact response framing and raw
+  state including deck fault are preserved, and timeout/disconnect/malformed or
+  otherwise ambiguous freshness poisons that epoch until reconnect. These slices
+  preserve `executionAuthority:false` and expose no WebeeBlocks motor/arming
+  command API
 - real-device checkpoint #226 was authoritatively closed `NOT_NEEDED` after the
   live-preflight product decision superseded the fixed all-reference-decks gate.
   Its bounded partial observation still established exact Crazyflie 2.1
@@ -244,9 +251,12 @@ Runtime/controller change is justified by #236 alone.
   separately authorized physical effect consumer remains unproven. On stock
   brushed Crazyflie 2.1, auto-arming is enabled, so explicit teacher
   authorization must gate every flight-capable command/effect rather than merely
-  a host arming request. The physical path must also establish an independent
-  emergency-stop watchdog/liveness guard plus controlled normal land/disarm
-  behavior before real student execution continuity can be claimed
+  a host arming request. Fresh supervisor observation itself is now established by
+  #257; the remaining physical path must consume it from the future authority
+  layer, establish an independent emergency-stop watchdog/liveness guard with a
+  proven activation fence and explicit powered-session lifecycle, plus controlled
+  normal land/disarm behavior before real student execution continuity can be
+  claimed
 - reopen simulation vocabulary only for a demonstrated pedagogical need or new
   contradictory evidence.
 
@@ -293,9 +303,11 @@ Runtime/controller change is justified by #236 alone.
   the production physical submission bridge that binds and immediately re-asserts
   the current profile/semantic AST with that live epoch; #256 establishes the
   pure no-effect body/world, world-Z and relative-yaw semantic adapter intended
-  for later direct HighLevelCommander consumption. The surface remains
-  non-authority with `executionAuthority:false`; the cflib close path retains its
-  safety-zero transport setpoint
+  for later direct HighLevelCommander consumption; and #257 establishes a fresh
+  fail-closed raw supervisor observer bound to that reconnect-sensitive epoch,
+  including deck-fault handling and epoch-wide ambiguity poisoning. The surface
+  remains non-authority with `executionAuthority:false`; the cflib close path
+  retains its safety-zero transport setpoint
 - bounded real-device evidence from superseded checkpoint #226 confirms the
   available Crazyflie 2.1 + Flow Deck V2 + Multi-ranger observation, but it is
   not a reusable live execution preflight and does not prove an absent Color LED
@@ -305,18 +317,24 @@ Runtime/controller change is justified by #236 alone.
   independent emergency-stop watchdog/liveness guard, controlled normal
   land/disarm behavior and proof of physical execution continuity. The pinned
   watchdog has no disable/reset command after first activation, so its trusted
-  keepalive lifecycle must span the reusable physical session; simply stopping
-  keepalives after a normal land would eventually enter the latching emergency
-  stop/locked state and require reboot. Do not assume a host arming packet is the
-  teacher gate: stock brushed Crazyflie 2.1 auto-arms when pre-flight checks pass
+  keepalive lifecycle must span the reusable powered physical session; simply
+  stopping keepalives after a normal land would eventually enter the latching
+  emergency-stop/locked state and require reboot. Its one-way keepalive command
+  also has no application-level reply: the current bounded activation-proof
+  direction is to enqueue the keepalive and then require a successful #257 fresh
+  GET_STATE read on the same unchanged connection epoch/supervisor port, relying
+  on the documented same-port ordering as a causal fence. That safety primitive
+  must be independently implemented/tested before effect authority relies on it.
+  Do not assume a host arming packet is the teacher gate: stock brushed Crazyflie
+  2.1 auto-arms when pre-flight checks pass
 - proof direction: preserve backend-neutral AST continuity and consume the
   integrated #256 pure semantic adapter from a later direct cflib
   `HighLevelCommander` effect substrate rather than the `MotionCommander` /
   `PositionHlCommander` helpers. The authority layer still must supply an
-  accepted current yaw, preserve the exact preflight/session binding and bound
-  command completion by fresh supervisor/high-level trajectory state plus
-  timeout/locked/crashed/deck-fault checks. Add only the minimum
-  teacher-authorized physical execution authority after the
+  accepted current yaw, preserve the exact preflight/session binding and consume
+  the integrated #257 fresh supervisor observer to bound command completion by
+  high-level trajectory state plus timeout/locked/crashed/deck-fault checks. Add
+  only the minimum teacher-authorized physical execution authority after the
   live capability and safety gates are independently established. Keep immediate
   emergency stop and high-level commander stop exceptional because both can cut
   motors in flight; normal completion/voluntary abort needs a controlled

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -333,8 +333,12 @@ Runtime/controller change is justified by #236 alone.
   `PositionHlCommander` helpers. The authority layer still must supply an
   accepted current yaw, preserve the exact preflight/session binding and consume
   the integrated #257 fresh supervisor observer to bound command completion by
-  high-level trajectory state plus timeout/locked/crashed/deck-fault checks. Add
-  only the minimum teacher-authorized physical execution authority after the
+  high-level trajectory state plus timeout/locked/crashed/deck-fault checks. That
+  observer must be the exclusive authoritative issuer of supervisor GET_STATE
+  requests on the connection epoch; do not invoke cflib `Supervisor` getters in
+  parallel or as a second safety oracle because they bypass #257's epoch-wide
+  serialization/ambiguity guard. Add only the minimum teacher-authorized physical
+  execution authority after the
   live capability and safety gates are independently established. Keep immediate
   emergency stop and high-level commander stop exceptional because both can cut
   motors in flight; normal completion/voluntary abort needs a controlled

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,8 +30,12 @@ invalidates it on disconnect and rebuilds capability descriptors from the curren
 connection; and #249 wires the production physical submission path to that live
 session, binding the exact current activity profile and semantic workspace AST and
 re-asserting both together with the connection epoch immediately before any later
-separately authorized effect. All of this remains non-authority with
-`executionAuthority:false`. The underlying cflib SyncCrazyflie close path still
+separately authorized effect. Integrated #256 additionally establishes the pure
+non-authority physical HighLevelCommander semantic adapter for the already-proven
+Runtime v2 horizontal/body-to-world geometry, relative world-Z and signed relative
+yaw; it imports no cflib command surface and emits no physical effect. All of this
+remains non-authority with `executionAuthority:false`. The underlying cflib
+SyncCrazyflie close path still
 emits its documented safety-zero commander setpoint, so this is not a claim that
 the transport emits no command packet. The substantive remaining product boundary
 now starts after that validated pre-effect assertion: a separately authorized
@@ -223,8 +227,11 @@ Runtime/controller change is justified by #236 alone.
   the production physical submission path to that live session, preserving the
   exact current activity profile and semantic workspace AST across preflight and
   re-asserting them with the same connection epoch immediately before any later
-  separately authorized effect. These slices preserve `executionAuthority:false`
-  and expose no WebeeBlocks motor/arming command API
+  separately authorized effect. Integrated #256 then codifies the physical
+  body-relative horizontal -> world-frame transform plus relative world-Z/yaw as
+  a pure semantic adapter, without importing cflib or emitting any command. These
+  slices preserve `executionAuthority:false` and expose no WebeeBlocks
+  motor/arming command API
 - real-device checkpoint #226 was authoritatively closed `NOT_NEEDED` after the
   live-preflight product decision superseded the fixed all-reference-decks gate.
   Its bounded partial observation still established exact Crazyflie 2.1
@@ -284,7 +291,9 @@ Runtime/controller change is justified by #236 alone.
   invalidation; #246 supplies the concrete host-side live session that owns the
   reconnect-sensitive epoch and current descriptor reads; and #249 integrates
   the production physical submission bridge that binds and immediately re-asserts
-  the current profile/semantic AST with that live epoch. The surface remains
+  the current profile/semantic AST with that live epoch; #256 establishes the
+  pure no-effect body/world, world-Z and relative-yaw semantic adapter intended
+  for later direct HighLevelCommander consumption. The surface remains
   non-authority with `executionAuthority:false`; the cflib close path retains its
   safety-zero transport setpoint
 - bounded real-device evidence from superseded checkpoint #226 confirms the
@@ -294,16 +303,20 @@ Runtime/controller change is justified by #236 alone.
 - depends: separately authorized physical effect consumption gated by explicit
   teacher authorization before any flight-capable command/effect, plus an
   independent emergency-stop watchdog/liveness guard, controlled normal
-  land/disarm behavior and proof of physical execution continuity. Do not assume
-  a host arming packet is the teacher gate: stock brushed Crazyflie 2.1
-  auto-arms when pre-flight checks pass
-- proof direction: preserve backend-neutral AST continuity and use direct cflib
-  `HighLevelCommander` as the primitive effect substrate rather than the
-  `MotionCommander` / `PositionHlCommander` helpers: rotate body-relative
-  horizontal intent into world-frame deltas from an accepted current yaw, use
-  relative world-Z/yaw as appropriate, and bound command completion by observed
-  supervisor/high-level trajectory state plus timeout/locked/crashed checks.
-  Add only the minimum teacher-authorized physical execution authority after the
+  land/disarm behavior and proof of physical execution continuity. The pinned
+  watchdog has no disable/reset command after first activation, so its trusted
+  keepalive lifecycle must span the reusable physical session; simply stopping
+  keepalives after a normal land would eventually enter the latching emergency
+  stop/locked state and require reboot. Do not assume a host arming packet is the
+  teacher gate: stock brushed Crazyflie 2.1 auto-arms when pre-flight checks pass
+- proof direction: preserve backend-neutral AST continuity and consume the
+  integrated #256 pure semantic adapter from a later direct cflib
+  `HighLevelCommander` effect substrate rather than the `MotionCommander` /
+  `PositionHlCommander` helpers. The authority layer still must supply an
+  accepted current yaw, preserve the exact preflight/session binding and bound
+  command completion by fresh supervisor/high-level trajectory state plus
+  timeout/locked/crashed/deck-fault checks. Add only the minimum
+  teacher-authorized physical execution authority after the
   live capability and safety gates are independently established. Keep immediate
   emergency stop and high-level commander stop exceptional because both can cut
   motors in flight; normal completion/voluntary abort needs a controlled


### PR DESCRIPTION
Updates durable product documentation after integrated #256 and the verified emergency-watchdog lifecycle finding on #157.

- records #256 as the established pure non-authority body/world, world-Z and relative-yaw semantic adapter instead of leaving that work as an unimplemented proof direction;
- preserves the separate physical execution-authority boundary;
- records that the pinned emergency-stop watchdog has no disable/reset command after first activation, so trusted keepalives must span the reusable physical session and stopping them implies the latching emergency-stop/reboot path;
- keeps fresh supervisor completion, teacher authorization, controlled landing/disarm and real execution proof as remaining gates.

Docs only. Refs #157 and #72.