### PR TITLE
Refine normal landing semantics for stock auto-arming

### DIFF
--- a/docs/REFERENCE_CAPABILITY_MATRIX.md
+++ b/docs/REFERENCE_CAPABILITY_MATRIX.md
@@ -82,7 +82,7 @@ assertion: a separately authorized physical effect consumer with explicit teache
 authorization before any flight-capable command/effect, firmware-independent
 arming semantics (stock brushed Crazyflie 2.1 auto-arms when pre-flight checks
 pass), an independent emergency-stop watchdog/liveness guard, controlled normal
-land/disarm behavior and proof of real execution continuity. Integrated #256
+landing/completion behavior and proof of real execution continuity. Integrated #256
 codifies the non-authority semantic transform for the future direct cflib
 HighLevelCommander path: body-relative horizontal movement is rotated into
 world-frame displacement from an accepted yaw, vertical intent stays relative
@@ -107,8 +107,16 @@ reply. The current bounded activation-proof direction is therefore a same-epoch,
 same-supervisor-port causal fence: enqueue a keepalive and then require a
 successful fresh #257 GET_STATE read, relying on the documented same-port ordering
 before treating watchdog liveness as active. That fence/lifecycle still requires
-its own non-motorized implementation proof. Immediate emergency stop and high-level
-commander stop remain exceptional motor-cut paths, not normal Stop/Land semantics.
+its own non-motorized implementation proof.
+
+Normal completion must use the controlled high-level landing trajectory rather
+than the high-level `stop()` motor-cut path and require fresh #257 evidence that
+flight ended without a blocking fault while trusted watchdog/session handling
+continues. Stock CF2.1 auto-arming can return the vehicle to ReadyToFly after the
+landing/reset cycle, so post-landing disarm is not a persistent teacher/safety
+gate; every later flight-capable effect still requires explicit teacher
+authorization. Immediate emergency stop and high-level commander stop remain
+exceptional motor-cut paths, not normal Stop/Land semantics.
 
 Do not turn source availability, Lab firmware experiments, preflight
 compatibility, simulation coverage or this implementation direction into a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,9 +45,11 @@ now starts after those validated pre-effect/safety observations: a separately
 authorized physical effect consumer plus explicit teacher authorization before any
 flight-capable command/effect, firmware-independent arming semantics, a causally
 activated and continuously maintained emergency-stop watchdog/liveness guard,
-controlled normal land/disarm behavior and proof of safe real execution continuity. Stock brushed
-Crazyflie 2.1 auto-arms when pre-flight checks pass, so teacher authorization
-must not be modeled as merely approving a host arming packet. Do not invent
+controlled normal landing/completion behavior and proof of safe real execution
+continuity. Stock brushed Crazyflie 2.1 auto-arms when pre-flight checks pass and
+can return to ReadyToFly after a normal landing/reset cycle, so post-landing
+disarm is not a persistent safety gate and teacher authorization must not be
+modeled as merely approving a host arming packet. Do not invent
 additional simulation vocabulary
 merely to keep #157 active. A new simulation slice needs a concrete pedagogical
 need or contradictory evidence.
@@ -254,9 +256,10 @@ Runtime/controller change is justified by #236 alone.
   a host arming request. Fresh supervisor observation itself is now established by
   #257; the remaining physical path must consume it from the future authority
   layer, establish an independent emergency-stop watchdog/liveness guard with a
-  proven activation fence and explicit powered-session lifecycle, plus controlled
-  normal land/disarm behavior before real student execution continuity can be
-  claimed
+  proven activation fence and explicit powered-session lifecycle, plus a
+  controlled high-level landing/completion proof from fresh #257 evidence. On
+  stock auto-arming firmware, post-landing disarm is not a persistent lockout;
+  later flight-capable effects still require a new teacher authorization
 - reopen simulation vocabulary only for a demonstrated pedagogical need or new
   contradictory evidence.
 
@@ -315,7 +318,9 @@ Runtime/controller change is justified by #236 alone.
 - depends: separately authorized physical effect consumption gated by explicit
   teacher authorization before any flight-capable command/effect, plus an
   independent emergency-stop watchdog/liveness guard, controlled normal
-  land/disarm behavior and proof of physical execution continuity. The pinned
+  landing/completion behavior and proof of physical execution continuity. Stock
+  auto-arming can return the vehicle to ReadyToFly after the landing/reset cycle,
+  so a host disarm request is not a durable post-mission lockout. The pinned
   watchdog has no disable/reset command after first activation, so its trusted
   keepalive lifecycle must span the reusable powered physical session; simply
   stopping keepalives after a normal land would eventually enter the latching
@@ -342,7 +347,10 @@ Runtime/controller change is justified by #236 alone.
   live capability and safety gates are independently established. Keep immediate
   emergency stop and high-level commander stop exceptional because both can cut
   motors in flight; normal completion/voluntary abort needs a controlled
-  high-level land then disarm path
+  high-level land, fresh #257 evidence that flight ended without a blocking
+  fault, and continued watchdog/session handling. A later flight-capable effect
+  still requires fresh teacher authorization even if stock auto-arming returns
+  the vehicle to ReadyToFly
 - expand only when this becomes near-term work.
 
 ### FF — Firefox same-file project semantics


### PR DESCRIPTION
Projects the verified #157 normal-completion finding into the durable physical roadmap and capability matrix.

- replaces the misleading idea of persistent post-landing disarm on stock CF2.1;
- records that a controlled high-level landing must complete without using the high-level `stop()` motor-cut path;
- requires fresh #257 supervisor evidence that flight ended without a blocking fault while the trusted watchdog/session remains live;
- preserves explicit teacher authorization for every later flight-capable effect because stock auto-arming may return the vehicle to `ReadyToFly` after the landing/reset cycle.

Docs only; no physical command, execution authority or motorized evidence. Refs #157 and #72.