### PR TITLE
Add fresh same-epoch physical yaw observer

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -53,6 +53,10 @@ def main():
     if physical_supervisor_test.returncode:
         print('FAIL connection-epoch physical supervisor freshness',file=sys.stderr);print(physical_supervisor_test.stdout,file=sys.stderr);print(physical_supervisor_test.stderr,file=sys.stderr);return physical_supervisor_test.returncode
     print(physical_supervisor_test.stdout.strip())
+    physical_yaw_test=subprocess.run([sys.executable,'tools/ci/test_physical_yaw_observer.py'],text=True,capture_output=True)
+    if physical_yaw_test.returncode:
+        print('FAIL fresh physical yaw observation',file=sys.stderr);print(physical_yaw_test.stdout,file=sys.stderr);print(physical_yaw_test.stderr,file=sys.stderr);return physical_yaw_test.returncode
+    print(physical_yaw_test.stdout.strip())
     physical_http_test=subprocess.run([sys.executable,'tools/ci/test_physical_capability_http_bridge.py'],text=True,capture_output=True)
     if physical_http_test.returncode:
         print('FAIL read-only physical capability HTTP bridge',file=sys.stderr);print(physical_http_test.stdout,file=sys.stderr);print(physical_http_test.stderr,file=sys.stderr);return physical_http_test.returncode

--- a/tools/ci/test_physical_yaw_observer.py
+++ b/tools/ci/test_physical_yaw_observer.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import math
+import pathlib
+import threading
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "yaw_observer.py"
+
+spec = importlib.util.spec_from_file_location("webeeblocks_yaw_observer", MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load yaw observer")
+yaw = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(yaw)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except yaw.YawReadError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected YawReadError containing {pattern!r}")
+
+
+class FakeCaller:
+    def __init__(self) -> None:
+        self.callbacks = []
+
+    def add_callback(self, callback) -> None:
+        self.callbacks.append(callback)
+
+    def remove_callback(self, callback) -> None:
+        self.callbacks.remove(callback)
+
+    def call(self, *args) -> None:
+        for callback in list(self.callbacks):
+            callback(*args)
+
+
+class FakeConfig:
+    def __init__(self, initial_sample=None) -> None:
+        self.data_received_cb = FakeCaller()
+        self.error_cb = FakeCaller()
+        self.initial_sample = initial_sample
+        self.started = False
+        self.stopped = False
+        self.deleted = False
+        self.start_error = None
+
+    def start(self) -> None:
+        if self.start_error is not None:
+            raise self.start_error
+        self.started = True
+        if self.initial_sample is not None:
+            timestamp, value = self.initial_sample
+            self.emit(timestamp, value)
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def delete(self) -> None:
+        self.deleted = True
+
+    def emit(self, timestamp, value) -> None:
+        data = value if isinstance(value, dict) else {yaw.YAW_VARIABLE: value}
+        self.data_received_cb.call(timestamp, data, self)
+
+    def fail(self, message: str) -> None:
+        self.error_cb.call(self, message)
+
+
+class FakeLog:
+    def __init__(self) -> None:
+        self.configs = []
+        self.add_error = None
+
+    def add_config(self, config) -> None:
+        if self.add_error is not None:
+            raise self.add_error
+        self.configs.append(config)
+
+
+class FakeCf:
+    def __init__(self) -> None:
+        self.log = FakeLog()
+        self.disconnected = FakeCaller()
+
+
+class Epoch:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+
+def make_observer(initial=(100, 10.0), epoch_value="epoch-yaw"):
+    cf = FakeCf()
+    epoch = Epoch(epoch_value)
+    config = FakeConfig(initial)
+    observer = yaw.FreshYawObserver(cf, epoch, log_config_factory=lambda: config)
+    return observer, cf, epoch, config
+
+
+def delayed(delay: float, function) -> None:
+    timer = threading.Timer(delay, function)
+    timer.daemon = True
+    timer.start()
+
+
+def test_open_baseline_and_later_read() -> None:
+    observer, _cf, _epoch, config = make_observer()
+    observer.open(timeout_seconds=0.05)
+    require(observer.is_open and observer.bound_connection_epoch == "epoch-yaw", "open epoch")
+    delayed(0.01, lambda: config.emit(110, 20.0))
+    result = observer.read(timeout_seconds=0.2)
+    require(result.firmware_timestamp_ms == 110 and result.yaw_deg == 20.0, "later sample")
+    require(math.isclose(result.yaw_rad, math.radians(20.0), abs_tol=1e-15), "degrees to radians")
+    observer.close()
+
+
+def test_cached_baseline_not_returned() -> None:
+    observer, _cf, _epoch, _config = make_observer()
+    observer.open(timeout_seconds=0.05)
+    expect_error(lambda: observer.read(timeout_seconds=0.01), "fresh yaw sample timed out")
+    observer.close()
+
+
+def test_duplicate_timestamp_ignored() -> None:
+    observer, _cf, _epoch, config = make_observer()
+    observer.open(timeout_seconds=0.05)
+    delayed(0.005, lambda: config.emit(100, 99.0))
+    delayed(0.015, lambda: config.emit(120, 30.0))
+    result = observer.read(timeout_seconds=0.2)
+    require(result.firmware_timestamp_ms == 120 and result.yaw_deg == 30.0, "duplicate timestamp")
+    observer.close()
+
+
+def test_timestamp_wrap() -> None:
+    observer, _cf, _epoch, config = make_observer(initial=(0xFFFFF8, -179.0), epoch_value="epoch-wrap")
+    observer.open(timeout_seconds=0.05)
+    delayed(0.01, lambda: config.emit(5, 179.0))
+    result = observer.read(timeout_seconds=0.2)
+    require(result.firmware_timestamp_ms == 5 and result.yaw_deg == 179.0, "24-bit wrap")
+    observer.close()
+
+
+def test_epoch_rotation_fails_closed() -> None:
+    observer, _cf, epoch, _config = make_observer(epoch_value="epoch-before")
+    observer.open(timeout_seconds=0.05)
+    epoch.value = "epoch-after"
+    expect_error(lambda: observer.read(timeout_seconds=0.05), "connection epoch changed")
+    observer.close()
+
+
+def test_disconnect_and_log_error_fail_closed() -> None:
+    observer, cf, _epoch, _config = make_observer(epoch_value="epoch-disconnect")
+    observer.open(timeout_seconds=0.05)
+    delayed(0.01, lambda: cf.disconnected.call("radio://test"))
+    expect_error(lambda: observer.read(timeout_seconds=0.2), "disconnected during yaw observation")
+    observer.close()
+
+    observer2, _cf2, _epoch2, config2 = make_observer(epoch_value="epoch-log-error")
+    observer2.open(timeout_seconds=0.05)
+    delayed(0.01, lambda: config2.fail("firmware log rejected"))
+    expect_error(lambda: observer2.read(timeout_seconds=0.2), "yaw logging failed")
+    observer2.close()
+
+
+def test_invalid_samples_fail_open_and_cleanup() -> None:
+    for epoch_value, initial, pattern in (
+        ("epoch-nan", (100, float("nan")), "not finite"),
+        ("epoch-missing", (100, {}), "missing stateEstimate.yaw"),
+        ("epoch-ts", (0x1000000, 0.0), "invalid firmware timestamp"),
+    ):
+        observer, cf, _epoch, config = make_observer(initial=initial, epoch_value=epoch_value)
+        expect_error(lambda o=observer: o.open(timeout_seconds=0.05), pattern)
+        require(config.stopped and config.deleted, "failed-open log cleanup")
+        require(cf.disconnected.callbacks == [], "failed-open disconnect cleanup")
+
+
+def test_add_and_start_failures_are_typed() -> None:
+    observer, cf, _epoch, config = make_observer(epoch_value="epoch-add-fail")
+    cf.log.add_error = RuntimeError("TOC unavailable")
+    expect_error(lambda: observer.open(timeout_seconds=0.05), "could not start fresh yaw logging")
+    require(config.stopped and config.deleted and cf.disconnected.callbacks == [], "add failure cleanup")
+
+    observer2, cf2, _epoch2, config2 = make_observer(epoch_value="epoch-start-fail")
+    config2.start_error = RuntimeError("start failed")
+    expect_error(lambda: observer2.open(timeout_seconds=0.05), "could not start fresh yaw logging")
+    require(config2.stopped and config2.deleted and cf2.disconnected.callbacks == [], "start failure cleanup")
+
+
+def test_close_removes_callbacks_and_is_idempotent() -> None:
+    observer, cf, _epoch, config = make_observer(epoch_value="epoch-close")
+    observer.open(timeout_seconds=0.05)
+    observer.close()
+    require(config.stopped and config.deleted, "close stops/deletes")
+    require(config.data_received_cb.callbacks == [] and config.error_cb.callbacks == [], "log callbacks removed")
+    require(cf.disconnected.callbacks == [], "disconnect callback removed")
+    require(not observer.is_open, "closed state")
+    observer.close()
+
+
+def test_local_errors_emit_no_log_request() -> None:
+    observer, cf, _epoch, config = make_observer(epoch_value="epoch-local")
+    expect_error(lambda: observer.open(timeout_seconds=0), "timeout must be positive")
+    require(cf.log.configs == [] and not config.started, "invalid open has no log effect")
+    expect_error(lambda: observer.read(timeout_seconds=0.01), "not open")
+
+
+def main() -> int:
+    test_open_baseline_and_later_read()
+    test_cached_baseline_not_returned()
+    test_duplicate_timestamp_ignored()
+    test_timestamp_wrap()
+    test_epoch_rotation_fails_closed()
+    test_disconnect_and_log_error_fail_closed()
+    test_invalid_samples_fail_open_and_cleanup()
+    test_add_and_start_failures_are_typed()
+    test_close_removes_callbacks_and_is_idempotent()
+    test_local_errors_emit_no_log_request()
+
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "send_arming_request",
+        "send_emergency_stop",
+        "send_emergency_stop_watchdog",
+        "HighLevelCommander(",
+        "send_setpoint",
+        "send_hover_setpoint",
+        "send_velocity_world_setpoint",
+    ):
+        require(forbidden not in source, f"yaw observer exposes authority surface: {forbidden}")
+
+    print("PASS fresh same-epoch stateEstimate.yaw observation has no execution authority")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/yaw_observer.py
+++ b/tools/physical/yaw_observer.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Fresh, non-authority yaw observation for the physical HighLevel path.
+
+Integrated physical movement semantics require an accepted current yaw to rotate
+body-relative horizontal intent into a world-frame displacement. This module
+obtains that yaw from the firmware's stateEstimate.yaw log variable without
+exposing any motor, arming, watchdog or commander operation.
+
+Opening establishes a first sample only as a timestamp baseline. Each read then
+requires a later firmware timestamp received after the read began on the same
+reconnect-sensitive connection epoch, so cached/UI values are not accepted as
+fresh execution evidence.
+"""
+
+from __future__ import annotations
+
+from math import isfinite, radians
+from threading import Condition, Lock
+from time import monotonic
+from typing import Callable, NamedTuple
+
+YAW_VARIABLE = "stateEstimate.yaw"
+LOG_PERIOD_MS = 10
+_TIMESTAMP_MASK = (1 << 24) - 1
+_TIMESTAMP_HALF_RANGE = 1 << 23
+
+
+class YawReadError(RuntimeError):
+    """Fail-closed error for unavailable or stale physical yaw evidence."""
+
+
+class YawObservation(NamedTuple):
+    connection_epoch: str
+    firmware_timestamp_ms: int
+    yaw_deg: float
+    yaw_rad: float
+
+
+def _timestamp_is_later(new_timestamp: int, old_timestamp: int) -> bool:
+    delta = (new_timestamp - old_timestamp) & _TIMESTAMP_MASK
+    return 0 < delta < _TIMESTAMP_HALF_RANGE
+
+
+class FreshYawObserver:
+    """Continuous log observer bound to one live physical connection epoch."""
+
+    def __init__(
+        self,
+        cf: object,
+        connection_epoch_reader: Callable[[], str],
+        *,
+        log_config_factory: Callable[[], object] | None = None,
+    ) -> None:
+        self._cf = cf
+        self._connection_epoch_reader = connection_epoch_reader
+        self._log_config_factory = log_config_factory
+        self._read_lock = Lock()
+        self._condition = Condition(Lock())
+        self._bound_connection_epoch: str | None = None
+        self._config: object | None = None
+        self._opened = False
+        self._sequence = 0
+        self._latest: tuple[int, float] | None = None
+        self._stream_error: YawReadError | None = None
+
+    @property
+    def bound_connection_epoch(self) -> str | None:
+        return self._bound_connection_epoch
+
+    @property
+    def is_open(self) -> bool:
+        return self._opened
+
+    def _read_epoch(self) -> str:
+        try:
+            epoch = self._connection_epoch_reader()
+        except Exception as exc:
+            raise YawReadError("connection epoch is unavailable for yaw observation") from exc
+        if not isinstance(epoch, str) or not epoch.strip():
+            raise YawReadError("connection epoch is invalid for yaw observation")
+        return epoch
+
+    def _verify_epoch(self) -> str:
+        current = self._read_epoch()
+        if self._bound_connection_epoch is not None and current != self._bound_connection_epoch:
+            raise YawReadError("connection epoch changed during yaw observation")
+        return current
+
+    def _make_config(self) -> object:
+        if self._log_config_factory is not None:
+            return self._log_config_factory()
+        try:
+            from cflib.crazyflie.log import LogConfig
+        except ImportError as exc:
+            raise YawReadError("cflib logging support is unavailable") from exc
+        config = LogConfig("WebeeBlocks fresh yaw", LOG_PERIOD_MS)
+        config.add_variable(YAW_VARIABLE, "float")
+        return config
+
+    def _set_error(self, message: str) -> None:
+        with self._condition:
+            if self._stream_error is None:
+                self._stream_error = YawReadError(message)
+            self._condition.notify_all()
+
+    def _on_log_error(self, _config: object, message: object) -> None:
+        self._set_error(f"yaw logging failed: {message}")
+
+    def _on_disconnect(self, _uri: str) -> None:
+        self._set_error("Crazyflie disconnected during yaw observation")
+
+    def _on_data(self, timestamp: object, data: object, config: object) -> None:
+        if config is not self._config:
+            return
+        try:
+            if not isinstance(timestamp, int) or timestamp < 0 or timestamp > _TIMESTAMP_MASK:
+                raise YawReadError("yaw sample has an invalid firmware timestamp")
+            if not isinstance(data, dict) or YAW_VARIABLE not in data:
+                raise YawReadError("yaw sample is missing stateEstimate.yaw")
+            yaw_deg = float(data[YAW_VARIABLE])
+            if not isfinite(yaw_deg):
+                raise YawReadError("yaw sample is not finite")
+        except (TypeError, ValueError, YawReadError) as exc:
+            message = str(exc) if isinstance(exc, YawReadError) else f"invalid yaw sample: {exc}"
+            self._set_error(message)
+            return
+
+        with self._condition:
+            if self._stream_error is not None:
+                return
+            self._sequence += 1
+            self._latest = (timestamp, yaw_deg)
+            self._condition.notify_all()
+
+    def _wait_for_sample(
+        self,
+        *,
+        after_sequence: int,
+        after_timestamp: int | None,
+        timeout_seconds: float,
+    ) -> tuple[int, float]:
+        deadline = monotonic() + timeout_seconds
+        with self._condition:
+            while True:
+                if self._stream_error is not None:
+                    raise self._stream_error
+                if self._sequence > after_sequence and self._latest is not None:
+                    timestamp, yaw_deg = self._latest
+                    if after_timestamp is None or _timestamp_is_later(timestamp, after_timestamp):
+                        return timestamp, yaw_deg
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    raise YawReadError("fresh yaw sample timed out")
+                self._condition.wait(remaining)
+
+    def open(self, *, timeout_seconds: float = 0.5) -> None:
+        """Start one session log stream and establish a fresh timestamp baseline."""
+        if timeout_seconds <= 0:
+            raise YawReadError("yaw timeout must be positive")
+
+        with self._read_lock:
+            if self._opened:
+                self._verify_epoch()
+                return
+
+            self._bound_connection_epoch = self._read_epoch()
+            with self._condition:
+                self._sequence = 0
+                self._latest = None
+                self._stream_error = None
+
+            config = self._make_config()
+            self._config = config
+            data_registered = False
+            error_registered = False
+            disconnect_registered = False
+            try:
+                config.data_received_cb.add_callback(self._on_data)
+                data_registered = True
+                config.error_cb.add_callback(self._on_log_error)
+                error_registered = True
+                self._cf.disconnected.add_callback(self._on_disconnect)
+                disconnect_registered = True
+                self._cf.log.add_config(config)
+                config.start()
+                self._wait_for_sample(
+                    after_sequence=0,
+                    after_timestamp=None,
+                    timeout_seconds=timeout_seconds,
+                )
+                self._verify_epoch()
+                self._opened = True
+            except YawReadError:
+                self._cleanup_failed_open(
+                    config,
+                    data_registered=data_registered,
+                    error_registered=error_registered,
+                    disconnect_registered=disconnect_registered,
+                )
+                raise
+            except Exception as exc:
+                self._cleanup_failed_open(
+                    config,
+                    data_registered=data_registered,
+                    error_registered=error_registered,
+                    disconnect_registered=disconnect_registered,
+                )
+                raise YawReadError(f"could not start fresh yaw logging: {exc}") from exc
+
+    def _cleanup_failed_open(
+        self,
+        config: object,
+        *,
+        data_registered: bool,
+        error_registered: bool,
+        disconnect_registered: bool,
+    ) -> None:
+        for action in (getattr(config, "stop", None), getattr(config, "delete", None)):
+            if callable(action):
+                try:
+                    action()
+                except Exception:
+                    pass
+        if data_registered:
+            try:
+                config.data_received_cb.remove_callback(self._on_data)
+            except Exception:
+                pass
+        if error_registered:
+            try:
+                config.error_cb.remove_callback(self._on_log_error)
+            except Exception:
+                pass
+        if disconnect_registered:
+            try:
+                self._cf.disconnected.remove_callback(self._on_disconnect)
+            except Exception:
+                pass
+        self._config = None
+        self._opened = False
+
+    def read(self, *, timeout_seconds: float = 0.5) -> YawObservation:
+        """Return one newly arrived post-call yaw sample from the bound epoch."""
+        if timeout_seconds <= 0:
+            raise YawReadError("yaw timeout must be positive")
+
+        with self._read_lock:
+            if not self._opened or self._config is None or self._bound_connection_epoch is None:
+                raise YawReadError("yaw observer is not open")
+            self._verify_epoch()
+            with self._condition:
+                if self._stream_error is not None:
+                    raise self._stream_error
+                baseline_sequence = self._sequence
+                if self._latest is None:
+                    raise YawReadError("yaw observer has no established baseline")
+                baseline_timestamp = self._latest[0]
+
+            timestamp, yaw_deg = self._wait_for_sample(
+                after_sequence=baseline_sequence,
+                after_timestamp=baseline_timestamp,
+                timeout_seconds=timeout_seconds,
+            )
+            epoch = self._verify_epoch()
+            return YawObservation(
+                connection_epoch=epoch,
+                firmware_timestamp_ms=timestamp,
+                yaw_deg=yaw_deg,
+                yaw_rad=radians(yaw_deg),
+            )
+
+    def close(self) -> None:
+        """Stop/delete the non-authority log stream and remove callbacks."""
+        with self._read_lock:
+            config = self._config
+            if config is None:
+                self._opened = False
+                return
+            errors: list[str] = []
+            for label, action in (("stop", config.stop), ("delete", config.delete)):
+                try:
+                    action()
+                except Exception as exc:
+                    errors.append(f"{label}: {exc}")
+            for callback_list, callback in (
+                (config.data_received_cb, self._on_data),
+                (config.error_cb, self._on_log_error),
+                (self._cf.disconnected, self._on_disconnect),
+            ):
+                try:
+                    callback_list.remove_callback(callback)
+                except Exception as exc:
+                    errors.append(f"callback cleanup: {exc}")
+            self._config = None
+            self._opened = False
+            if errors:
+                raise YawReadError("could not close yaw observer cleanly: " + "; ".join(errors))


### PR DESCRIPTION
Adds the non-authority accepted-yaw prerequisite identified on #157 for later consumption by integrated #256.

- logs the firmware `stateEstimate.yaw` source instead of deriving yaw from synthetic planner state or the student program;
- binds observation to the live reconnect-sensitive connection epoch;
- uses the first newly received sample only as a timestamp baseline, then requires a later post-call firmware sample before returning an accepted yaw;
- handles the 24-bit firmware log timestamp wrap, rejects duplicate/stale timestamps and non-finite/malformed samples, and fails closed on timeout, log error, disconnect or epoch rotation;
- converts degrees to radians exactly once in the returned observation;
- keeps a continuous session log stream and exposes no commander, arming, watchdog, setpoint or other execution authority;
- wires deterministic regressions into the Runtime v2 core harness.

No physical command, motorized evidence or flight authority. Refs #157 and #72.