### PR TITLE
Add fresh controlled landing completion evidence

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -53,6 +53,10 @@ def main():
     if physical_supervisor_test.returncode:
         print('FAIL connection-epoch physical supervisor freshness',file=sys.stderr);print(physical_supervisor_test.stdout,file=sys.stderr);print(physical_supervisor_test.stderr,file=sys.stderr);return physical_supervisor_test.returncode
     print(physical_supervisor_test.stdout.strip())
+    physical_landing_completion_test=subprocess.run([sys.executable,'tools/ci/test_physical_landing_completion.py'],text=True,capture_output=True)
+    if physical_landing_completion_test.returncode:
+        print('FAIL controlled physical landing completion evidence',file=sys.stderr);print(physical_landing_completion_test.stdout,file=sys.stderr);print(physical_landing_completion_test.stderr,file=sys.stderr);return physical_landing_completion_test.returncode
+    print(physical_landing_completion_test.stdout.strip())
     physical_yaw_test=subprocess.run([sys.executable,'tools/ci/test_physical_yaw_observer.py'],text=True,capture_output=True)
     if physical_yaw_test.returncode:
         print('FAIL fresh physical yaw observation',file=sys.stderr);print(physical_yaw_test.stdout,file=sys.stderr);print(physical_yaw_test.stderr,file=sys.stderr);return physical_yaw_test.returncode

--- a/tools/ci/test_physical_landing_completion.py
+++ b/tools/ci/test_physical_landing_completion.py
@@ -79,6 +79,7 @@ class FakeReader:
         self.read_count = 0
         self.timeouts: list[float] = []
         self.error: Exception | None = None
+        self.on_read = None
 
     def read(self, *, timeout_seconds: float):
         require(timeout_seconds > 0, "fresh read timeout positive")
@@ -86,6 +87,8 @@ class FakeReader:
         self.timeouts.append(timeout_seconds)
         if self.error is not None:
             raise self.error
+        if self.on_read is not None:
+            self.on_read()
         if len(self.states) > 1:
             return self.states.pop(0)
         if self.states:
@@ -281,6 +284,75 @@ def test_finished_but_still_active_is_not_completion() -> None:
     require(result.observations == 3, "active trajectory states are not completion")
 
 
+
+def test_pre_land_evidence_is_observer_issued_one_shot() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x200, is_flying=False, hl_control_active=False, hl_traj_finished=True),
+        ],
+        epoch_value="epoch-issued",
+    )
+    forged = landing.PreLandingFlightEvidence("epoch-issued", 0x110)
+    expect_error(
+        lambda: observer.await_completion(forged, total_timeout_seconds=0.5),
+        "not freshly issued by this observer",
+    )
+    require(reader.read_count == 0, "forged same-epoch evidence triggers no completion read")
+
+    baseline = observer.capture_pre_land_flight()
+    result = observer.await_completion(baseline, total_timeout_seconds=0.5)
+    require(result.supervisor_state.hl_traj_finished, "issued baseline can complete once")
+    reads_after_completion = reader.read_count
+    expect_error(
+        lambda: observer.await_completion(baseline, total_timeout_seconds=0.5),
+        "not freshly issued by this observer",
+    )
+    require(reader.read_count == reads_after_completion, "consumed baseline cannot be reused")
+
+
+def test_new_baseline_supersedes_old_same_epoch_evidence() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x112, is_flying=True, hl_control_active=True),
+            state(0x200, is_flying=False, hl_control_active=False, hl_traj_finished=True),
+        ],
+        epoch_value="epoch-supersede",
+    )
+    old = observer.capture_pre_land_flight()
+    current = observer.capture_pre_land_flight()
+    expect_error(
+        lambda: observer.await_completion(old, total_timeout_seconds=0.5),
+        "not freshly issued by this observer",
+    )
+    result = observer.await_completion(current, total_timeout_seconds=0.5)
+    require(result.supervisor_state.hl_traj_finished, "latest baseline remains usable")
+    require(reader.read_count == 3, "superseded evidence adds no read")
+
+
+def test_completion_returned_after_total_deadline_is_rejected() -> None:
+    observer, reader, _epoch, clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x200, is_flying=False, hl_control_active=False, hl_traj_finished=True),
+        ],
+        epoch_value="epoch-late-read",
+    )
+    baseline = observer.capture_pre_land_flight()
+    reader.on_read = lambda: clock.sleep(0.25)
+    expect_error(
+        lambda: observer.await_completion(
+            baseline,
+            total_timeout_seconds=0.2,
+            per_read_timeout_seconds=0.2,
+            poll_interval_seconds=0.05,
+        ),
+        "completion timed out",
+    )
+    require(reader.read_count == 2, "late valid state is observed but never promoted")
+
+
 def test_malformed_state_and_arguments_have_no_false_pass() -> None:
     observer, reader, _epoch, _clock = make_observer(
         [SimpleNamespace(
@@ -333,6 +405,9 @@ def main() -> int:
         test_fresh_reader_failure_fails_closed,
         test_timeout_never_promotes_incomplete_landing,
         test_finished_but_still_active_is_not_completion,
+        test_pre_land_evidence_is_observer_issued_one_shot,
+        test_new_baseline_supersedes_old_same_epoch_evidence,
+        test_completion_returned_after_total_deadline_is_rejected,
         test_malformed_state_and_arguments_have_no_false_pass,
         test_source_is_observation_only,
     ]

--- a/tools/ci/test_physical_landing_completion.py
+++ b/tools/ci/test_physical_landing_completion.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+from types import SimpleNamespace
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "landing_completion.py"
+spec = importlib.util.spec_from_file_location("webeeblocks_landing_completion", MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load landing completion observer")
+landing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(landing)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except landing.LandingCompletionError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected LandingCompletionError containing {pattern!r}")
+
+
+class Epoch:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        require(seconds > 0, "poll delay must be positive")
+        self.value += seconds
+
+
+def state(
+    bitfield: int,
+    *,
+    blocking_fault: bool = False,
+    is_flying: bool = False,
+    hl_control_active: bool = False,
+    hl_traj_finished: bool = False,
+    is_armed: bool = False,
+    is_auto_armed: bool = False,
+    can_fly: bool = False,
+):
+    return SimpleNamespace(
+        bitfield=bitfield,
+        blocking_fault=blocking_fault,
+        is_flying=is_flying,
+        hl_control_active=hl_control_active,
+        hl_traj_finished=hl_traj_finished,
+        is_armed=is_armed,
+        is_auto_armed=is_auto_armed,
+        can_fly=can_fly,
+    )
+
+
+class FakeReader:
+    def __init__(self, epoch: str, states: list[object]) -> None:
+        self.bound_connection_epoch = epoch
+        self.poisoned = False
+        self.states = list(states)
+        self.read_count = 0
+        self.timeouts: list[float] = []
+        self.error: Exception | None = None
+
+    def read(self, *, timeout_seconds: float):
+        require(timeout_seconds > 0, "fresh read timeout positive")
+        self.read_count += 1
+        self.timeouts.append(timeout_seconds)
+        if self.error is not None:
+            raise self.error
+        if len(self.states) > 1:
+            return self.states.pop(0)
+        if self.states:
+            return self.states[0]
+        raise RuntimeError("no fake supervisor state")
+
+
+def make_observer(states: list[object], *, epoch_value: str = "epoch-land"):
+    epoch = Epoch(epoch_value)
+    reader = FakeReader(epoch_value, states)
+    clock = FakeClock()
+    observer = landing.ControlledLandingCompletionObserver(
+        reader,
+        epoch,
+        clock=clock,
+        sleeper=clock.sleep,
+    )
+    return observer, reader, epoch, clock
+
+
+def test_fresh_flight_then_finished_landed_transition() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x300, is_flying=False, hl_control_active=True, hl_traj_finished=True),
+            state(0x208, is_flying=False, hl_control_active=False, hl_traj_finished=True),
+        ]
+    )
+    baseline = observer.capture_pre_land_flight(timeout_seconds=0.1)
+    require(baseline.connection_epoch == "epoch-land", "baseline epoch")
+    require(baseline.bitfield == 0x110, "baseline bitfield")
+
+    result = observer.await_completion(
+        baseline,
+        total_timeout_seconds=1.0,
+        per_read_timeout_seconds=0.1,
+        poll_interval_seconds=0.05,
+    )
+    require(result.connection_epoch == "epoch-land", "completion epoch")
+    require(result.observations == 3, "three post-effect fresh observations")
+    require(result.supervisor_state.hl_traj_finished, "trajectory finished")
+    require(not result.supervisor_state.is_flying, "physical flight ended")
+    require(not result.supervisor_state.hl_control_active, "HL control inactive")
+    require(reader.read_count == 4, "baseline plus completion reads")
+
+
+def test_stock_auto_arm_after_landing_is_not_rejected() -> None:
+    observer, _reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(
+                0x20E,
+                is_flying=False,
+                hl_control_active=False,
+                hl_traj_finished=True,
+                is_armed=True,
+                is_auto_armed=True,
+                can_fly=True,
+            ),
+        ],
+        epoch_value="epoch-autoarm",
+    )
+    baseline = observer.capture_pre_land_flight()
+    result = observer.await_completion(baseline, total_timeout_seconds=0.5)
+    require(result.supervisor_state.is_armed, "auto-armed final state is preserved")
+    require(result.supervisor_state.is_auto_armed, "auto-arm bit is preserved")
+
+
+def test_stale_non_flying_state_cannot_become_a_baseline() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [state(0x200, hl_traj_finished=True)],
+        epoch_value="epoch-stale",
+    )
+    expect_error(
+        observer.capture_pre_land_flight,
+        "did not observe active physical flight",
+    )
+    require(reader.read_count == 1, "baseline requires one fresh observation")
+
+
+def test_blocking_fault_refutes_completion_immediately() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(
+                0x240,
+                blocking_fault=True,
+                is_flying=False,
+                hl_traj_finished=True,
+            ),
+        ],
+        epoch_value="epoch-fault",
+    )
+    baseline = observer.capture_pre_land_flight()
+    expect_error(
+        lambda: observer.await_completion(baseline, total_timeout_seconds=1.0),
+        "blocking supervisor fault",
+    )
+    require(reader.read_count == 2, "fault terminates observation immediately")
+
+
+def test_same_epoch_is_required_for_completion() -> None:
+    observer, reader, epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x208, hl_traj_finished=True),
+        ],
+        epoch_value="epoch-before",
+    )
+    baseline = observer.capture_pre_land_flight()
+    epoch.value = "epoch-after"
+    expect_error(
+        lambda: observer.await_completion(baseline, total_timeout_seconds=1.0),
+        "connection epoch changed",
+    )
+    require(reader.read_count == 1, "epoch rotation fails before a post-effect read")
+
+
+def test_fresh_reader_failure_fails_closed() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [state(0x110, is_flying=True, hl_control_active=True)],
+        epoch_value="epoch-reader-error",
+    )
+    baseline = observer.capture_pre_land_flight()
+    reader.error = RuntimeError("supervisor timeout")
+    expect_error(
+        lambda: observer.await_completion(baseline, total_timeout_seconds=1.0),
+        "fresh supervisor landing observation failed",
+    )
+
+
+def test_timeout_never_promotes_incomplete_landing() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x110, is_flying=True, hl_control_active=True),
+        ],
+        epoch_value="epoch-timeout",
+    )
+    baseline = observer.capture_pre_land_flight()
+    expect_error(
+        lambda: observer.await_completion(
+            baseline,
+            total_timeout_seconds=0.12,
+            per_read_timeout_seconds=0.05,
+            poll_interval_seconds=0.05,
+        ),
+        "completion timed out",
+    )
+    require(reader.read_count >= 2, "timeout follows fresh post-effect evidence")
+
+
+def test_finished_but_still_active_is_not_completion() -> None:
+    observer, _reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(
+                0x310,
+                is_flying=True,
+                hl_control_active=True,
+                hl_traj_finished=True,
+            ),
+            state(
+                0x300,
+                is_flying=False,
+                hl_control_active=True,
+                hl_traj_finished=True,
+            ),
+            state(
+                0x200,
+                is_flying=False,
+                hl_control_active=False,
+                hl_traj_finished=True,
+            ),
+        ],
+        epoch_value="epoch-active",
+    )
+    baseline = observer.capture_pre_land_flight()
+    result = observer.await_completion(baseline, total_timeout_seconds=1.0)
+    require(result.observations == 3, "active trajectory states are not completion")
+
+
+def test_malformed_state_and_arguments_have_no_false_pass() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [SimpleNamespace(
+            bitfield=1,
+            blocking_fault=False,
+            is_flying="yes",
+            hl_control_active=False,
+            hl_traj_finished=False,
+        )],
+        epoch_value="epoch-malformed",
+    )
+    expect_error(observer.capture_pre_land_flight, "invalid is_flying")
+    require(reader.read_count == 1, "malformed state was fresh but rejected")
+
+    clean, clean_reader, _ep, _cl = make_observer(
+        [state(0x110, is_flying=True, hl_control_active=True)],
+        epoch_value="epoch-args",
+    )
+    for value in (0, -1, True, float("inf"), float("nan"), "0.2"):
+        expect_error(
+            lambda v=value: clean.capture_pre_land_flight(timeout_seconds=v),
+            "positive finite",
+        )
+    require(clean_reader.read_count == 0, "invalid baseline arguments emit no read")
+
+
+def test_source_is_observation_only() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "send_arming_request",
+        "send_emergency_stop",
+        "send_emergency_stop_watchdog",
+        "HighLevelCommander(",
+        "send_setpoint",
+        "send_hover_setpoint",
+        "send_velocity_world_setpoint",
+        ".read_bitfield(",
+    ):
+        require(forbidden not in source, f"landing observer exposes authority: {forbidden}")
+
+
+def main() -> int:
+    tests = [
+        test_fresh_flight_then_finished_landed_transition,
+        test_stock_auto_arm_after_landing_is_not_rejected,
+        test_stale_non_flying_state_cannot_become_a_baseline,
+        test_blocking_fault_refutes_completion_immediately,
+        test_same_epoch_is_required_for_completion,
+        test_fresh_reader_failure_fails_closed,
+        test_timeout_never_promotes_incomplete_landing,
+        test_finished_but_still_active_is_not_completion,
+        test_malformed_state_and_arguments_have_no_false_pass,
+        test_source_is_observation_only,
+    ]
+    for test in tests:
+        test()
+
+    print(
+        "PASS controlled landing completion requires fresh flight -> finished/non-flying evidence"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_landing_completion.py
+++ b/tools/ci/test_physical_landing_completion.py
@@ -155,6 +155,18 @@ def test_stock_auto_arm_after_landing_is_not_rejected() -> None:
     require(result.supervisor_state.is_auto_armed, "auto-arm bit is preserved")
 
 
+def test_low_level_flight_cannot_become_high_level_landing_baseline() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [state(0x010, is_flying=True, hl_control_active=False)],
+        epoch_value="epoch-low-level",
+    )
+    expect_error(
+        observer.capture_pre_land_flight,
+        "did not observe active high-level control",
+    )
+    require(reader.read_count == 1, "low-level flight is freshly observed then rejected")
+
+
 def test_stale_non_flying_state_cannot_become_a_baseline() -> None:
     observer, reader, _epoch, _clock = make_observer(
         [state(0x200, hl_traj_finished=True)],
@@ -314,6 +326,7 @@ def main() -> int:
     tests = [
         test_fresh_flight_then_finished_landed_transition,
         test_stock_auto_arm_after_landing_is_not_rejected,
+        test_low_level_flight_cannot_become_high_level_landing_baseline,
         test_stale_non_flying_state_cannot_become_a_baseline,
         test_blocking_fault_refutes_completion_immediately,
         test_same_epoch_is_required_for_completion,
@@ -327,7 +340,7 @@ def main() -> int:
         test()
 
     print(
-        "PASS controlled landing completion requires fresh flight -> finished/non-flying evidence"
+        "PASS controlled landing completion requires fresh high-level flight -> finished/non-flying evidence"
     )
     return 0
 

--- a/tools/ci/test_physical_landing_completion.py
+++ b/tools/ci/test_physical_landing_completion.py
@@ -331,6 +331,28 @@ def test_new_baseline_supersedes_old_same_epoch_evidence() -> None:
     require(reader.read_count == 3, "superseded evidence adds no read")
 
 
+
+def test_failed_new_baseline_attempt_invalidates_older_evidence() -> None:
+    observer, reader, _epoch, _clock = make_observer(
+        [
+            state(0x110, is_flying=True, hl_control_active=True),
+            state(0x200, is_flying=False, hl_control_active=False, hl_traj_finished=True),
+        ],
+        epoch_value="epoch-failed-recapture",
+    )
+    old = observer.capture_pre_land_flight()
+    expect_error(
+        observer.capture_pre_land_flight,
+        "did not observe active physical flight",
+    )
+    reads_after_recapture = reader.read_count
+    expect_error(
+        lambda: observer.await_completion(old, total_timeout_seconds=0.5),
+        "not freshly issued by this observer",
+    )
+    require(reader.read_count == reads_after_recapture, "failed recapture invalidates old evidence")
+
+
 def test_completion_returned_after_total_deadline_is_rejected() -> None:
     observer, reader, _epoch, clock = make_observer(
         [
@@ -407,6 +429,7 @@ def main() -> int:
         test_finished_but_still_active_is_not_completion,
         test_pre_land_evidence_is_observer_issued_one_shot,
         test_new_baseline_supersedes_old_same_epoch_evidence,
+        test_failed_new_baseline_attempt_invalidates_older_evidence,
         test_completion_returned_after_total_deadline_is_rejected,
         test_malformed_state_and_arguments_have_no_false_pass,
         test_source_is_observation_only,

--- a/tools/physical/landing_completion.py
+++ b/tools/physical/landing_completion.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Fresh fail-closed evidence for controlled high-level landing completion.
+
+This module deliberately emits no Crazyflie command. It consumes only the
+exclusive fresh #257 supervisor-state reader and one reconnect-sensitive
+connection epoch.
+
+The future trusted authority path is expected to:
+1. capture a fresh in-flight baseline;
+2. issue the separately authorized high-level landing effect;
+3. await completion here while the independent watchdog/session remains live.
+
+Completion is accepted only after the same observer has first established
+physical flight, and a later fresh supervisor state reports:
+- no blocking fault;
+- physical flight ended;
+- high-level control no longer actively flying;
+- the high-level trajectory finished.
+
+Stock auto-arming is intentionally not treated as a failure: after a normal
+landing the firmware may become armed/ReadyToFly again, so teacher authorization
+must remain a separate gate for every later flight-capable effect.
+"""
+
+from __future__ import annotations
+
+from math import isfinite
+from time import monotonic, sleep
+from typing import Callable, NamedTuple
+
+
+class LandingCompletionError(RuntimeError):
+    """Fail-closed error for unavailable or inconsistent landing evidence."""
+
+
+class PreLandingFlightEvidence(NamedTuple):
+    connection_epoch: str
+    bitfield: int
+
+
+class LandingCompletionEvidence(NamedTuple):
+    connection_epoch: str
+    observations: int
+    supervisor_state: object
+
+
+def _positive_finite(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LandingCompletionError(f"{name} must be a positive finite number")
+    parsed = float(value)
+    if not isfinite(parsed) or parsed <= 0:
+        raise LandingCompletionError(f"{name} must be a positive finite number")
+    return parsed
+
+
+class ControlledLandingCompletionObserver:
+    """Observe a fresh physical-flight -> controlled-completion transition."""
+
+    def __init__(
+        self,
+        supervisor_reader: object,
+        connection_epoch_reader: Callable[[], str],
+        *,
+        clock: Callable[[], float] = monotonic,
+        sleeper: Callable[[float], None] = sleep,
+    ) -> None:
+        self._supervisor_reader = supervisor_reader
+        self._connection_epoch_reader = connection_epoch_reader
+        self._clock = clock
+        self._sleeper = sleeper
+
+        bound_epoch = getattr(supervisor_reader, "bound_connection_epoch", None)
+        if not isinstance(bound_epoch, str) or not bound_epoch.strip():
+            raise LandingCompletionError(
+                "fresh supervisor reader has no valid connection epoch"
+            )
+        if not callable(getattr(supervisor_reader, "read", None)):
+            raise LandingCompletionError(
+                "fresh supervisor reader is unavailable for landing completion"
+            )
+        if getattr(supervisor_reader, "poisoned", None) is not False:
+            raise LandingCompletionError(
+                "fresh supervisor reader is poisoned for landing completion"
+            )
+
+        self._bound_connection_epoch = bound_epoch.strip()
+        self._verify_epoch()
+
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._bound_connection_epoch
+
+    def _read_epoch(self) -> str:
+        try:
+            value = self._connection_epoch_reader()
+        except Exception as exc:
+            raise LandingCompletionError(
+                "connection epoch is unavailable for landing completion"
+            ) from exc
+        if not isinstance(value, str) or not value.strip():
+            raise LandingCompletionError(
+                "connection epoch is invalid for landing completion"
+            )
+        return value.strip()
+
+    def _verify_epoch(self) -> None:
+        if self._read_epoch() != self._bound_connection_epoch:
+            raise LandingCompletionError(
+                "connection epoch changed during landing completion observation"
+            )
+
+    def _clock_now(self) -> float:
+        try:
+            value = float(self._clock())
+        except Exception as exc:
+            raise LandingCompletionError(
+                "landing completion monotonic clock is unavailable"
+            ) from exc
+        if not isfinite(value):
+            raise LandingCompletionError(
+                "landing completion monotonic clock is invalid"
+            )
+        return value
+
+    def _verify_reader_ready(self) -> None:
+        poisoned = getattr(self._supervisor_reader, "poisoned", None)
+        if poisoned is not False:
+            raise LandingCompletionError(
+                "fresh supervisor reader is poisoned for landing completion"
+            )
+
+    @staticmethod
+    def _validate_state(state: object) -> None:
+        bitfield = getattr(state, "bitfield", None)
+        if isinstance(bitfield, bool) or not isinstance(bitfield, int) or bitfield < 0:
+            raise LandingCompletionError(
+                "fresh supervisor landing state has an invalid bitfield"
+            )
+        for name in (
+            "blocking_fault",
+            "is_flying",
+            "hl_control_active",
+            "hl_traj_finished",
+        ):
+            if not isinstance(getattr(state, name, None), bool):
+                raise LandingCompletionError(
+                    f"fresh supervisor landing state has invalid {name}"
+                )
+
+    def _read_fresh(self, timeout_seconds: float) -> object:
+        self._verify_epoch()
+        self._verify_reader_ready()
+        try:
+            state = self._supervisor_reader.read(timeout_seconds=timeout_seconds)
+        except Exception as exc:
+            raise LandingCompletionError(
+                f"fresh supervisor landing observation failed: {exc}"
+            ) from exc
+        self._verify_epoch()
+        self._validate_state(state)
+        return state
+
+    @staticmethod
+    def _raise_on_fault(state: object) -> None:
+        if state.blocking_fault:
+            raise LandingCompletionError(
+                "blocking supervisor fault during controlled landing completion"
+            )
+
+    def capture_pre_land_flight(
+        self,
+        *,
+        timeout_seconds: float = 0.2,
+    ) -> PreLandingFlightEvidence:
+        """Establish fresh same-epoch evidence that physical flight is active."""
+        timeout = _positive_finite(
+            timeout_seconds,
+            "pre-land supervisor read timeout",
+        )
+        state = self._read_fresh(timeout)
+        self._raise_on_fault(state)
+        if not state.is_flying:
+            raise LandingCompletionError(
+                "pre-land baseline did not observe active physical flight"
+            )
+        return PreLandingFlightEvidence(
+            connection_epoch=self._bound_connection_epoch,
+            bitfield=state.bitfield,
+        )
+
+    def await_completion(
+        self,
+        baseline: PreLandingFlightEvidence,
+        *,
+        total_timeout_seconds: float = 8.0,
+        per_read_timeout_seconds: float = 0.2,
+        poll_interval_seconds: float = 0.05,
+    ) -> LandingCompletionEvidence:
+        """Wait for a later fresh same-epoch finished-and-not-flying state."""
+        total_timeout = _positive_finite(
+            total_timeout_seconds,
+            "landing completion timeout",
+        )
+        per_read_timeout = _positive_finite(
+            per_read_timeout_seconds,
+            "landing supervisor read timeout",
+        )
+        poll_interval = _positive_finite(
+            poll_interval_seconds,
+            "landing poll interval",
+        )
+        if not isinstance(baseline, PreLandingFlightEvidence):
+            raise LandingCompletionError(
+                "landing completion requires pre-land flight evidence"
+            )
+        if baseline.connection_epoch != self._bound_connection_epoch:
+            raise LandingCompletionError(
+                "pre-land evidence belongs to a different connection epoch"
+            )
+
+        started_at = self._clock_now()
+        deadline = started_at + total_timeout
+        observations = 0
+
+        while True:
+            self._verify_epoch()
+            now = self._clock_now()
+            remaining = deadline - now
+            if remaining <= 0:
+                raise LandingCompletionError(
+                    "controlled landing completion timed out"
+                )
+
+            state = self._read_fresh(min(per_read_timeout, remaining))
+            observations += 1
+            self._raise_on_fault(state)
+
+            if (
+                not state.is_flying
+                and not state.hl_control_active
+                and state.hl_traj_finished
+            ):
+                return LandingCompletionEvidence(
+                    connection_epoch=self._bound_connection_epoch,
+                    observations=observations,
+                    supervisor_state=state,
+                )
+
+            now = self._clock_now()
+            remaining = deadline - now
+            if remaining <= 0:
+                raise LandingCompletionError(
+                    "controlled landing completion timed out"
+                )
+            delay = min(poll_interval, remaining)
+            try:
+                self._sleeper(delay)
+            except Exception as exc:
+                raise LandingCompletionError(
+                    "landing completion polling delay failed"
+                ) from exc

--- a/tools/physical/landing_completion.py
+++ b/tools/physical/landing_completion.py
@@ -11,7 +11,8 @@ The future trusted authority path is expected to:
 3. await completion here while the independent watchdog/session remains live.
 
 Completion is accepted only after the same observer has first established
-physical flight, and a later fresh supervisor state reports:
+physical flight under active high-level control, and a later fresh supervisor
+state reports:
 - no blocking fault;
 - physical flight ended;
 - high-level control no longer actively flying;
@@ -172,7 +173,7 @@ class ControlledLandingCompletionObserver:
         *,
         timeout_seconds: float = 0.2,
     ) -> PreLandingFlightEvidence:
-        """Establish fresh same-epoch evidence that physical flight is active."""
+        """Establish fresh same-epoch evidence of flight under high-level control."""
         timeout = _positive_finite(
             timeout_seconds,
             "pre-land supervisor read timeout",
@@ -182,6 +183,10 @@ class ControlledLandingCompletionObserver:
         if not state.is_flying:
             raise LandingCompletionError(
                 "pre-land baseline did not observe active physical flight"
+            )
+        if not state.hl_control_active:
+            raise LandingCompletionError(
+                "pre-land baseline did not observe active high-level control"
             )
         return PreLandingFlightEvidence(
             connection_epoch=self._bound_connection_epoch,

--- a/tools/physical/landing_completion.py
+++ b/tools/physical/landing_completion.py
@@ -26,6 +26,7 @@ must remain a separate gate for every later flight-capable effect.
 from __future__ import annotations
 
 from math import isfinite
+from threading import Lock
 from time import monotonic, sleep
 from typing import Callable, NamedTuple
 
@@ -69,6 +70,8 @@ class ControlledLandingCompletionObserver:
         self._connection_epoch_reader = connection_epoch_reader
         self._clock = clock
         self._sleeper = sleeper
+        self._state_lock = Lock()
+        self._pending_baseline: PreLandingFlightEvidence | None = None
 
         bound_epoch = getattr(supervisor_reader, "bound_connection_epoch", None)
         if not isinstance(bound_epoch, str) or not bound_epoch.strip():
@@ -188,10 +191,14 @@ class ControlledLandingCompletionObserver:
             raise LandingCompletionError(
                 "pre-land baseline did not observe active high-level control"
             )
-        return PreLandingFlightEvidence(
+        evidence = PreLandingFlightEvidence(
             connection_epoch=self._bound_connection_epoch,
             bitfield=state.bitfield,
         )
+        with self._state_lock:
+            # A newer fresh baseline supersedes any earlier unused baseline.
+            self._pending_baseline = evidence
+        return evidence
 
     def await_completion(
         self,
@@ -222,6 +229,15 @@ class ControlledLandingCompletionObserver:
             raise LandingCompletionError(
                 "pre-land evidence belongs to a different connection epoch"
             )
+        with self._state_lock:
+            if baseline is not self._pending_baseline:
+                raise LandingCompletionError(
+                    "pre-land evidence was not freshly issued by this observer "
+                    "for the current completion attempt"
+                )
+            # Completion observation is one-shot. Any timeout/fault/reader failure
+            # remains fail-closed and cannot be retried using the same baseline.
+            self._pending_baseline = None
 
         started_at = self._clock_now()
         deadline = started_at + total_timeout
@@ -238,6 +254,11 @@ class ControlledLandingCompletionObserver:
 
             state = self._read_fresh(min(per_read_timeout, remaining))
             observations += 1
+            now = self._clock_now()
+            if deadline - now <= 0:
+                raise LandingCompletionError(
+                    "controlled landing completion timed out"
+                )
             self._raise_on_fault(state)
 
             if (

--- a/tools/physical/landing_completion.py
+++ b/tools/physical/landing_completion.py
@@ -181,6 +181,10 @@ class ControlledLandingCompletionObserver:
             timeout_seconds,
             "pre-land supervisor read timeout",
         )
+        # Starting any new baseline attempt invalidates an older unused baseline,
+        # even if the new fresh observation later fails closed.
+        with self._state_lock:
+            self._pending_baseline = None
         state = self._read_fresh(timeout)
         self._raise_on_fault(state)
         if not state.is_flying:


### PR DESCRIPTION
Adds a non-authority completion observer for the remaining #157 physical boundary.

Candidate scope:
- capture a fresh same-epoch #257 supervisor baseline proving physical flight under active high-level control before the future separately authorized landing effect;
- bind that baseline to exact observer issuance and one completion attempt so forged, superseded, stale or consumed same-epoch evidence cannot be replayed;
- after that effect, accept completion only from later fresh #257 evidence with no blocking fault, `is_flying=false`, `hl_control_active=false`, and `hl_traj_finished=true`;
- enforce one monotonic total deadline across blocking reads, including rejecting an otherwise valid state that arrives after that deadline;
- preserve stock CF2.1 auto-arming semantics by not treating a later armed/ReadyToFly state as a completion failure;
- fail closed on epoch rotation, poisoned/failing supervisor freshness, malformed state, blocking fault, or timeout;
- issue no Crazyflie command and expose no arming, landing, HighLevelCommander, setpoint, watchdog, teacher-authorization or browser/student API.

Deterministic regressions cover the high-level-flight→finished/non-flying transition, low-level/stale baseline rejection, exact one-shot evidence binding, auto-arm after landing, blocking faults, epoch rotation, reader failure, total-deadline overrun, still-active high-level control, malformed state, and the no-authority source boundary.

This does not issue or acknowledge the landing command and does not by itself prove watchdog continuity or teacher authorization; those remain separate gates. Refs #157 and #72.