### PR TITLE
Add trusted powered-session reset authority

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -65,6 +65,10 @@ def main():
     if physical_watchdog_test.returncode:
         print('FAIL physical watchdog activation/liveness guard',file=sys.stderr);print(physical_watchdog_test.stdout,file=sys.stderr);print(physical_watchdog_test.stderr,file=sys.stderr);return physical_watchdog_test.returncode
     print(physical_watchdog_test.stdout.strip())
+    powered_session_test=subprocess.run([sys.executable,'tools/ci/test_physical_powered_session_authority.py'],text=True,capture_output=True)
+    if powered_session_test.returncode:
+        print('FAIL trusted physical powered-session/reset authority',file=sys.stderr);print(powered_session_test.stdout,file=sys.stderr);print(powered_session_test.stderr,file=sys.stderr);return powered_session_test.returncode
+    print(powered_session_test.stdout.strip())
     physical_http_test=subprocess.run([sys.executable,'tools/ci/test_physical_capability_http_bridge.py'],text=True,capture_output=True)
     if physical_http_test.returncode:
         print('FAIL read-only physical capability HTTP bridge',file=sys.stderr);print(physical_http_test.stdout,file=sys.stderr);print(physical_http_test.stderr,file=sys.stderr);return physical_http_test.returncode

--- a/tools/ci/test_physical_powered_session_authority.py
+++ b/tools/ci/test_physical_powered_session_authority.py
@@ -288,6 +288,9 @@ def test_explicit_cflib_power_cycle_helper_is_lazy_and_uri_bound() -> None:
         def stm_power_cycle(self) -> None:
             calls.append("cycle")
 
+        def close(self) -> None:
+            calls.append("close")
+
     reset = authority.make_cflib_stm_deck_power_cycle(
         "radio://0/80/2M/E7E7E7E7E7",
         power_switch_factory=FakePowerSwitch,
@@ -298,9 +301,62 @@ def test_explicit_cflib_power_cycle_helper_is_lazy_and_uri_bound() -> None:
         calls == [
             ("construct", "radio://0/80/2M/E7E7E7E7E7"),
             "cycle",
+            "close",
         ],
-        "explicit reset delegates once to cflib PowerSwitch STM+deck cycle",
+        "explicit reset delegates once and releases the PowerSwitch transport",
     )
+
+    failing_calls: list[str] = []
+
+    class FailingCyclePowerSwitch:
+        def __init__(self, _uri: str) -> None:
+            failing_calls.append("construct")
+
+        def stm_power_cycle(self) -> None:
+            failing_calls.append("cycle")
+            raise RuntimeError("reset ambiguity")
+
+        def close(self) -> None:
+            failing_calls.append("close")
+
+    failing_reset = authority.make_cflib_stm_deck_power_cycle(
+        "radio://0/80/2M/E7E7E7E7E7",
+        power_switch_factory=FailingCyclePowerSwitch,
+    )
+    try:
+        failing_reset()
+    except RuntimeError as exc:
+        require("reset ambiguity" in str(exc), "reset failure remains fail-closed")
+    else:
+        raise AssertionError("expected reset ambiguity")
+    require(
+        failing_calls == ["construct", "cycle", "close"],
+        "PowerSwitch transport closes even when STM power-cycle fails",
+    )
+
+    close_failure_calls: list[str] = []
+
+    class FailingClosePowerSwitch:
+        def __init__(self, _uri: str) -> None:
+            close_failure_calls.append("construct")
+
+        def stm_power_cycle(self) -> None:
+            close_failure_calls.append("cycle")
+
+        def close(self) -> None:
+            close_failure_calls.append("close")
+            raise RuntimeError("radio release failed")
+
+    close_failing_reset = authority.make_cflib_stm_deck_power_cycle(
+        "radio://0/80/2M/E7E7E7E7E7",
+        power_switch_factory=FailingClosePowerSwitch,
+    )
+    expect_error(close_failing_reset, "PowerSwitch cleanup failed")
+    require(
+        close_failure_calls == ["construct", "cycle", "close"],
+        "cleanup failure is observed after the exact reset attempt",
+    )
+
     expect_error(
         lambda: authority.make_cflib_stm_deck_power_cycle("usb://not-radio"),
         "explicit Crazyradio radio:// URI",

--- a/tools/ci/test_physical_powered_session_authority.py
+++ b/tools/ci/test_physical_powered_session_authority.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import sys
+from types import SimpleNamespace
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(PHYSICAL))
+
+import powered_session_authority as authority
+import watchdog_liveness as watchdog
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except authority.PoweredSessionAuthorityError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(
+        f"expected PoweredSessionAuthorityError containing {pattern!r}"
+    )
+
+
+def descriptor(
+    *,
+    connected: bool = True,
+    execution_authority: bool = False,
+    model: str | None = "crazyflie-2.1",
+    model_evidence: str = "verified",
+    self_test: bool = True,
+    protocol: int = 12,
+):
+    return {
+        "connected": connected,
+        "executionAuthority": execution_authority,
+        "identity": {
+            "family": "crazyflie",
+            "model": model,
+            "modelEvidence": model_evidence,
+        },
+        "evidence": {
+            "systemSelfTestPassed": self_test,
+            "protocolVersion": protocol,
+        },
+    }
+
+
+class Fixture:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.safe = True
+        self.epoch = "epoch-after-reset"
+        self.capabilities = descriptor()
+        self.preflight_ok = True
+        self.supervisor = SimpleNamespace(blocking_fault=False)
+        self.reset_error: Exception | None = None
+        self.open_error: Exception | None = None
+        self.preflight_error: Exception | None = None
+        self.supervisor_error: Exception | None = None
+        self.close_error: Exception | None = None
+        self.session = object()
+
+    def factory(self):
+        def safe_gate():
+            self.events.append("safe")
+            return self.safe
+
+        def invalidate():
+            self.events.append("invalidate")
+
+        def reset():
+            self.events.append("reset")
+            if self.reset_error is not None:
+                raise self.reset_error
+
+        def open_session():
+            self.events.append("open")
+            if self.open_error is not None:
+                raise self.open_error
+            return self.session
+
+        def close_session(session):
+            require(session is self.session, "cleanup exact session")
+            self.events.append("close")
+            if self.close_error is not None:
+                raise self.close_error
+
+        def read_epoch(session):
+            require(session is self.session, "epoch exact session")
+            self.events.append("epoch")
+            return self.epoch
+
+        def read_capabilities(session):
+            require(session is self.session, "capabilities exact session")
+            self.events.append("capabilities")
+            return self.capabilities
+
+        def assert_preflight(session, epoch):
+            require(session is self.session, "preflight exact session")
+            require(epoch == self.epoch, "preflight exact epoch")
+            self.events.append("preflight")
+            if self.preflight_error is not None:
+                raise self.preflight_error
+            return self.preflight_ok
+
+        def fresh_supervisor(session, epoch):
+            require(session is self.session, "supervisor exact session")
+            require(epoch == self.epoch, "supervisor exact epoch")
+            self.events.append("supervisor")
+            if self.supervisor_error is not None:
+                raise self.supervisor_error
+            return self.supervisor
+
+        def identity():
+            self.events.append("identity")
+            return "powered-session-1"
+
+        return authority.TrustedPoweredSessionFactory(
+            require_flight_known_inactive=safe_gate,
+            invalidate_prior_evidence=invalidate,
+            stm_deck_power_cycle=reset,
+            open_post_reset_session=open_session,
+            close_post_reset_session=close_session,
+            read_connection_epoch=read_epoch,
+            read_capabilities=read_capabilities,
+            assert_bound_preflight=assert_preflight,
+            read_fresh_supervisor=fresh_supervisor,
+            identity_factory=identity,
+        )
+
+
+def test_direct_construction_cannot_mint_fresh_authority() -> None:
+    expect_error(
+        lambda: authority.EphemeralPoweredSessionWatchdogAuthority("forged"),
+        "only be minted after trusted reset proof",
+    )
+    require(
+        not hasattr(authority.EphemeralPoweredSessionWatchdogAuthority, "restore"),
+        "authority must expose no restore API",
+    )
+    require(
+        not hasattr(authority.EphemeralPoweredSessionWatchdogAuthority, "from_identity"),
+        "serialized identity must not mint authority",
+    )
+
+
+def test_factory_establishes_exact_reset_postconditions_before_minting() -> None:
+    f = Fixture()
+    established = f.factory().establish(previous_connection_epoch="epoch-before")
+    require(established.session is f.session, "factory returns exact live session")
+    require(established.connection_epoch == f.epoch, "factory returns exact new epoch")
+    lifecycle = established.watchdog_authority
+    require(
+        isinstance(lifecycle, watchdog.PoweredSessionWatchdogAuthority),
+        "concrete lifecycle satisfies #262 authority contract",
+    )
+    require(lifecycle.identity == "powered-session-1", "trusted identity")
+    require(lifecycle.state == "new", "factory mints only fresh new state")
+    lifecycle.require_fresh_reset_proof()
+    require(
+        f.events == [
+            "safe",
+            "invalidate",
+            "reset",
+            "open",
+            "epoch",
+            "capabilities",
+            "preflight",
+            "supervisor",
+            "identity",
+        ],
+        f"unexpected establishment order: {f.events}",
+    )
+
+
+def test_authority_reset_proof_is_one_shot_and_terminal_is_latching() -> None:
+    lifecycle = Fixture().factory().establish().watchdog_authority
+    lifecycle.begin_activation()
+    require(lifecycle.state == "activating", "activation atomically consumes freshness")
+    expect_error(
+        lifecycle.require_fresh_reset_proof,
+        "fresh STM+deck reset proof is unavailable",
+    )
+    lifecycle.mark_active()
+    require(lifecycle.state == "active", "active follows activating only")
+    lifecycle.mark_terminal("lost watchdog certainty")
+    require(lifecycle.state == "terminal", "terminal state")
+    require(
+        lifecycle.terminal_reason == "lost watchdog certainty",
+        "first terminal reason durable in lifecycle",
+    )
+    lifecycle.mark_terminal("later reason")
+    require(
+        lifecycle.terminal_reason == "lost watchdog certainty",
+        "terminal transition is idempotent and never recovers",
+    )
+    expect_error(
+        lifecycle.require_fresh_reset_proof,
+        "fresh STM+deck reset proof is unavailable",
+    )
+
+
+def test_unsafe_or_unknown_flight_state_prevents_reset_effect() -> None:
+    f = Fixture()
+    f.safe = False
+    expect_error(
+        f.factory().establish,
+        "physical flight to be explicitly known inactive",
+    )
+    require(f.events == ["safe"], "unsafe state emits no invalidation or reset")
+
+
+def test_prior_evidence_is_invalidated_before_ambiguous_reset() -> None:
+    f = Fixture()
+    f.reset_error = RuntimeError("radio ambiguity")
+    expect_error(
+        f.factory().establish,
+        "power-cycle transaction failed or is ambiguous",
+    )
+    require(
+        f.events == ["safe", "invalidate", "reset"],
+        "ambiguous reset cannot leave old evidence reusable or open a new session",
+    )
+
+
+def test_transport_success_alone_never_mints_authority() -> None:
+    cases = [
+        ("same epoch", lambda f: setattr(f, "epoch", "epoch-before"),
+         "reused the previous connection epoch"),
+        ("wrong model", lambda f: setattr(f, "capabilities", descriptor(model=None)),
+         "exact Crazyflie 2.1 identity is unproven"),
+        ("failed self test", lambda f: setattr(f, "capabilities", descriptor(self_test=False)),
+         "self-test did not pass"),
+        ("old protocol", lambda f: setattr(f, "capabilities", descriptor(protocol=11)),
+         "protocol is too old"),
+        ("preflight false", lambda f: setattr(f, "preflight_ok", False),
+         "preflight was not positively established"),
+        ("supervisor fault", lambda f: setattr(
+            f, "supervisor", SimpleNamespace(blocking_fault=True)
+         ), "supervisor safety state is unavailable or blocking"),
+    ]
+    for label, mutate, message in cases:
+        f = Fixture()
+        mutate(f)
+        expect_error(
+            lambda f=f: f.factory().establish(
+                previous_connection_epoch="epoch-before"
+            ),
+            message,
+        )
+        require("identity" not in f.events, f"{label}: authority identity minted too early")
+        require(f.events[-1] == "close", f"{label}: failed post-reset session must close")
+
+
+def test_callback_failures_fail_closed_and_cleanup_new_session() -> None:
+    f = Fixture()
+    f.preflight_error = RuntimeError("binding unavailable")
+    expect_error(
+        f.factory().establish,
+        "preflight was not re-established",
+    )
+    require(f.events[-1] == "close", "failed preflight closes post-reset session")
+
+    f = Fixture()
+    f.supervisor_error = RuntimeError("freshness timeout")
+    expect_error(
+        f.factory().establish,
+        "supervisor safety observation failed",
+    )
+    require(f.events[-1] == "close", "failed supervisor read closes post-reset session")
+
+
+def test_explicit_cflib_power_cycle_helper_is_lazy_and_uri_bound() -> None:
+    calls: list[object] = []
+
+    class FakePowerSwitch:
+        def __init__(self, uri: str) -> None:
+            calls.append(("construct", uri))
+
+        def stm_power_cycle(self) -> None:
+            calls.append("cycle")
+
+    reset = authority.make_cflib_stm_deck_power_cycle(
+        "radio://0/80/2M/E7E7E7E7E7",
+        power_switch_factory=FakePowerSwitch,
+    )
+    require(calls == [], "helper construction must not power-cycle hardware")
+    reset()
+    require(
+        calls == [
+            ("construct", "radio://0/80/2M/E7E7E7E7E7"),
+            "cycle",
+        ],
+        "explicit reset delegates once to cflib PowerSwitch STM+deck cycle",
+    )
+    expect_error(
+        lambda: authority.make_cflib_stm_deck_power_cycle("usb://not-radio"),
+        "explicit Crazyradio radio:// URI",
+    )
+
+
+def main() -> int:
+    test_direct_construction_cannot_mint_fresh_authority()
+    test_factory_establishes_exact_reset_postconditions_before_minting()
+    test_authority_reset_proof_is_one_shot_and_terminal_is_latching()
+    test_unsafe_or_unknown_flight_state_prevents_reset_effect()
+    test_prior_evidence_is_invalidated_before_ambiguous_reset()
+    test_transport_success_alone_never_mints_authority()
+    test_callback_failures_fail_closed_and_cleanup_new_session()
+    test_explicit_cflib_power_cycle_helper_is_lazy_and_uri_bound()
+    print(
+        "PASS trusted powered-session authority requires explicit reset plus fresh postconditions"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/powered_session_authority.py
+++ b/tools/physical/powered_session_authority.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Trusted powered-session/reset authority for the physical Crazyflie path.
+
+The stock emergency-stop watchdog survives ordinary Crazyradio reconnects and has
+no benign disable operation. A fresh watchdog lifecycle may therefore exist
+only after an explicit trusted STM+deck reset plus fresh post-reset evidence.
+
+This module provides the concrete host-only authority consumed by
+watchdog_liveness.EmergencyWatchdogLivenessGuard and the smallest factory that
+can mint it. A replacement host process starts with no authority: there is no
+restore/import API and reconnecting or constructing a new object cannot mint
+"new" state.
+
+Reset is a recovery/setup effect because powering the STM down cuts motor
+control. The factory consequently requires an explicit fresh "flight is known
+inactive" gate immediately before invalidating prior evidence and issuing the
+reset. Transport success alone is not reset proof: a genuinely live post-reset
+session, exact reference identity/self-test evidence, an exact-bound preflight
+assertion and one fresh non-fault supervisor observation are required before a
+new authority is returned.
+
+This module exposes no browser/student endpoint, teacher authorization, arming,
+HighLevelCommander, setpoint, movement or landing command surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from secrets import token_hex
+from threading import Lock
+from typing import Callable, Mapping
+
+from watchdog_liveness import PoweredSessionWatchdogAuthority
+
+_STATE_NEW = "new"
+_STATE_ACTIVATING = "activating"
+_STATE_ACTIVE = "active"
+_STATE_TERMINAL = "terminal"
+
+_MIN_SUPERVISOR_PROTOCOL_VERSION = 12
+_EXACT_AIRFRAME_MODEL = "crazyflie-2.1"
+_FACTORY_TOKEN = object()
+
+
+class PoweredSessionAuthorityError(RuntimeError):
+    """Fail-closed trusted powered-session establishment/lifecycle error."""
+
+
+def _nonempty_text(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise PoweredSessionAuthorityError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _require_callable(value: object, name: str) -> Callable:
+    if not callable(value):
+        raise PoweredSessionAuthorityError(f"{name} must be callable")
+    return value
+
+
+class EphemeralPoweredSessionWatchdogAuthority(PoweredSessionWatchdogAuthority):
+    """One non-restorable watchdog lifecycle minted only by the reset factory."""
+
+    def __init__(
+        self,
+        identity: str,
+        *,
+        _factory_token: object | None = None,
+    ) -> None:
+        if _factory_token is not _FACTORY_TOKEN:
+            raise PoweredSessionAuthorityError(
+                "powered-session authority can only be minted after trusted reset proof"
+            )
+        self._identity = _nonempty_text(identity, "powered-session identity")
+        self._state = _STATE_NEW
+        self._terminal_reason: str | None = None
+        self._fresh_reset_proof = True
+        self._lock = Lock()
+
+    @property
+    def identity(self) -> str:
+        return self._identity
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            return self._state
+
+    @property
+    def terminal_reason(self) -> str | None:
+        with self._lock:
+            return self._terminal_reason
+
+    def require_fresh_reset_proof(self) -> None:
+        with self._lock:
+            if self._state != _STATE_NEW or not self._fresh_reset_proof:
+                raise PoweredSessionAuthorityError(
+                    "fresh STM+deck reset proof is unavailable for this powered session"
+                )
+
+    def begin_activation(self) -> None:
+        with self._lock:
+            if self._state != _STATE_NEW or not self._fresh_reset_proof:
+                raise PoweredSessionAuthorityError(
+                    "powered-session watchdog activation requires unconsumed reset proof"
+                )
+            self._fresh_reset_proof = False
+            self._state = _STATE_ACTIVATING
+
+    def mark_active(self) -> None:
+        with self._lock:
+            if self._state != _STATE_ACTIVATING:
+                raise PoweredSessionAuthorityError(
+                    "powered-session watchdog can become active only from activating"
+                )
+            self._state = _STATE_ACTIVE
+
+    def mark_terminal(self, reason: str) -> None:
+        normalized = _nonempty_text(reason, "powered-session terminal reason")
+        with self._lock:
+            if self._state == _STATE_TERMINAL:
+                return
+            self._fresh_reset_proof = False
+            self._terminal_reason = normalized
+            self._state = _STATE_TERMINAL
+
+
+@dataclass(frozen=True)
+class EstablishedPoweredSession:
+    """Successful trusted reset/postcondition result for later host composition."""
+
+    session: object
+    connection_epoch: str
+    watchdog_authority: EphemeralPoweredSessionWatchdogAuthority
+
+
+class TrustedPoweredSessionFactory:
+    """Establish a fresh powered-session authority from reset + live evidence.
+
+    All collaborators are trusted-host callables. The factory owns the safety
+    ordering and refuses to mint authority unless every postcondition succeeds.
+
+    assert_bound_preflight(session, epoch) must re-assert the exact profile/AST
+    preflight on the new epoch and return exactly True.
+    read_fresh_supervisor(session, epoch) must use the #257 freshness path and
+    return a state whose blocking_fault attribute is exactly False.
+    """
+
+    def __init__(
+        self,
+        *,
+        require_flight_known_inactive: Callable[[], object],
+        invalidate_prior_evidence: Callable[[], object],
+        stm_deck_power_cycle: Callable[[], object],
+        open_post_reset_session: Callable[[], object],
+        close_post_reset_session: Callable[[object], object],
+        read_connection_epoch: Callable[[object], str],
+        read_capabilities: Callable[[object], Mapping[str, object]],
+        assert_bound_preflight: Callable[[object, str], object],
+        read_fresh_supervisor: Callable[[object, str], object],
+        identity_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._require_flight_known_inactive = _require_callable(
+            require_flight_known_inactive,
+            "flight-inactive safety gate",
+        )
+        self._invalidate_prior_evidence = _require_callable(
+            invalidate_prior_evidence,
+            "prior-evidence invalidation",
+        )
+        self._stm_deck_power_cycle = _require_callable(
+            stm_deck_power_cycle,
+            "STM+deck power-cycle transaction",
+        )
+        self._open_post_reset_session = _require_callable(
+            open_post_reset_session,
+            "post-reset session opener",
+        )
+        self._close_post_reset_session = _require_callable(
+            close_post_reset_session,
+            "post-reset session closer",
+        )
+        self._read_connection_epoch = _require_callable(
+            read_connection_epoch,
+            "connection-epoch reader",
+        )
+        self._read_capabilities = _require_callable(
+            read_capabilities,
+            "capability reader",
+        )
+        self._assert_bound_preflight = _require_callable(
+            assert_bound_preflight,
+            "exact-bound preflight assertion",
+        )
+        self._read_fresh_supervisor = _require_callable(
+            read_fresh_supervisor,
+            "fresh supervisor reader",
+        )
+        self._identity_factory = identity_factory or (lambda: token_hex(16))
+        _require_callable(self._identity_factory, "powered-session identity factory")
+
+    def _validate_capabilities(self, descriptor: object) -> None:
+        if not isinstance(descriptor, Mapping):
+            raise PoweredSessionAuthorityError(
+                "post-reset capability descriptor is unavailable"
+            )
+        if descriptor.get("connected") is not True:
+            raise PoweredSessionAuthorityError(
+                "post-reset capability descriptor is not live"
+            )
+        if descriptor.get("executionAuthority") is not False:
+            raise PoweredSessionAuthorityError(
+                "post-reset capability descriptor crossed the non-authority boundary"
+            )
+
+        identity = descriptor.get("identity")
+        if not isinstance(identity, Mapping):
+            raise PoweredSessionAuthorityError(
+                "post-reset exact Crazyflie identity evidence is unavailable"
+            )
+        if (
+            identity.get("model") != _EXACT_AIRFRAME_MODEL
+            or identity.get("modelEvidence") != "verified"
+        ):
+            raise PoweredSessionAuthorityError(
+                "post-reset exact Crazyflie 2.1 identity is unproven"
+            )
+
+        evidence = descriptor.get("evidence")
+        if not isinstance(evidence, Mapping):
+            raise PoweredSessionAuthorityError(
+                "post-reset firmware/self-test evidence is unavailable"
+            )
+        if evidence.get("systemSelfTestPassed") is not True:
+            raise PoweredSessionAuthorityError(
+                "post-reset Crazyflie self-test did not pass"
+            )
+        protocol = evidence.get("protocolVersion")
+        if isinstance(protocol, bool) or not isinstance(protocol, int):
+            raise PoweredSessionAuthorityError(
+                "post-reset supervisor protocol version is unavailable"
+            )
+        if protocol < _MIN_SUPERVISOR_PROTOCOL_VERSION:
+            raise PoweredSessionAuthorityError(
+                "post-reset supervisor protocol is too old for watchdog safety"
+            )
+
+    def _safe_close(self, session: object) -> str | None:
+        try:
+            self._close_post_reset_session(session)
+            return None
+        except Exception as exc:
+            return f"post-reset session cleanup failed: {exc}"
+
+    def establish(
+        self,
+        *,
+        previous_connection_epoch: str | None = None,
+    ) -> EstablishedPoweredSession:
+        """Perform one explicit reset-establishment transaction.
+
+        Prior evidence is invalidated before the physical reset attempt so an
+        ambiguous transaction can never leave old authority reusable. No
+        authority object exists until all postconditions have succeeded.
+        """
+        previous = None
+        if previous_connection_epoch is not None:
+            previous = _nonempty_text(
+                previous_connection_epoch,
+                "previous connection epoch",
+            )
+
+        try:
+            safe = self._require_flight_known_inactive()
+        except Exception as exc:
+            raise PoweredSessionAuthorityError(
+                "STM+deck reset safety gate is unavailable"
+            ) from exc
+        if safe is not True:
+            raise PoweredSessionAuthorityError(
+                "STM+deck reset requires physical flight to be explicitly known inactive"
+            )
+
+        try:
+            self._invalidate_prior_evidence()
+        except Exception as exc:
+            raise PoweredSessionAuthorityError(
+                "could not invalidate prior physical evidence before reset"
+            ) from exc
+
+        try:
+            self._stm_deck_power_cycle()
+        except Exception as exc:
+            raise PoweredSessionAuthorityError(
+                "STM+deck power-cycle transaction failed or is ambiguous"
+            ) from exc
+
+        session: object | None = None
+        try:
+            session = self._open_post_reset_session()
+            if session is None:
+                raise PoweredSessionAuthorityError(
+                    "post-reset live Crazyflie session was not established"
+                )
+
+            epoch = _nonempty_text(
+                self._read_connection_epoch(session),
+                "post-reset connection epoch",
+            )
+            if previous is not None and epoch == previous:
+                raise PoweredSessionAuthorityError(
+                    "post-reset session reused the previous connection epoch"
+                )
+
+            descriptor = self._read_capabilities(session)
+            self._validate_capabilities(descriptor)
+
+            try:
+                preflight_ok = self._assert_bound_preflight(session, epoch)
+            except Exception as exc:
+                raise PoweredSessionAuthorityError(
+                    "exact profile/AST preflight was not re-established after reset"
+                ) from exc
+            if preflight_ok is not True:
+                raise PoweredSessionAuthorityError(
+                    "exact profile/AST preflight was not positively established after reset"
+                )
+
+            try:
+                supervisor_state = self._read_fresh_supervisor(session, epoch)
+            except Exception as exc:
+                raise PoweredSessionAuthorityError(
+                    "fresh supervisor safety observation failed after reset"
+                ) from exc
+            if getattr(supervisor_state, "blocking_fault", None) is not False:
+                raise PoweredSessionAuthorityError(
+                    "post-reset supervisor safety state is unavailable or blocking"
+                )
+
+            identity = _nonempty_text(
+                self._identity_factory(),
+                "powered-session identity",
+            )
+            authority = EphemeralPoweredSessionWatchdogAuthority(
+                identity,
+                _factory_token=_FACTORY_TOKEN,
+            )
+            return EstablishedPoweredSession(
+                session=session,
+                connection_epoch=epoch,
+                watchdog_authority=authority,
+            )
+        except Exception as exc:
+            cleanup_failure = None
+            if session is not None:
+                cleanup_failure = self._safe_close(session)
+            if isinstance(exc, PoweredSessionAuthorityError):
+                if cleanup_failure is None:
+                    raise
+                raise PoweredSessionAuthorityError(
+                    f"{exc}; {cleanup_failure}"
+                ) from exc
+            message = f"post-reset authority establishment failed: {exc}"
+            if cleanup_failure is not None:
+                message += "; " + cleanup_failure
+            raise PoweredSessionAuthorityError(message) from exc
+
+
+def make_cflib_stm_deck_power_cycle(
+    uri: str,
+    *,
+    power_switch_factory: Callable[[str], object] | None = None,
+) -> Callable[[], None]:
+    """Build, but do not execute, the trusted cflib STM+deck power-cycle effect."""
+    radio_uri = _nonempty_text(uri, "Crazyradio URI")
+    if not radio_uri.startswith("radio://"):
+        raise PoweredSessionAuthorityError(
+            "STM+deck reset requires an explicit Crazyradio radio:// URI"
+        )
+
+    def reset() -> None:
+        factory = power_switch_factory
+        if factory is None:
+            try:
+                from cflib.utils.power_switch import PowerSwitch
+            except ImportError as exc:
+                raise PoweredSessionAuthorityError(
+                    "cflib PowerSwitch support is unavailable"
+                ) from exc
+            factory = PowerSwitch
+        switch = factory(radio_uri)
+        method = getattr(switch, "stm_power_cycle", None)
+        if not callable(method):
+            raise PoweredSessionAuthorityError(
+                "cflib PowerSwitch STM power-cycle operation is unavailable"
+            )
+        method()
+
+    return reset

--- a/tools/physical/powered_session_authority.py
+++ b/tools/physical/powered_session_authority.py
@@ -389,11 +389,33 @@ def make_cflib_stm_deck_power_cycle(
                 ) from exc
             factory = PowerSwitch
         switch = factory(radio_uri)
-        method = getattr(switch, "stm_power_cycle", None)
-        if not callable(method):
-            raise PoweredSessionAuthorityError(
-                "cflib PowerSwitch STM power-cycle operation is unavailable"
-            )
-        method()
+        failure: Exception | None = None
+        try:
+            method = getattr(switch, "stm_power_cycle", None)
+            if not callable(method):
+                raise PoweredSessionAuthorityError(
+                    "cflib PowerSwitch STM power-cycle operation is unavailable"
+                )
+            method()
+        except Exception as exc:
+            failure = exc
+
+        try:
+            close_method = getattr(switch, "close", None)
+            if not callable(close_method):
+                raise PoweredSessionAuthorityError(
+                    "cflib PowerSwitch close operation is unavailable"
+                )
+            close_method()
+        except Exception as close_exc:
+            detail = f"cflib PowerSwitch cleanup failed: {close_exc}"
+            if failure is not None:
+                raise PoweredSessionAuthorityError(
+                    f"STM+deck power-cycle failed or is ambiguous: {failure}; {detail}"
+                ) from failure
+            raise PoweredSessionAuthorityError(detail) from close_exc
+
+        if failure is not None:
+            raise failure
 
     return reset


### PR DESCRIPTION
Implements the next bounded #157 safety prerequisite without adding flight authority.\n\n- adds an ephemeral concrete `PoweredSessionWatchdogAuthority` that cannot be reconstructed into `new` state from reconnect/process restart or serialized identity;\n- adds a trusted-host reset/postcondition factory that requires an explicit known-inactive gate, invalidates prior evidence before the STM+deck reset attempt, opens a fresh session, rejects reuse of the prior connection epoch, revalidates exact Crazyflie 2.1/self-test/protocol evidence, requires exact-bound preflight re-assertion, and requires one fresh non-blocking supervisor observation before minting authority;\n- adds a lazy explicit cflib `PowerSwitch.stm_power_cycle()` adapter, so merely constructing the helper has no physical effect;\n- adds deterministic regressions for safe ordering, one-shot lifecycle consumption, ambiguous reset, stale epoch, identity/self-test/protocol/preflight/supervisor failures, cleanup, and non-restorability;\n- wires the regression into the existing Runtime core CI harness.\n\nThis is trusted host safety/reset infrastructure only. It exposes no browser/student endpoint, teacher authorization, arming, HighLevelCommander, movement, landing or motorized checkpoint.\n\nRefs #157, #262, #72.