### PR TITLE
Add host-only teacher run authorization binding

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -73,6 +73,10 @@ def main():
     if physical_submission_test.returncode:
         print('FAIL session-bound physical submission bridge',file=sys.stderr);print(physical_submission_test.stdout,file=sys.stderr);print(physical_submission_test.stderr,file=sys.stderr);return physical_submission_test.returncode
     print(physical_submission_test.stdout.strip())
+    teacher_authorization_test=subprocess.run([sys.executable,'tools/ci/test_teacher_run_authorization.py'],text=True,capture_output=True)
+    if teacher_authorization_test.returncode:
+        print('FAIL host-only teacher run authorization binding',file=sys.stderr);print(teacher_authorization_test.stdout,file=sys.stderr);print(teacher_authorization_test.stderr,file=sys.stderr);return teacher_authorization_test.returncode
+    print(teacher_authorization_test.stdout.strip())
     physical_high_level_semantics_test=subprocess.run([sys.executable,'tools/ci/test_physical_high_level_semantics.py'],text=True,capture_output=True)
     if physical_high_level_semantics_test.returncode:
         print('FAIL physical HighLevelCommander semantic adapter',file=sys.stderr);print(physical_high_level_semantics_test.stdout,file=sys.stderr);print(physical_high_level_semantics_test.stderr,file=sys.stderr);return physical_high_level_semantics_test.returncode

--- a/tools/ci/test_teacher_run_authorization.py
+++ b/tools/ci/test_teacher_run_authorization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "tools" / "physical" / "teacher_run_authorization.py"
@@ -10,6 +11,7 @@ spec = importlib.util.spec_from_file_location("webeeblocks_teacher_run_authoriza
 if spec is None or spec.loader is None:
     raise RuntimeError("cannot load teacher run authorization")
 auth = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = auth
 spec.loader.exec_module(auth)
 
 

--- a/tools/ci/test_teacher_run_authorization.py
+++ b/tools/ci/test_teacher_run_authorization.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "teacher_run_authorization.py"
+spec = importlib.util.spec_from_file_location("webeeblocks_teacher_run_authorization", MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load teacher run authorization")
+auth = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(auth)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except auth.TeacherRunAuthorizationError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected TeacherRunAuthorizationError containing {pattern!r}")
+
+
+def binding(epoch: str = "epoch-a", ast: str = "ast-123", profile: str = "activity-1"):
+    return auth.PhysicalRunBinding(
+        profile_id=profile,
+        ast_binding=ast,
+        connection_epoch=epoch,
+    )
+
+
+def test_exact_binding_authorizes_one_run() -> None:
+    gate = auth.TrustedTeacherAuthorizer()
+    seen = []
+
+    def approve(exact):
+        seen.append(exact)
+        return True
+
+    exact = binding()
+    receipt = gate.authorize_run(exact, approve)
+    require(seen == [exact], "teacher decision sees exact proposed run binding")
+    require(receipt.active, "approved run is active")
+    require(gate.has_active_run, "host gate exposes active-run state")
+    require(receipt.binding == exact, "receipt preserves exact binding")
+    require(isinstance(receipt.run_id, str) and len(receipt.run_id) >= 20, "run id is opaque")
+
+    # One human decision authorizes the exact run, not one click per primitive.
+    for _ in range(3):
+        receipt.assert_effect_binding(
+            profile_id=exact.profile_id,
+            ast_binding=exact.ast_binding,
+            connection_epoch=exact.connection_epoch,
+        )
+    require(receipt.active, "multiple exact effect-boundary checks preserve one run authority")
+
+
+def test_denial_non_boolean_and_decision_failure_fail_closed() -> None:
+    for decision in (lambda _b: False, lambda _b: None, lambda _b: 1, lambda _b: "yes"):
+        gate = auth.TrustedTeacherAuthorizer()
+        expect_error(
+            lambda d=decision, g=gate: g.authorize_run(binding(), d),
+            "did not explicitly authorize",
+        )
+        require(not gate.has_active_run, "failed decision creates no run authority")
+
+    gate = auth.TrustedTeacherAuthorizer()
+
+    def broken(_binding):
+        raise RuntimeError("UI channel failed")
+
+    expect_error(lambda: gate.authorize_run(binding(), broken), "teacher decision failed")
+    require(not gate.has_active_run, "decision exception creates no authority")
+
+
+def test_changed_binding_invalidates_permanently() -> None:
+    for field, kwargs in (
+        ("profile", {"profile_id": "activity-2", "ast_binding": "ast-123", "connection_epoch": "epoch-a"}),
+        ("ast", {"profile_id": "activity-1", "ast_binding": "ast-456", "connection_epoch": "epoch-a"}),
+        ("epoch", {"profile_id": "activity-1", "ast_binding": "ast-123", "connection_epoch": "epoch-b"}),
+    ):
+        gate = auth.TrustedTeacherAuthorizer()
+        receipt = gate.authorize_run(binding(), lambda _b: True)
+        expect_error(lambda kw=kwargs, r=receipt: r.assert_effect_binding(**kw), "binding changed")
+        require(not receipt.active, f"{field} mismatch invalidates run")
+        require(receipt.invalid_reason == "physical run binding changed", "mismatch reason is durable in receipt")
+        # Correcting inputs later must not resurrect a stale teacher decision.
+        expect_error(
+            lambda r=receipt: r.assert_effect_binding(
+                profile_id="activity-1",
+                ast_binding="ast-123",
+                connection_epoch="epoch-a",
+            ),
+            "unavailable",
+        )
+
+
+def test_one_active_run_and_explicit_close() -> None:
+    gate = auth.TrustedTeacherAuthorizer()
+    first = gate.authorize_run(binding(), lambda _b: True)
+    expect_error(
+        lambda: gate.authorize_run(binding(epoch="epoch-b"), lambda _b: True),
+        "already active",
+    )
+    gate.close_run(first, "physical run completed")
+    require(not first.active and not gate.has_active_run, "close consumes run authority")
+
+    second = gate.authorize_run(binding(epoch="epoch-b"), lambda _b: True)
+    require(second.run_id != first.run_id, "new run requires a distinct receipt")
+    expect_error(lambda: gate.close_run(first, "stale close"), "does not belong")
+    gate.close_run(second, "physical run cancelled")
+
+
+def test_receipt_cannot_be_minted_or_restored_from_serialized_identity() -> None:
+    exact = binding()
+    expect_error(
+        lambda: auth.TeacherRunAuthorization(exact, "forged", _mint_key=object()),
+        "may only be minted",
+    )
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "def restore",
+        "def import_authorization",
+        "from_json",
+        "requests.",
+        "http.server",
+        "HighLevelCommander",
+        "send_setpoint",
+        "send_arming_request",
+        "send_emergency_stop",
+        "stm_power_cycle",
+    ):
+        require(forbidden not in source, f"teacher gate contains forbidden authority surface: {forbidden}")
+
+
+def test_binding_validation() -> None:
+    for kwargs in (
+        {"profile_id": "", "ast_binding": "a", "connection_epoch": "e"},
+        {"profile_id": "p", "ast_binding": " ", "connection_epoch": "e"},
+        {"profile_id": "p", "ast_binding": "a", "connection_epoch": " e "},
+    ):
+        expect_error(lambda kw=kwargs: auth.PhysicalRunBinding(**kw), "physical run")
+
+
+def main() -> int:
+    test_exact_binding_authorizes_one_run()
+    test_denial_non_boolean_and_decision_failure_fail_closed()
+    test_changed_binding_invalidates_permanently()
+    test_one_active_run_and_explicit_close()
+    test_receipt_cannot_be_minted_or_restored_from_serialized_identity()
+    test_binding_validation()
+    print(
+        "PASS host-only teacher run authorization: one explicit decision binds one exact "
+        "profile/AST/epoch run and every effect boundary re-checks it"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/teacher_run_authorization.py
+++ b/tools/physical/teacher_run_authorization.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Host-only one-run teacher authorization binding for future physical effects.
+
+This module deliberately emits no Crazyflie command and exposes no HTTP/browser
+surface. It captures the product trust invariant established on #157/#72:
+one explicit trusted-host teacher decision may authorize one exact physical run,
+bound to the canonical profile/AST preflight identity and live connection epoch.
+Every later flight-capable effect must re-check that exact binding immediately
+before emission. A changed profile, AST binding or connection epoch invalidates
+the run authority permanently.
+
+The teacher decision source itself remains outside this bounded primitive. A
+future trusted host UI/service may supply it, but the existing browser-held
+capability bearer must never be reused as that source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from secrets import token_urlsafe
+from threading import Lock
+from typing import Callable
+
+
+class TeacherRunAuthorizationError(RuntimeError):
+    """Fail-closed error for unavailable or invalid teacher run authority."""
+
+
+@dataclass(frozen=True)
+class PhysicalRunBinding:
+    """Exact non-authority preflight identity that one teacher decision approves."""
+
+    profile_id: str
+    ast_binding: str
+    connection_epoch: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("profile_id", self.profile_id),
+            ("ast_binding", self.ast_binding),
+            ("connection_epoch", self.connection_epoch),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise TeacherRunAuthorizationError(
+                    f"physical run {name} must be a non-empty string"
+                )
+            if value != value.strip():
+                raise TeacherRunAuthorizationError(
+                    f"physical run {name} must not contain surrounding whitespace"
+                )
+
+
+_MINT_KEY = object()
+
+
+class TeacherRunAuthorization:
+    """One exact run authorization minted only by TrustedTeacherAuthorizer."""
+
+    def __init__(
+        self,
+        binding: PhysicalRunBinding,
+        run_id: str,
+        *,
+        _mint_key: object,
+    ) -> None:
+        if _mint_key is not _MINT_KEY:
+            raise TeacherRunAuthorizationError(
+                "teacher run authorization may only be minted by trusted host authority"
+            )
+        self._binding = binding
+        self._run_id = run_id
+        self._lock = Lock()
+        self._active = True
+        self._invalid_reason: str | None = None
+
+    @property
+    def binding(self) -> PhysicalRunBinding:
+        return self._binding
+
+    @property
+    def run_id(self) -> str:
+        return self._run_id
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return self._active
+
+    @property
+    def invalid_reason(self) -> str | None:
+        with self._lock:
+            return self._invalid_reason
+
+    def invalidate(self, reason: str) -> None:
+        if not isinstance(reason, str) or not reason.strip():
+            raise TeacherRunAuthorizationError(
+                "teacher run invalidation reason must be a non-empty string"
+            )
+        with self._lock:
+            if self._active:
+                self._active = False
+                self._invalid_reason = reason.strip()
+
+    def assert_effect_binding(
+        self,
+        *,
+        profile_id: str,
+        ast_binding: str,
+        connection_epoch: str,
+    ) -> None:
+        """Re-check run identity immediately before one flight-capable effect.
+
+        This method authorizes no command by itself. It only proves that this
+        still-active teacher decision names the exact current binding. Any
+        mismatch permanently invalidates the run so correcting inputs later
+        cannot resurrect stale authority.
+        """
+        candidate = PhysicalRunBinding(
+            profile_id=profile_id,
+            ast_binding=ast_binding,
+            connection_epoch=connection_epoch,
+        )
+        with self._lock:
+            if not self._active:
+                detail = self._invalid_reason or "run authority is inactive"
+                raise TeacherRunAuthorizationError(
+                    "teacher run authorization is unavailable: " + detail
+                )
+            if candidate != self._binding:
+                self._active = False
+                self._invalid_reason = "physical run binding changed"
+                raise TeacherRunAuthorizationError(
+                    "teacher run binding changed; a new explicit teacher decision is required"
+                )
+
+
+class TrustedTeacherAuthorizer:
+    """Trusted-host boundary that turns one explicit decision into one run receipt.
+
+    This object is intentionally process-local. A host-process restart restores
+    no prior run authority. The future teacher UI remains separate; callers must
+    provide a trusted decision callback for each new run.
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._current: TeacherRunAuthorization | None = None
+
+    @property
+    def has_active_run(self) -> bool:
+        with self._lock:
+            current = self._current
+        return current is not None and current.active
+
+    def authorize_run(
+        self,
+        binding: PhysicalRunBinding,
+        teacher_decision: Callable[[PhysicalRunBinding], bool],
+    ) -> TeacherRunAuthorization:
+        if not isinstance(binding, PhysicalRunBinding):
+            raise TeacherRunAuthorizationError(
+                "exact physical run binding is required before teacher authorization"
+            )
+        if not callable(teacher_decision):
+            raise TeacherRunAuthorizationError(
+                "trusted teacher decision callback is required"
+            )
+
+        with self._lock:
+            if self._current is not None and self._current.active:
+                raise TeacherRunAuthorizationError(
+                    "an authorized physical run is already active"
+                )
+
+        try:
+            decision = teacher_decision(binding)
+        except Exception as exc:
+            raise TeacherRunAuthorizationError(
+                "trusted teacher decision failed"
+            ) from exc
+        if decision is not True:
+            raise TeacherRunAuthorizationError(
+                "teacher did not explicitly authorize this exact physical run"
+            )
+
+        receipt = TeacherRunAuthorization(
+            binding,
+            token_urlsafe(24),
+            _mint_key=_MINT_KEY,
+        )
+        with self._lock:
+            if self._current is not None and self._current.active:
+                receipt.invalidate("another physical run became active")
+                raise TeacherRunAuthorizationError(
+                    "an authorized physical run is already active"
+                )
+            self._current = receipt
+        return receipt
+
+    def close_run(self, receipt: TeacherRunAuthorization, reason: str) -> None:
+        if not isinstance(receipt, TeacherRunAuthorization):
+            raise TeacherRunAuthorizationError(
+                "trusted teacher run receipt is required"
+            )
+        with self._lock:
+            if receipt is not self._current:
+                raise TeacherRunAuthorizationError(
+                    "teacher run receipt does not belong to this host authority"
+                )
+            receipt.invalidate(reason)
+            self._current = None


### PR DESCRIPTION
Adds the smallest non-command teacher-authorization primitive for the remaining #157/#72 physical boundary.

Bounded claim:
- one explicit trusted-host teacher decision authorizes one exact physical run bound to `profile_id + canonical ast_binding + live connection_epoch`;
- every later flight-capable effect boundary must re-check that exact binding; any profile/AST/epoch mismatch permanently invalidates the receipt so correcting inputs cannot resurrect stale authority;
- one authorization can cover the primitives of that same exact run, avoiding an impractical teacher click per primitive while still checking the invariant before every effect;
- authorization is one-active-run/process-local and has no restore/import surface, so reconnect, reset, host restart or a later run cannot silently inherit a prior teacher decision;
- the implementation exposes no browser/HTTP endpoint, reuses no capability bearer, imports no cflib command surface and emits no arming, setpoint, watchdog, reset or flight effect;
- teacher UI/decision transport, concrete powered-session/reset authority and the actual physical effect consumer remain separate future boundaries.

The Runtime v2 core CI harness runs deterministic regressions for explicit approval/denial, exact binding, permanent mismatch invalidation, single-run lifecycle and anti-forging/no-effect surface checks.

Refs #157 and #72.