### PR TITLE
Add pure HighLevel trajectory timing policy

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -81,6 +81,10 @@ def main():
     if physical_high_level_semantics_test.returncode:
         print('FAIL physical HighLevelCommander semantic adapter',file=sys.stderr);print(physical_high_level_semantics_test.stdout,file=sys.stderr);print(physical_high_level_semantics_test.stderr,file=sys.stderr);return physical_high_level_semantics_test.returncode
     print(physical_high_level_semantics_test.stdout.strip())
+    physical_high_level_timing_test=subprocess.run([sys.executable,'tools/ci/test_physical_high_level_timing.py'],text=True,capture_output=True)
+    if physical_high_level_timing_test.returncode:
+        print('FAIL physical HighLevelCommander timing policy',file=sys.stderr);print(physical_high_level_timing_test.stdout,file=sys.stderr);print(physical_high_level_timing_test.stderr,file=sys.stderr);return physical_high_level_timing_test.returncode
+    print(physical_high_level_timing_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_high_level_timing.py
+++ b/tools/ci/test_physical_high_level_timing.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "high_level_timing.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+import high_level_timing as timing  # noqa: E402
+
+
+def close(actual: float, expected: float, tolerance: float = 1e-12) -> None:
+    assert math.isclose(actual, expected, rel_tol=0.0, abs_tol=tolerance), (
+        actual,
+        expected,
+    )
+
+
+def expect_error(callable_) -> None:
+    try:
+        callable_()
+    except timing.HighLevelTimingError:
+        return
+    raise AssertionError("expected fail-closed HighLevelTimingError")
+
+
+policy = timing.HighLevelTimingPolicy()
+close(policy.horizontal_speed_m_s, 0.35)
+close(timing.REST_TO_REST_PEAK_FACTOR, 35.0 / 16.0)
+
+for distance in (0.1, 0.35, 2.0):
+    duration = policy.horizontal_move_duration(distance)
+    peak = timing.REST_TO_REST_PEAK_FACTOR * distance / duration
+    close(peak, 0.35)
+
+policy.set_horizontal_speed(0.1)
+close(policy.horizontal_speed_m_s, 0.1)
+duration = policy.horizontal_move_duration(0.5)
+close(duration, (35.0 / 16.0) * 5.0)
+close(timing.REST_TO_REST_PEAK_FACTOR * 0.5 / duration, 0.1)
+
+turn_90 = policy.turn_duration(90.0)
+close(
+    timing.REST_TO_REST_PEAK_FACTOR * math.radians(90.0) / turn_90,
+    timing.MAX_YAW_RATE_RAD_S,
+)
+policy.set_horizontal_speed(0.35)
+close(policy.turn_duration(90.0), turn_90)
+
+for bad_speed in (0.0, 0.09, 0.36, True, float("inf"), float("nan")):
+    expect_error(lambda value=bad_speed: timing.HighLevelTimingPolicy(value))
+    expect_error(lambda value=bad_speed: policy.set_horizontal_speed(value))
+for bad_distance in (0.0, 0.09, 2.01, True, float("nan")):
+    expect_error(lambda value=bad_distance: policy.horizontal_move_duration(value))
+for bad_turn in (0.0, 0.9, 180.0, True, float("inf"), float("nan")):
+    expect_error(lambda value=bad_turn: policy.turn_duration(value))
+
+source = MODULE_PATH.read_text(encoding="utf-8")
+assert "import cflib" not in source
+assert "HighLevelCommander(" not in source
+assert "send_packet" not in source
+assert "takeoff_duration" not in source
+assert "landing_duration" not in source
+
+print(
+    "PASS pure physical timing preserves horizontal speed/yaw-rate ceilings "
+    "for serialized rest-to-rest HighLevelCommander trajectories"
+)

--- a/tools/physical/high_level_timing.py
+++ b/tools/physical/high_level_timing.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Pure HighLevelCommander timing policy for established Runtime v2 rate semantics.
+
+The pinned Crazyflie high-level planner uses a seventh-order rest-to-rest
+polynomial for normal go_to commands. With zero endpoint
+velocity/acceleration/jerk, normalized position is
+
+    35*s^4 - 84*s^5 + 70*s^6 - 20*s^7
+
+and normalized speed peaks at s=0.5 with factor 35/16 over average speed.
+
+This module therefore converts the already-established Runtime v2 horizontal
+move-speed limit and yaw-rate limit into trajectory durations without emitting
+any command or granting authority. It assumes the later effect consumer
+serializes motion and obtains fresh supervisor trajectory-completion evidence
+before planning the next motion, so each planned segment starts from the
+rest-to-rest boundary this factor describes.
+
+Vertical, takeoff and landing durations are intentionally absent: Runtime v2 has
+no student vertical/takeoff/landing speed semantic, so those remain separate
+host safety-policy decisions rather than being silently coupled to set_speed.
+"""
+
+from __future__ import annotations
+
+from math import isfinite, radians
+
+REST_TO_REST_PEAK_FACTOR = 35.0 / 16.0
+DEFAULT_HORIZONTAL_SPEED_M_S = 0.35
+MIN_HORIZONTAL_SPEED_M_S = 0.10
+MAX_HORIZONTAL_SPEED_M_S = 0.35
+MAX_YAW_RATE_RAD_S = 0.70
+
+MIN_MOVE_DISTANCE_M = 0.10
+MAX_MOVE_DISTANCE_M = 2.00
+MIN_TURN_DEG = 1.0
+MAX_TURN_DEG = 179.0
+
+
+class HighLevelTimingError(ValueError):
+    """Fail-closed error for invalid pure physical trajectory timing input."""
+
+
+def _finite(value: object, name: str) -> float:
+    if isinstance(value, bool):
+        raise HighLevelTimingError(f"{name} must be finite")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise HighLevelTimingError(f"{name} must be finite") from exc
+    if not isfinite(number):
+        raise HighLevelTimingError(f"{name} must be finite")
+    return number
+
+
+def _bounded(value: object, name: str, minimum: float, maximum: float) -> float:
+    number = _finite(value, name)
+    if number < minimum or number > maximum:
+        raise HighLevelTimingError(f"{name} outside established bounds: {number}")
+    return number
+
+
+class HighLevelTimingPolicy:
+    """Per-run host timing state for rate-constrained smooth high-level motion."""
+
+    def __init__(self, horizontal_speed_m_s: object = DEFAULT_HORIZONTAL_SPEED_M_S) -> None:
+        self._horizontal_speed_m_s = _bounded(
+            horizontal_speed_m_s,
+            "horizontal_speed_m_s",
+            MIN_HORIZONTAL_SPEED_M_S,
+            MAX_HORIZONTAL_SPEED_M_S,
+        )
+
+    @property
+    def horizontal_speed_m_s(self) -> float:
+        return self._horizontal_speed_m_s
+
+    def set_horizontal_speed(self, speed_m_s: object) -> None:
+        """Apply Runtime v2 set_speed semantics to subsequent horizontal moves only."""
+        self._horizontal_speed_m_s = _bounded(
+            speed_m_s,
+            "speed_m_s",
+            MIN_HORIZONTAL_SPEED_M_S,
+            MAX_HORIZONTAL_SPEED_M_S,
+        )
+
+    def horizontal_move_duration(self, distance_m: object) -> float:
+        """Duration whose rest-to-rest polynomial peak speed is the selected limit."""
+        distance = _bounded(
+            distance_m,
+            "distance_m",
+            MIN_MOVE_DISTANCE_M,
+            MAX_MOVE_DISTANCE_M,
+        )
+        return REST_TO_REST_PEAK_FACTOR * distance / self._horizontal_speed_m_s
+
+    def turn_duration(self, angle_deg: object) -> float:
+        """Duration preserving Runtime v2's established 0.7 rad/s yaw-rate ceiling."""
+        angle = _finite(angle_deg, "angle_deg")
+        magnitude = abs(angle)
+        if magnitude < MIN_TURN_DEG or magnitude > MAX_TURN_DEG:
+            raise HighLevelTimingError(f"angle_deg outside established bounds: {angle}")
+        return REST_TO_REST_PEAK_FACTOR * abs(radians(angle)) / MAX_YAW_RATE_RAD_S


### PR DESCRIPTION
Implements the bounded no-effect timing slice established on #157 before direct physical command consumption.

- models the pinned smooth rest-to-rest seventh-order HighLevelCommander planner peak/average speed factor (`35/16`);
- keeps the already-proven Runtime v2 `set_speed` meaning as horizontal-move speed only, default 0.35 m/s and bounded 0.1–0.35 m/s;
- derives horizontal `go_to` duration so the smooth trajectory peak speed does not exceed the selected student speed;
- derives turn duration against the existing Runtime v2 0.7 rad/s yaw-rate ceiling, independent of horizontal `set_speed`;
- deliberately leaves vertical/takeoff/landing duration policy unimplemented because the product has no established student speed semantic for those axes/actions;
- imports no cflib command surface and emits no effect or authority;
- adds deterministic math/bounds regressions to the Runtime v2 core harness.

The future effect consumer must still serialize commands from fresh supervisor completion and compose exact preflight, teacher authorization, powered-session/watchdog, fresh yaw, #256 geometry and #257/#264 completion. No motorized checkpoint is authorized.

Refs #157 and #72.