### PR TITLE
Add pure HighLevel acknowledgement freshness domain

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -89,6 +89,10 @@ def main():
     if physical_high_level_timing_test.returncode:
         print('FAIL physical HighLevelCommander timing policy',file=sys.stderr);print(physical_high_level_timing_test.stdout,file=sys.stderr);print(physical_high_level_timing_test.stderr,file=sys.stderr);return physical_high_level_timing_test.returncode
     print(physical_high_level_timing_test.stdout.strip())
+    physical_high_level_ack_test=subprocess.run([sys.executable,'tools/ci/test_physical_high_level_ack.py'],text=True,capture_output=True)
+    if physical_high_level_ack_test.returncode:
+        print('FAIL pure SETPOINT_HL acknowledgement freshness domain',file=sys.stderr);print(physical_high_level_ack_test.stdout,file=sys.stderr);print(physical_high_level_ack_test.stderr,file=sys.stderr);return physical_high_level_ack_test.returncode
+    print(physical_high_level_ack_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_high_level_ack.py
+++ b/tools/ci/test_physical_high_level_ack.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "high_level_ack.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+import high_level_ack as ack  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except ack.HighLevelAckError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected HighLevelAckError containing {pattern!r}")
+
+
+class Epoch:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+
+def unique(name: str) -> str:
+    return "ack-test-" + name
+
+
+def request(prefix: bytes = b"\x0c\x00\x00") -> bytes:
+    return prefix + b"payload"
+
+
+def test_success_and_definitive_rejection_are_not_poison() -> None:
+    epoch = Epoch(unique("success"))
+    domain = ack.HighLevelAckDomain(epoch)
+
+    with domain.transaction(request()) as txn:
+        require(not txn.emitted, "preparation alone is not an effect")
+        txn.mark_emitted()
+        result = txn.resolve_reply(b"\x0c\x00\x00\x00")
+        require(result.accepted and result.status == 0, "zero firmware result accepted")
+        require(result.connection_epoch == epoch.value, "reply is epoch-bound")
+    require(not domain.poisoned, "definitive success preserves reply freshness")
+
+    with domain.transaction(request(b"\x07\x00\x11")) as txn:
+        txn.mark_emitted()
+        result = txn.resolve_reply(b"\x07\x00\x11\x10")
+        require(
+            not result.accepted and result.status == 0x10,
+            "nonzero result is definitive rejection",
+        )
+    require(
+        not domain.poisoned,
+        "exact nonzero firmware result is rejection, not transport ambiguity",
+    )
+
+
+def test_malformed_or_wrong_prefix_poison_across_reconstruction() -> None:
+    for label, reply, pattern in (
+        ("short", b"\x0c\x00\x00", "malformed"),
+        ("long", b"\x0c\x00\x00\x00\x00", "malformed"),
+        ("prefix", b"\x0c\x00\x01\x00", "prefix"),
+    ):
+        epoch = Epoch(unique(label))
+        domain = ack.HighLevelAckDomain(epoch)
+        with domain.transaction(request()) as txn:
+            txn.mark_emitted()
+            expect_error(lambda r=reply, t=txn: t.resolve_reply(r), pattern)
+        require(domain.poisoned, label + ": malformed reply poisons epoch")
+        expect_error(lambda e=epoch: ack.HighLevelAckDomain(e), "poisoned")
+
+
+def test_timeout_disconnect_and_unresolved_close_poison() -> None:
+    for label, reason, pattern in (
+        ("timeout", "ack timeout", "timeout"),
+        ("disconnect", "Crazyflie disconnected", "disconnected"),
+    ):
+        epoch = Epoch(unique(label))
+        domain = ack.HighLevelAckDomain(epoch)
+        with domain.transaction(request()) as txn:
+            txn.mark_emitted()
+            expect_error(lambda t=txn, r=reason: t.fail_ambiguous(r), pattern)
+        require(domain.poisoned, label + ": ambiguous physical outcome poisons epoch")
+
+    epoch = Epoch(unique("implicit-close"))
+    domain = ack.HighLevelAckDomain(epoch)
+    with domain.transaction(request()) as txn:
+        txn.mark_emitted()
+    require(domain.poisoned, "leaving an emitted request unresolved poisons epoch")
+
+
+def test_pre_emission_failure_does_not_poison() -> None:
+    epoch = Epoch(unique("pre-effect"))
+    domain = ack.HighLevelAckDomain(epoch)
+    try:
+        with domain.transaction(request()):
+            raise RuntimeError("local validation failed before send")
+    except RuntimeError:
+        pass
+    require(not domain.poisoned, "pre-effect failure creates no reply ambiguity")
+    with domain.transaction(request()) as txn:
+        txn.mark_emitted()
+        require(
+            txn.resolve_reply(b"\x0c\x00\x00\x00").accepted,
+            "later request still works",
+        )
+
+
+def test_epoch_change_after_emission_poison_old_epoch_only() -> None:
+    old = unique("epoch-old")
+    new = unique("epoch-new")
+    epoch = Epoch(old)
+    domain = ack.HighLevelAckDomain(epoch)
+    with domain.transaction(request()) as txn:
+        txn.mark_emitted()
+        epoch.value = new
+        expect_error(
+            lambda: txn.resolve_reply(b"\x0c\x00\x00\x00"),
+            "epoch changed",
+        )
+    require(domain.poisoned, "old reply domain is poisoned on epoch rotation")
+    fresh = ack.HighLevelAckDomain(epoch)
+    require(
+        fresh.bound_connection_epoch == new and not fresh.poisoned,
+        "new epoch clears reply matching ambiguity only",
+    )
+
+
+def test_same_epoch_transactions_are_process_wide_serialized() -> None:
+    epoch = Epoch(unique("serialization"))
+    first = ack.HighLevelAckDomain(epoch)
+    second = ack.HighLevelAckDomain(epoch)
+    txn = first.transaction(request())
+    try:
+        expect_error(
+            lambda: second.transaction(request(b"\x07\x00\x01")),
+            "already active",
+        )
+        require(
+            not first.poisoned,
+            "rejected concurrent preparation creates no ambiguity",
+        )
+    finally:
+        txn.close()
+    with second.transaction(request()) as retry:
+        retry.mark_emitted()
+        retry.resolve_reply(b"\x0c\x00\x00\x00")
+
+
+def test_invalid_inputs_fail_before_effect() -> None:
+    epoch = Epoch(unique("validation"))
+    domain = ack.HighLevelAckDomain(epoch)
+    for bad in (b"", b"12", "not-bytes", bytearray(31)):
+        expect_error(lambda value=bad: domain.transaction(value), "request")
+    require(not domain.poisoned, "local request validation cannot poison transport")
+
+
+def test_source_has_no_physical_send_or_cflib_retry_surface() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "import cflib",
+        "CRTPPacket",
+        "HighLevelCommander(",
+        ".send_packet(",
+        "add_port_callback(",
+        "expected_" + "reply",
+    ):
+        require(
+            forbidden not in source,
+            "pure ack domain contains effect surface: " + forbidden,
+        )
+
+
+def main() -> int:
+    test_success_and_definitive_rejection_are_not_poison()
+    test_malformed_or_wrong_prefix_poison_across_reconstruction()
+    test_timeout_disconnect_and_unresolved_close_poison()
+    test_pre_emission_failure_does_not_poison()
+    test_epoch_change_after_emission_poison_old_epoch_only()
+    test_same_epoch_transactions_are_process_wide_serialized()
+    test_invalid_inputs_fail_before_effect()
+    test_source_has_no_physical_send_or_cflib_retry_surface()
+    print(
+        "PASS pure SETPOINT_HL acknowledgement freshness serializes one request "
+        "and poisons ambiguous same-epoch replies without any physical send"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/high_level_ack.py
+++ b/tools/physical/high_level_ack.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Pure freshness/serialization domain for HighLevel SETPOINT_HL acknowledgements.
+
+The pinned Crazyflie firmware acknowledges high-level commander requests with a
+four-byte reply containing only request bytes 0..2 plus one result byte. There
+is no transaction nonce. A timeout, malformed reply, disconnect or epoch change
+can therefore leave an old reply in flight, exactly where blind command retry
+would be unsafe.
+
+This module deliberately emits no CRTP packet and imports no cflib command
+surface. It supplies the process-wide connection-epoch freshness discipline that
+a later trusted host transport must wrap around its single physical send.
+
+A new connection epoch clears only reply-matching ambiguity. It does not prove
+the outcome of a previously emitted physical effect and must never be treated as
+flight-inactive or reset evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Callable
+
+_REPLY_SIZE = 4
+_REPLY_PREFIX_SIZE = 3
+_MAX_CRTP_DATA_SIZE = 30
+
+_EPOCH_STATE_LOCK = Lock()
+_POISONED_EPOCHS: dict[str, str] = {}
+_EPOCH_TRANSACTION_LOCKS: dict[str, Lock] = {}
+
+
+class HighLevelAckError(RuntimeError):
+    """Fail-closed error for unavailable HighLevel acknowledgement freshness."""
+
+
+def _read_nonempty_epoch(reader: Callable[[], str]) -> str:
+    try:
+        value = reader()
+    except Exception as exc:
+        raise HighLevelAckError(
+            "connection epoch is unavailable for HighLevel acknowledgement"
+        ) from exc
+    if not isinstance(value, str) or not value.strip():
+        raise HighLevelAckError(
+            "connection epoch is invalid for HighLevel acknowledgement"
+        )
+    return value.strip()
+
+
+def _poison_epoch(epoch: str, reason: str) -> None:
+    message = str(reason).strip() or "ambiguous HighLevel acknowledgement outcome"
+    with _EPOCH_STATE_LOCK:
+        _POISONED_EPOCHS.setdefault(epoch, message)
+
+
+def _poison_reason(epoch: str) -> str | None:
+    with _EPOCH_STATE_LOCK:
+        return _POISONED_EPOCHS.get(epoch)
+
+
+def _transaction_lock(epoch: str) -> Lock:
+    with _EPOCH_STATE_LOCK:
+        lock = _EPOCH_TRANSACTION_LOCKS.get(epoch)
+        if lock is None:
+            lock = Lock()
+            _EPOCH_TRANSACTION_LOCKS[epoch] = lock
+        return lock
+
+
+def _request_bytes(value: object) -> bytes:
+    if isinstance(value, bytearray):
+        data = bytes(value)
+    elif isinstance(value, bytes):
+        data = value
+    else:
+        raise HighLevelAckError("HighLevel request must be bytes")
+    if len(data) < _REPLY_PREFIX_SIZE:
+        raise HighLevelAckError(
+            "HighLevel request is too short for firmware acknowledgement correlation"
+        )
+    if len(data) > _MAX_CRTP_DATA_SIZE:
+        raise HighLevelAckError("HighLevel request exceeds CRTP data capacity")
+    return data
+
+
+def _reply_bytes(value: object) -> bytes:
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, bytes):
+        return value
+    raise HighLevelAckError("HighLevel acknowledgement must be bytes")
+
+
+@dataclass(frozen=True)
+class HighLevelAckResult:
+    """Definitive application-level reply for one exactly serialized request."""
+
+    connection_epoch: str
+    request_prefix: bytes
+    status: int
+
+    @property
+    def accepted(self) -> bool:
+        return self.status == 0
+
+
+class HighLevelAckDomain:
+    """Process-wide epoch-bound acknowledgement freshness/serialization domain."""
+
+    def __init__(self, connection_epoch_reader: Callable[[], str]) -> None:
+        if not callable(connection_epoch_reader):
+            raise HighLevelAckError(
+                "connection epoch reader is required for HighLevel acknowledgement"
+            )
+        self._connection_epoch_reader = connection_epoch_reader
+        self._bound_connection_epoch = _read_nonempty_epoch(
+            self._connection_epoch_reader
+        )
+        self._lock = _transaction_lock(self._bound_connection_epoch)
+        self._raise_if_poisoned()
+
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._bound_connection_epoch
+
+    @property
+    def poisoned(self) -> bool:
+        return _poison_reason(self._bound_connection_epoch) is not None
+
+    def _raise_if_poisoned(self) -> None:
+        reason = _poison_reason(self._bound_connection_epoch)
+        if reason is not None:
+            raise HighLevelAckError(
+                "HighLevel acknowledgement freshness is poisoned for this "
+                "connection epoch: " + reason
+            )
+
+    def _verify_epoch(self, *, poison_on_change: bool) -> None:
+        self._raise_if_poisoned()
+        current = _read_nonempty_epoch(self._connection_epoch_reader)
+        if current != self._bound_connection_epoch:
+            reason = "connection epoch changed during HighLevel acknowledgement"
+            if poison_on_change:
+                _poison_epoch(self._bound_connection_epoch, reason)
+            raise HighLevelAckError(reason)
+
+    def transaction(self, request: object) -> "HighLevelAckTransaction":
+        """Reserve one epoch for one request; this method emits no physical effect."""
+        self._verify_epoch(poison_on_change=False)
+        data = _request_bytes(request)
+        if not self._lock.acquire(blocking=False):
+            raise HighLevelAckError(
+                "another HighLevel acknowledgement transaction is already active"
+            )
+        try:
+            self._verify_epoch(poison_on_change=False)
+            return HighLevelAckTransaction(self, data, self._lock)
+        except Exception:
+            self._lock.release()
+            raise
+
+
+class HighLevelAckTransaction:
+    """One prepared request around which a later transport performs one send."""
+
+    _PREPARED = "prepared"
+    _EMITTED = "emitted"
+    _RESOLVED = "resolved"
+    _AMBIGUOUS = "ambiguous"
+    _CLOSED = "closed"
+
+    def __init__(self, domain: HighLevelAckDomain, request: bytes, lock: Lock) -> None:
+        self._domain = domain
+        self._request = request
+        self._prefix = request[:_REPLY_PREFIX_SIZE]
+        self._lock = lock
+        self._state = self._PREPARED
+        self._released = False
+
+    @property
+    def request(self) -> bytes:
+        return self._request
+
+    @property
+    def request_prefix(self) -> bytes:
+        return self._prefix
+
+    @property
+    def emitted(self) -> bool:
+        return self._state in (self._EMITTED, self._RESOLVED, self._AMBIGUOUS)
+
+    def __enter__(self) -> "HighLevelAckTransaction":
+        return self
+
+    def mark_emitted(self) -> None:
+        """Cross the effect boundary immediately before the caller's one send.
+
+        The later physical transport must call this before invoking its send
+        primitive. Any send exception then exits an emitted transaction and
+        poisons acknowledgement freshness rather than being mistaken for a
+        pre-effect local failure.
+        """
+        if self._state != self._PREPARED:
+            raise HighLevelAckError(
+                "HighLevel acknowledgement transaction is not prepared for emission"
+            )
+        try:
+            self._domain._verify_epoch(poison_on_change=True)
+        except Exception:
+            self._state = self._AMBIGUOUS
+            raise
+        self._state = self._EMITTED
+
+    def resolve_reply(self, reply: object) -> HighLevelAckResult:
+        """Resolve one firmware reply; exact transport certainty is definitive."""
+        if self._state != self._EMITTED:
+            raise HighLevelAckError(
+                "HighLevel acknowledgement reply requires an emitted request"
+            )
+        try:
+            self._domain._verify_epoch(poison_on_change=True)
+            data = _reply_bytes(reply)
+            if len(data) != _REPLY_SIZE:
+                raise HighLevelAckError("malformed HighLevel acknowledgement size")
+            if data[:_REPLY_PREFIX_SIZE] != self._prefix:
+                raise HighLevelAckError(
+                    "HighLevel acknowledgement prefix does not match current request"
+                )
+        except Exception as exc:
+            _poison_epoch(
+                self._domain.bound_connection_epoch,
+                str(exc) or "malformed HighLevel acknowledgement",
+            )
+            self._state = self._AMBIGUOUS
+            raise
+        self._state = self._RESOLVED
+        return HighLevelAckResult(
+            connection_epoch=self._domain.bound_connection_epoch,
+            request_prefix=self._prefix,
+            status=data[3],
+        )
+
+    def fail_ambiguous(self, reason: object) -> None:
+        """Poison this epoch after timeout/disconnect/unknown post-send outcome."""
+        if self._state != self._EMITTED:
+            raise HighLevelAckError(
+                "only an emitted HighLevel request can become transport-ambiguous"
+            )
+        message = str(reason).strip() or "ambiguous HighLevel acknowledgement outcome"
+        _poison_epoch(self._domain.bound_connection_epoch, message)
+        self._state = self._AMBIGUOUS
+        raise HighLevelAckError(message)
+
+    def _release(self) -> None:
+        if not self._released:
+            self._released = True
+            self._lock.release()
+
+    def close(self) -> None:
+        """Release the transaction; unresolved post-send state poisons the epoch."""
+        if self._state == self._EMITTED:
+            _poison_epoch(
+                self._domain.bound_connection_epoch,
+                "emitted HighLevel request closed without definitive acknowledgement",
+            )
+            self._state = self._AMBIGUOUS
+        elif self._state in (self._PREPARED, self._RESOLVED, self._AMBIGUOUS):
+            self._state = self._CLOSED
+        self._release()
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        self.close()
+        return False


### PR DESCRIPTION
Implements the smallest no-effect prerequisite from the current #157 SETPOINT_HL acknowledgement findings.\n\n- adds a process-wide connection-epoch acknowledgement freshness domain with one-at-a-time transaction serialization;\n- models the pinned firmware reply contract exactly: four bytes, surviving request prefix bytes 0..2 plus result byte;\n- treats exact zero/nonzero firmware results as definitive acceptance/rejection without confusing rejection with transport ambiguity;\n- poisons the current epoch after malformed/wrong-prefix reply, timeout/disconnect/unknown post-send outcome, epoch change, or unresolved emitted transaction, and prevents reconstructed same-epoch domains from bypassing that poison;\n- allows a new epoch to clear reply-matching ambiguity only, explicitly without claiming that the prior physical effect outcome became safe;\n- keeps pre-effect validation/concurrency rejection non-poisoning;\n- deliberately imports no cflib/CRTP command surface and performs no physical send, so the future trusted transport must still register its callback, mark the boundary immediately before one plain send, wait for the reply and compose the #266/#267/#262 execution gates;\n- intentionally rejects requests shorter than the three-byte prefix the firmware can deterministically echo; this bounded slice therefore does not claim acknowledgement correlation for the two-byte high-level STOP/group-mask requests, and STOP remains an exceptional motor-cut path rather than an ordinary first-consumer command;\n- adds deterministic regressions and wires them into the Runtime v2 core harness.\n\nNo browser surface, physical command authority, automatic retry or motorized checkpoint is added. Refs #157, #257, #262, #266, #267 and #72.