### PR TITLE
Add live SafeLink physical precondition

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -93,6 +93,10 @@ def main():
     if physical_high_level_ack_test.returncode:
         print('FAIL pure SETPOINT_HL acknowledgement freshness domain',file=sys.stderr);print(physical_high_level_ack_test.stdout,file=sys.stderr);print(physical_high_level_ack_test.stderr,file=sys.stderr);return physical_high_level_ack_test.returncode
     print(physical_high_level_ack_test.stdout.strip())
+    physical_safelink_test=subprocess.run([sys.executable,'tools/ci/test_physical_safelink_precondition.py'],text=True,capture_output=True)
+    if physical_safelink_test.returncode:
+        print('FAIL live radio SafeLink duplicate-suppression precondition',file=sys.stderr);print(physical_safelink_test.stdout,file=sys.stderr);print(physical_safelink_test.stderr,file=sys.stderr);return physical_safelink_test.returncode
+    print(physical_safelink_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_safelink_precondition.py
+++ b/tools/ci/test_physical_safelink_precondition.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "safelink_precondition.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+import safelink_precondition as safelink  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except safelink.SafeLinkPreconditionError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(
+        f"expected SafeLinkPreconditionError containing {pattern!r}"
+    )
+
+
+class Epoch:
+    def __init__(self, values) -> None:
+        if isinstance(values, str):
+            values = [values]
+        self.values = list(values)
+        self.index = 0
+
+    def __call__(self) -> str:
+        value = self.values[min(self.index, len(self.values) - 1)]
+        self.index += 1
+        return value
+
+
+class Link:
+    def __init__(self, needs_resending) -> None:
+        self.needs_resending = needs_resending
+
+
+class Crazyflie:
+    def __init__(
+        self,
+        *,
+        link=None,
+        link_uri: str = "radio://0/80/2M/E7E7E7E7E7",
+        connected=True,
+    ) -> None:
+        self.link = link if link is not None else Link(False)
+        self.link_uri = link_uri
+        self.connected = connected
+
+    def is_connected(self):
+        return self.connected
+
+
+def test_exact_live_radio_safelink_passes() -> None:
+    cf = Crazyflie(link=Link(False))
+    epoch = Epoch("epoch-ok")
+    guard = safelink.LiveSafeLinkPrecondition(cf, epoch)
+    evidence = guard.assert_ready()
+    require(guard.bound_crazyflie is cf, "guard must retain exact Crazyflie identity")
+    require(
+        guard.bound_connection_epoch == "epoch-ok",
+        "guard must bind exact connection epoch",
+    )
+    require(
+        evidence
+        == safelink.SafeLinkEvidence(
+            connection_epoch="epoch-ok",
+            link_uri="radio://0/80/2M/E7E7E7E7E7",
+        ),
+        "evidence is exact same-epoch radio SafeLink observation",
+    )
+
+
+def test_resending_or_unknown_safelink_fails_closed() -> None:
+    for value in (True, None, 0, "", object()):
+        cf = Crazyflie(link=Link(value))
+        guard = safelink.LiveSafeLinkPrecondition(
+            cf,
+            Epoch("epoch-unsafe-" + type(value).__name__),
+        )
+        expect_error(guard.assert_ready, "not positively established")
+
+    class MissingState:
+        pass
+
+    guard = safelink.LiveSafeLinkPrecondition(
+        Crazyflie(link=MissingState()),
+        Epoch("epoch-missing"),
+    )
+    expect_error(guard.assert_ready, "SafeLink state is unavailable")
+
+
+def test_connection_and_radio_identity_are_required() -> None:
+    disconnected = safelink.LiveSafeLinkPrecondition(
+        Crazyflie(connected=False),
+        Epoch("epoch-disconnected"),
+    )
+    expect_error(disconnected.assert_ready, "not positively connected")
+
+    for uri in ("", "usb://0", "radio://0/80/2M/E7E7E7E7E7 ", None):
+        guard = safelink.LiveSafeLinkPrecondition(
+            Crazyflie(link_uri=uri),
+            Epoch("epoch-uri-" + repr(uri)),
+        )
+        expect_error(guard.assert_ready, "explicit radio:// link")
+
+    missing_link = safelink.LiveSafeLinkPrecondition(
+        Crazyflie(link=Link(False)),
+        Epoch("epoch-link"),
+    )
+    missing_link.bound_crazyflie.link = None
+    expect_error(missing_link.assert_ready, "radio link is unavailable")
+
+
+def test_epoch_rotation_fails_closed() -> None:
+    cf = Crazyflie()
+    guard = safelink.LiveSafeLinkPrecondition(
+        cf,
+        Epoch(["epoch-a", "epoch-a", "epoch-b"]),
+    )
+    expect_error(guard.assert_ready, "connection epoch changed")
+
+
+def test_link_replacement_during_observation_fails_closed() -> None:
+    first = Link(False)
+    second = Link(False)
+
+    class ReplacingCrazyflie:
+        link_uri = "radio://0/80/2M/E7E7E7E7E7"
+
+        def __init__(self) -> None:
+            self.reads = 0
+
+        @property
+        def link(self):
+            self.reads += 1
+            return first if self.reads == 1 else second
+
+        def is_connected(self):
+            return True
+
+    cf = ReplacingCrazyflie()
+    guard = safelink.LiveSafeLinkPrecondition(cf, Epoch("epoch-replace"))
+    expect_error(guard.assert_ready, "radio link changed")
+
+
+def test_no_physical_effect_surface() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "import cflib",
+        "CRTPPacket",
+        "HighLevelCommander(",
+        ".send_packet(",
+        "add_port_callback(",
+        "expected_" + "reply",
+        "send_arming_request",
+        "send_emergency_stop",
+    ):
+        require(
+            forbidden not in source,
+            "SafeLink precondition contains physical effect surface: " + forbidden,
+        )
+
+
+def main() -> int:
+    test_exact_live_radio_safelink_passes()
+    test_resending_or_unknown_safelink_fails_closed()
+    test_connection_and_radio_identity_are_required()
+    test_epoch_rotation_fails_closed()
+    test_link_replacement_during_observation_fails_closed()
+    test_no_physical_effect_surface()
+    print(
+        "PASS live radio SafeLink duplicate suppression is required on one exact "
+        "Crazyflie/connection epoch without physical effect authority"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/safelink_precondition.py
+++ b/tools/physical/safelink_precondition.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Live SafeLink eligibility precondition for future Crazyflie physical effects.
+
+Pinned cflib exposes radio-level duplicate-suppression certainty through the exact
+live Crazyflie link: RadioDriver starts with ``needs_resending = True`` and flips
+it to ``False`` only when the radio thread has positively established SafeLink.
+
+This module emits no CRTP packet and grants no command authority. It provides a
+small same-connection-epoch observation that a later trusted SETPOINT_HL effect
+consumer must call immediately before entering its acknowledged effect
+transaction. A successful observation proves only that the exact live radio link
+currently reports the duplicate-suppression precondition; it does not prove
+teacher authorization, watchdog liveness, command acknowledgement/completion or
+the outcome of any earlier ambiguous physical effect.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+class SafeLinkPreconditionError(RuntimeError):
+    """Fail-closed error for unavailable live SafeLink evidence."""
+
+
+def _read_epoch(reader: Callable[[], str]) -> str:
+    try:
+        value = reader()
+    except Exception as exc:
+        raise SafeLinkPreconditionError(
+            "connection epoch is unavailable for SafeLink precondition"
+        ) from exc
+    if not isinstance(value, str) or not value.strip():
+        raise SafeLinkPreconditionError(
+            "connection epoch is invalid for SafeLink precondition"
+        )
+    return value.strip()
+
+
+@dataclass(frozen=True)
+class SafeLinkEvidence:
+    """One non-authority observation of live radio duplicate suppression."""
+
+    connection_epoch: str
+    link_uri: str
+
+
+class LiveSafeLinkPrecondition:
+    """Observe SafeLink on one exact Crazyflie and connection epoch."""
+
+    def __init__(
+        self,
+        crazyflie: object,
+        connection_epoch_reader: Callable[[], str],
+    ) -> None:
+        if crazyflie is None:
+            raise SafeLinkPreconditionError(
+                "exact live Crazyflie object is required for SafeLink precondition"
+            )
+        if not callable(connection_epoch_reader):
+            raise SafeLinkPreconditionError(
+                "connection epoch reader is required for SafeLink precondition"
+            )
+        self._cf = crazyflie
+        self._connection_epoch_reader = connection_epoch_reader
+        self._bound_connection_epoch = _read_epoch(connection_epoch_reader)
+
+    @property
+    def bound_crazyflie(self) -> object:
+        return self._cf
+
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._bound_connection_epoch
+
+    def _verify_epoch(self) -> None:
+        current = _read_epoch(self._connection_epoch_reader)
+        if current != self._bound_connection_epoch:
+            raise SafeLinkPreconditionError(
+                "connection epoch changed during SafeLink precondition"
+            )
+
+    def _require_connected(self) -> None:
+        method = getattr(self._cf, "is_connected", None)
+        if not callable(method):
+            raise SafeLinkPreconditionError(
+                "Crazyflie live connection state is unavailable for SafeLink precondition"
+            )
+        try:
+            connected = method()
+        except Exception as exc:
+            raise SafeLinkPreconditionError(
+                "Crazyflie live connection state is unavailable for SafeLink precondition"
+            ) from exc
+        if connected is not True:
+            raise SafeLinkPreconditionError(
+                "Crazyflie is not positively connected for SafeLink precondition"
+            )
+
+    def assert_ready(self) -> SafeLinkEvidence:
+        """Require exact live radio SafeLink evidence without emitting an effect."""
+        self._verify_epoch()
+        self._require_connected()
+
+        link_uri = getattr(self._cf, "link_uri", None)
+        if (
+            not isinstance(link_uri, str)
+            or not link_uri.strip()
+            or link_uri != link_uri.strip()
+            or not link_uri.startswith("radio://")
+        ):
+            raise SafeLinkPreconditionError(
+                "SafeLink physical effect precondition requires an explicit radio:// link"
+            )
+
+        link = getattr(self._cf, "link", None)
+        if link is None:
+            raise SafeLinkPreconditionError(
+                "live Crazyflie radio link is unavailable for SafeLink precondition"
+            )
+
+        try:
+            needs_resending = getattr(link, "needs_resending")
+        except Exception as exc:
+            raise SafeLinkPreconditionError(
+                "live radio SafeLink state is unavailable"
+            ) from exc
+        if needs_resending is not False:
+            raise SafeLinkPreconditionError(
+                "live radio SafeLink duplicate suppression is not positively established"
+            )
+
+        if getattr(self._cf, "link", None) is not link:
+            raise SafeLinkPreconditionError(
+                "Crazyflie live radio link changed during SafeLink precondition"
+            )
+        try:
+            if getattr(link, "needs_resending") is not False:
+                raise SafeLinkPreconditionError(
+                    "live radio SafeLink duplicate suppression changed during observation"
+                )
+        except SafeLinkPreconditionError:
+            raise
+        except Exception as exc:
+            raise SafeLinkPreconditionError(
+                "live radio SafeLink state became unavailable"
+            ) from exc
+        self._require_connected()
+        self._verify_epoch()
+
+        return SafeLinkEvidence(
+            connection_epoch=self._bound_connection_epoch,
+            link_uri=link_uri,
+        )


### PR DESCRIPTION
Implements the smallest no-effect prerequisite from the current #157 SafeLink finding before any ordinary physical SETPOINT_HL command can be eligible.

- binds one exact Crazyflie object to one live connection epoch;
- requires the exact live cflib connection to be positively connected on an explicit `radio://` URI;
- accepts duplicate-suppression evidence only when the exact current link reports `needs_resending is False`, matching pinned cflib's post-SafeLink state;
- rechecks link identity, SafeLink state, connection liveness and epoch before returning evidence so one observation is internally same-link/same-epoch;
- fails closed for missing/unknown/true/non-boolean retry state, disconnect, non-radio link, link replacement or epoch rotation;
- exposes only non-authority evidence and deliberately imports no cflib/CRTP send surface, callback, acknowledgement retry, arming, watchdog or HighLevel command API;
- adds deterministic regressions and wires them into the Runtime v2 core harness.

The later trusted effect consumer must call this precondition immediately before entering #271's acknowledgement transaction and must still compose #266/#267/#262, exact preflight, reset/effect exclusion, fresh #257/#260 evidence, #256/#268 semantics/timing and #257/#264 completion. This slice does not make an ambiguous prior effect safe and authorizes no motorized checkpoint.

Refs #157, #271, #266, #267, #262 and #72.