### PR TITLE
Add trusted physical reset/effect exclusion domain

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -97,6 +97,10 @@ def main():
     if physical_safelink_test.returncode:
         print('FAIL live radio SafeLink duplicate-suppression precondition',file=sys.stderr);print(physical_safelink_test.stdout,file=sys.stderr);print(physical_safelink_test.stderr,file=sys.stderr);return physical_safelink_test.returncode
     print(physical_safelink_test.stdout.strip())
+    physical_execution_domain_test=subprocess.run([sys.executable,'tools/ci/test_physical_execution_domain.py'],text=True,capture_output=True)
+    if physical_execution_domain_test.returncode:
+        print('FAIL trusted physical reset/effect exclusion domain',file=sys.stderr);print(physical_execution_domain_test.stdout,file=sys.stderr);print(physical_execution_domain_test.stderr,file=sys.stderr);return physical_execution_domain_test.returncode
+    print(physical_execution_domain_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_execution_domain.py
+++ b/tools/ci/test_physical_execution_domain.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Event, Thread
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "physical" / "physical_execution_domain.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+import physical_execution_domain as domain  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except domain.PhysicalExecutionDomainError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(
+        f"expected PhysicalExecutionDomainError containing {pattern!r}"
+    )
+
+
+def reset_ok(
+    execution: domain.PhysicalExecutionDomain,
+    token: object | None = None,
+):
+    marker = token if token is not None else object()
+    result = execution.run_reset_establishment(lambda: marker)
+    require(result is marker, "reset wrapper must preserve established-session result")
+    require(
+        execution.phase == domain.INACTIVE,
+        "successful #266 reset establishes inactive",
+    )
+    return marker
+
+
+def test_new_process_requires_reset_establishment() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    require(
+        execution.phase == domain.RECOVERY_REQUIRED,
+        "fresh process must not infer reusable run authority",
+    )
+    expect_error(
+        lambda: execution.effect_transaction(lambda: None).__enter__(),
+        "not eligible",
+    )
+    reset_ok(execution)
+
+
+def test_reset_failure_is_fail_closed() -> None:
+    execution = domain.PhysicalExecutionDomain()
+
+    def fail():
+        raise RuntimeError("ambiguous reset")
+
+    expect_error(
+        lambda: execution.run_reset_establishment(fail),
+        "failed or is ambiguous",
+    )
+    require(
+        execution.phase == domain.RECOVERY_REQUIRED,
+        "failed reset must not mint effect eligibility",
+    )
+    expect_error(
+        lambda: execution.run_reset_establishment(lambda: None),
+        "returned no established session",
+    )
+    require(
+        execution.phase == domain.RECOVERY_REQUIRED,
+        "empty reset result fails closed",
+    )
+
+
+def test_preconditions_run_inside_exclusion_and_pre_effect_failure_is_neutral() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    calls: list[str] = []
+
+    def first():
+        calls.append("first")
+        require(
+            execution.phase == domain.INACTIVE,
+            "precondition sees stable prior phase",
+        )
+
+    def fail():
+        calls.append("fail")
+        raise RuntimeError("teacher binding mismatch")
+
+    transaction = execution.effect_transaction(
+        first,
+        fail,
+        lambda: calls.append("late"),
+    )
+    try:
+        with transaction:
+            raise AssertionError("failing precondition must prevent effect body")
+    except RuntimeError as exc:
+        require(
+            "teacher binding mismatch" in str(exc),
+            "original assertion failure preserved",
+        )
+    require(calls == ["first", "fail"], "preconditions stop at first failure")
+    require(
+        execution.phase == domain.INACTIVE,
+        "pre-effect failure preserves prior phase",
+    )
+
+
+def test_unresolved_emission_requires_recovery() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        require(
+            execution.phase == domain.EFFECT_UNRESOLVED,
+            "emission immediately blocks reset and later effects",
+        )
+    require(
+        execution.phase == domain.RECOVERY_REQUIRED,
+        "unresolved emitted outcome becomes recovery-required",
+    )
+    expect_error(
+        lambda: execution.effect_transaction(lambda: None).__enter__(),
+        "not eligible",
+    )
+    reset_ok(execution)
+
+
+def test_definitive_rejection_restores_exact_prior_phase() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        effect.mark_definitive_rejection()
+    require(
+        execution.phase == domain.INACTIVE,
+        "rejected takeoff preserves inactive",
+    )
+
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        effect.mark_accepted()
+    execution.complete_accepted_effect(domain.FLYING, lambda: True)
+    require(
+        execution.phase == domain.FLYING,
+        "accepted takeoff completion establishes flying",
+    )
+
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        effect.mark_definitive_rejection()
+    require(
+        execution.phase == domain.FLYING,
+        "rejected in-flight command preserves flying",
+    )
+
+
+def test_positive_ack_requires_fresh_completion_before_next_transition() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        effect.mark_accepted()
+
+    require(
+        execution.phase == domain.AWAITING_COMPLETION,
+        "positive acknowledgement alone is not completion evidence",
+    )
+    expect_error(
+        lambda: execution.effect_transaction(lambda: None).__enter__(),
+        "not eligible",
+    )
+    expect_error(
+        lambda: execution.run_reset_establishment(lambda: object()),
+        "blocked",
+    )
+    execution.complete_accepted_effect(domain.FLYING, lambda: True)
+    require(
+        execution.phase == domain.FLYING,
+        "fresh trajectory completion can establish flying",
+    )
+    expect_error(
+        lambda: execution.run_reset_establishment(lambda: object()),
+        "blocked",
+    )
+
+    with execution.effect_transaction(lambda: None) as landing:
+        landing.mark_emitted()
+        landing.mark_accepted()
+    execution.complete_accepted_effect(domain.INACTIVE, lambda: True)
+    require(
+        execution.phase == domain.INACTIVE,
+        "fresh #264 landing completion can establish inactive",
+    )
+    reset_ok(execution)
+
+
+def test_completion_uncertainty_forces_recovery() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        effect.mark_accepted()
+    expect_error(
+        lambda: execution.complete_accepted_effect(domain.FLYING, lambda: False),
+        "not positively established",
+    )
+    require(
+        execution.phase == domain.RECOVERY_REQUIRED,
+        "negative completion proof cannot preserve ordinary run authority",
+    )
+    reset_ok(execution)
+
+    with execution.effect_transaction(lambda: None) as effect:
+        effect.mark_emitted()
+        effect.mark_accepted()
+
+    def fail_proof():
+        raise RuntimeError("fresh supervisor poisoned")
+
+    expect_error(
+        lambda: execution.complete_accepted_effect(domain.INACTIVE, fail_proof),
+        "failed or is ambiguous",
+    )
+    require(
+        execution.phase == domain.RECOVERY_REQUIRED,
+        "ambiguous completion requires recovery",
+    )
+
+
+def test_reset_and_effect_boundary_are_mutually_exclusive() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    reset_entered = Event()
+    release_reset = Event()
+    effect_entered = Event()
+    failures: list[BaseException] = []
+
+    def held_reset():
+        try:
+            def establish():
+                reset_entered.set()
+                require(
+                    release_reset.wait(1.0),
+                    "test reset release signal",
+                )
+                return object()
+
+            execution.run_reset_establishment(establish)
+        except BaseException as exc:
+            failures.append(exc)
+
+    def effect_attempt():
+        try:
+            with execution.effect_transaction(lambda: None):
+                effect_entered.set()
+        except BaseException as exc:
+            failures.append(exc)
+
+    reset_thread = Thread(target=held_reset)
+    reset_thread.start()
+    require(
+        reset_entered.wait(1.0),
+        "reset transaction entered exclusion",
+    )
+    effect_thread = Thread(target=effect_attempt)
+    effect_thread.start()
+    require(
+        not effect_entered.wait(0.05),
+        "effect must not enter while reset establishment owns exclusion",
+    )
+    release_reset.set()
+    reset_thread.join(1.0)
+    effect_thread.join(1.0)
+    require(
+        not reset_thread.is_alive() and not effect_thread.is_alive(),
+        "threads completed",
+    )
+    require(not failures, f"concurrency fixture failed: {failures!r}")
+    require(
+        effect_entered.is_set(),
+        "effect may enter only after reset exclusion releases",
+    )
+
+
+def test_no_physical_effect_or_browser_surface() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "import cflib",
+        "CRTPPacket",
+        "HighLevelCommander(",
+        ".send_packet(",
+        "add_port_callback(",
+        "expected_" + "reply",
+        "send_arming_request",
+        "send_emergency_stop",
+        "http.server",
+    ):
+        require(
+            forbidden not in source,
+            "execution exclusion contains physical/browser effect surface: "
+            + forbidden,
+        )
+
+
+def main() -> int:
+    test_new_process_requires_reset_establishment()
+    test_reset_failure_is_fail_closed()
+    test_preconditions_run_inside_exclusion_and_pre_effect_failure_is_neutral()
+    test_unresolved_emission_requires_recovery()
+    test_definitive_rejection_restores_exact_prior_phase()
+    test_positive_ack_requires_fresh_completion_before_next_transition()
+    test_completion_uncertainty_forces_recovery()
+    test_reset_and_effect_boundary_are_mutually_exclusive()
+    test_no_physical_effect_or_browser_surface()
+    print(
+        "PASS trusted physical reset/effect exclusion is process-local, fail-closed "
+        "and emits no physical effect"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_execution_domain.py
+++ b/tools/ci/test_physical_execution_domain.py
@@ -162,6 +162,13 @@ def test_definitive_rejection_restores_exact_prior_phase() -> None:
         "rejected in-flight command preserves flying",
     )
 
+    # Keep the process-wide fixture in a stable non-flying phase for the next
+    # independent regression without bypassing the public lifecycle.
+    with execution.effect_transaction(lambda: None) as landing:
+        landing.mark_emitted()
+        landing.mark_accepted()
+    execution.complete_accepted_effect(domain.INACTIVE, lambda: True)
+
 
 def test_positive_ack_requires_fresh_completion_before_next_transition() -> None:
     execution = domain.PhysicalExecutionDomain()
@@ -234,6 +241,7 @@ def test_completion_uncertainty_forces_recovery() -> None:
         execution.phase == domain.RECOVERY_REQUIRED,
         "ambiguous completion requires recovery",
     )
+    reset_ok(execution)
 
 
 def test_reset_and_effect_boundary_are_mutually_exclusive() -> None:
@@ -291,6 +299,67 @@ def test_reset_and_effect_boundary_are_mutually_exclusive() -> None:
     )
 
 
+def test_independent_handles_share_process_wide_exclusion() -> None:
+    effect_execution = domain.PhysicalExecutionDomain()
+    reset_execution = domain.PhysicalExecutionDomain()
+    reset_ok(effect_execution)
+    effect_entered = Event()
+    release_effect = Event()
+    reset_entered = Event()
+    failures: list[BaseException] = []
+
+    def held_effect():
+        try:
+            with effect_execution.effect_transaction(lambda: None):
+                effect_entered.set()
+                require(
+                    release_effect.wait(1.0),
+                    "test effect release signal",
+                )
+        except BaseException as exc:
+            failures.append(exc)
+
+    def reset_attempt():
+        try:
+            def establish():
+                reset_entered.set()
+                return object()
+
+            reset_execution.run_reset_establishment(establish)
+        except BaseException as exc:
+            failures.append(exc)
+
+    effect_thread = Thread(target=held_effect)
+    effect_thread.start()
+    require(
+        effect_entered.wait(1.0),
+        "effect transaction entered process-wide exclusion",
+    )
+    reset_thread = Thread(target=reset_attempt)
+    reset_thread.start()
+    require(
+        not reset_entered.wait(0.05),
+        "independent reset handle must not enter while another handle owns effect exclusion",
+    )
+    release_effect.set()
+    effect_thread.join(1.0)
+    reset_thread.join(1.0)
+    require(
+        not effect_thread.is_alive() and not reset_thread.is_alive(),
+        "independent-handle threads completed",
+    )
+    require(not failures, f"independent-handle concurrency fixture failed: {failures!r}")
+    require(
+        reset_entered.is_set(),
+        "reset may enter only after the independent effect handle releases exclusion",
+    )
+    require(
+        effect_execution.phase == domain.INACTIVE
+        and reset_execution.phase == domain.INACTIVE,
+        "all handles must observe one shared stable process phase",
+    )
+
+
 def test_no_physical_effect_or_browser_surface() -> None:
     source = MODULE_PATH.read_text(encoding="utf-8")
     for forbidden in (
@@ -320,6 +389,7 @@ def main() -> int:
     test_positive_ack_requires_fresh_completion_before_next_transition()
     test_completion_uncertainty_forces_recovery()
     test_reset_and_effect_boundary_are_mutually_exclusive()
+    test_independent_handles_share_process_wide_exclusion()
     test_no_physical_effect_or_browser_surface()
     print(
         "PASS trusted physical reset/effect exclusion is process-local, fail-closed "

--- a/tools/physical/physical_execution_domain.py
+++ b/tools/physical/physical_execution_domain.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Process-local reset/effect exclusion for the trusted Crazyflie host path.
+
+This module is deliberately a no-effect prerequisite. It owns only the
+process-local lifecycle needed to compose the already established physical
+safety primitives without allowing reset and flight-capable command emission to
+race.
+
+A fresh process starts in ``recovery-required``. It may not emit a physical
+effect until the caller has completed the trusted #266 reset-establishment
+transaction under :meth:`run_reset_establishment`. That transaction's own
+fresh flight-inactive gate therefore executes while this domain holds the same
+exclusion used by every later effect boundary.
+
+An effect transaction holds that exclusion across all supplied immediate
+preconditions and the caller's emission/acknowledgement boundary. Once emission
+is marked, any unresolved or exceptional outcome moves the domain back to
+``recovery-required``. A definitive firmware rejection restores the prior
+stable phase. A positive acknowledgement moves to ``awaiting-completion`` and
+no reset or later effect is eligible until a separately supplied fresh
+completion proof establishes either ``flying`` or ``inactive``.
+
+The module imports no cflib/CRTP command API and emits no packet. The later
+trusted transport must compose exact preflight, #267 teacher binding, #266/#262
+powered-session/watchdog state, #272 SafeLink, #271 acknowledgement freshness,
+action-specific #257/#260 evidence and #256/#268 semantics/timing. Completion
+proof must come from the appropriate fresh #257/#264 path; this domain does not
+mint such evidence.
+"""
+
+from __future__ import annotations
+
+from threading import RLock, get_ident
+from typing import Callable
+
+RECOVERY_REQUIRED = "recovery-required"
+INACTIVE = "inactive"
+FLYING = "flying"
+EFFECT_UNRESOLVED = "effect-unresolved"
+AWAITING_COMPLETION = "awaiting-completion"
+
+_STABLE_EFFECT_PHASES = frozenset((INACTIVE, FLYING))
+_COMPLETION_PHASES = frozenset((INACTIVE, FLYING))
+
+
+class PhysicalExecutionDomainError(RuntimeError):
+    """Fail-closed error for the trusted physical execution exclusion domain."""
+
+
+def _require_callable(value: object, name: str) -> Callable:
+    if not callable(value):
+        raise PhysicalExecutionDomainError(f"{name} must be callable")
+    return value
+
+
+class PhysicalExecutionDomain:
+    """Serialize trusted reset establishment and flight-capable effect boundaries."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._phase = RECOVERY_REQUIRED
+        self._active_section: str | None = None
+        self._section_owner: int | None = None
+
+    @property
+    def phase(self) -> str:
+        with self._lock:
+            return self._phase
+
+    def _enter_section(self, name: str) -> None:
+        self._lock.acquire()
+        if self._active_section is not None:
+            self._lock.release()
+            raise PhysicalExecutionDomainError(
+                "physical execution exclusion is already active"
+            )
+        self._active_section = name
+        self._section_owner = get_ident()
+
+    def _leave_section(self, expected: str) -> None:
+        if (
+            self._active_section != expected
+            or self._section_owner != get_ident()
+        ):
+            raise PhysicalExecutionDomainError(
+                "physical execution exclusion ownership was lost"
+            )
+        self._active_section = None
+        self._section_owner = None
+        self._lock.release()
+
+    def run_reset_establishment(self, establish_reset: Callable[[], object]) -> object:
+        """Run the complete trusted #266 reset-establishment path under exclusion.
+
+        ``establish_reset`` must be the trusted host transaction whose own
+        ``require_flight_known_inactive`` check occurs immediately before #266
+        invalidates prior evidence and attempts the STM+deck reset. A failed or
+        ambiguous transaction leaves this domain in ``recovery-required``.
+        """
+        transaction = _require_callable(
+            establish_reset,
+            "trusted reset-establishment transaction",
+        )
+        self._enter_section("reset")
+        try:
+            if self._phase not in (RECOVERY_REQUIRED, INACTIVE):
+                raise PhysicalExecutionDomainError(
+                    "STM+deck reset is blocked by current physical execution state"
+                )
+            # Invalidate ordinary effect eligibility before invoking any reset
+            # collaborator. #266 performs its own evidence invalidation and
+            # fresh flight-inactive check inside this same exclusion.
+            self._phase = RECOVERY_REQUIRED
+            try:
+                result = transaction()
+            except Exception as exc:
+                raise PhysicalExecutionDomainError(
+                    "trusted reset-establishment failed or is ambiguous"
+                ) from exc
+            if result is None:
+                raise PhysicalExecutionDomainError(
+                    "trusted reset-establishment returned no established session"
+                )
+            self._phase = INACTIVE
+            return result
+        finally:
+            self._leave_section("reset")
+
+    def effect_transaction(
+        self,
+        *immediate_preconditions: Callable[[], object],
+    ) -> "PhysicalEffectTransaction":
+        """Create one no-effect transaction for the next trusted command boundary.
+
+        Preconditions are assertion-style trusted-host callables: success means
+        returning normally; failure must raise. They are executed only after
+        the exclusion is held and immediately before the transaction becomes
+        eligible for :meth:`PhysicalEffectTransaction.mark_emitted`.
+        """
+        checks = tuple(
+            _require_callable(check, "physical effect precondition")
+            for check in immediate_preconditions
+        )
+        if not checks:
+            raise PhysicalExecutionDomainError(
+                "at least one immediate physical effect precondition is required"
+            )
+        return PhysicalEffectTransaction(self, checks)
+
+    def _begin_effect(
+        self,
+        checks: tuple[Callable[[], object], ...],
+    ) -> str:
+        self._enter_section("effect")
+        try:
+            if self._phase not in _STABLE_EFFECT_PHASES:
+                raise PhysicalExecutionDomainError(
+                    "physical effect is not eligible in current execution state"
+                )
+            prior_phase = self._phase
+            for check in checks:
+                check()
+            return prior_phase
+        except Exception:
+            self._leave_section("effect")
+            raise
+
+    def _mark_effect_emitted(self) -> None:
+        if (
+            self._active_section != "effect"
+            or self._section_owner != get_ident()
+        ):
+            raise PhysicalExecutionDomainError(
+                "physical effect emission is outside the execution exclusion"
+            )
+        self._phase = EFFECT_UNRESOLVED
+
+    def _mark_effect_rejected(self, prior_phase: str) -> None:
+        if self._phase != EFFECT_UNRESOLVED:
+            raise PhysicalExecutionDomainError(
+                "definitive rejection requires one emitted unresolved effect"
+            )
+        if prior_phase not in _STABLE_EFFECT_PHASES:
+            raise PhysicalExecutionDomainError(
+                "prior physical execution phase is invalid"
+            )
+        self._phase = prior_phase
+
+    def _mark_effect_accepted(self) -> None:
+        if self._phase != EFFECT_UNRESOLVED:
+            raise PhysicalExecutionDomainError(
+                "positive acknowledgement requires one emitted unresolved effect"
+            )
+        self._phase = AWAITING_COMPLETION
+
+    def _close_effect(
+        self,
+        *,
+        prior_phase: str | None,
+        emitted: bool,
+        resolved: bool,
+    ) -> None:
+        try:
+            if emitted and not resolved:
+                # Any exception/return after the caller crossed the effect
+                # boundary without a definitive application result is
+                # consequential uncertainty. Only #266 recovery may re-open
+                # ordinary effect eligibility.
+                self._phase = RECOVERY_REQUIRED
+            elif not emitted and prior_phase in _STABLE_EFFECT_PHASES:
+                self._phase = prior_phase
+        finally:
+            self._leave_section("effect")
+
+    def complete_accepted_effect(
+        self,
+        next_phase: str,
+        prove_completion: Callable[[], object],
+    ) -> None:
+        """Establish a fresh post-effect stable phase after positive acknowledgement.
+
+        The proof callable runs under the same exclusion and must return exactly
+        ``True``. The caller is responsible for binding it to fresh #257/#264
+        evidence appropriate to the command. Unavailable/negative proof moves
+        the run to ``recovery-required`` rather than guessing completion.
+        """
+        if next_phase not in _COMPLETION_PHASES:
+            raise PhysicalExecutionDomainError(
+                "post-effect phase must be exactly 'flying' or 'inactive'"
+            )
+        proof = _require_callable(prove_completion, "fresh effect-completion proof")
+        self._enter_section("completion")
+        try:
+            if self._phase != AWAITING_COMPLETION:
+                raise PhysicalExecutionDomainError(
+                    "no positively acknowledged effect is awaiting completion"
+                )
+            try:
+                proven = proof()
+            except Exception as exc:
+                self._phase = RECOVERY_REQUIRED
+                raise PhysicalExecutionDomainError(
+                    "fresh effect-completion proof failed or is ambiguous"
+                ) from exc
+            if proven is not True:
+                self._phase = RECOVERY_REQUIRED
+                raise PhysicalExecutionDomainError(
+                    "fresh effect completion was not positively established"
+                )
+            self._phase = next_phase
+        finally:
+            self._leave_section("completion")
+
+
+class PhysicalEffectTransaction:
+    """One exclusion-held precondition -> emission -> acknowledgement boundary."""
+
+    def __init__(
+        self,
+        domain: PhysicalExecutionDomain,
+        checks: tuple[Callable[[], object], ...],
+    ) -> None:
+        self._domain = domain
+        self._checks = checks
+        self._prior_phase: str | None = None
+        self._entered = False
+        self._emitted = False
+        self._resolved = False
+        self._closed = False
+
+    @property
+    def emitted(self) -> bool:
+        return self._emitted
+
+    def __enter__(self) -> "PhysicalEffectTransaction":
+        if self._entered or self._closed:
+            raise PhysicalExecutionDomainError(
+                "physical effect transaction cannot be re-entered"
+            )
+        self._prior_phase = self._domain._begin_effect(self._checks)
+        self._entered = True
+        return self
+
+    def mark_emitted(self) -> None:
+        """Cross the physical effect boundary immediately before the one-shot send."""
+        if not self._entered or self._closed or self._emitted:
+            raise PhysicalExecutionDomainError(
+                "physical effect transaction is not prepared for emission"
+            )
+        self._domain._mark_effect_emitted()
+        self._emitted = True
+
+    def mark_definitive_rejection(self) -> None:
+        """Record a definitive non-zero firmware result from the exact request."""
+        if not self._emitted or self._resolved or self._prior_phase is None:
+            raise PhysicalExecutionDomainError(
+                "definitive rejection requires one unresolved emitted effect"
+            )
+        self._domain._mark_effect_rejected(self._prior_phase)
+        self._resolved = True
+
+    def mark_accepted(self) -> None:
+        """Record a definitive zero firmware result; completion remains required."""
+        if not self._emitted or self._resolved:
+            raise PhysicalExecutionDomainError(
+                "positive acknowledgement requires one unresolved emitted effect"
+            )
+        self._domain._mark_effect_accepted()
+        self._resolved = True
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if not self._entered:
+            self._closed = True
+            return
+        self._domain._close_effect(
+            prior_phase=self._prior_phase,
+            emitted=self._emitted,
+            resolved=self._resolved,
+        )
+        self._closed = True
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        self.close()
+        return False

--- a/tools/physical/physical_execution_domain.py
+++ b/tools/physical/physical_execution_domain.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Process-local reset/effect exclusion for the trusted Crazyflie host path.
 
-This module is deliberately a no-effect prerequisite. It owns only the
-process-local lifecycle needed to compose the already established physical
-safety primitives without allowing reset and flight-capable command emission to
-race.
+This module is deliberately a no-effect prerequisite. It owns one
+process-wide lifecycle, shared by every `PhysicalExecutionDomain` handle, needed
+to compose the already established physical safety primitives without allowing
+reset and flight-capable command emission to race through independently
+constructed handles.
 
 A fresh process starts in ``recovery-required``. It may not emit a physical
 effect until the caller has completed the trusted #266 reset-establishment
@@ -53,41 +54,48 @@ def _require_callable(value: object, name: str) -> Callable:
     return value
 
 
-class PhysicalExecutionDomain:
-    """Serialize trusted reset establishment and flight-capable effect boundaries."""
+class _ProcessExecutionState:
+    """Single trusted-host lifecycle shared by every handle in this process."""
 
     def __init__(self) -> None:
-        self._lock = RLock()
-        self._phase = RECOVERY_REQUIRED
-        self._active_section: str | None = None
-        self._section_owner: int | None = None
+        self.lock = RLock()
+        self.phase = RECOVERY_REQUIRED
+        self.active_section: str | None = None
+        self.section_owner: int | None = None
+
+
+_PROCESS_STATE = _ProcessExecutionState()
+
+
+class PhysicalExecutionDomain:
+    """Handle onto the one process-wide trusted physical execution domain."""
 
     @property
     def phase(self) -> str:
-        with self._lock:
-            return self._phase
+        with _PROCESS_STATE.lock:
+            return _PROCESS_STATE.phase
 
     def _enter_section(self, name: str) -> None:
-        self._lock.acquire()
-        if self._active_section is not None:
-            self._lock.release()
+        _PROCESS_STATE.lock.acquire()
+        if _PROCESS_STATE.active_section is not None:
+            _PROCESS_STATE.lock.release()
             raise PhysicalExecutionDomainError(
                 "physical execution exclusion is already active"
             )
-        self._active_section = name
-        self._section_owner = get_ident()
+        _PROCESS_STATE.active_section = name
+        _PROCESS_STATE.section_owner = get_ident()
 
     def _leave_section(self, expected: str) -> None:
         if (
-            self._active_section != expected
-            or self._section_owner != get_ident()
+            _PROCESS_STATE.active_section != expected
+            or _PROCESS_STATE.section_owner != get_ident()
         ):
             raise PhysicalExecutionDomainError(
                 "physical execution exclusion ownership was lost"
             )
-        self._active_section = None
-        self._section_owner = None
-        self._lock.release()
+        _PROCESS_STATE.active_section = None
+        _PROCESS_STATE.section_owner = None
+        _PROCESS_STATE.lock.release()
 
     def run_reset_establishment(self, establish_reset: Callable[[], object]) -> object:
         """Run the complete trusted #266 reset-establishment path under exclusion.
@@ -103,14 +111,14 @@ class PhysicalExecutionDomain:
         )
         self._enter_section("reset")
         try:
-            if self._phase not in (RECOVERY_REQUIRED, INACTIVE):
+            if _PROCESS_STATE.phase not in (RECOVERY_REQUIRED, INACTIVE):
                 raise PhysicalExecutionDomainError(
                     "STM+deck reset is blocked by current physical execution state"
                 )
             # Invalidate ordinary effect eligibility before invoking any reset
             # collaborator. #266 performs its own evidence invalidation and
             # fresh flight-inactive check inside this same exclusion.
-            self._phase = RECOVERY_REQUIRED
+            _PROCESS_STATE.phase = RECOVERY_REQUIRED
             try:
                 result = transaction()
             except Exception as exc:
@@ -121,7 +129,7 @@ class PhysicalExecutionDomain:
                 raise PhysicalExecutionDomainError(
                     "trusted reset-establishment returned no established session"
                 )
-            self._phase = INACTIVE
+            _PROCESS_STATE.phase = INACTIVE
             return result
         finally:
             self._leave_section("reset")
@@ -153,11 +161,11 @@ class PhysicalExecutionDomain:
     ) -> str:
         self._enter_section("effect")
         try:
-            if self._phase not in _STABLE_EFFECT_PHASES:
+            if _PROCESS_STATE.phase not in _STABLE_EFFECT_PHASES:
                 raise PhysicalExecutionDomainError(
                     "physical effect is not eligible in current execution state"
                 )
-            prior_phase = self._phase
+            prior_phase = _PROCESS_STATE.phase
             for check in checks:
                 check()
             return prior_phase
@@ -167,16 +175,16 @@ class PhysicalExecutionDomain:
 
     def _mark_effect_emitted(self) -> None:
         if (
-            self._active_section != "effect"
-            or self._section_owner != get_ident()
+            _PROCESS_STATE.active_section != "effect"
+            or _PROCESS_STATE.section_owner != get_ident()
         ):
             raise PhysicalExecutionDomainError(
                 "physical effect emission is outside the execution exclusion"
             )
-        self._phase = EFFECT_UNRESOLVED
+        _PROCESS_STATE.phase = EFFECT_UNRESOLVED
 
     def _mark_effect_rejected(self, prior_phase: str) -> None:
-        if self._phase != EFFECT_UNRESOLVED:
+        if _PROCESS_STATE.phase != EFFECT_UNRESOLVED:
             raise PhysicalExecutionDomainError(
                 "definitive rejection requires one emitted unresolved effect"
             )
@@ -184,14 +192,14 @@ class PhysicalExecutionDomain:
             raise PhysicalExecutionDomainError(
                 "prior physical execution phase is invalid"
             )
-        self._phase = prior_phase
+        _PROCESS_STATE.phase = prior_phase
 
     def _mark_effect_accepted(self) -> None:
-        if self._phase != EFFECT_UNRESOLVED:
+        if _PROCESS_STATE.phase != EFFECT_UNRESOLVED:
             raise PhysicalExecutionDomainError(
                 "positive acknowledgement requires one emitted unresolved effect"
             )
-        self._phase = AWAITING_COMPLETION
+        _PROCESS_STATE.phase = AWAITING_COMPLETION
 
     def _close_effect(
         self,
@@ -206,9 +214,9 @@ class PhysicalExecutionDomain:
                 # boundary without a definitive application result is
                 # consequential uncertainty. Only #266 recovery may re-open
                 # ordinary effect eligibility.
-                self._phase = RECOVERY_REQUIRED
+                _PROCESS_STATE.phase = RECOVERY_REQUIRED
             elif not emitted and prior_phase in _STABLE_EFFECT_PHASES:
-                self._phase = prior_phase
+                _PROCESS_STATE.phase = prior_phase
         finally:
             self._leave_section("effect")
 
@@ -231,23 +239,23 @@ class PhysicalExecutionDomain:
         proof = _require_callable(prove_completion, "fresh effect-completion proof")
         self._enter_section("completion")
         try:
-            if self._phase != AWAITING_COMPLETION:
+            if _PROCESS_STATE.phase != AWAITING_COMPLETION:
                 raise PhysicalExecutionDomainError(
                     "no positively acknowledged effect is awaiting completion"
                 )
             try:
                 proven = proof()
             except Exception as exc:
-                self._phase = RECOVERY_REQUIRED
+                _PROCESS_STATE.phase = RECOVERY_REQUIRED
                 raise PhysicalExecutionDomainError(
                     "fresh effect-completion proof failed or is ambiguous"
                 ) from exc
             if proven is not True:
-                self._phase = RECOVERY_REQUIRED
+                _PROCESS_STATE.phase = RECOVERY_REQUIRED
                 raise PhysicalExecutionDomainError(
                     "fresh effect completion was not positively established"
                 )
-            self._phase = next_phase
+            _PROCESS_STATE.phase = next_phase
         finally:
             self._leave_section("completion")
 


### PR DESCRIPTION
Implements the smallest no-effect execution-order prerequisite from the current #157 physical backend boundary.\n\n- starts every host process in `recovery-required`, so reconstructed process state cannot mint flight authority;\n- runs the complete #266 reset-establishment transaction under the same process-local exclusion used by command boundaries;\n- runs all immediate command assertions inside that exclusion before an explicit `mark_emitted()` boundary;\n- blocks reset and later effects after positive acknowledgement until a separately supplied fresh completion proof establishes `flying` or `inactive`;\n- converts unresolved/exceptional post-emission outcomes and unavailable completion proof to `recovery-required`;\n- restores the exact prior stable phase only after a definitive firmware rejection;\n- proves reset/effect mutual exclusion with deterministic lifecycle/concurrency regressions and wires them into Runtime v2 core CI;\n- imports no cflib/CRTP send surface and emits no physical effect.\n\nThe future trusted effect consumer must compose this domain with exact preflight, #267 teacher binding, #266/#262 powered-session/watchdog state, #272 SafeLink, #271 acknowledgement freshness, fresh #257/#260 evidence where applicable, #256/#268 semantics/timing, one one-shot SETPOINT_HL send, and fresh #257/#264 completion. This PR grants no browser/HTTP authority and authorizes no motorized checkpoint.\n\nRefs #157, #266, #267, #272, #271, #262 and #72.