### PR TITLE
Bridge current-program preflight into trusted physical host

### DIFF
--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js
@@ -24,15 +24,21 @@
     if (typeof fetchImpl !== 'function')
       fail('fetch implementation is required');
 
-    async function read(path) {
-      var response = await fetchImpl(baseUrl + path, {
-        method: 'GET',
-        headers: {
-          'Authorization': 'Bearer ' + token,
-          'Cache-Control': 'no-store'
-        },
+    async function request(path, method, body) {
+      var headers = {
+        'Authorization': 'Bearer ' + token,
+        'Cache-Control': 'no-store'
+      };
+      var options = {
+        method: method,
+        headers: headers,
         cache: 'no-store'
-      });
+      };
+      if (body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        options.body = JSON.stringify(body);
+      }
+      var response = await fetchImpl(baseUrl + path, options);
       var payload;
       try {
         payload = await response.json();
@@ -40,8 +46,12 @@
         fail('bridge returned malformed JSON');
       }
       if (!response.ok)
-        fail('bridge read failed (' + response.status + '): ' + String(payload && payload.error || 'unknown error'));
+        fail('bridge request failed (' + response.status + '): ' + String(payload && payload.error || 'unknown error'));
       return payload;
+    }
+
+    async function read(path) {
+      return request(path, 'GET');
     }
 
     var adapter = {
@@ -51,6 +61,29 @@
       async readConnectionEpoch() {
         var payload = await read('/v1/connection-epoch');
         return requireText(payload && payload.connectionEpoch, 'connectionEpoch');
+      },
+      async readCurrentProgramChallenge() {
+        var payload = await read('/v1/preflight-challenge');
+        if (!payload || payload.executionAuthority !== false)
+          fail('preflight challenge must remain non-authority');
+        if (payload.challengeId === null)
+          return null;
+        return requireText(payload.challengeId, 'challengeId');
+      },
+      async submitCurrentProgramAssertion(assertion) {
+        if (!assertion || typeof assertion !== 'object')
+          fail('current-program assertion is required');
+        requireText(assertion.challengeId, 'challengeId');
+        if (assertion.executionAuthority !== false)
+          fail('current-program assertion must remain non-authority');
+        if (assertion.ok !== true && assertion.ok !== false)
+          fail('current-program assertion status must be boolean');
+        if (assertion.ok === true) {
+          requireText(assertion.profileId, 'profileId');
+          requireText(assertion.astBinding, 'astBinding');
+          requireText(assertion.connectionEpoch, 'connectionEpoch');
+        }
+        return request('/v1/preflight-assertion', 'POST', assertion);
       }
     };
     return Object.freeze(adapter);

--- a/plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js
+++ b/plugins/robot_windows/blockly/webeeblocks/physical_capability_http_adapter.js
@@ -24,21 +24,15 @@
     if (typeof fetchImpl !== 'function')
       fail('fetch implementation is required');
 
-    async function request(path, method, body) {
-      var headers = {
-        'Authorization': 'Bearer ' + token,
-        'Cache-Control': 'no-store'
-      };
-      var options = {
-        method: method,
-        headers: headers,
+    async function read(path) {
+      var response = await fetchImpl(baseUrl + path, {
+        method: 'GET',
+        headers: {
+          'Authorization': 'Bearer ' + token,
+          'Cache-Control': 'no-store'
+        },
         cache: 'no-store'
-      };
-      if (body !== undefined) {
-        headers['Content-Type'] = 'application/json';
-        options.body = JSON.stringify(body);
-      }
-      var response = await fetchImpl(baseUrl + path, options);
+      });
       var payload;
       try {
         payload = await response.json();
@@ -46,12 +40,8 @@
         fail('bridge returned malformed JSON');
       }
       if (!response.ok)
-        fail('bridge request failed (' + response.status + '): ' + String(payload && payload.error || 'unknown error'));
+        fail('bridge read failed (' + response.status + '): ' + String(payload && payload.error || 'unknown error'));
       return payload;
-    }
-
-    async function read(path) {
-      return request(path, 'GET');
     }
 
     var adapter = {
@@ -61,29 +51,6 @@
       async readConnectionEpoch() {
         var payload = await read('/v1/connection-epoch');
         return requireText(payload && payload.connectionEpoch, 'connectionEpoch');
-      },
-      async readCurrentProgramChallenge() {
-        var payload = await read('/v1/preflight-challenge');
-        if (!payload || payload.executionAuthority !== false)
-          fail('preflight challenge must remain non-authority');
-        if (payload.challengeId === null)
-          return null;
-        return requireText(payload.challengeId, 'challengeId');
-      },
-      async submitCurrentProgramAssertion(assertion) {
-        if (!assertion || typeof assertion !== 'object')
-          fail('current-program assertion is required');
-        requireText(assertion.challengeId, 'challengeId');
-        if (assertion.executionAuthority !== false)
-          fail('current-program assertion must remain non-authority');
-        if (assertion.ok !== true && assertion.ok !== false)
-          fail('current-program assertion status must be boolean');
-        if (assertion.ok === true) {
-          requireText(assertion.profileId, 'profileId');
-          requireText(assertion.astBinding, 'astBinding');
-          requireText(assertion.connectionEpoch, 'connectionEpoch');
-        }
-        return request('/v1/preflight-assertion', 'POST', assertion);
       }
     };
     return Object.freeze(adapter);

--- a/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
+++ b/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
@@ -8,6 +8,7 @@
   var adapter = null;
   var bridge = null;
   var boundProfile = null;
+  var responderGeneration = 0;
 
   function profileBinding(profile) {
     if (!profile || typeof profile.id !== 'string' || profile.id.trim() === '' ||
@@ -40,12 +41,64 @@
       fail('current Blockly workspace is unavailable');
   }
 
+  function delay(ms) {
+    return new Promise(function(resolve) {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  async function answerCurrentProgramChallenges(generation, activeAdapter) {
+    while (adapter === activeAdapter && responderGeneration === generation) {
+      var challengeId;
+      try {
+        challengeId = await activeAdapter.readCurrentProgramChallenge();
+      } catch (_error) {
+        if (adapter !== activeAdapter || responderGeneration !== generation)
+          return;
+        await delay(100);
+        continue;
+      }
+      if (adapter !== activeAdapter || responderGeneration !== generation)
+        return;
+      if (challengeId === null)
+        continue;
+
+      var assertion = {
+        challengeId: challengeId,
+        ok: false,
+        executionAuthority: false
+      };
+      try {
+        var result = await assertCurrentProgram();
+        if (adapter !== activeAdapter || responderGeneration !== generation)
+          return;
+        assertion.ok = true;
+        assertion.profileId = root.runtimeProfile.id;
+        assertion.astBinding = result.preflight.astBinding;
+        assertion.connectionEpoch = result.preflight.connectionEpoch;
+      } catch (_error) {
+        assertion.ok = false;
+      }
+
+      try {
+        await activeAdapter.submitCurrentProgramAssertion(assertion);
+      } catch (_error) {
+        // The host may have timed out, reconnected or invalidated the challenge.
+        // A rejected/late assertion creates no authority and is never retried.
+      }
+    }
+  }
+
   function configure(options) {
+    responderGeneration += 1;
     if (bridge && typeof bridge.clear === 'function')
       bridge.clear();
     bridge = null;
     boundProfile = null;
     adapter = root.WebeeBlocksPhysicalCapabilityHttpAdapter.create(options || {});
+    var generation = responderGeneration;
+    var activeAdapter = adapter;
+    answerCurrentProgramChallenges(generation, activeAdapter);
     return true;
   }
 
@@ -110,6 +163,7 @@
   }
 
   function clear() {
+    responderGeneration += 1;
     if (bridge && typeof bridge.clear === 'function')
       bridge.clear();
     bridge = null;

--- a/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
+++ b/plugins/robot_windows/blockly_v2/physical_preflight_runtime.js
@@ -5,9 +5,16 @@
     throw new Error('physical preflight runtime: ' + message);
   }
 
+  function requireText(value, name) {
+    if (typeof value !== 'string' || value.trim() === '')
+      fail(name + ' must be a non-empty string');
+    return value.trim();
+  }
+
   var adapter = null;
   var bridge = null;
   var boundProfile = null;
+  var responder = null;
   var responderGeneration = 0;
 
   function profileBinding(profile) {
@@ -41,24 +48,98 @@
       fail('current Blockly workspace is unavailable');
   }
 
+  function createResponder(options) {
+    options = options || {};
+    var baseUrl = requireText(options.baseUrl, 'baseUrl').replace(/\/$/, '');
+    var token = requireText(
+      options.preflightResponderToken,
+      'preflightResponderToken'
+    );
+    var fetchImpl = options.fetchImpl ||
+      (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+    if (typeof fetchImpl !== 'function')
+      fail('fetch implementation is required');
+
+    async function request(path, method, body) {
+      var headers = {
+        'Authorization': 'Bearer ' + token,
+        'Cache-Control': 'no-store'
+      };
+      var requestOptions = {
+        method: method,
+        headers: headers,
+        cache: 'no-store'
+      };
+      if (body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        requestOptions.body = JSON.stringify(body);
+      }
+      var response = await fetchImpl(baseUrl + path, requestOptions);
+      var payload;
+      try {
+        payload = await response.json();
+      } catch (_error) {
+        fail('preflight responder returned malformed JSON');
+      }
+      if (!response.ok)
+        fail(
+          'preflight responder request failed (' +
+          response.status +
+          '): ' +
+          String(payload && payload.error || 'unknown error')
+        );
+      return payload;
+    }
+
+    return Object.freeze({
+      async readChallenge() {
+        var payload = await request('/v1/preflight-challenge', 'GET');
+        if (!payload || payload.executionAuthority !== false)
+          fail('preflight challenge must remain non-authority');
+        if (payload.challengeId === null)
+          return null;
+        return requireText(payload.challengeId, 'challengeId');
+      },
+      async submitAssertion(assertion) {
+        return request('/v1/preflight-assertion', 'POST', assertion);
+      }
+    });
+  }
+
   function delay(ms) {
     return new Promise(function(resolve) {
       setTimeout(resolve, ms);
     });
   }
 
-  async function answerCurrentProgramChallenges(generation, activeAdapter) {
-    while (adapter === activeAdapter && responderGeneration === generation) {
+  async function answerCurrentProgramChallenges(
+    generation,
+    activeAdapter,
+    activeResponder
+  ) {
+    while (
+      adapter === activeAdapter &&
+      responder === activeResponder &&
+      responderGeneration === generation
+    ) {
       var challengeId;
       try {
-        challengeId = await activeAdapter.readCurrentProgramChallenge();
+        challengeId = await activeResponder.readChallenge();
       } catch (_error) {
-        if (adapter !== activeAdapter || responderGeneration !== generation)
+        if (
+          adapter !== activeAdapter ||
+          responder !== activeResponder ||
+          responderGeneration !== generation
+        )
           return;
         await delay(100);
         continue;
       }
-      if (adapter !== activeAdapter || responderGeneration !== generation)
+      if (
+        adapter !== activeAdapter ||
+        responder !== activeResponder ||
+        responderGeneration !== generation
+      )
         return;
       if (challengeId === null)
         continue;
@@ -70,7 +151,11 @@
       };
       try {
         var result = await assertCurrentProgram();
-        if (adapter !== activeAdapter || responderGeneration !== generation)
+        if (
+          adapter !== activeAdapter ||
+          responder !== activeResponder ||
+          responderGeneration !== generation
+        )
           return;
         assertion.ok = true;
         assertion.profileId = root.runtimeProfile.id;
@@ -81,10 +166,10 @@
       }
 
       try {
-        await activeAdapter.submitCurrentProgramAssertion(assertion);
+        await activeResponder.submitAssertion(assertion);
       } catch (_error) {
-        // The host may have timed out, reconnected or invalidated the challenge.
-        // A rejected/late assertion creates no authority and is never retried.
+        // Host timeout/reconnect/replay rejection creates no authority.
+        // Never retry a settled assertion response.
       }
     }
   }
@@ -95,10 +180,17 @@
       bridge.clear();
     bridge = null;
     boundProfile = null;
+    responder = null;
     adapter = root.WebeeBlocksPhysicalCapabilityHttpAdapter.create(options || {});
+    responder = createResponder(options || {});
     var generation = responderGeneration;
     var activeAdapter = adapter;
-    answerCurrentProgramChallenges(generation, activeAdapter);
+    var activeResponder = responder;
+    answerCurrentProgramChallenges(
+      generation,
+      activeAdapter,
+      activeResponder
+    );
     return true;
   }
 
@@ -116,7 +208,10 @@
     bridge = activeBridge;
     boundProfile = null;
     var result = await activeBridge.preflightWorkspace(root.workspace);
-    if (bridge !== activeBridge || profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+    if (
+      bridge !== activeBridge ||
+      profileBinding(root.runtimeProfile) !== expectedProfileBinding
+    ) {
       activeBridge.clear();
       if (bridge === activeBridge)
         bridge = null;
@@ -142,16 +237,21 @@
     try {
       result = await activeBridge.assertCurrentWorkspace(root.workspace);
     } catch (error) {
-      if (bridge === activeBridge &&
-          profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+      if (
+        bridge === activeBridge &&
+        profileBinding(root.runtimeProfile) !== expectedProfileBinding
+      ) {
         activeBridge.clear();
         bridge = null;
         boundProfile = null;
       }
       throw error;
     }
-    if (bridge !== activeBridge || boundProfile !== expectedProfileBinding ||
-        profileBinding(root.runtimeProfile) !== expectedProfileBinding) {
+    if (
+      bridge !== activeBridge ||
+      boundProfile !== expectedProfileBinding ||
+      profileBinding(root.runtimeProfile) !== expectedProfileBinding
+    ) {
       activeBridge.clear();
       if (bridge === activeBridge) {
         bridge = null;
@@ -168,6 +268,7 @@
       bridge.clear();
     bridge = null;
     boundProfile = null;
+    responder = null;
     adapter = null;
   }
 

--- a/tools/ci/test_physical_capability_http_bridge.py
+++ b/tools/ci/test_physical_capability_http_bridge.py
@@ -18,6 +18,9 @@ spec = importlib.util.spec_from_file_location("serve_reference_capabilities", BR
 if spec is None or spec.loader is None:
     raise RuntimeError("cannot load capability HTTP bridge")
 bridge_module = importlib.util.module_from_spec(spec)
+# exec_module does not register manually created modules; dataclasses resolves
+# postponed annotations through sys.modules while the module is executing.
+sys.modules[spec.name] = bridge_module
 spec.loader.exec_module(bridge_module)
 
 

--- a/tools/ci/test_physical_capability_http_bridge.py
+++ b/tools/ci/test_physical_capability_http_bridge.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+from dataclasses import FrozenInstanceError
 import json
 from pathlib import Path
 import sys
@@ -103,21 +104,21 @@ def start_host_assertion(
 
 def complete_host_assertion(
     base: str,
-    token: str,
+    responder_token: str,
     *,
     profile_id: str = "activity-1",
     ast_binding: str = "ast-1",
     connection_epoch: str = "connection-one",
 ):
-    status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+    status, challenge, _ = request(base + "/v1/preflight-challenge", responder_token)
     assert status == 200
     assert challenge["executionAuthority"] is False
     challenge_id = challenge["challengeId"]
     assert isinstance(challenge_id, str) and challenge_id
     status, response, _ = request(
         base + "/v1/preflight-assertion",
-        token,
-        method="POST",
+            responder_token,
+            method="POST",
         payload={
             "challengeId": challenge_id,
             "ok": True,
@@ -133,7 +134,12 @@ def complete_host_assertion(
 def main() -> int:
     fake = FakeSession()
     token = "test-bridge-token"
-    bridge = bridge_module.ReadOnlyCapabilityHttpBridge(fake, token=token)
+    responder_token = "test-preflight-responder-token"
+    bridge = bridge_module.ReadOnlyCapabilityHttpBridge(
+        fake,
+        token=token,
+        preflight_responder_token=responder_token,
+    )
     host, port = bridge.address
     thread = Thread(target=bridge.serve_forever, daemon=True)
     thread.start()
@@ -166,9 +172,32 @@ def main() -> int:
         assert status == 405 and payload == {"error": "read-only bridge"}
         assert fake.epoch_reads == 1, "effect-shaped methods must never reach the live session"
 
-        # Only the trusted host can create a fresh current-program challenge.
+        # The ordinary capability bearer cannot claim or answer trusted #249
+        # challenges, even if it knows plausible binding values.
+        status, payload, _ = request(base + "/v1/preflight-challenge", token)
+        assert status == 401 and payload == {"error": "unauthorized"}
+        status, payload, _ = request(
+            base + "/v1/preflight-assertion",
+            token,
+            method="POST",
+            payload={
+                "challengeId": "guessed",
+                "ok": True,
+                "profileId": "activity-1",
+                "astBinding": "ast-1",
+                "connectionEpoch": "connection-one",
+                "executionAuthority": False,
+            },
+        )
+        assert status == 401 and payload == {"error": "unauthorized"}
+
+        # Only the separately authenticated production responder can complete a
+        # fresh host-created current-program challenge.
         thread, outcome = start_host_assertion(bridge)
-        status, response, challenge_id = complete_host_assertion(base, token)
+        status, response, challenge_id = complete_host_assertion(
+            base,
+            responder_token,
+        )
         assert status == 200 and response["accepted"] is True
         assert response["executionAuthority"] is False
         thread.join(timeout=2)
@@ -179,11 +208,26 @@ def main() -> int:
         assert evidence.connection_epoch == "connection-one"
         assert evidence.challenge_id == challenge_id
         assert evidence.execution_authority is False
+        for field, replacement in (
+            ("profile_id", "other-activity"),
+            ("ast_binding", "other-ast"),
+            ("connection_epoch", "other-epoch"),
+            ("challenge_id", "other-challenge"),
+            ("execution_authority", True),
+        ):
+            try:
+                setattr(evidence, field, replacement)
+            except (FrozenInstanceError, AttributeError):
+                pass
+            else:
+                raise AssertionError(
+                    "minted current-program evidence must be immutable: " + field
+                )
 
         # The exact challenge is one-shot; replay/late responses are rejected.
         status, replay, _ = request(
             base + "/v1/preflight-assertion",
-            token,
+            responder_token,
             method="POST",
             payload={
                 "challengeId": challenge_id,
@@ -198,11 +242,11 @@ def main() -> int:
 
         # A same-challenge profile/AST mismatch settles the host request fail-closed.
         thread, outcome = start_host_assertion(bridge)
-        status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+        status, challenge, _ = request(base + "/v1/preflight-challenge", responder_token)
         mismatch_id = challenge["challengeId"]
         status, mismatch, _ = request(
             base + "/v1/preflight-assertion",
-            token,
+            responder_token,
             method="POST",
             payload={
                 "challengeId": mismatch_id,
@@ -221,12 +265,12 @@ def main() -> int:
         # Reconnect after challenge creation but before host acceptance is stale.
         fake.epoch = "connection-one"
         thread, outcome = start_host_assertion(bridge)
-        status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+        status, challenge, _ = request(base + "/v1/preflight-challenge", responder_token)
         epoch_id = challenge["challengeId"]
         fake.epoch = "connection-two"
         status, response, _ = request(
             base + "/v1/preflight-assertion",
-            token,
+            responder_token,
             method="POST",
             payload={
                 "challengeId": epoch_id,
@@ -245,14 +289,14 @@ def main() -> int:
         # A host timeout invalidates the challenge; a later response cannot revive it.
         fake.epoch = "connection-one"
         thread, outcome = start_host_assertion(bridge, timeout_seconds=0.03)
-        status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+        status, challenge, _ = request(base + "/v1/preflight-challenge", responder_token)
         timeout_id = challenge["challengeId"]
         thread.join(timeout=2)
         assert isinstance(outcome.get("error"), bridge_module.CapabilityBridgeError)
         assert "timed out" in str(outcome["error"])
         status, late, _ = request(
             base + "/v1/preflight-assertion",
-            token,
+            responder_token,
             method="POST",
             payload={
                 "challengeId": timeout_id,
@@ -268,7 +312,7 @@ def main() -> int:
         # Browser responses cannot create a challenge on their own.
         status, unsolicited, _ = request(
             base + "/v1/preflight-assertion",
-            token,
+            responder_token,
             method="POST",
             payload={
                 "challengeId": "fabricated-challenge",

--- a/tools/ci/test_physical_capability_http_bridge.py
+++ b/tools/ci/test_physical_capability_http_bridge.py
@@ -51,9 +51,18 @@ class FakeSession:
         }
 
 
-def request(url: str, token: str | None = None, method: str = "GET") -> tuple[int, object | None, object]:
+def request(
+    url: str,
+    token: str | None = None,
+    method: str = "GET",
+    payload: object | None = None,
+) -> tuple[int, object | None, object]:
     headers = {} if token is None else {"Authorization": f"Bearer {token}"}
-    req = Request(url, method=method, headers=headers)
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = Request(url, method=method, headers=headers, data=data)
     try:
         with urlopen(req, timeout=2) as response:
             raw = response.read()
@@ -63,6 +72,62 @@ def request(url: str, token: str | None = None, method: str = "GET") -> tuple[in
         raw = exc.read()
         payload = json.loads(raw.decode("utf-8")) if raw else None
         return exc.code, payload, exc.headers
+
+
+
+def start_host_assertion(
+    bridge,
+    *,
+    profile_id: str = "activity-1",
+    ast_binding: str = "ast-1",
+    connection_epoch: str = "connection-one",
+    timeout_seconds: float = 0.5,
+):
+    outcome: dict[str, object] = {}
+
+    def run() -> None:
+        try:
+            outcome["evidence"] = bridge.assert_current_program(
+                profile_id=profile_id,
+                ast_binding=ast_binding,
+                connection_epoch=connection_epoch,
+                timeout_seconds=timeout_seconds,
+            )
+        except Exception as exc:
+            outcome["error"] = exc
+
+    thread = Thread(target=run, daemon=True)
+    thread.start()
+    return thread, outcome
+
+
+def complete_host_assertion(
+    base: str,
+    token: str,
+    *,
+    profile_id: str = "activity-1",
+    ast_binding: str = "ast-1",
+    connection_epoch: str = "connection-one",
+):
+    status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+    assert status == 200
+    assert challenge["executionAuthority"] is False
+    challenge_id = challenge["challengeId"]
+    assert isinstance(challenge_id, str) and challenge_id
+    status, response, _ = request(
+        base + "/v1/preflight-assertion",
+        token,
+        method="POST",
+        payload={
+            "challengeId": challenge_id,
+            "ok": True,
+            "profileId": profile_id,
+            "astBinding": ast_binding,
+            "connectionEpoch": connection_epoch,
+            "executionAuthority": False,
+        },
+    )
+    return status, response, challenge_id
 
 
 def main() -> int:
@@ -88,8 +153,9 @@ def main() -> int:
         status, payload, cors = request(base + "/v1/capabilities", method="OPTIONS")
         assert status == 204 and payload is None
         assert cors["Access-Control-Allow-Origin"] == "*"
-        assert cors["Access-Control-Allow-Methods"] == "GET, OPTIONS"
+        assert cors["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
         assert "Authorization" in cors["Access-Control-Allow-Headers"]
+        assert "Content-Type" in cors["Access-Control-Allow-Headers"]
         assert fake.epoch_reads == 1 and fake.capability_reads == 1, "CORS preflight must not touch live session"
 
         status, payload, _ = request(base + "/v1/capabilities")
@@ -99,6 +165,135 @@ def main() -> int:
         status, payload, _ = request(base + "/v1/connection-epoch", token, method="POST")
         assert status == 405 and payload == {"error": "read-only bridge"}
         assert fake.epoch_reads == 1, "effect-shaped methods must never reach the live session"
+
+        # Only the trusted host can create a fresh current-program challenge.
+        thread, outcome = start_host_assertion(bridge)
+        status, response, challenge_id = complete_host_assertion(base, token)
+        assert status == 200 and response["accepted"] is True
+        assert response["executionAuthority"] is False
+        thread.join(timeout=2)
+        assert not thread.is_alive() and "error" not in outcome
+        evidence = outcome["evidence"]
+        assert evidence.profile_id == "activity-1"
+        assert evidence.ast_binding == "ast-1"
+        assert evidence.connection_epoch == "connection-one"
+        assert evidence.challenge_id == challenge_id
+        assert evidence.execution_authority is False
+
+        # The exact challenge is one-shot; replay/late responses are rejected.
+        status, replay, _ = request(
+            base + "/v1/preflight-assertion",
+            token,
+            method="POST",
+            payload={
+                "challengeId": challenge_id,
+                "ok": True,
+                "profileId": "activity-1",
+                "astBinding": "ast-1",
+                "connectionEpoch": "connection-one",
+                "executionAuthority": False,
+            },
+        )
+        assert status == 409 and "stale" in replay["error"]
+
+        # A same-challenge profile/AST mismatch settles the host request fail-closed.
+        thread, outcome = start_host_assertion(bridge)
+        status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+        mismatch_id = challenge["challengeId"]
+        status, mismatch, _ = request(
+            base + "/v1/preflight-assertion",
+            token,
+            method="POST",
+            payload={
+                "challengeId": mismatch_id,
+                "ok": True,
+                "profileId": "wrong-activity",
+                "astBinding": "ast-1",
+                "connectionEpoch": "connection-one",
+                "executionAuthority": False,
+            },
+        )
+        assert status == 409 and "does not match" in mismatch["error"]
+        thread.join(timeout=2)
+        assert isinstance(outcome.get("error"), bridge_module.CapabilityBridgeError)
+        assert "does not match" in str(outcome["error"])
+
+        # Reconnect after challenge creation but before host acceptance is stale.
+        fake.epoch = "connection-one"
+        thread, outcome = start_host_assertion(bridge)
+        status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+        epoch_id = challenge["challengeId"]
+        fake.epoch = "connection-two"
+        status, response, _ = request(
+            base + "/v1/preflight-assertion",
+            token,
+            method="POST",
+            payload={
+                "challengeId": epoch_id,
+                "ok": True,
+                "profileId": "activity-1",
+                "astBinding": "ast-1",
+                "connectionEpoch": "connection-one",
+                "executionAuthority": False,
+            },
+        )
+        assert status == 200
+        thread.join(timeout=2)
+        assert isinstance(outcome.get("error"), bridge_module.CapabilityBridgeError)
+        assert "changed during" in str(outcome["error"])
+
+        # A host timeout invalidates the challenge; a later response cannot revive it.
+        fake.epoch = "connection-one"
+        thread, outcome = start_host_assertion(bridge, timeout_seconds=0.03)
+        status, challenge, _ = request(base + "/v1/preflight-challenge", token)
+        timeout_id = challenge["challengeId"]
+        thread.join(timeout=2)
+        assert isinstance(outcome.get("error"), bridge_module.CapabilityBridgeError)
+        assert "timed out" in str(outcome["error"])
+        status, late, _ = request(
+            base + "/v1/preflight-assertion",
+            token,
+            method="POST",
+            payload={
+                "challengeId": timeout_id,
+                "ok": True,
+                "profileId": "activity-1",
+                "astBinding": "ast-1",
+                "connectionEpoch": "connection-one",
+                "executionAuthority": False,
+            },
+        )
+        assert status == 409 and "stale" in late["error"]
+
+        # Browser responses cannot create a challenge on their own.
+        status, unsolicited, _ = request(
+            base + "/v1/preflight-assertion",
+            token,
+            method="POST",
+            payload={
+                "challengeId": "fabricated-challenge",
+                "ok": True,
+                "profileId": "activity-1",
+                "astBinding": "ast-1",
+                "connectionEpoch": "connection-one",
+                "executionAuthority": False,
+            },
+        )
+        assert status == 409 and "unknown" in unsolicited["error"]
+
+        # Exact evidence cannot be constructed by an arbitrary binding source.
+        try:
+            bridge_module.CurrentProgramPreflightEvidence(
+                profile_id="activity-1",
+                ast_binding="ast-1",
+                connection_epoch="connection-one",
+                challenge_id="fabricated",
+                _mint_key=object(),
+            )
+        except bridge_module.CapabilityBridgeError as exc:
+            assert "trusted host bridge" in str(exc)
+        else:
+            raise AssertionError("fabricated current-program evidence must fail closed")
 
         fake.epoch = "connection-two"
         status, payload, _ = request(base + "/v1/connection-epoch", token)
@@ -122,7 +317,7 @@ def main() -> int:
     for name in forbidden:
         assert not hasattr(bridge, name), f"HTTP bridge exposes authority method: {name}"
 
-    print("PASS loopback capability bridge supports browser reads with authentication and no physical authority")
+    print("PASS loopback capability bridge provides fresh host-initiated #249 handoff with no physical authority")
     return 0
 
 

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -51,6 +51,7 @@ function program(distance) {
   let assertionWaiter = null;
   const assertionQueue = [];
   const token = 'unit-test-secret';
+  const responderToken = 'unit-test-preflight-responder-secret';
 
   function response(payload, ok, status) {
     return {
@@ -100,20 +101,22 @@ function program(distance) {
   }
 
   async function fakeFetch(url, options) {
-    assert.strictEqual(options.headers.Authorization, 'Bearer ' + token);
     if (url.endsWith('/v1/preflight-challenge')) {
+      assert.strictEqual(options.headers.Authorization, 'Bearer ' + responderToken);
       assert.strictEqual(options.method, 'GET');
       if (challengeQueue.length)
         return response(challengeQueue.shift());
       return new Promise(resolve => { challengeWaiter = resolve; });
     }
     if (url.endsWith('/v1/preflight-assertion')) {
+      assert.strictEqual(options.headers.Authorization, 'Bearer ' + responderToken);
       assert.strictEqual(options.method, 'POST');
       assert.strictEqual(options.headers['Content-Type'], 'application/json');
       const payload = JSON.parse(options.body);
       recordAssertion(payload);
       return response({accepted: true, executionAuthority: false});
     }
+    assert.strictEqual(options.headers.Authorization, 'Bearer ' + token);
     assert.strictEqual(options.method, 'GET');
     if (url.endsWith('/v1/capabilities')) {
       capabilityReads += 1;
@@ -138,7 +141,17 @@ function program(distance) {
   });
   assert.deepStrictEqual(
     Object.keys(adapter).sort(),
-    ['readCapabilities', 'readConnectionEpoch', 'readCurrentProgramChallenge', 'submitCurrentProgramAssertion']
+    ['readCapabilities', 'readConnectionEpoch']
+  );
+  assert.strictEqual(
+    typeof adapter.readCurrentProgramChallenge,
+    'undefined',
+    'ordinary capability bearer must not expose challenge claim'
+  );
+  assert.strictEqual(
+    typeof adapter.submitCurrentProgramAssertion,
+    'undefined',
+    'ordinary capability bearer must not expose assertion submit'
   );
   assert.strictEqual(Object.isFrozen(adapter), true);
 
@@ -198,7 +211,7 @@ function program(distance) {
   });
   await assert.rejects(
     () => failingAdapter.readCapabilities(),
-    /bridge request failed \(401\): unauthorized/
+    /bridge read failed \(401\): unauthorized/
   );
 
   const productHtml = fs.readFileSync(path.join(__dirname, '../../plugins/robot_windows/blockly_v2/blockly_v2.html'), 'utf8');
@@ -226,7 +239,12 @@ function program(distance) {
 
   epoch = 'connection-product';
   currentAst = program(0.2);
-  productBridge.configure({baseUrl: 'http://127.0.0.1:8765', token: token, fetchImpl: fakeFetch});
+  productBridge.configure({
+    baseUrl: 'http://127.0.0.1:8765',
+    token: token,
+    preflightResponderToken: responderToken,
+    fetchImpl: fakeFetch
+  });
   const productPreflight = await productBridge.preflightCurrentProgram();
   assert.strictEqual(productPreflight.connectionEpoch, 'connection-product');
   const productAssertion = await productBridge.assertCurrentProgram();

--- a/tools/ci/test_physical_submission_bridge.js
+++ b/tools/ci/test_physical_submission_bridge.js
@@ -46,7 +46,46 @@ function program(distance) {
   let capabilityReads = 0;
   let epochReads = 0;
   let epochReadHook = null;
+  let challengeWaiter = null;
+  const challengeQueue = [];
+  let assertionWaiter = null;
+  const assertionQueue = [];
   const token = 'unit-test-secret';
+
+  function response(payload, ok, status) {
+    return {
+      ok: ok === undefined ? true : ok,
+      status: status === undefined ? 200 : status,
+      async json() { return JSON.parse(JSON.stringify(payload)); }
+    };
+  }
+
+  function enqueueChallenge(challengeId) {
+    const payload = {challengeId: challengeId, executionAuthority: false};
+    if (challengeWaiter) {
+      const resolve = challengeWaiter;
+      challengeWaiter = null;
+      resolve(response(payload));
+    } else {
+      challengeQueue.push(payload);
+    }
+  }
+
+  function waitForAssertion() {
+    if (assertionQueue.length)
+      return Promise.resolve(assertionQueue.shift());
+    return new Promise(resolve => { assertionWaiter = resolve; });
+  }
+
+  function recordAssertion(payload) {
+    if (assertionWaiter) {
+      const resolve = assertionWaiter;
+      assertionWaiter = null;
+      resolve(payload);
+    } else {
+      assertionQueue.push(payload);
+    }
+  }
 
   function delayNextEpochRead() {
     let startedResolve;
@@ -61,11 +100,24 @@ function program(distance) {
   }
 
   async function fakeFetch(url, options) {
-    assert.strictEqual(options.method, 'GET');
     assert.strictEqual(options.headers.Authorization, 'Bearer ' + token);
+    if (url.endsWith('/v1/preflight-challenge')) {
+      assert.strictEqual(options.method, 'GET');
+      if (challengeQueue.length)
+        return response(challengeQueue.shift());
+      return new Promise(resolve => { challengeWaiter = resolve; });
+    }
+    if (url.endsWith('/v1/preflight-assertion')) {
+      assert.strictEqual(options.method, 'POST');
+      assert.strictEqual(options.headers['Content-Type'], 'application/json');
+      const payload = JSON.parse(options.body);
+      recordAssertion(payload);
+      return response({accepted: true, executionAuthority: false});
+    }
+    assert.strictEqual(options.method, 'GET');
     if (url.endsWith('/v1/capabilities')) {
       capabilityReads += 1;
-      return {ok: true, status: 200, async json() { return JSON.parse(JSON.stringify(descriptor)); }};
+      return response(descriptor);
     }
     if (url.endsWith('/v1/connection-epoch')) {
       epochReads += 1;
@@ -74,9 +126,9 @@ function program(distance) {
         epochReadHook = null;
         await hook();
       }
-      return {ok: true, status: 200, async json() { return {connectionEpoch: epoch}; }};
+      return response({connectionEpoch: epoch});
     }
-    return {ok: false, status: 404, async json() { return {error: 'not-found'}; }};
+    return response({error: 'not-found'}, false, 404);
   }
 
   const adapter = HttpAdapter.create({
@@ -84,7 +136,10 @@ function program(distance) {
     token: token,
     fetchImpl: fakeFetch
   });
-  assert.deepStrictEqual(Object.keys(adapter).sort(), ['readCapabilities', 'readConnectionEpoch']);
+  assert.deepStrictEqual(
+    Object.keys(adapter).sort(),
+    ['readCapabilities', 'readConnectionEpoch', 'readCurrentProgramChallenge', 'submitCurrentProgramAssertion']
+  );
   assert.strictEqual(Object.isFrozen(adapter), true);
 
   const bridge = SubmissionBridge.create(profile, adapter, () => JSON.parse(JSON.stringify(currentAst)));
@@ -143,7 +198,7 @@ function program(distance) {
   });
   await assert.rejects(
     () => failingAdapter.readCapabilities(),
-    /bridge read failed \(401\): unauthorized/
+    /bridge request failed \(401\): unauthorized/
   );
 
   const productHtml = fs.readFileSync(path.join(__dirname, '../../plugins/robot_windows/blockly_v2/blockly_v2.html'), 'utf8');
@@ -177,6 +232,65 @@ function program(distance) {
   const productAssertion = await productBridge.assertCurrentProgram();
   assert.strictEqual(productAssertion.executionAuthority, false);
   assert.strictEqual(productAssertion.preflight.connectionEpoch, 'connection-product');
+
+
+  // Production handoff answers a host-created challenge only by running the real
+  // exact-current #249 re-assertion; the challenge does not carry expected data.
+  const exactAssertionPromise = waitForAssertion();
+  enqueueChallenge('challenge-exact');
+  const exactAssertion = await exactAssertionPromise;
+  assert.strictEqual(exactAssertion.challengeId, 'challenge-exact');
+  assert.strictEqual(exactAssertion.ok, true);
+  assert.strictEqual(exactAssertion.executionAuthority, false);
+  assert.strictEqual(exactAssertion.profileId, global.runtimeProfile.id);
+  assert.strictEqual(exactAssertion.astBinding, productPreflight.astBinding);
+  assert.strictEqual(exactAssertion.connectionEpoch, 'connection-product');
+
+  // A changed AST cannot be turned into a positive host assertion.
+  currentAst = program(0.3);
+  const astFailurePromise = waitForAssertion();
+  enqueueChallenge('challenge-ast-change');
+  const astFailure = await astFailurePromise;
+  assert.strictEqual(astFailure.challengeId, 'challenge-ast-change');
+  assert.strictEqual(astFailure.ok, false);
+  assert.strictEqual(astFailure.executionAuthority, false);
+  currentAst = program(0.2);
+  await assert.rejects(
+    () => productBridge.assertCurrentProgram(),
+    /physical preflight is required/,
+    'challenge-time AST mismatch must invalidate the old #249 binding'
+  );
+  await productBridge.preflightCurrentProgram();
+
+  // A changed activity profile likewise fails at the real #249 runtime boundary.
+  const handoffProfile = global.runtimeProfile;
+  global.runtimeProfile = Profiles.resolveById(
+    Activities.DOCUMENT,
+    'progression-precise-movement-v1',
+    Activities.BLOCK_CATALOG
+  );
+  const profileFailurePromise = waitForAssertion();
+  enqueueChallenge('challenge-profile-change');
+  const profileFailure = await profileFailurePromise;
+  assert.strictEqual(profileFailure.ok, false);
+  assert.strictEqual(profileFailure.executionAuthority, false);
+  global.runtimeProfile = handoffProfile;
+  await assert.rejects(
+    () => productBridge.assertCurrentProgram(),
+    /physical preflight is required/,
+    'challenge-time profile mismatch must invalidate the old #249 binding'
+  );
+  await productBridge.preflightCurrentProgram();
+
+  // Reconnect/epoch drift cannot produce a positive assertion for the old session.
+  epoch = 'connection-product-changed';
+  const epochFailurePromise = waitForAssertion();
+  enqueueChallenge('challenge-epoch-change');
+  const epochFailure = await epochFailurePromise;
+  assert.strictEqual(epochFailure.ok, false);
+  assert.strictEqual(epochFailure.executionAuthority, false);
+  epoch = 'connection-product';
+  await productBridge.preflightCurrentProgram();
 
   const workspaceDelay = delayNextEpochRead();
   const pendingWorkspaceAssertion = productBridge.assertCurrentProgram();
@@ -227,7 +341,7 @@ function program(distance) {
   );
   productBridge.clear();
 
-  console.log('PASS non-authority physical submission bridge binds the live student AST to one Crazyradio connection epoch');
+  console.log('PASS non-authority physical submission bridge provides fresh host-initiated exact-current #249 evidence');
 })().catch(error => {
   console.error(error);
   process.exit(1);

--- a/tools/physical/serve_reference_capabilities.py
+++ b/tools/physical/serve_reference_capabilities.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Loopback-only, non-authority bridge to one live Crazyflie capability session.
 
-The service intentionally exposes only the two reads required by
-physical_capability_contract.js: the current connection epoch and a fresh
-capability descriptor. It owns no arming, setpoint, movement, light or other
-physical effect API.
+The service exposes fresh capability/epoch reads plus a bounded current-program
+challenge/response handoff for the already-integrated #249 browser preflight.
+Only the trusted host can create a challenge. The browser-held bearer can answer
+that pending challenge, but cannot create one and gains no arming, setpoint,
+movement, light or other physical-effect API.
 """
 
 from __future__ import annotations
@@ -12,13 +13,57 @@ from __future__ import annotations
 import argparse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
+import math
 import secrets
+from threading import Condition
+from time import monotonic
 
 from probe_reference_hardware import ProbeError, ReadOnlyCapabilitySession
 
 
 class CapabilityBridgeError(RuntimeError):
     """Fail-closed request/bridge error."""
+
+
+_EVIDENCE_MINT_KEY = object()
+
+
+class CurrentProgramPreflightEvidence:
+    """One fresh exact-current-program assertion minted only by the host bridge."""
+
+    def __init__(
+        self,
+        *,
+        profile_id: str,
+        ast_binding: str,
+        connection_epoch: str,
+        challenge_id: str,
+        _mint_key: object,
+    ) -> None:
+        if _mint_key is not _EVIDENCE_MINT_KEY:
+            raise CapabilityBridgeError(
+                "current-program evidence may only be minted by the trusted host bridge"
+            )
+        self.profile_id = _require_text(profile_id, "profileId")
+        self.ast_binding = _require_text(ast_binding, "astBinding")
+        self.connection_epoch = _require_text(connection_epoch, "connectionEpoch")
+        self.challenge_id = _require_text(challenge_id, "challengeId")
+        self.execution_authority = False
+
+
+def _require_text(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise CapabilityBridgeError(f"{name} must be a non-empty trimmed string")
+    return value
+
+
+def _require_timeout(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CapabilityBridgeError("current-program assertion timeout must be positive")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout <= 0.0:
+        raise CapabilityBridgeError("current-program assertion timeout must be positive")
+    return timeout
 
 
 class ReadOnlyCapabilityHttpBridge:
@@ -36,7 +81,174 @@ class ReadOnlyCapabilityHttpBridge:
         self.token = token or secrets.token_urlsafe(32)
         if not isinstance(self.token, str) or not self.token.strip():
             raise CapabilityBridgeError("capability bridge token must be non-empty")
+        self._preflight_condition = Condition()
+        self._preflight_pending: dict[str, object] | None = None
+        self._preflight_closed = False
         self._server = ThreadingHTTPServer((host, port), self._handler_type())
+        self._server.daemon_threads = True
+
+    def assert_current_program(
+        self,
+        *,
+        profile_id: str,
+        ast_binding: str,
+        connection_epoch: str,
+        timeout_seconds: float = 1.0,
+    ) -> CurrentProgramPreflightEvidence:
+        """Require one fresh #249 browser assertion for this exact host binding."""
+        expected_profile = _require_text(profile_id, "profileId")
+        expected_ast = _require_text(ast_binding, "astBinding")
+        expected_epoch = _require_text(connection_epoch, "connectionEpoch")
+        timeout = _require_timeout(timeout_seconds)
+
+        try:
+            before_epoch = self.session.read_connection_epoch()
+        except Exception as exc:
+            raise CapabilityBridgeError(
+                "live connection epoch unavailable before current-program challenge"
+            ) from exc
+        if before_epoch != expected_epoch:
+            raise CapabilityBridgeError(
+                "live connection changed before current-program challenge"
+            )
+
+        pending = {
+            "challenge_id": secrets.token_urlsafe(24),
+            "profile_id": expected_profile,
+            "ast_binding": expected_ast,
+            "connection_epoch": expected_epoch,
+            "claimed": False,
+            "settled": False,
+            "error": None,
+        }
+        deadline = monotonic() + timeout
+        with self._preflight_condition:
+            if self._preflight_closed:
+                raise CapabilityBridgeError("capability bridge is shut down")
+            if self._preflight_pending is not None:
+                raise CapabilityBridgeError(
+                    "another current-program challenge is already pending"
+                )
+            self._preflight_pending = pending
+            self._preflight_condition.notify_all()
+            while not pending["settled"] and not self._preflight_closed:
+                remaining = deadline - monotonic()
+                if remaining <= 0.0:
+                    if self._preflight_pending is pending:
+                        self._preflight_pending = None
+                        self._preflight_condition.notify_all()
+                    raise CapabilityBridgeError(
+                        "current-program assertion timed out"
+                    )
+                self._preflight_condition.wait(remaining)
+
+            if self._preflight_closed:
+                if self._preflight_pending is pending:
+                    self._preflight_pending = None
+                raise CapabilityBridgeError("capability bridge shut down during assertion")
+
+            if self._preflight_pending is pending:
+                self._preflight_pending = None
+                self._preflight_condition.notify_all()
+            error = pending["error"]
+
+        if error is not None:
+            raise CapabilityBridgeError(str(error))
+
+        try:
+            after_epoch = self.session.read_connection_epoch()
+        except Exception as exc:
+            raise CapabilityBridgeError(
+                "live connection epoch unavailable after current-program assertion"
+            ) from exc
+        if after_epoch != expected_epoch:
+            raise CapabilityBridgeError(
+                "live connection changed during current-program assertion"
+            )
+
+        return CurrentProgramPreflightEvidence(
+            profile_id=expected_profile,
+            ast_binding=expected_ast,
+            connection_epoch=expected_epoch,
+            challenge_id=str(pending["challenge_id"]),
+            _mint_key=_EVIDENCE_MINT_KEY,
+        )
+
+    def _claim_current_program_challenge(
+        self,
+        *,
+        timeout_seconds: float = 1.0,
+    ) -> str | None:
+        deadline = monotonic() + _require_timeout(timeout_seconds)
+        with self._preflight_condition:
+            while True:
+                if self._preflight_closed:
+                    raise CapabilityBridgeError("capability bridge is shut down")
+                pending = self._preflight_pending
+                if (
+                    pending is not None
+                    and pending["settled"] is False
+                    and pending["claimed"] is False
+                ):
+                    pending["claimed"] = True
+                    return str(pending["challenge_id"])
+                remaining = deadline - monotonic()
+                if remaining <= 0.0:
+                    return None
+                self._preflight_condition.wait(remaining)
+
+    def _submit_current_program_assertion(self, payload: object) -> None:
+        if not isinstance(payload, dict):
+            raise CapabilityBridgeError("current-program assertion must be a JSON object")
+        challenge_id = _require_text(payload.get("challengeId"), "challengeId")
+
+        with self._preflight_condition:
+            pending = self._preflight_pending
+            if (
+                pending is None
+                or pending["settled"] is True
+                or pending["challenge_id"] != challenge_id
+            ):
+                raise CapabilityBridgeError(
+                    "current-program assertion is stale, replayed or unknown"
+                )
+            if pending["claimed"] is not True:
+                raise CapabilityBridgeError(
+                    "current-program challenge was not claimed by the browser"
+                )
+
+            error: str | None = None
+            try:
+                if payload.get("executionAuthority") is not False:
+                    raise CapabilityBridgeError(
+                        "current-program assertion must remain non-authority"
+                    )
+                if payload.get("ok") is not True:
+                    raise CapabilityBridgeError(
+                        "browser current-program re-assertion failed"
+                    )
+                profile_id = _require_text(payload.get("profileId"), "profileId")
+                ast_binding = _require_text(payload.get("astBinding"), "astBinding")
+                connection_epoch = _require_text(
+                    payload.get("connectionEpoch"), "connectionEpoch"
+                )
+                if (
+                    profile_id != pending["profile_id"]
+                    or ast_binding != pending["ast_binding"]
+                    or connection_epoch != pending["connection_epoch"]
+                ):
+                    raise CapabilityBridgeError(
+                        "browser current-program assertion does not match host binding"
+                    )
+            except CapabilityBridgeError as exc:
+                error = str(exc)
+
+            pending["error"] = error
+            pending["settled"] = True
+            self._preflight_condition.notify_all()
+
+        if error is not None:
+            raise CapabilityBridgeError(error)
 
     def _handler_type(self):
         bridge = self
@@ -46,11 +258,14 @@ class ReadOnlyCapabilityHttpBridge:
                 return
 
             def _cors(self) -> None:
-                # The service is loopback-only and every data read still requires
+                # The service is loopback-only and every request still requires
                 # the unguessable bearer capability. No cookies/credentials are used.
                 self.send_header("Access-Control-Allow-Origin", "*")
-                self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
-                self.send_header("Access-Control-Allow-Headers", "Authorization, Cache-Control")
+                self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+                self.send_header(
+                    "Access-Control-Allow-Headers",
+                    "Authorization, Cache-Control, Content-Type",
+                )
 
             def _json(self, status: int, payload: object) -> None:
                 data = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -64,6 +279,20 @@ class ReadOnlyCapabilityHttpBridge:
 
             def _authorized(self) -> bool:
                 return self.headers.get("Authorization") == f"Bearer {bridge.token}"
+
+            def _read_json(self) -> object:
+                try:
+                    length = int(self.headers.get("Content-Length", "0"))
+                except ValueError as exc:
+                    raise CapabilityBridgeError("invalid request length") from exc
+                if length <= 0 or length > 4096:
+                    raise CapabilityBridgeError("invalid current-program assertion size")
+                try:
+                    return json.loads(self.rfile.read(length).decode("utf-8"))
+                except Exception as exc:
+                    raise CapabilityBridgeError(
+                        "malformed current-program assertion JSON"
+                    ) from exc
 
             def do_OPTIONS(self) -> None:  # noqa: N802 - browser CORS preflight only
                 self.send_response(204)
@@ -81,13 +310,38 @@ class ReadOnlyCapabilityHttpBridge:
                         self._json(200, {"connectionEpoch": bridge.session.read_connection_epoch()})
                     elif self.path == "/v1/capabilities":
                         self._json(200, bridge.session.read_capabilities())
+                    elif self.path == "/v1/preflight-challenge":
+                        challenge_id = bridge._claim_current_program_challenge()
+                        self._json(
+                            200,
+                            {
+                                "challengeId": challenge_id,
+                                "executionAuthority": False,
+                            },
+                        )
                     else:
                         self._json(404, {"error": "not-found"})
-                except ProbeError as exc:
+                except (ProbeError, CapabilityBridgeError) as exc:
                     self._json(409, {"error": str(exc)})
 
-            def do_POST(self) -> None:  # noqa: N802 - fail closed on effects
-                self._json(405, {"error": "read-only bridge"})
+            def do_POST(self) -> None:  # noqa: N802 - non-effect assertion response only
+                if not self._authorized():
+                    self._json(401, {"error": "unauthorized"})
+                    return
+                if self.path != "/v1/preflight-assertion":
+                    self._json(405, {"error": "read-only bridge"})
+                    return
+                try:
+                    bridge._submit_current_program_assertion(self._read_json())
+                    self._json(
+                        200,
+                        {
+                            "accepted": True,
+                            "executionAuthority": False,
+                        },
+                    )
+                except CapabilityBridgeError as exc:
+                    self._json(409, {"error": str(exc)})
 
             def do_PUT(self) -> None:  # noqa: N802
                 self._json(405, {"error": "read-only bridge"})
@@ -106,6 +360,9 @@ class ReadOnlyCapabilityHttpBridge:
         self._server.serve_forever()
 
     def shutdown(self) -> None:
+        with self._preflight_condition:
+            self._preflight_closed = True
+            self._preflight_condition.notify_all()
         self._server.shutdown()
         self._server.server_close()
 

--- a/tools/physical/serve_reference_capabilities.py
+++ b/tools/physical/serve_reference_capabilities.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
-"""Loopback-only, non-authority bridge to one live Crazyflie capability session.
+"""Loopback capability bridge plus a separate trusted #249 responder channel.
 
-The service exposes fresh capability/epoch reads plus a bounded current-program
-challenge/response handoff for the already-integrated #249 browser preflight.
-Only the trusted host can create a challenge. The browser-held bearer can answer
-that pending challenge, but cannot create one and gains no arming, setpoint,
-movement, light or other physical-effect API.
+The ordinary browser capability bearer remains read-only: it can only read the
+live connection epoch and capability descriptor. A distinct host-generated
+preflight-responder bearer is required to claim/answer one-shot host challenges.
+That responder channel is consumed only by the production #249 runtime path and
+adds no arming, setpoint, movement, light or other physical-effect API.
 """
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import math
@@ -28,29 +29,6 @@ class CapabilityBridgeError(RuntimeError):
 _EVIDENCE_MINT_KEY = object()
 
 
-class CurrentProgramPreflightEvidence:
-    """One fresh exact-current-program assertion minted only by the host bridge."""
-
-    def __init__(
-        self,
-        *,
-        profile_id: str,
-        ast_binding: str,
-        connection_epoch: str,
-        challenge_id: str,
-        _mint_key: object,
-    ) -> None:
-        if _mint_key is not _EVIDENCE_MINT_KEY:
-            raise CapabilityBridgeError(
-                "current-program evidence may only be minted by the trusted host bridge"
-            )
-        self.profile_id = _require_text(profile_id, "profileId")
-        self.ast_binding = _require_text(ast_binding, "astBinding")
-        self.connection_epoch = _require_text(connection_epoch, "connectionEpoch")
-        self.challenge_id = _require_text(challenge_id, "challengeId")
-        self.execution_authority = False
-
-
 def _require_text(value: object, name: str) -> str:
     if not isinstance(value, str) or not value.strip() or value != value.strip():
         raise CapabilityBridgeError(f"{name} must be a non-empty trimmed string")
@@ -66,12 +44,51 @@ def _require_timeout(value: object) -> float:
     return timeout
 
 
+@dataclass(frozen=True, slots=True, init=False)
+class CurrentProgramPreflightEvidence:
+    """Immutable exact-current-program evidence minted only by the host bridge."""
+
+    profile_id: str
+    ast_binding: str
+    connection_epoch: str
+    challenge_id: str
+    execution_authority: bool
+
+    def __init__(
+        self,
+        *,
+        profile_id: str,
+        ast_binding: str,
+        connection_epoch: str,
+        challenge_id: str,
+        _mint_key: object,
+    ) -> None:
+        if _mint_key is not _EVIDENCE_MINT_KEY:
+            raise CapabilityBridgeError(
+                "current-program evidence may only be minted by the trusted host bridge"
+            )
+        object.__setattr__(self, "profile_id", _require_text(profile_id, "profileId"))
+        object.__setattr__(self, "ast_binding", _require_text(ast_binding, "astBinding"))
+        object.__setattr__(
+            self,
+            "connection_epoch",
+            _require_text(connection_epoch, "connectionEpoch"),
+        )
+        object.__setattr__(
+            self,
+            "challenge_id",
+            _require_text(challenge_id, "challengeId"),
+        )
+        object.__setattr__(self, "execution_authority", False)
+
+
 class ReadOnlyCapabilityHttpBridge:
     def __init__(
         self,
         session: ReadOnlyCapabilitySession,
         *,
         token: str | None = None,
+        preflight_responder_token: str | None = None,
         host: str = "127.0.0.1",
         port: int = 0,
     ) -> None:
@@ -79,8 +96,22 @@ class ReadOnlyCapabilityHttpBridge:
             raise CapabilityBridgeError("capability bridge must bind to IPv4 loopback")
         self.session = session
         self.token = token or secrets.token_urlsafe(32)
+        self.preflight_responder_token = (
+            preflight_responder_token or secrets.token_urlsafe(32)
+        )
         if not isinstance(self.token, str) or not self.token.strip():
             raise CapabilityBridgeError("capability bridge token must be non-empty")
+        if (
+            not isinstance(self.preflight_responder_token, str)
+            or not self.preflight_responder_token.strip()
+        ):
+            raise CapabilityBridgeError(
+                "preflight responder token must be non-empty"
+            )
+        if self.preflight_responder_token == self.token:
+            raise CapabilityBridgeError(
+                "preflight responder token must be distinct from capability token"
+            )
         self._preflight_condition = Condition()
         self._preflight_pending: dict[str, object] | None = None
         self._preflight_closed = False
@@ -95,7 +126,7 @@ class ReadOnlyCapabilityHttpBridge:
         connection_epoch: str,
         timeout_seconds: float = 1.0,
     ) -> CurrentProgramPreflightEvidence:
-        """Require one fresh #249 browser assertion for this exact host binding."""
+        """Require one fresh #249 production-runtime assertion for this binding."""
         expected_profile = _require_text(profile_id, "profileId")
         expected_ast = _require_text(ast_binding, "astBinding")
         expected_epoch = _require_text(connection_epoch, "connectionEpoch")
@@ -137,15 +168,15 @@ class ReadOnlyCapabilityHttpBridge:
                     if self._preflight_pending is pending:
                         self._preflight_pending = None
                         self._preflight_condition.notify_all()
-                    raise CapabilityBridgeError(
-                        "current-program assertion timed out"
-                    )
+                    raise CapabilityBridgeError("current-program assertion timed out")
                 self._preflight_condition.wait(remaining)
 
             if self._preflight_closed:
                 if self._preflight_pending is pending:
                     self._preflight_pending = None
-                raise CapabilityBridgeError("capability bridge shut down during assertion")
+                raise CapabilityBridgeError(
+                    "capability bridge shut down during assertion"
+                )
 
             if self._preflight_pending is pending:
                 self._preflight_pending = None
@@ -199,7 +230,9 @@ class ReadOnlyCapabilityHttpBridge:
 
     def _submit_current_program_assertion(self, payload: object) -> None:
         if not isinstance(payload, dict):
-            raise CapabilityBridgeError("current-program assertion must be a JSON object")
+            raise CapabilityBridgeError(
+                "current-program assertion must be a JSON object"
+            )
         challenge_id = _require_text(payload.get("challengeId"), "challengeId")
 
         with self._preflight_condition:
@@ -214,7 +247,7 @@ class ReadOnlyCapabilityHttpBridge:
                 )
             if pending["claimed"] is not True:
                 raise CapabilityBridgeError(
-                    "current-program challenge was not claimed by the browser"
+                    "current-program challenge was not claimed by the responder"
                 )
 
             error: str | None = None
@@ -230,7 +263,8 @@ class ReadOnlyCapabilityHttpBridge:
                 profile_id = _require_text(payload.get("profileId"), "profileId")
                 ast_binding = _require_text(payload.get("astBinding"), "astBinding")
                 connection_epoch = _require_text(
-                    payload.get("connectionEpoch"), "connectionEpoch"
+                    payload.get("connectionEpoch"),
+                    "connectionEpoch",
                 )
                 if (
                     profile_id != pending["profile_id"]
@@ -258,8 +292,6 @@ class ReadOnlyCapabilityHttpBridge:
                 return
 
             def _cors(self) -> None:
-                # The service is loopback-only and every request still requires
-                # the unguessable bearer capability. No cookies/credentials are used.
                 self.send_header("Access-Control-Allow-Origin", "*")
                 self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
                 self.send_header(
@@ -268,7 +300,11 @@ class ReadOnlyCapabilityHttpBridge:
                 )
 
             def _json(self, status: int, payload: object) -> None:
-                data = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+                data = json.dumps(
+                    payload,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode("utf-8")
                 self.send_response(status)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(data)))
@@ -277,8 +313,17 @@ class ReadOnlyCapabilityHttpBridge:
                 self.end_headers()
                 self.wfile.write(data)
 
-            def _authorized(self) -> bool:
-                return self.headers.get("Authorization") == f"Bearer {bridge.token}"
+            def _capability_authorized(self) -> bool:
+                return (
+                    self.headers.get("Authorization")
+                    == f"Bearer {bridge.token}"
+                )
+
+            def _responder_authorized(self) -> bool:
+                return (
+                    self.headers.get("Authorization")
+                    == f"Bearer {bridge.preflight_responder_token}"
+                )
 
             def _read_json(self) -> object:
                 try:
@@ -286,7 +331,9 @@ class ReadOnlyCapabilityHttpBridge:
                 except ValueError as exc:
                     raise CapabilityBridgeError("invalid request length") from exc
                 if length <= 0 or length > 4096:
-                    raise CapabilityBridgeError("invalid current-program assertion size")
+                    raise CapabilityBridgeError(
+                        "invalid current-program assertion size"
+                    )
                 try:
                     return json.loads(self.rfile.read(length).decode("utf-8"))
                 except Exception as exc:
@@ -294,23 +341,19 @@ class ReadOnlyCapabilityHttpBridge:
                         "malformed current-program assertion JSON"
                     ) from exc
 
-            def do_OPTIONS(self) -> None:  # noqa: N802 - browser CORS preflight only
+            def do_OPTIONS(self) -> None:  # noqa: N802
                 self.send_response(204)
                 self.send_header("Content-Length", "0")
                 self.send_header("Cache-Control", "no-store")
                 self._cors()
                 self.end_headers()
 
-            def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-                if not self._authorized():
-                    self._json(401, {"error": "unauthorized"})
-                    return
+            def do_GET(self) -> None:  # noqa: N802
                 try:
-                    if self.path == "/v1/connection-epoch":
-                        self._json(200, {"connectionEpoch": bridge.session.read_connection_epoch()})
-                    elif self.path == "/v1/capabilities":
-                        self._json(200, bridge.session.read_capabilities())
-                    elif self.path == "/v1/preflight-challenge":
+                    if self.path == "/v1/preflight-challenge":
+                        if not self._responder_authorized():
+                            self._json(401, {"error": "unauthorized"})
+                            return
                         challenge_id = bridge._claim_current_program_challenge()
                         self._json(
                             200,
@@ -319,29 +362,48 @@ class ReadOnlyCapabilityHttpBridge:
                                 "executionAuthority": False,
                             },
                         )
+                        return
+
+                    if not self._capability_authorized():
+                        self._json(401, {"error": "unauthorized"})
+                        return
+                    if self.path == "/v1/connection-epoch":
+                        self._json(
+                            200,
+                            {
+                                "connectionEpoch":
+                                    bridge.session.read_connection_epoch()
+                            },
+                        )
+                    elif self.path == "/v1/capabilities":
+                        self._json(200, bridge.session.read_capabilities())
                     else:
                         self._json(404, {"error": "not-found"})
                 except (ProbeError, CapabilityBridgeError) as exc:
                     self._json(409, {"error": str(exc)})
 
-            def do_POST(self) -> None:  # noqa: N802 - non-effect assertion response only
-                if not self._authorized():
+            def do_POST(self) -> None:  # noqa: N802
+                if self.path == "/v1/preflight-assertion":
+                    if not self._responder_authorized():
+                        self._json(401, {"error": "unauthorized"})
+                        return
+                    try:
+                        bridge._submit_current_program_assertion(self._read_json())
+                        self._json(
+                            200,
+                            {
+                                "accepted": True,
+                                "executionAuthority": False,
+                            },
+                        )
+                    except CapabilityBridgeError as exc:
+                        self._json(409, {"error": str(exc)})
+                    return
+
+                if not self._capability_authorized():
                     self._json(401, {"error": "unauthorized"})
                     return
-                if self.path != "/v1/preflight-assertion":
-                    self._json(405, {"error": "read-only bridge"})
-                    return
-                try:
-                    bridge._submit_current_program_assertion(self._read_json())
-                    self._json(
-                        200,
-                        {
-                            "accepted": True,
-                            "executionAuthority": False,
-                        },
-                    )
-                except CapabilityBridgeError as exc:
-                    self._json(409, {"error": str(exc)})
+                self._json(405, {"error": "read-only bridge"})
 
             def do_PUT(self) -> None:  # noqa: N802
                 self._json(405, {"error": "read-only bridge"})
@@ -369,19 +431,34 @@ class ReadOnlyCapabilityHttpBridge:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--uri", required=True, help="explicit radio:// Crazyradio URI")
+    parser.add_argument(
+        "--uri",
+        required=True,
+        help="explicit radio:// Crazyradio URI",
+    )
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=0)
     args = parser.parse_args()
 
     with ReadOnlyCapabilitySession(args.uri) as session:
-        bridge = ReadOnlyCapabilityHttpBridge(session, host=args.host, port=args.port)
+        bridge = ReadOnlyCapabilityHttpBridge(
+            session,
+            host=args.host,
+            port=args.port,
+        )
         host, port = bridge.address
-        print(json.dumps({
-            "baseUrl": f"http://{host}:{port}",
-            "token": bridge.token,
-            "executionAuthority": False,
-        }, separators=(",", ":")), flush=True)
+        print(
+            json.dumps(
+                {
+                    "baseUrl": f"http://{host}:{port}",
+                    "token": bridge.token,
+                    "preflightResponderToken": bridge.preflight_responder_token,
+                    "executionAuthority": False,
+                },
+                separators=(",", ":"),
+            ),
+            flush=True,
+        )
         try:
             bridge.serve_forever()
         except KeyboardInterrupt:


### PR DESCRIPTION
Implements the smallest production non-authority handoff required by #277 / #276.

The trusted physical host creates one-shot current-program challenges bound to the exact expected profile ID, semantic AST binding and live connection epoch. The ordinary browser capability bearer remains strictly read-only and still exposes only `readCapabilities()` / `readConnectionEpoch()`.

A distinct host-generated `preflightResponderToken` authenticates a closure-private responder inside the production `physical_preflight_runtime.js`. That responder cannot be invoked through the ordinary capability adapter and derives every positive response by calling the already-integrated exact-current #249 `assertCurrentProgram()` path. The ordinary capability bearer receives 401 on both responder endpoints.

The host mints one immutable `CurrentProgramPreflightEvidence` only after:
- a live epoch check before challenge creation;
- one responder-authenticated claim of the host-created nonce;
- one matching non-authority response derived from the real #249 runtime assertion;
- a second live epoch check after the response.

Timeout, failed #249 assertion, profile/AST/epoch mismatch, replay, late/unknown response and reconnect fail closed. Evidence construction requires the host-only mint key and the minted profile/AST/epoch/challenge fields are frozen after construction. The responder capability remains non-authority and exposes no arming, setpoint, movement, light or other physical effect.

Deterministic regressions cover exact success, ordinary-bearer rejection on responder endpoints, production responder use of the real #249 path, AST/profile/epoch invalidation, one-shot replay/late response, host timeout, fabricated evidence and post-mint mutation attempts.

No motorized checkpoint is requested or required.

Refs #277. Parent #157. Blocks #276.