### PR TITLE
Add trusted teacher decision channel to physical host

### DIFF
--- a/tools/ci/test_teacher_decision_channel.py
+++ b/tools/ci/test_teacher_decision_channel.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import socket
+from threading import Thread
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+HOST = PHYSICAL / "serve_physical_host.py"
+
+import sys
+sys.path.insert(0, str(PHYSICAL))
+
+import teacher_decision_channel as channel  # noqa: E402
+import teacher_run_authorization as auth  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except channel.TeacherDecisionChannelError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError("expected TeacherDecisionChannelError containing " + repr(pattern))
+
+
+class Epoch:
+    def __init__(self, value: str = "epoch-1") -> None:
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+
+def binding(epoch: str = "epoch-1") -> auth.PhysicalRunBinding:
+    return auth.PhysicalRunBinding(
+        profile_id="activity-1",
+        ast_binding="ast-1",
+        connection_epoch=epoch,
+    )
+
+
+def read_line(sock: socket.socket) -> dict:
+    data = bytearray()
+    while True:
+        part = sock.recv(1)
+        require(part != b"", "teacher peer received unexpected EOF")
+        data.extend(part)
+        if part == b"\n":
+            return json.loads(bytes(data[:-1]).decode("utf-8"))
+
+
+def reply_for(request: dict, *, approved: bool = True, **changes) -> dict:
+    reply = {
+        "op": "teacher-run-decision-result",
+        "requestId": request["requestId"],
+        "profileId": request["profileId"],
+        "astBinding": request["astBinding"],
+        "connectionEpoch": request["connectionEpoch"],
+        "approved": approved,
+        "executionAuthority": False,
+    }
+    reply.update(changes)
+    return reply
+
+
+def send_line(sock: socket.socket, payload: object) -> None:
+    sock.sendall(
+        (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+    )
+
+
+def test_exact_positive_decision_mints_one_local_receipt() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    epoch = Epoch()
+    decision = channel.TrustedTeacherDecisionChannel(
+        host_sock,
+        epoch,
+        request_id_factory=lambda: "decision-1",
+    )
+    authorizer = auth.TrustedTeacherAuthorizer()
+    observed: list[dict] = []
+
+    def teacher() -> None:
+        request = read_line(teacher_sock)
+        observed.append(request)
+        send_line(teacher_sock, reply_for(request, approved=True))
+        teacher_sock.close()
+
+    worker = Thread(target=teacher, daemon=True)
+    worker.start()
+    receipt = decision.authorize_run(
+        binding(),
+        authorizer,
+        timeout_seconds=0.5,
+    )
+    worker.join(timeout=1.0)
+
+    require(type(receipt) is auth.TeacherRunAuthorization, "exact #267 receipt")
+    require(receipt.binding == binding(), "receipt keeps exact approved binding")
+    require(receipt.active is True and authorizer.has_active_run, "approved run is active")
+    require(decision.terminal, "one teacher decision consumes the channel")
+    require(len(observed) == 1, "teacher receives one decision challenge")
+    request = observed[0]
+    require(request["op"] == "teacher-run-decision", "bounded teacher operation")
+    require(request["requestId"] == "decision-1", "host correlation id")
+    require(request["executionAuthority"] is False, "teacher transport is non-authority data")
+    expect_error(
+        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.1),
+        "terminal",
+    )
+    decision.close()
+
+
+def test_denial_does_not_mint_authority() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+
+    def teacher() -> None:
+        request = read_line(teacher_sock)
+        send_line(teacher_sock, reply_for(request, approved=False))
+        teacher_sock.close()
+
+    worker = Thread(target=teacher, daemon=True)
+    worker.start()
+    authorizer = auth.TrustedTeacherAuthorizer()
+    expect_error(
+        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+        "explicitly denied",
+    )
+    worker.join(timeout=1.0)
+    require(not authorizer.has_active_run, "denial must not mint #267 authority")
+    require(decision.terminal, "denial consumes the one-shot channel")
+    decision.close()
+
+
+def test_wrong_correlation_or_binding_fails_closed_and_stays_terminal() -> None:
+    cases = (
+        ("correlation", {"requestId": "wrong"}, "correlation"),
+        ("binding", {"astBinding": "different-ast"}, "exact run binding"),
+    )
+    for _label, changes, pattern in cases:
+        host_sock, teacher_sock = socket.socketpair()
+        decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+        authorizer = auth.TrustedTeacherAuthorizer()
+
+        def teacher(changes=changes) -> None:
+            request = read_line(teacher_sock)
+            send_line(teacher_sock, reply_for(request, **changes))
+            teacher_sock.close()
+
+        worker = Thread(target=teacher, daemon=True)
+        worker.start()
+        expect_error(
+            lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+            pattern,
+        )
+        worker.join(timeout=1.0)
+        require(not authorizer.has_active_run, "mismatched decision cannot mint authority")
+        require(decision.terminal, "mismatched reply poisons one-shot channel")
+        expect_error(
+            lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.1),
+            "terminal",
+        )
+        decision.close()
+
+
+def test_eof_and_malformed_reply_fail_closed() -> None:
+    for mode, pattern in (("eof", "closed"), ("json", "malformed JSON")):
+        host_sock, teacher_sock = socket.socketpair()
+        decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+        authorizer = auth.TrustedTeacherAuthorizer()
+
+        def teacher(mode=mode) -> None:
+            read_line(teacher_sock)
+            if mode == "json":
+                teacher_sock.sendall(b"{not-json}\n")
+            teacher_sock.close()
+
+        worker = Thread(target=teacher, daemon=True)
+        worker.start()
+        expect_error(
+            lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+            pattern,
+        )
+        worker.join(timeout=1.0)
+        require(not authorizer.has_active_run, "ambiguous/malformed transport mints no authority")
+        require(decision.terminal, "ambiguous/malformed transport is terminal")
+        decision.close()
+
+
+def test_reconnect_during_decision_fails_closed() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    epoch = Epoch()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, epoch)
+    authorizer = auth.TrustedTeacherAuthorizer()
+
+    def teacher() -> None:
+        request = read_line(teacher_sock)
+        epoch.value = "epoch-2"
+        send_line(teacher_sock, reply_for(request))
+        teacher_sock.close()
+
+    worker = Thread(target=teacher, daemon=True)
+    worker.start()
+    expect_error(
+        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+        "epoch changed",
+    )
+    worker.join(timeout=1.0)
+    require(not authorizer.has_active_run, "reconnect cannot inherit teacher authority")
+    require(decision.terminal, "reconnect ambiguity consumes channel")
+    decision.close()
+
+
+def test_untrusted_substitute_socket_cannot_replace_installed_teacher_channel() -> None:
+    installed_host, installed_teacher = socket.socketpair()
+    fake_host, fake_peer = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(installed_host, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+
+    # An ordinary caller may manufacture arbitrary positive JSON on another
+    # socket; it has no route into the launcher-installed channel.
+    send_line(
+        fake_peer,
+        {
+            "op": "teacher-run-decision-result",
+            "requestId": "forged",
+            "profileId": "activity-1",
+            "astBinding": "ast-1",
+            "connectionEpoch": "epoch-1",
+            "approved": True,
+            "executionAuthority": False,
+        },
+    )
+
+    def teacher() -> None:
+        request = read_line(installed_teacher)
+        send_line(installed_teacher, reply_for(request, approved=False))
+        installed_teacher.close()
+
+    worker = Thread(target=teacher, daemon=True)
+    worker.start()
+    expect_error(
+        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+        "explicitly denied",
+    )
+    worker.join(timeout=1.0)
+    require(not authorizer.has_active_run, "forged side socket cannot authorize installed host")
+    forged = read_line(fake_host)
+    require(forged["approved"] is True, "forged data remained isolated on substitute socket")
+    fake_host.close()
+    fake_peer.close()
+    decision.close()
+
+
+def test_module_and_host_composition_expose_no_effect_or_receipt_channel() -> None:
+    module_source = (PHYSICAL / "teacher_decision_channel.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "send_packet(",
+        "HighLevelCommander(",
+        "PowerSwitch(",
+        "send_setpoint(",
+        "send_emergency_stop(",
+    ):
+        require(forbidden not in module_source, "teacher channel leaked effect primitive: " + forbidden)
+
+    host_source = HOST.read_text(encoding="utf-8")
+    for required in (
+        "--teacher-fd",
+        "TrustedTeacherDecisionChannel",
+        "TrustedTeacherAuthorizer",
+        "PhysicalRunBinding",
+        "authorize-run-context",
+        "teacher_channel.authorize_run(",
+        "active_teacher_authorization =",
+        "bridge.assert_current_program(",
+    ):
+        require(required in host_source, "host lacks trusted teacher composition: " + required)
+    require(
+        host_source.index("bridge.assert_current_program(")
+        < host_source.index("teacher_channel.authorize_run("),
+        "fresh #249 assertion must precede the teacher decision for the exact run",
+    )
+    require('"runId"' not in host_source, "caller response must not serialize #267 receipt identity")
+
+    spec = importlib.util.spec_from_file_location("teacher_host_import_probe", HOST)
+    require(spec is not None and spec.loader is not None, "physical-host import spec")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for forbidden_attr in (
+        "TrustedTeacherDecisionChannel",
+        "TrustedTeacherAuthorizer",
+        "teacher_channel",
+        "teacher_socket",
+        "active_teacher_authorization",
+    ):
+        require(
+            not hasattr(module, forbidden_attr),
+            "imported physical host leaked trusted teacher state/API: " + forbidden_attr,
+        )
+
+
+def main() -> int:
+    test_exact_positive_decision_mints_one_local_receipt()
+    test_denial_does_not_mint_authority()
+    test_wrong_correlation_or_binding_fails_closed_and_stays_terminal()
+    test_eof_and_malformed_reply_fail_closed()
+    test_reconnect_during_decision_fails_closed()
+    test_untrusted_substitute_socket_cannot_replace_installed_teacher_channel()
+    test_module_and_host_composition_expose_no_effect_or_receipt_channel()
+    print(
+        "PASS trusted teacher decision channel mints one exact #267 run receipt "
+        "inside the physical host and fails closed on substitution/ambiguity"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_teacher_decision_channel.py
+++ b/tools/ci/test_teacher_decision_channel.py
@@ -324,7 +324,7 @@ def test_untrusted_channels_cannot_trigger_or_substitute_teacher_authority() -> 
         "run_teacher_decision_channel",
         "teacher_channel.receive_authorization(teacher_authorizer)",
         'if request.get("op") != "validate-run-context":',
-        "active_teacher_authorization = receipt",
+        'teacher_state["authorization"] = receipt',
     ):
         require(required in host_source, "host lacks trusted teacher composition: " + required)
     for forbidden in (

--- a/tools/ci/test_teacher_decision_channel.py
+++ b/tools/ci/test_teacher_decision_channel.py
@@ -40,11 +40,37 @@ class Epoch:
         return self.value
 
 
-def binding(epoch: str = "epoch-1") -> auth.PhysicalRunBinding:
-    return auth.PhysicalRunBinding(
-        profile_id="activity-1",
-        ast_binding="ast-1",
-        connection_epoch=epoch,
+def proposal(*, epoch: str = "epoch-1", **changes) -> dict:
+    value = {
+        "op": "teacher-run-authorization-request",
+        "requestId": "teacher-request-1",
+        "profileId": "activity-1",
+        "astBinding": "ast-1",
+        "connectionEpoch": epoch,
+        "executionAuthority": False,
+    }
+    value.update(changes)
+    return value
+
+
+def decision_for(challenge: dict, *, approved: bool = True, **changes) -> dict:
+    value = {
+        "op": "teacher-run-decision-result",
+        "requestId": challenge["requestId"],
+        "challengeId": challenge["challengeId"],
+        "profileId": challenge["profileId"],
+        "astBinding": challenge["astBinding"],
+        "connectionEpoch": challenge["connectionEpoch"],
+        "approved": approved,
+        "executionAuthority": False,
+    }
+    value.update(changes)
+    return value
+
+
+def send_line(sock: socket.socket, payload: object) -> None:
+    sock.sendall(
+        (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
     )
 
 
@@ -58,24 +84,29 @@ def read_line(sock: socket.socket) -> dict:
             return json.loads(bytes(data[:-1]).decode("utf-8"))
 
 
-def reply_for(request: dict, *, approved: bool = True, **changes) -> dict:
-    reply = {
-        "op": "teacher-run-decision-result",
-        "requestId": request["requestId"],
-        "profileId": request["profileId"],
-        "astBinding": request["astBinding"],
-        "connectionEpoch": request["connectionEpoch"],
-        "approved": approved,
-        "executionAuthority": False,
-    }
-    reply.update(changes)
-    return reply
-
-
-def send_line(sock: socket.socket, payload: object) -> None:
-    sock.sendall(
-        (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+def run_teacher_exchange(
+    teacher_sock: socket.socket,
+    *,
+    request: dict | None = None,
+    approved: bool = True,
+    decision_changes: dict | None = None,
+    duplicate: bool = False,
+    mutate_epoch=None,
+) -> None:
+    send_line(teacher_sock, request or proposal())
+    challenge = read_line(teacher_sock)
+    require(challenge["op"] == "teacher-run-decision-challenge", "host challenge op")
+    if mutate_epoch is not None:
+        mutate_epoch()
+    result = decision_for(
+        challenge,
+        approved=approved,
+        **(decision_changes or {}),
     )
+    send_line(teacher_sock, result)
+    if duplicate:
+        send_line(teacher_sock, result)
+    teacher_sock.shutdown(socket.SHUT_WR)
 
 
 def test_exact_positive_decision_mints_one_local_receipt() -> None:
@@ -84,185 +115,195 @@ def test_exact_positive_decision_mints_one_local_receipt() -> None:
     decision = channel.TrustedTeacherDecisionChannel(
         host_sock,
         epoch,
-        request_id_factory=lambda: "decision-1",
+        challenge_id_factory=lambda: "challenge-1",
     )
     authorizer = auth.TrustedTeacherAuthorizer()
-    observed: list[dict] = []
 
-    def teacher() -> None:
-        request = read_line(teacher_sock)
-        observed.append(request)
-        send_line(teacher_sock, reply_for(request, approved=True))
-        teacher_sock.close()
-
-    worker = Thread(target=teacher, daemon=True)
+    worker = Thread(target=run_teacher_exchange, args=(teacher_sock,), daemon=True)
     worker.start()
-    receipt = decision.authorize_run(
-        binding(),
-        authorizer,
-        timeout_seconds=0.5,
-    )
+    receipt = decision.receive_authorization(authorizer, decision_timeout_seconds=0.5)
     worker.join(timeout=1.0)
 
     require(type(receipt) is auth.TeacherRunAuthorization, "exact #267 receipt")
-    require(receipt.binding == binding(), "receipt keeps exact approved binding")
-    require(receipt.active is True and authorizer.has_active_run, "approved run is active")
-    require(decision.terminal, "one teacher decision consumes the channel")
-    require(len(observed) == 1, "teacher receives one decision challenge")
-    request = observed[0]
-    require(request["op"] == "teacher-run-decision", "bounded teacher operation")
-    require(request["requestId"] == "decision-1", "host correlation id")
-    require(request["executionAuthority"] is False, "teacher transport is non-authority data")
+    require(
+        receipt.binding
+        == auth.PhysicalRunBinding("activity-1", "ast-1", "epoch-1"),
+        "receipt keeps exact teacher-approved binding",
+    )
+    require(receipt.active and authorizer.has_active_run, "approved run is active")
+    require(decision.terminal, "one positive decision consumes the channel")
     expect_error(
-        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.1),
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.1),
         "terminal",
     )
+    teacher_sock.close()
     decision.close()
 
 
-def test_denial_does_not_mint_authority() -> None:
+def test_denial_eof_and_malformed_messages_fail_closed() -> None:
     host_sock, teacher_sock = socket.socketpair()
     decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
-
-    def teacher() -> None:
-        request = read_line(teacher_sock)
-        send_line(teacher_sock, reply_for(request, approved=False))
-        teacher_sock.close()
-
-    worker = Thread(target=teacher, daemon=True)
-    worker.start()
     authorizer = auth.TrustedTeacherAuthorizer()
+    worker = Thread(
+        target=run_teacher_exchange,
+        args=(teacher_sock,),
+        kwargs={"approved": False},
+        daemon=True,
+    )
+    worker.start()
     expect_error(
-        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.5),
         "explicitly denied",
     )
     worker.join(timeout=1.0)
-    require(not authorizer.has_active_run, "denial must not mint #267 authority")
-    require(decision.terminal, "denial consumes the one-shot channel")
+    require(not authorizer.has_active_run, "denial mints no authority")
+    teacher_sock.close()
+    decision.close()
+
+    host_sock, teacher_sock = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    teacher_sock.close()
+    expect_error(
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.1),
+        "closed",
+    )
+    require(not authorizer.has_active_run, "EOF mints no authority")
+    decision.close()
+
+    host_sock, teacher_sock = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    teacher_sock.sendall(b"{bad-json}\n")
+    expect_error(
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.1),
+        "malformed JSON",
+    )
+    require(not authorizer.has_active_run, "malformed request mints no authority")
+    teacher_sock.close()
     decision.close()
 
 
-def test_wrong_correlation_or_binding_fails_closed_and_stays_terminal() -> None:
+def test_wrong_correlation_or_binding_fails_closed() -> None:
     cases = (
-        ("correlation", {"requestId": "wrong"}, "correlation"),
-        ("binding", {"astBinding": "different-ast"}, "exact run binding"),
+        ({"requestId": "wrong"}, "request correlation"),
+        ({"challengeId": "wrong"}, "challenge correlation"),
+        ({"profileId": "activity-2"}, "exact run binding"),
+        ({"astBinding": "other-ast"}, "exact run binding"),
+        ({"connectionEpoch": "other-epoch"}, "exact run binding"),
     )
-    for _label, changes, pattern in cases:
+    for changes, pattern in cases:
         host_sock, teacher_sock = socket.socketpair()
         decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
         authorizer = auth.TrustedTeacherAuthorizer()
-
-        def teacher(changes=changes) -> None:
-            request = read_line(teacher_sock)
-            send_line(teacher_sock, reply_for(request, **changes))
-            teacher_sock.close()
-
-        worker = Thread(target=teacher, daemon=True)
+        worker = Thread(
+            target=run_teacher_exchange,
+            args=(teacher_sock,),
+            kwargs={"decision_changes": changes},
+            daemon=True,
+        )
         worker.start()
         expect_error(
-            lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+            lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.5),
             pattern,
         )
         worker.join(timeout=1.0)
-        require(not authorizer.has_active_run, "mismatched decision cannot mint authority")
-        require(decision.terminal, "mismatched reply poisons one-shot channel")
-        expect_error(
-            lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.1),
-            "terminal",
-        )
+        require(not authorizer.has_active_run, "mismatched decision mints no authority")
+        require(decision.terminal, "mismatch consumes one-shot channel")
+        teacher_sock.close()
         decision.close()
 
 
-def test_eof_and_malformed_reply_fail_closed() -> None:
-    for mode, pattern in (("eof", "closed"), ("json", "malformed JSON")):
-        host_sock, teacher_sock = socket.socketpair()
-        decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
-        authorizer = auth.TrustedTeacherAuthorizer()
+def test_wrong_request_binding_and_reconnect_fail_closed() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    send_line(teacher_sock, proposal(epoch="epoch-2"))
+    expect_error(
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.1),
+        "live connection epoch",
+    )
+    require(not authorizer.has_active_run, "wrong-epoch request mints no authority")
+    teacher_sock.close()
+    decision.close()
 
-        def teacher(mode=mode) -> None:
-            read_line(teacher_sock)
-            if mode == "json":
-                teacher_sock.sendall(b"{not-json}\n")
-            teacher_sock.close()
-
-        worker = Thread(target=teacher, daemon=True)
-        worker.start()
-        expect_error(
-            lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
-            pattern,
-        )
-        worker.join(timeout=1.0)
-        require(not authorizer.has_active_run, "ambiguous/malformed transport mints no authority")
-        require(decision.terminal, "ambiguous/malformed transport is terminal")
-        decision.close()
-
-
-def test_reconnect_during_decision_fails_closed() -> None:
     host_sock, teacher_sock = socket.socketpair()
     epoch = Epoch()
     decision = channel.TrustedTeacherDecisionChannel(host_sock, epoch)
     authorizer = auth.TrustedTeacherAuthorizer()
-
-    def teacher() -> None:
-        request = read_line(teacher_sock)
-        epoch.value = "epoch-2"
-        send_line(teacher_sock, reply_for(request))
-        teacher_sock.close()
-
-    worker = Thread(target=teacher, daemon=True)
+    worker = Thread(
+        target=run_teacher_exchange,
+        args=(teacher_sock,),
+        kwargs={"mutate_epoch": lambda: setattr(epoch, "value", "epoch-2")},
+        daemon=True,
+    )
     worker.start()
     expect_error(
-        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.5),
         "epoch changed",
     )
     worker.join(timeout=1.0)
-    require(not authorizer.has_active_run, "reconnect cannot inherit teacher authority")
-    require(decision.terminal, "reconnect ambiguity consumes channel")
+    require(not authorizer.has_active_run, "reconnect mints no stale authority")
+    teacher_sock.close()
     decision.close()
 
 
-def test_untrusted_substitute_socket_cannot_replace_installed_teacher_channel() -> None:
-    installed_host, installed_teacher = socket.socketpair()
-    fake_host, fake_peer = socket.socketpair()
-    decision = channel.TrustedTeacherDecisionChannel(installed_host, Epoch())
+def test_duplicate_or_late_decision_data_fails_before_mint() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
     authorizer = auth.TrustedTeacherAuthorizer()
-
-    # An ordinary caller may manufacture arbitrary positive JSON on another
-    # socket; it has no route into the launcher-installed channel.
-    send_line(
-        fake_peer,
-        {
-            "op": "teacher-run-decision-result",
-            "requestId": "forged",
-            "profileId": "activity-1",
-            "astBinding": "ast-1",
-            "connectionEpoch": "epoch-1",
-            "approved": True,
-            "executionAuthority": False,
-        },
+    worker = Thread(
+        target=run_teacher_exchange,
+        args=(teacher_sock,),
+        kwargs={"duplicate": True},
+        daemon=True,
     )
-
-    def teacher() -> None:
-        request = read_line(installed_teacher)
-        send_line(installed_teacher, reply_for(request, approved=False))
-        installed_teacher.close()
-
-    worker = Thread(target=teacher, daemon=True)
     worker.start()
     expect_error(
-        lambda: decision.authorize_run(binding(), authorizer, timeout_seconds=0.5),
-        "explicitly denied",
+        lambda: decision.receive_authorization(authorizer, decision_timeout_seconds=0.5),
+        "duplicate or late",
     )
     worker.join(timeout=1.0)
-    require(not authorizer.has_active_run, "forged side socket cannot authorize installed host")
-    forged = read_line(fake_host)
-    require(forged["approved"] is True, "forged data remained isolated on substitute socket")
-    fake_host.close()
-    fake_peer.close()
+    require(not authorizer.has_active_run, "duplicate/late decision mints no authority")
+    teacher_sock.close()
     decision.close()
 
 
-def test_module_and_host_composition_expose_no_effect_or_receipt_channel() -> None:
+def test_receipt_binding_change_stays_permanently_invalid() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    decision = channel.TrustedTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    worker = Thread(target=run_teacher_exchange, args=(teacher_sock,), daemon=True)
+    worker.start()
+    receipt = decision.receive_authorization(authorizer, decision_timeout_seconds=0.5)
+    worker.join(timeout=1.0)
+
+    try:
+        receipt.assert_effect_binding(
+            profile_id="activity-2",
+            ast_binding="ast-1",
+            connection_epoch="epoch-1",
+        )
+    except auth.TeacherRunAuthorizationError:
+        pass
+    else:
+        raise AssertionError("changed exact run binding must invalidate #267 receipt")
+    require(not receipt.active, "binding mismatch permanently invalidates receipt")
+    try:
+        receipt.assert_effect_binding(
+            profile_id="activity-1",
+            ast_binding="ast-1",
+            connection_epoch="epoch-1",
+        )
+    except auth.TeacherRunAuthorizationError:
+        pass
+    else:
+        raise AssertionError("correcting binding must not resurrect stale receipt")
+    teacher_sock.close()
+    decision.close()
+
+
+def test_untrusted_channels_cannot_trigger_or_substitute_teacher_authority() -> None:
     module_source = (PHYSICAL / "teacher_decision_channel.py").read_text(encoding="utf-8")
     for forbidden in (
         "send_packet(",
@@ -270,6 +311,8 @@ def test_module_and_host_composition_expose_no_effect_or_receipt_channel() -> No
         "PowerSwitch(",
         "send_setpoint(",
         "send_emergency_stop(",
+        "TAKEOFF",
+        "LAND",
     ):
         require(forbidden not in module_source, "teacher channel leaked effect primitive: " + forbidden)
 
@@ -278,19 +321,23 @@ def test_module_and_host_composition_expose_no_effect_or_receipt_channel() -> No
         "--teacher-fd",
         "TrustedTeacherDecisionChannel",
         "TrustedTeacherAuthorizer",
-        "PhysicalRunBinding",
-        "authorize-run-context",
-        "teacher_channel.authorize_run(",
-        "active_teacher_authorization =",
-        "bridge.assert_current_program(",
+        "run_teacher_decision_channel",
+        "teacher_channel.receive_authorization(teacher_authorizer)",
+        'if request.get("op") != "validate-run-context":',
+        "active_teacher_authorization = receipt",
     ):
         require(required in host_source, "host lacks trusted teacher composition: " + required)
+    for forbidden in (
+        "authorize-run-context",
+        '"runId"',
+        '"teacherDecision"',
+        '"approved"',
+    ):
+        require(forbidden not in host_source, "ordinary caller path leaked teacher authority: " + forbidden)
     require(
-        host_source.index("bridge.assert_current_program(")
-        < host_source.index("teacher_channel.authorize_run("),
-        "fresh #249 assertion must precede the teacher decision for the exact run",
+        "args.teacher_fd in {args.caller_fd, args.browser_config_fd}" in host_source,
+        "teacher fd must be distinct from caller/browser channels",
     )
-    require('"runId"' not in host_source, "caller response must not serialize #267 receipt identity")
 
     spec = importlib.util.spec_from_file_location("teacher_host_import_probe", HOST)
     require(spec is not None and spec.loader is not None, "physical-host import spec")
@@ -311,15 +358,15 @@ def test_module_and_host_composition_expose_no_effect_or_receipt_channel() -> No
 
 def main() -> int:
     test_exact_positive_decision_mints_one_local_receipt()
-    test_denial_does_not_mint_authority()
-    test_wrong_correlation_or_binding_fails_closed_and_stays_terminal()
-    test_eof_and_malformed_reply_fail_closed()
-    test_reconnect_during_decision_fails_closed()
-    test_untrusted_substitute_socket_cannot_replace_installed_teacher_channel()
-    test_module_and_host_composition_expose_no_effect_or_receipt_channel()
+    test_denial_eof_and_malformed_messages_fail_closed()
+    test_wrong_correlation_or_binding_fails_closed()
+    test_wrong_request_binding_and_reconnect_fail_closed()
+    test_duplicate_or_late_decision_data_fails_before_mint()
+    test_receipt_binding_change_stays_permanently_invalid()
+    test_untrusted_channels_cannot_trigger_or_substitute_teacher_authority()
     print(
         "PASS trusted teacher decision channel mints one exact #267 run receipt "
-        "inside the physical host and fails closed on substitution/ambiguity"
+        "inside the physical host without an ordinary caller flight-request path"
     )
     return 0
 

--- a/tools/ci/test_teacher_run_authorization.py
+++ b/tools/ci/test_teacher_run_authorization.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import subprocess
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "tools" / "physical" / "teacher_run_authorization.py"
-spec = importlib.util.spec_from_file_location("webeeblocks_teacher_run_authorization", MODULE_PATH)
+spec = importlib.util.spec_from_file_location(
+    "webeeblocks_teacher_run_authorization",
+    MODULE_PATH,
+)
 if spec is None or spec.loader is None:
     raise RuntimeError("cannot load teacher run authorization")
 auth = importlib.util.module_from_spec(spec)
@@ -26,10 +30,16 @@ def expect_error(callable_, pattern: str) -> None:
     except auth.TeacherRunAuthorizationError as exc:
         require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
         return
-    raise AssertionError(f"expected TeacherRunAuthorizationError containing {pattern!r}")
+    raise AssertionError(
+        f"expected TeacherRunAuthorizationError containing {pattern!r}"
+    )
 
 
-def binding(epoch: str = "epoch-a", ast: str = "ast-123", profile: str = "activity-1"):
+def binding(
+    epoch: str = "epoch-a",
+    ast: str = "ast-123",
+    profile: str = "activity-1",
+):
     return auth.PhysicalRunBinding(
         profile_id=profile,
         ast_binding=ast,
@@ -51,48 +61,90 @@ def test_exact_binding_authorizes_one_run() -> None:
     require(receipt.active, "approved run is active")
     require(gate.has_active_run, "host gate exposes active-run state")
     require(receipt.binding == exact, "receipt preserves exact binding")
-    require(isinstance(receipt.run_id, str) and len(receipt.run_id) >= 20, "run id is opaque")
+    require(
+        isinstance(receipt.run_id, str) and len(receipt.run_id) >= 20,
+        "run id is opaque",
+    )
 
-    # One human decision authorizes the exact run, not one click per primitive.
     for _ in range(3):
         receipt.assert_effect_binding(
             profile_id=exact.profile_id,
             ast_binding=exact.ast_binding,
             connection_epoch=exact.connection_epoch,
         )
-    require(receipt.active, "multiple exact effect-boundary checks preserve one run authority")
+    require(
+        receipt.active,
+        "multiple exact effect-boundary checks preserve one run authority",
+    )
 
 
 def test_denial_non_boolean_and_decision_failure_fail_closed() -> None:
-    for decision in (lambda _b: False, lambda _b: None, lambda _b: 1, lambda _b: "yes"):
+    for decision in (
+        lambda _b: False,
+        lambda _b: None,
+        lambda _b: 1,
+        lambda _b: "yes",
+    ):
         gate = auth.TrustedTeacherAuthorizer()
         expect_error(
             lambda d=decision, g=gate: g.authorize_run(binding(), d),
             "did not explicitly authorize",
         )
-        require(not gate.has_active_run, "failed decision creates no run authority")
+        require(
+            not gate.has_active_run,
+            "failed decision creates no run authority",
+        )
 
     gate = auth.TrustedTeacherAuthorizer()
 
     def broken(_binding):
         raise RuntimeError("UI channel failed")
 
-    expect_error(lambda: gate.authorize_run(binding(), broken), "teacher decision failed")
+    expect_error(
+        lambda: gate.authorize_run(binding(), broken),
+        "teacher decision failed",
+    )
     require(not gate.has_active_run, "decision exception creates no authority")
 
 
 def test_changed_binding_invalidates_permanently() -> None:
     for field, kwargs in (
-        ("profile", {"profile_id": "activity-2", "ast_binding": "ast-123", "connection_epoch": "epoch-a"}),
-        ("ast", {"profile_id": "activity-1", "ast_binding": "ast-456", "connection_epoch": "epoch-a"}),
-        ("epoch", {"profile_id": "activity-1", "ast_binding": "ast-123", "connection_epoch": "epoch-b"}),
+        (
+            "profile",
+            {
+                "profile_id": "activity-2",
+                "ast_binding": "ast-123",
+                "connection_epoch": "epoch-a",
+            },
+        ),
+        (
+            "ast",
+            {
+                "profile_id": "activity-1",
+                "ast_binding": "ast-456",
+                "connection_epoch": "epoch-a",
+            },
+        ),
+        (
+            "epoch",
+            {
+                "profile_id": "activity-1",
+                "ast_binding": "ast-123",
+                "connection_epoch": "epoch-b",
+            },
+        ),
     ):
         gate = auth.TrustedTeacherAuthorizer()
         receipt = gate.authorize_run(binding(), lambda _b: True)
-        expect_error(lambda kw=kwargs, r=receipt: r.assert_effect_binding(**kw), "binding changed")
+        expect_error(
+            lambda kw=kwargs, r=receipt: r.assert_effect_binding(**kw),
+            "binding changed",
+        )
         require(not receipt.active, f"{field} mismatch invalidates run")
-        require(receipt.invalid_reason == "physical run binding changed", "mismatch reason is durable in receipt")
-        # Correcting inputs later must not resurrect a stale teacher decision.
+        require(
+            receipt.invalid_reason == "physical run binding changed",
+            "mismatch reason is durable in receipt",
+        )
         expect_error(
             lambda r=receipt: r.assert_effect_binding(
                 profile_id="activity-1",
@@ -107,22 +159,38 @@ def test_one_active_run_and_explicit_close() -> None:
     gate = auth.TrustedTeacherAuthorizer()
     first = gate.authorize_run(binding(), lambda _b: True)
     expect_error(
-        lambda: gate.authorize_run(binding(epoch="epoch-b"), lambda _b: True),
+        lambda: gate.authorize_run(
+            binding(epoch="epoch-b"),
+            lambda _b: True,
+        ),
         "already active",
     )
     gate.close_run(first, "physical run completed")
-    require(not first.active and not gate.has_active_run, "close consumes run authority")
+    require(
+        not first.active and not gate.has_active_run,
+        "close consumes run authority",
+    )
 
-    second = gate.authorize_run(binding(epoch="epoch-b"), lambda _b: True)
+    second = gate.authorize_run(
+        binding(epoch="epoch-b"),
+        lambda _b: True,
+    )
     require(second.run_id != first.run_id, "new run requires a distinct receipt")
-    expect_error(lambda: gate.close_run(first, "stale close"), "does not belong")
+    expect_error(
+        lambda: gate.close_run(first, "stale close"),
+        "does not belong",
+    )
     gate.close_run(second, "physical run cancelled")
 
 
 def test_receipt_cannot_be_minted_or_restored_from_serialized_identity() -> None:
     exact = binding()
     expect_error(
-        lambda: auth.TeacherRunAuthorization(exact, "forged", _mint_key=object()),
+        lambda: auth.TeacherRunAuthorization(
+            exact,
+            "forged",
+            _mint_key=object(),
+        ),
         "may only be minted",
     )
     source = MODULE_PATH.read_text(encoding="utf-8")
@@ -138,16 +206,51 @@ def test_receipt_cannot_be_minted_or_restored_from_serialized_identity() -> None
         "send_emergency_stop",
         "stm_power_cycle",
     ):
-        require(forbidden not in source, f"teacher gate contains forbidden authority surface: {forbidden}")
+        require(
+            forbidden not in source,
+            f"teacher gate contains forbidden authority surface: {forbidden}",
+        )
 
 
 def test_binding_validation() -> None:
     for kwargs in (
-        {"profile_id": "", "ast_binding": "a", "connection_epoch": "e"},
-        {"profile_id": "p", "ast_binding": " ", "connection_epoch": "e"},
-        {"profile_id": "p", "ast_binding": "a", "connection_epoch": " e "},
+        {
+            "profile_id": "",
+            "ast_binding": "a",
+            "connection_epoch": "e",
+        },
+        {
+            "profile_id": "p",
+            "ast_binding": " ",
+            "connection_epoch": "e",
+        },
+        {
+            "profile_id": "p",
+            "ast_binding": "a",
+            "connection_epoch": " e ",
+        },
     ):
-        expect_error(lambda kw=kwargs: auth.PhysicalRunBinding(**kw), "physical run")
+        expect_error(
+            lambda kw=kwargs: auth.PhysicalRunBinding(**kw),
+            "physical run",
+        )
+
+
+def test_trusted_teacher_decision_channel_contract() -> None:
+    result = subprocess.run(
+        [sys.executable, "tools/ci/test_teacher_decision_channel.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode:
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise AssertionError("trusted teacher decision channel regression failed")
+    require(
+        "PASS trusted teacher decision channel" in result.stdout,
+        "trusted teacher decision channel PASS marker",
+    )
 
 
 def main() -> int:
@@ -157,6 +260,7 @@ def main() -> int:
     test_one_active_run_and_explicit_close()
     test_receipt_cannot_be_minted_or_restored_from_serialized_identity()
     test_binding_validation()
+    test_trusted_teacher_decision_channel_contract()
     print(
         "PASS host-only teacher run authorization: one explicit decision binds one exact "
         "profile/AST/epoch run and every effect boundary re-checks it"

--- a/tools/physical/serve_physical_host.py
+++ b/tools/physical/serve_physical_host.py
@@ -8,14 +8,17 @@ session and the integrated #278 bridge/responder relationship.
 
 The ordinary caller/UI is outside this process. Its IPC messages are untrusted
 run-context requests only; a positive reply is diagnostic/non-authority data and
-must never be accepted later as an effect capability. The future #276 transport
-belongs *inside this same process* so the fresh #249 assertion and all
-identity-sensitive #257/#260/#262/#266/#267/#271/#272/#273 objects share the
-one live Crazyflie/session/connection epoch.
+must never be accepted later as an effect capability. A distinct optional
+launcher-installed teacher channel may approve one exact run through #267; its
+receipt remains local to this host. The future #276 transport belongs *inside this
+same process* so the fresh #249 assertion and all identity-sensitive
+#257/#260/#262/#266/#267/#271/#272/#273 objects share the one live
+Crazyflie/session/connection epoch.
 
 Browser bootstrap is a distinct one-way composition channel. The responder
 credential is written there once and is never returned on the ordinary caller
-channel. Live bridge/session/responder state remains local to the running host
+channel. The teacher decision channel is also distinct from both paths. Live
+bridge/session/responder/teacher-authority state remains local to the running host
 composition instead of being installed as attributes on the process' importable
 ``__main__`` module. This executable emits no flight, arming, setpoint or reset
 command.
@@ -41,6 +44,14 @@ if __name__ == "__main__":
             CapabilityBridgeError,
             ReadOnlyCapabilityHttpBridge,
         )
+        from teacher_decision_channel import (
+            TeacherDecisionChannelError,
+            TrustedTeacherDecisionChannel,
+        )
+        from teacher_run_authorization import (
+            PhysicalRunBinding,
+            TrustedTeacherAuthorizer,
+        )
 
         max_message_bytes = 8192
         assertion_timeout_seconds = 1.0
@@ -61,6 +72,12 @@ if __name__ == "__main__":
             type=int,
             help="distinct one-way browser bootstrap descriptor",
         )
+        parser.add_argument(
+            "--teacher-fd",
+            type=int,
+            default=None,
+            help="distinct launcher-installed trusted teacher decision socket handle",
+        )
         args = parser.parse_args()
 
         if not args.uri.startswith("radio://"):
@@ -69,16 +86,39 @@ if __name__ == "__main__":
             raise SystemExit("physical host channels must be inherited non-stdio handles")
         if args.caller_fd == args.browser_config_fd:
             raise SystemExit("caller and browser bootstrap channels must be distinct")
+        if args.teacher_fd is not None:
+            if args.teacher_fd < 3:
+                raise SystemExit("teacher decision channel must be an inherited non-stdio handle")
+            if args.teacher_fd in {args.caller_fd, args.browser_config_fd}:
+                raise SystemExit(
+                    "teacher decision channel must be distinct from caller/browser channels"
+                )
 
         caller_socket = socket.socket(fileno=args.caller_fd)
         caller_reader = caller_socket.makefile("r", encoding="utf-8", newline="\n")
         caller_writer = caller_socket.makefile("w", encoding="utf-8", newline="\n")
+        teacher_socket = (
+            None if args.teacher_fd is None else socket.socket(fileno=args.teacher_fd)
+        )
 
         with ReadOnlyCapabilitySession(args.uri) as session:
             bridge = ReadOnlyCapabilityHttpBridge(session)
             bridge_thread = Thread(target=bridge.serve_forever, daemon=True)
             bridge_thread.start()
             host, port = bridge.address
+
+            teacher_authorizer = TrustedTeacherAuthorizer()
+            teacher_channel = (
+                None
+                if teacher_socket is None
+                else TrustedTeacherDecisionChannel(
+                    teacher_socket,
+                    session.read_connection_epoch,
+                )
+            )
+            # A future co-located #276 transport consumes this exact local receipt.
+            # It is never serialized onto the ordinary caller or browser channels.
+            active_teacher_authorization = None
 
             # Trusted composition routes this descriptor only to the production
             # browser #249 responder. It never crosses the caller IPC channel.
@@ -113,7 +153,11 @@ if __name__ == "__main__":
                         break
                     if not isinstance(request, dict):
                         break
-                    if request.get("op") != "validate-run-context":
+                    operation = request.get("op")
+                    if operation not in {
+                        "validate-run-context",
+                        "authorize-run-context",
+                    }:
                         break
 
                     request_id = request.get("requestId")
@@ -135,8 +179,9 @@ if __name__ == "__main__":
 
                     try:
                         # This evidence stays inside the trusted physical host.
-                        # Future #276 composition must consume it here immediately
-                        # before the effect; caller replies are never provenance.
+                        # Future #276 composition must consume the same bridge
+                        # immediately before each effect; caller replies are never
+                        # accepted as provenance.
                         evidence = bridge.assert_current_program(
                             profile_id=profile_id,
                             ast_binding=ast_binding,
@@ -152,6 +197,26 @@ if __name__ == "__main__":
                             raise CapabilityBridgeError(
                                 "current-program evidence does not match requested run"
                             )
+
+                        if operation == "authorize-run-context":
+                            if teacher_channel is None:
+                                raise CapabilityBridgeError(
+                                    "trusted teacher decision channel is unavailable"
+                                )
+                            run_binding = PhysicalRunBinding(
+                                profile_id=profile_id,
+                                ast_binding=ast_binding,
+                                connection_epoch=connection_epoch,
+                            )
+                            try:
+                                active_teacher_authorization = (
+                                    teacher_channel.authorize_run(
+                                        run_binding,
+                                        teacher_authorizer,
+                                    )
+                                )
+                            except TeacherDecisionChannelError as exc:
+                                raise CapabilityBridgeError(str(exc)) from exc
                     except CapabilityBridgeError as exc:
                         response = {
                             "requestId": request_id,
@@ -181,6 +246,21 @@ if __name__ == "__main__":
             finally:
                 bridge.shutdown()
                 bridge_thread.join(timeout=1.0)
+                if active_teacher_authorization is not None:
+                    try:
+                        teacher_authorizer.close_run(
+                            active_teacher_authorization,
+                            "physical host shutting down",
+                        )
+                    except Exception:
+                        pass
+                if teacher_channel is not None:
+                    teacher_channel.close()
+                elif teacher_socket is not None:
+                    try:
+                        teacher_socket.close()
+                    except OSError:
+                        pass
                 try:
                     caller_reader.close()
                     caller_writer.close()

--- a/tools/physical/serve_physical_host.py
+++ b/tools/physical/serve_physical_host.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         from pathlib import Path
         import socket
         import sys
-        from threading import Lock, Thread
+        from threading import Thread
 
         physical = Path(__file__).resolve().parent
         if str(physical) not in sys.path:
@@ -114,23 +114,21 @@ if __name__ == "__main__":
                     session.read_connection_epoch,
                 )
             )
-            teacher_state_lock = Lock()
-            active_teacher_authorization = None
-            teacher_channel_error = None
+            teacher_state = {
+                "authorization": None,
+                "error": None,
+            }
             teacher_thread = None
 
             def run_teacher_decision_channel() -> None:
-                nonlocal active_teacher_authorization, teacher_channel_error
                 if teacher_channel is None:
                     return
                 try:
                     receipt = teacher_channel.receive_authorization(teacher_authorizer)
                 except TeacherDecisionChannelError as exc:
-                    with teacher_state_lock:
-                        teacher_channel_error = str(exc)
+                    teacher_state["error"] = str(exc)
                     return
-                with teacher_state_lock:
-                    active_teacher_authorization = receipt
+                teacher_state["authorization"] = receipt
 
             # Trusted composition routes this descriptor only to the production
             # browser #249 responder. It never crosses the caller IPC channel.
@@ -256,9 +254,8 @@ if __name__ == "__main__":
                 if teacher_thread is not None:
                     teacher_thread.join(timeout=1.0)
 
-                with teacher_state_lock:
-                    receipt = active_teacher_authorization
-                    _teacher_channel_error = teacher_channel_error
+                receipt = teacher_state["authorization"]
+                _teacher_channel_error = teacher_state["error"]
                 if receipt is not None:
                     try:
                         teacher_authorizer.close_run(

--- a/tools/physical/serve_physical_host.py
+++ b/tools/physical/serve_physical_host.py
@@ -2,26 +2,25 @@
 """Trusted physical-host composition root for current-program provenance.
 
 This executable is the #280 authority boundary. Importing this file creates no
-session, bridge, responder, mint/bind API or physical effect object. When run by
-trusted production composition it alone owns the live Crazyflie capability
+session, bridge, responder, teacher channel or physical effect object. When run
+by trusted production composition it alone owns the live Crazyflie capability
 session and the integrated #278 bridge/responder relationship.
 
 The ordinary caller/UI is outside this process. Its IPC messages are untrusted
-run-context requests only; a positive reply is diagnostic/non-authority data and
-must never be accepted later as an effect capability. A distinct optional
-launcher-installed teacher channel may approve one exact run through #267; its
-receipt remains local to this host. The future #276 transport belongs *inside this
-same process* so the fresh #249 assertion and all identity-sensitive
-#257/#260/#262/#266/#267/#271/#272/#273 objects share the one live
-Crazyflie/session/connection epoch.
+run-context validation requests only; a positive reply is diagnostic/non-authority
+data and must never be accepted later as an effect capability. A distinct
+launcher-installed teacher socket may independently approve one exact #267 run;
+that receipt remains process-local and is never returned on caller/browser IPC.
+The future #276 transport belongs *inside this same process* so fresh #249 and all
+identity-sensitive #257/#260/#262/#266/#267/#271/#272/#273 objects share the one
+live Crazyflie/session/connection epoch.
 
-Browser bootstrap is a distinct one-way composition channel. The responder
-credential is written there once and is never returned on the ordinary caller
-channel. The teacher decision channel is also distinct from both paths. Live
-bridge/session/responder/teacher-authority state remains local to the running host
-composition instead of being installed as attributes on the process' importable
-``__main__`` module. This executable emits no flight, arming, setpoint or reset
-command.
+Browser bootstrap is a distinct one-way composition channel. Its responder
+credential is written there once and never returned on ordinary caller IPC. The
+teacher decision socket is distinct from both channels and is consumed by its own
+one-shot trusted control path; ordinary caller data cannot trigger, select,
+replace or write that decision path. This executable emits no flight, arming,
+setpoint or reset command.
 """
 
 if __name__ == "__main__":
@@ -33,7 +32,7 @@ if __name__ == "__main__":
         from pathlib import Path
         import socket
         import sys
-        from threading import Thread
+        from threading import Lock, Thread
 
         physical = Path(__file__).resolve().parent
         if str(physical) not in sys.path:
@@ -48,10 +47,7 @@ if __name__ == "__main__":
             TeacherDecisionChannelError,
             TrustedTeacherDecisionChannel,
         )
-        from teacher_run_authorization import (
-            PhysicalRunBinding,
-            TrustedTeacherAuthorizer,
-        )
+        from teacher_run_authorization import TrustedTeacherAuthorizer
 
         max_message_bytes = 8192
         assertion_timeout_seconds = 1.0
@@ -88,7 +84,9 @@ if __name__ == "__main__":
             raise SystemExit("caller and browser bootstrap channels must be distinct")
         if args.teacher_fd is not None:
             if args.teacher_fd < 3:
-                raise SystemExit("teacher decision channel must be an inherited non-stdio handle")
+                raise SystemExit(
+                    "teacher decision channel must be an inherited non-stdio handle"
+                )
             if args.teacher_fd in {args.caller_fd, args.browser_config_fd}:
                 raise SystemExit(
                     "teacher decision channel must be distinct from caller/browser channels"
@@ -116,9 +114,23 @@ if __name__ == "__main__":
                     session.read_connection_epoch,
                 )
             )
-            # A future co-located #276 transport consumes this exact local receipt.
-            # It is never serialized onto the ordinary caller or browser channels.
+            teacher_state_lock = Lock()
             active_teacher_authorization = None
+            teacher_channel_error = None
+            teacher_thread = None
+
+            def run_teacher_decision_channel() -> None:
+                nonlocal active_teacher_authorization, teacher_channel_error
+                if teacher_channel is None:
+                    return
+                try:
+                    receipt = teacher_channel.receive_authorization(teacher_authorizer)
+                except TeacherDecisionChannelError as exc:
+                    with teacher_state_lock:
+                        teacher_channel_error = str(exc)
+                    return
+                with teacher_state_lock:
+                    active_teacher_authorization = receipt
 
             # Trusted composition routes this descriptor only to the production
             # browser #249 responder. It never crosses the caller IPC channel.
@@ -143,6 +155,16 @@ if __name__ == "__main__":
                 )
                 browser_config.flush()
 
+            # The teacher protocol is independent from ordinary caller requests.
+            # It may remain idle until the trusted launcher/teacher writes its
+            # one-run request, and it never serializes the resulting #267 receipt.
+            if teacher_channel is not None:
+                teacher_thread = Thread(
+                    target=run_teacher_decision_channel,
+                    daemon=True,
+                )
+                teacher_thread.start()
+
             try:
                 for line in caller_reader:
                     if len(line.encode("utf-8")) > max_message_bytes:
@@ -153,11 +175,7 @@ if __name__ == "__main__":
                         break
                     if not isinstance(request, dict):
                         break
-                    operation = request.get("op")
-                    if operation not in {
-                        "validate-run-context",
-                        "authorize-run-context",
-                    }:
+                    if request.get("op") != "validate-run-context":
                         break
 
                     request_id = request.get("requestId")
@@ -179,9 +197,8 @@ if __name__ == "__main__":
 
                     try:
                         # This evidence stays inside the trusted physical host.
-                        # Future #276 composition must consume the same bridge
-                        # immediately before each effect; caller replies are never
-                        # accepted as provenance.
+                        # Future #276 composition must consume it here immediately
+                        # before the effect; caller replies are never provenance.
                         evidence = bridge.assert_current_program(
                             profile_id=profile_id,
                             ast_binding=ast_binding,
@@ -197,26 +214,6 @@ if __name__ == "__main__":
                             raise CapabilityBridgeError(
                                 "current-program evidence does not match requested run"
                             )
-
-                        if operation == "authorize-run-context":
-                            if teacher_channel is None:
-                                raise CapabilityBridgeError(
-                                    "trusted teacher decision channel is unavailable"
-                                )
-                            run_binding = PhysicalRunBinding(
-                                profile_id=profile_id,
-                                ast_binding=ast_binding,
-                                connection_epoch=connection_epoch,
-                            )
-                            try:
-                                active_teacher_authorization = (
-                                    teacher_channel.authorize_run(
-                                        run_binding,
-                                        teacher_authorizer,
-                                    )
-                                )
-                            except TeacherDecisionChannelError as exc:
-                                raise CapabilityBridgeError(str(exc)) from exc
                     except CapabilityBridgeError as exc:
                         response = {
                             "requestId": request_id,
@@ -246,14 +243,9 @@ if __name__ == "__main__":
             finally:
                 bridge.shutdown()
                 bridge_thread.join(timeout=1.0)
-                if active_teacher_authorization is not None:
-                    try:
-                        teacher_authorizer.close_run(
-                            active_teacher_authorization,
-                            "physical host shutting down",
-                        )
-                    except Exception:
-                        pass
+
+                # Closing the trusted channel first unblocks an idle one-shot
+                # teacher worker; no late decision can survive host teardown.
                 if teacher_channel is not None:
                     teacher_channel.close()
                 elif teacher_socket is not None:
@@ -261,6 +253,24 @@ if __name__ == "__main__":
                         teacher_socket.close()
                     except OSError:
                         pass
+                if teacher_thread is not None:
+                    teacher_thread.join(timeout=1.0)
+
+                with teacher_state_lock:
+                    receipt = active_teacher_authorization
+                    _teacher_channel_error = teacher_channel_error
+                if receipt is not None:
+                    try:
+                        teacher_authorizer.close_run(
+                            receipt,
+                            "physical host shutting down",
+                        )
+                    except Exception:
+                        pass
+                # Keep the local error value deliberately non-observable to caller
+                # IPC while retaining it for a future co-located trusted lifecycle.
+                del _teacher_channel_error
+
                 try:
                     caller_reader.close()
                     caller_writer.close()

--- a/tools/physical/teacher_decision_channel.py
+++ b/tools/physical/teacher_decision_channel.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """One-shot trusted teacher decision channel for physical-run authorization.
 
-This module transports only one exact teacher decision into the trusted physical
-host.  It does not grant execution authority by itself and exposes no Crazyflie
-command surface.  The trusted launcher chooses the connected socket; ordinary
-caller/browser channels must never be substituted for it.
+The channel is installed by the trusted launcher as a distinct connected socket.
+It is not reachable through the ordinary caller or browser-responder paths.  A
+teacher-side request names one exact profile/AST/connection-epoch binding; the
+host then creates a fresh correlation challenge and accepts exactly one matching
+positive/negative decision.  Any malformed, mismatched, duplicated, late or
+transport-ambiguous exchange makes the channel terminal.
 
-The host sends one exact profile/AST/connection-epoch challenge and accepts only
-one correlated reply.  Any denial, malformed/ambiguous transport, wrong binding,
-or connection-epoch change makes the channel terminal.  A positive decision is
-turned into the existing #267 TeacherRunAuthorization by a host-local
-TrustedTeacherAuthorizer; the receipt never needs to cross this channel.
+A positive decision is converted into the existing #267
+``TeacherRunAuthorization`` by a process-local ``TrustedTeacherAuthorizer``.
+This module exposes no physical-effect operation and serializes no authorization
+receipt.
 """
 
 from __future__ import annotations
@@ -30,7 +31,7 @@ from teacher_run_authorization import (
 )
 
 _MAX_MESSAGE_BYTES = 8192
-_DEFAULT_TIMEOUT_SECONDS = 5.0
+_DEFAULT_DECISION_TIMEOUT_SECONDS = 5.0
 
 
 class TeacherDecisionChannelError(RuntimeError):
@@ -60,15 +61,21 @@ def _read_epoch(reader: Callable[[], str]) -> str:
     return epoch
 
 
+def _nonempty_text(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise TeacherDecisionChannelError(f"{name} must be non-empty trimmed text")
+    return value
+
+
 class TrustedTeacherDecisionChannel:
-    """One launcher-installed duplex channel for one exact teacher decision."""
+    """One launcher-installed duplex socket consumed by one teacher decision."""
 
     def __init__(
         self,
         channel_socket: socket.socket,
         connection_epoch_reader: Callable[[], str],
         *,
-        request_id_factory: Callable[[], str] | None = None,
+        challenge_id_factory: Callable[[], str] | None = None,
     ) -> None:
         if type(channel_socket) is not socket.socket:
             raise TeacherDecisionChannelError(
@@ -80,14 +87,15 @@ class TrustedTeacherDecisionChannel:
             )
         self._socket = channel_socket
         self._epoch_reader = connection_epoch_reader
-        self._request_id_factory = request_id_factory or (
+        self._challenge_id_factory = challenge_id_factory or (
             lambda: secrets.token_urlsafe(24)
         )
-        if not callable(self._request_id_factory):
+        if not callable(self._challenge_id_factory):
             raise TeacherDecisionChannelError(
-                "teacher decision request-id factory must be callable"
+                "teacher decision challenge-id factory must be callable"
             )
         self._lock = Lock()
+        self._started = False
         self._terminal = False
         self._terminal_reason: str | None = None
 
@@ -101,39 +109,38 @@ class TrustedTeacherDecisionChannel:
         with self._lock:
             return self._terminal_reason
 
-    def _finish(self, reason: str) -> None:
+    def _finish(self, reason: object) -> None:
         message = str(reason).strip() or "teacher decision channel is terminal"
-        self._terminal = True
-        self._terminal_reason = message
+        with self._lock:
+            self._terminal = True
+            self._terminal_reason = message
 
-    def _request_id(self) -> str:
+    def _challenge_id(self) -> str:
         try:
-            value = self._request_id_factory()
+            value = self._challenge_id_factory()
         except Exception as exc:
             raise TeacherDecisionChannelError(
-                "teacher decision request id is unavailable"
+                "teacher decision challenge id is unavailable"
             ) from exc
-        if not isinstance(value, str) or not value.strip() or value != value.strip():
-            raise TeacherDecisionChannelError(
-                "teacher decision request id must be non-empty trimmed text"
-            )
-        return value
+        return _nonempty_text(value, "teacher decision challenge id")
 
     def _send_json_line(self, payload: dict[str, object], timeout: float) -> None:
         encoded = (
             json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
         ).encode("utf-8")
         if len(encoded) > _MAX_MESSAGE_BYTES:
-            raise TeacherDecisionChannelError("teacher decision request is too large")
+            raise TeacherDecisionChannelError("teacher decision message is too large")
         try:
             self._socket.settimeout(timeout)
             self._socket.sendall(encoded)
+        except socket.timeout as exc:
+            raise TeacherDecisionChannelError("teacher decision timed out") from exc
         except OSError as exc:
             raise TeacherDecisionChannelError(
-                "teacher decision request transport failed"
+                "teacher decision transport failed"
             ) from exc
 
-    def _recv_json_line(self, timeout: float) -> dict[str, object]:
+    def _recv_json_line(self, timeout: float | None) -> dict[str, object]:
         data = bytearray()
         try:
             self._socket.settimeout(timeout)
@@ -141,55 +148,74 @@ class TrustedTeacherDecisionChannel:
                 chunk = self._socket.recv(1)
                 if not chunk:
                     raise TeacherDecisionChannelError(
-                        "teacher decision channel closed before a reply"
+                        "teacher decision channel closed before a complete message"
                     )
                 data.extend(chunk)
                 if chunk == b"\n":
                     break
             else:
                 raise TeacherDecisionChannelError(
-                    "teacher decision reply exceeds size limit"
+                    "teacher decision message exceeds size limit"
                 )
         except socket.timeout as exc:
             raise TeacherDecisionChannelError("teacher decision timed out") from exc
         except OSError as exc:
             raise TeacherDecisionChannelError(
-                "teacher decision reply transport failed"
+                "teacher decision transport failed"
             ) from exc
 
         if not data.endswith(b"\n"):
             raise TeacherDecisionChannelError(
-                "teacher decision reply is not line terminated"
+                "teacher decision message is not line terminated"
             )
         try:
             payload = json.loads(bytes(data[:-1]).decode("utf-8"))
         except (UnicodeError, json.JSONDecodeError) as exc:
             raise TeacherDecisionChannelError(
-                "teacher decision reply is malformed JSON"
+                "teacher decision message is malformed JSON"
             ) from exc
         if not isinstance(payload, dict):
             raise TeacherDecisionChannelError(
-                "teacher decision reply must be a JSON object"
+                "teacher decision message must be a JSON object"
             )
         return payload
 
-    def authorize_run(
+    def _require_peer_write_closed(self, timeout: float) -> None:
+        """Require end-of-stream before minting so late/duplicate decisions cannot follow."""
+        try:
+            self._socket.settimeout(timeout)
+            extra = self._socket.recv(1)
+        except socket.timeout as exc:
+            raise TeacherDecisionChannelError(
+                "teacher decision channel did not finish the one-shot exchange"
+            ) from exc
+        except OSError as exc:
+            raise TeacherDecisionChannelError(
+                "teacher decision transport failed while sealing the exchange"
+            ) from exc
+        if extra != b"":
+            raise TeacherDecisionChannelError(
+                "duplicate or late teacher decision data followed the reply"
+            )
+
+    def receive_authorization(
         self,
-        binding: PhysicalRunBinding,
         authorizer: TrustedTeacherAuthorizer,
         *,
-        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        decision_timeout_seconds: float = _DEFAULT_DECISION_TIMEOUT_SECONDS,
     ) -> TeacherRunAuthorization:
-        """Request exactly one teacher decision and mint the matching #267 receipt."""
-        if type(binding) is not PhysicalRunBinding:
-            raise TeacherDecisionChannelError(
-                "exact physical run binding is required for teacher decision"
-            )
+        """Receive one trusted request/decision exchange and mint its exact #267 receipt.
+
+        Waiting for the initial teacher request has no application timeout: the
+        launcher-installed channel may remain idle until a teacher chooses to act.
+        Once a request is received, the correlated decision must complete within
+        ``decision_timeout_seconds``.  Any attempted exchange consumes the channel.
+        """
         if type(authorizer) is not TrustedTeacherAuthorizer:
             raise TeacherDecisionChannelError(
                 "exact trusted teacher authorizer is required"
             )
-        timeout = _require_timeout(timeout_seconds)
+        timeout = _require_timeout(decision_timeout_seconds)
 
         with self._lock:
             if self._terminal:
@@ -197,106 +223,205 @@ class TrustedTeacherDecisionChannel:
                     "teacher decision channel is terminal: "
                     + (self._terminal_reason or "prior decision consumed")
                 )
-            try:
-                before_epoch = _read_epoch(self._epoch_reader)
-                if before_epoch != binding.connection_epoch:
-                    raise TeacherDecisionChannelError(
-                        "teacher decision binding does not match the live connection epoch"
-                    )
-
-                request_id = self._request_id()
-                self._send_json_line(
-                    {
-                        "op": "teacher-run-decision",
-                        "requestId": request_id,
-                        "profileId": binding.profile_id,
-                        "astBinding": binding.ast_binding,
-                        "connectionEpoch": binding.connection_epoch,
-                        "executionAuthority": False,
-                    },
-                    timeout,
-                )
-                response = self._recv_json_line(timeout)
-
-                if response.get("op") != "teacher-run-decision-result":
-                    raise TeacherDecisionChannelError(
-                        "teacher decision reply has the wrong operation"
-                    )
-                if response.get("requestId") != request_id:
-                    raise TeacherDecisionChannelError(
-                        "teacher decision reply has the wrong correlation id"
-                    )
-                if response.get("executionAuthority") is not False:
-                    raise TeacherDecisionChannelError(
-                        "teacher decision transport must remain non-authority"
-                    )
-                if (
-                    response.get("profileId") != binding.profile_id
-                    or response.get("astBinding") != binding.ast_binding
-                    or response.get("connectionEpoch") != binding.connection_epoch
-                ):
-                    raise TeacherDecisionChannelError(
-                        "teacher decision reply does not match the exact run binding"
-                    )
-
-                approved = response.get("approved")
-                if not isinstance(approved, bool):
-                    raise TeacherDecisionChannelError(
-                        "teacher decision reply must contain a boolean approved value"
-                    )
-
-                after_epoch = _read_epoch(self._epoch_reader)
-                if after_epoch != before_epoch:
-                    raise TeacherDecisionChannelError(
-                        "connection epoch changed during teacher decision"
-                    )
-
-                if approved is not True:
-                    raise TeacherDecisionChannelError(
-                        "teacher explicitly denied this physical run"
-                    )
-
-                try:
-                    receipt = authorizer.authorize_run(
-                        binding,
-                        lambda exact_binding: exact_binding == binding,
-                    )
-                except TeacherRunAuthorizationError as exc:
-                    raise TeacherDecisionChannelError(
-                        "teacher authorization receipt could not be minted"
-                    ) from exc
-                if (
-                    type(receipt) is not TeacherRunAuthorization
-                    or receipt.binding != binding
-                    or receipt.active is not True
-                ):
-                    try:
-                        if type(receipt) is TeacherRunAuthorization:
-                            authorizer.close_run(
-                                receipt,
-                                "invalid teacher authorization receipt",
-                            )
-                    except TeacherRunAuthorizationError:
-                        pass
-                    raise TeacherDecisionChannelError(
-                        "teacher authorization receipt does not match the approved run"
-                    )
-                self._finish("teacher decision consumed")
-                return receipt
-            except Exception as exc:
-                if not self._terminal:
-                    self._finish(str(exc))
-                if isinstance(exc, TeacherDecisionChannelError):
-                    raise
+            if self._started:
                 raise TeacherDecisionChannelError(
-                    "teacher decision failed closed"
+                    "teacher decision channel already has an active exchange"
+                )
+            self._started = True
+
+        receipt: TeacherRunAuthorization | None = None
+        try:
+            request = self._recv_json_line(None)
+            if set(request) != {
+                "op",
+                "requestId",
+                "profileId",
+                "astBinding",
+                "connectionEpoch",
+                "executionAuthority",
+            }:
+                raise TeacherDecisionChannelError(
+                    "teacher authorization request has unsupported fields"
+                )
+            if request.get("op") != "teacher-run-authorization-request":
+                raise TeacherDecisionChannelError(
+                    "teacher authorization request has the wrong operation"
+                )
+            if request.get("executionAuthority") is not False:
+                raise TeacherDecisionChannelError(
+                    "teacher decision transport must remain non-authority data"
+                )
+            request_id = _nonempty_text(
+                request.get("requestId"),
+                "teacher authorization request id",
+            )
+            binding = PhysicalRunBinding(
+                profile_id=_nonempty_text(
+                    request.get("profileId"),
+                    "teacher authorization profile id",
+                ),
+                ast_binding=_nonempty_text(
+                    request.get("astBinding"),
+                    "teacher authorization AST binding",
+                ),
+                connection_epoch=_nonempty_text(
+                    request.get("connectionEpoch"),
+                    "teacher authorization connection epoch",
+                ),
+            )
+
+            before_epoch = _read_epoch(self._epoch_reader)
+            if binding.connection_epoch != before_epoch:
+                raise TeacherDecisionChannelError(
+                    "teacher authorization request does not match the live connection epoch"
+                )
+
+            challenge_id = self._challenge_id()
+            challenge = {
+                "op": "teacher-run-decision-challenge",
+                "requestId": request_id,
+                "challengeId": challenge_id,
+                "profileId": binding.profile_id,
+                "astBinding": binding.ast_binding,
+                "connectionEpoch": binding.connection_epoch,
+                "executionAuthority": False,
+            }
+            self._send_json_line(challenge, timeout)
+            response = self._recv_json_line(timeout)
+
+            if set(response) != {
+                "op",
+                "requestId",
+                "challengeId",
+                "profileId",
+                "astBinding",
+                "connectionEpoch",
+                "approved",
+                "executionAuthority",
+            }:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has unsupported fields"
+                )
+            if response.get("op") != "teacher-run-decision-result":
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has the wrong operation"
+                )
+            if response.get("requestId") != request_id:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has the wrong request correlation"
+                )
+            if response.get("challengeId") != challenge_id:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has the wrong challenge correlation"
+                )
+            if response.get("executionAuthority") is not False:
+                raise TeacherDecisionChannelError(
+                    "teacher decision transport must remain non-authority data"
+                )
+            if (
+                response.get("profileId") != binding.profile_id
+                or response.get("astBinding") != binding.ast_binding
+                or response.get("connectionEpoch") != binding.connection_epoch
+            ):
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply does not match the exact run binding"
+                )
+            approved = response.get("approved")
+            if not isinstance(approved, bool):
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply must contain a boolean approved value"
+                )
+
+            after_decision_epoch = _read_epoch(self._epoch_reader)
+            if after_decision_epoch != before_epoch:
+                raise TeacherDecisionChannelError(
+                    "connection epoch changed during teacher decision"
+                )
+            if approved is not True:
+                raise TeacherDecisionChannelError(
+                    "teacher explicitly denied this physical run"
+                )
+
+            # Positive authority is minted only after the teacher write side is
+            # definitively closed. This makes duplicate/late frames impossible
+            # after authority publication rather than merely ignored.
+            self._require_peer_write_closed(timeout)
+            if _read_epoch(self._epoch_reader) != before_epoch:
+                raise TeacherDecisionChannelError(
+                    "connection epoch changed while sealing teacher decision"
+                )
+
+            try:
+                receipt = authorizer.authorize_run(
+                    binding,
+                    lambda exact_binding: exact_binding == binding,
+                )
+            except TeacherRunAuthorizationError as exc:
+                raise TeacherDecisionChannelError(
+                    "teacher authorization receipt could not be minted"
                 ) from exc
+
+            after_mint_epoch = _read_epoch(self._epoch_reader)
+            if after_mint_epoch != before_epoch:
+                try:
+                    authorizer.close_run(
+                        receipt,
+                        "connection epoch changed while minting teacher authorization",
+                    )
+                except TeacherRunAuthorizationError:
+                    receipt.invalidate(
+                        "connection epoch changed while minting teacher authorization"
+                    )
+                raise TeacherDecisionChannelError(
+                    "connection epoch changed while minting teacher authorization"
+                )
+            if (
+                type(receipt) is not TeacherRunAuthorization
+                or receipt.binding != binding
+                or receipt.active is not True
+            ):
+                if type(receipt) is TeacherRunAuthorization:
+                    try:
+                        authorizer.close_run(
+                            receipt,
+                            "invalid teacher authorization receipt",
+                        )
+                    except TeacherRunAuthorizationError:
+                        receipt.invalidate("invalid teacher authorization receipt")
+                raise TeacherDecisionChannelError(
+                    "teacher authorization receipt does not match the approved run"
+                )
+
+            self._finish("teacher decision consumed")
+            return receipt
+        except Exception as exc:
+            if receipt is not None and receipt.active:
+                try:
+                    authorizer.close_run(receipt, "teacher decision failed closed")
+                except TeacherRunAuthorizationError:
+                    receipt.invalidate("teacher decision failed closed")
+            with self._lock:
+                already_terminal = self._terminal
+            if not already_terminal:
+                self._finish(exc)
+            if isinstance(exc, TeacherDecisionChannelError):
+                raise
+            if isinstance(exc, TeacherRunAuthorizationError):
+                raise TeacherDecisionChannelError(str(exc)) from exc
+            raise TeacherDecisionChannelError(
+                "teacher decision failed closed"
+            ) from exc
 
     def close(self) -> None:
         with self._lock:
             if not self._terminal:
-                self._finish("teacher decision channel closed")
-            try:
-                self._socket.close()
-            except OSError:
-                pass
+                self._terminal = True
+                self._terminal_reason = "teacher decision channel closed"
+        try:
+            self._socket.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            self._socket.close()
+        except OSError:
+            pass

--- a/tools/physical/teacher_decision_channel.py
+++ b/tools/physical/teacher_decision_channel.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""One-shot trusted teacher decision channel for physical-run authorization.
+
+This module transports only one exact teacher decision into the trusted physical
+host.  It does not grant execution authority by itself and exposes no Crazyflie
+command surface.  The trusted launcher chooses the connected socket; ordinary
+caller/browser channels must never be substituted for it.
+
+The host sends one exact profile/AST/connection-epoch challenge and accepts only
+one correlated reply.  Any denial, malformed/ambiguous transport, wrong binding,
+or connection-epoch change makes the channel terminal.  A positive decision is
+turned into the existing #267 TeacherRunAuthorization by a host-local
+TrustedTeacherAuthorizer; the receipt never needs to cross this channel.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import secrets
+import socket
+from threading import Lock
+from typing import Callable
+
+from teacher_run_authorization import (
+    PhysicalRunBinding,
+    TeacherRunAuthorization,
+    TeacherRunAuthorizationError,
+    TrustedTeacherAuthorizer,
+)
+
+_MAX_MESSAGE_BYTES = 8192
+_DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+class TeacherDecisionChannelError(RuntimeError):
+    """Fail-closed teacher-decision transport or correlation error."""
+
+
+def _require_timeout(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TeacherDecisionChannelError("teacher decision timeout must be positive")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout <= 0.0:
+        raise TeacherDecisionChannelError("teacher decision timeout must be positive")
+    return timeout
+
+
+def _read_epoch(reader: Callable[[], str]) -> str:
+    try:
+        epoch = reader()
+    except Exception as exc:
+        raise TeacherDecisionChannelError(
+            "connection epoch is unavailable for teacher decision"
+        ) from exc
+    if not isinstance(epoch, str) or not epoch.strip() or epoch != epoch.strip():
+        raise TeacherDecisionChannelError(
+            "connection epoch is invalid for teacher decision"
+        )
+    return epoch
+
+
+class TrustedTeacherDecisionChannel:
+    """One launcher-installed duplex channel for one exact teacher decision."""
+
+    def __init__(
+        self,
+        channel_socket: socket.socket,
+        connection_epoch_reader: Callable[[], str],
+        *,
+        request_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        if type(channel_socket) is not socket.socket:
+            raise TeacherDecisionChannelError(
+                "trusted teacher decision requires an exact socket capability"
+            )
+        if not callable(connection_epoch_reader):
+            raise TeacherDecisionChannelError(
+                "connection epoch reader is required for teacher decision"
+            )
+        self._socket = channel_socket
+        self._epoch_reader = connection_epoch_reader
+        self._request_id_factory = request_id_factory or (
+            lambda: secrets.token_urlsafe(24)
+        )
+        if not callable(self._request_id_factory):
+            raise TeacherDecisionChannelError(
+                "teacher decision request-id factory must be callable"
+            )
+        self._lock = Lock()
+        self._terminal = False
+        self._terminal_reason: str | None = None
+
+    @property
+    def terminal(self) -> bool:
+        with self._lock:
+            return self._terminal
+
+    @property
+    def terminal_reason(self) -> str | None:
+        with self._lock:
+            return self._terminal_reason
+
+    def _finish(self, reason: str) -> None:
+        message = str(reason).strip() or "teacher decision channel is terminal"
+        self._terminal = True
+        self._terminal_reason = message
+
+    def _request_id(self) -> str:
+        try:
+            value = self._request_id_factory()
+        except Exception as exc:
+            raise TeacherDecisionChannelError(
+                "teacher decision request id is unavailable"
+            ) from exc
+        if not isinstance(value, str) or not value.strip() or value != value.strip():
+            raise TeacherDecisionChannelError(
+                "teacher decision request id must be non-empty trimmed text"
+            )
+        return value
+
+    def _send_json_line(self, payload: dict[str, object], timeout: float) -> None:
+        encoded = (
+            json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
+        ).encode("utf-8")
+        if len(encoded) > _MAX_MESSAGE_BYTES:
+            raise TeacherDecisionChannelError("teacher decision request is too large")
+        try:
+            self._socket.settimeout(timeout)
+            self._socket.sendall(encoded)
+        except OSError as exc:
+            raise TeacherDecisionChannelError(
+                "teacher decision request transport failed"
+            ) from exc
+
+    def _recv_json_line(self, timeout: float) -> dict[str, object]:
+        data = bytearray()
+        try:
+            self._socket.settimeout(timeout)
+            while len(data) <= _MAX_MESSAGE_BYTES:
+                chunk = self._socket.recv(1)
+                if not chunk:
+                    raise TeacherDecisionChannelError(
+                        "teacher decision channel closed before a reply"
+                    )
+                data.extend(chunk)
+                if chunk == b"\n":
+                    break
+            else:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply exceeds size limit"
+                )
+        except socket.timeout as exc:
+            raise TeacherDecisionChannelError("teacher decision timed out") from exc
+        except OSError as exc:
+            raise TeacherDecisionChannelError(
+                "teacher decision reply transport failed"
+            ) from exc
+
+        if not data.endswith(b"\n"):
+            raise TeacherDecisionChannelError(
+                "teacher decision reply is not line terminated"
+            )
+        try:
+            payload = json.loads(bytes(data[:-1]).decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise TeacherDecisionChannelError(
+                "teacher decision reply is malformed JSON"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise TeacherDecisionChannelError(
+                "teacher decision reply must be a JSON object"
+            )
+        return payload
+
+    def authorize_run(
+        self,
+        binding: PhysicalRunBinding,
+        authorizer: TrustedTeacherAuthorizer,
+        *,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> TeacherRunAuthorization:
+        """Request exactly one teacher decision and mint the matching #267 receipt."""
+        if type(binding) is not PhysicalRunBinding:
+            raise TeacherDecisionChannelError(
+                "exact physical run binding is required for teacher decision"
+            )
+        if type(authorizer) is not TrustedTeacherAuthorizer:
+            raise TeacherDecisionChannelError(
+                "exact trusted teacher authorizer is required"
+            )
+        timeout = _require_timeout(timeout_seconds)
+
+        with self._lock:
+            if self._terminal:
+                raise TeacherDecisionChannelError(
+                    "teacher decision channel is terminal: "
+                    + (self._terminal_reason or "prior decision consumed")
+                )
+            try:
+                before_epoch = _read_epoch(self._epoch_reader)
+                if before_epoch != binding.connection_epoch:
+                    raise TeacherDecisionChannelError(
+                        "teacher decision binding does not match the live connection epoch"
+                    )
+
+                request_id = self._request_id()
+                self._send_json_line(
+                    {
+                        "op": "teacher-run-decision",
+                        "requestId": request_id,
+                        "profileId": binding.profile_id,
+                        "astBinding": binding.ast_binding,
+                        "connectionEpoch": binding.connection_epoch,
+                        "executionAuthority": False,
+                    },
+                    timeout,
+                )
+                response = self._recv_json_line(timeout)
+
+                if response.get("op") != "teacher-run-decision-result":
+                    raise TeacherDecisionChannelError(
+                        "teacher decision reply has the wrong operation"
+                    )
+                if response.get("requestId") != request_id:
+                    raise TeacherDecisionChannelError(
+                        "teacher decision reply has the wrong correlation id"
+                    )
+                if response.get("executionAuthority") is not False:
+                    raise TeacherDecisionChannelError(
+                        "teacher decision transport must remain non-authority"
+                    )
+                if (
+                    response.get("profileId") != binding.profile_id
+                    or response.get("astBinding") != binding.ast_binding
+                    or response.get("connectionEpoch") != binding.connection_epoch
+                ):
+                    raise TeacherDecisionChannelError(
+                        "teacher decision reply does not match the exact run binding"
+                    )
+
+                approved = response.get("approved")
+                if not isinstance(approved, bool):
+                    raise TeacherDecisionChannelError(
+                        "teacher decision reply must contain a boolean approved value"
+                    )
+
+                after_epoch = _read_epoch(self._epoch_reader)
+                if after_epoch != before_epoch:
+                    raise TeacherDecisionChannelError(
+                        "connection epoch changed during teacher decision"
+                    )
+
+                if approved is not True:
+                    raise TeacherDecisionChannelError(
+                        "teacher explicitly denied this physical run"
+                    )
+
+                try:
+                    receipt = authorizer.authorize_run(
+                        binding,
+                        lambda exact_binding: exact_binding == binding,
+                    )
+                except TeacherRunAuthorizationError as exc:
+                    raise TeacherDecisionChannelError(
+                        "teacher authorization receipt could not be minted"
+                    ) from exc
+                if (
+                    type(receipt) is not TeacherRunAuthorization
+                    or receipt.binding != binding
+                    or receipt.active is not True
+                ):
+                    try:
+                        if type(receipt) is TeacherRunAuthorization:
+                            authorizer.close_run(
+                                receipt,
+                                "invalid teacher authorization receipt",
+                            )
+                    except TeacherRunAuthorizationError:
+                        pass
+                    raise TeacherDecisionChannelError(
+                        "teacher authorization receipt does not match the approved run"
+                    )
+                self._finish("teacher decision consumed")
+                return receipt
+            except Exception as exc:
+                if not self._terminal:
+                    self._finish(str(exc))
+                if isinstance(exc, TeacherDecisionChannelError):
+                    raise
+                raise TeacherDecisionChannelError(
+                    "teacher decision failed closed"
+                ) from exc
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._terminal:
+                self._finish("teacher decision channel closed")
+            try:
+                self._socket.close()
+            except OSError:
+                pass


### PR DESCRIPTION
Implements #286 as the smallest distinct trusted teacher-decision path inside the #283/#280 physical host.

The trusted launcher may install an optional, distinct `--teacher-fd`. The teacher channel is independent of ordinary caller IPC and browser bootstrap. The teacher side names one exact profile/AST/connection-epoch binding; the host creates a fresh correlation challenge; only one exact boolean decision is accepted. Positive #267 authority is minted only after the teacher write side reaches EOF, so duplicate or late frames fail closed before authority publication. The live connection epoch is checked before, during and after minting. Denial, EOF, malformed data, wrong correlation/binding, duplicate/late data, reconnect/epoch change or channel ambiguity is terminal.

`serve_physical_host.py` starts this one-shot trusted path independently. Ordinary caller IPC remains `validate-run-context` only and cannot trigger, select, replace or write teacher decisions. The resulting `TeacherRunAuthorization` remains process-local and is never serialized to caller or browser channels. No student flight-request workflow or physical-effect operation is added.

Deterministic coverage exercises exact positive binding, denial/EOF/malformed data, correlation and binding failures, duplicate/late frames, epoch changes, permanent #267 invalidation, separation from ordinary/browser channels, and absence of effect surfaces. The core harness reaches this regression through the existing teacher-authorization test.

No motorized checkpoint is requested.

Refs #286 #157. This is the trusted teacher-source prerequisite for completing #276 production activation.