### PR TITLE
Publish post-reset binding on trusted teacher channel

### DIFF
--- a/tools/ci/test_post_reset_teacher_decision.py
+++ b/tools/ci/test_post_reset_teacher_decision.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import socket
+from threading import Thread
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+
+import sys
+sys.path.insert(0, str(PHYSICAL))
+
+import post_reset_teacher_decision as post_reset  # noqa: E402
+import teacher_decision_channel as base_channel  # noqa: E402
+import teacher_run_authorization as auth  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except base_channel.TeacherDecisionChannelError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError("expected TeacherDecisionChannelError containing " + repr(pattern))
+
+
+class Epoch:
+    def __init__(self, value: str = "epoch-post-reset") -> None:
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+
+def read_line(sock: socket.socket) -> dict:
+    data = bytearray()
+    while True:
+        part = sock.recv(1)
+        require(part != b"", "teacher peer received unexpected EOF")
+        data.extend(part)
+        if part == b"\n":
+            return json.loads(bytes(data[:-1]).decode("utf-8"))
+
+
+def send_line(sock: socket.socket, payload: object) -> None:
+    sock.sendall(
+        (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+    )
+
+
+def decision_for(proposal: dict, *, approved: bool = True, **changes) -> dict:
+    result = {
+        "op": "teacher-run-decision-result",
+        "requestId": proposal["requestId"],
+        "challengeId": proposal["challengeId"],
+        "profileId": proposal["profileId"],
+        "astBinding": proposal["astBinding"],
+        "connectionEpoch": proposal["connectionEpoch"],
+        "approved": approved,
+        "executionAuthority": False,
+    }
+    result.update(changes)
+    return result
+
+
+def teacher_peer(
+    sock: socket.socket,
+    *,
+    approved: bool = True,
+    changes: dict | None = None,
+    duplicate: bool = False,
+    mutate_epoch=None,
+) -> None:
+    proposal = read_line(sock)
+    require(
+        proposal["op"] == "teacher-run-binding-proposal",
+        "host must publish the post-reset binding first",
+    )
+    require(proposal["executionAuthority"] is False, "binding proposal is non-authority")
+    if mutate_epoch is not None:
+        mutate_epoch()
+    result = decision_for(proposal, approved=approved, **(changes or {}))
+    send_line(sock, result)
+    if duplicate:
+        send_line(sock, result)
+    sock.shutdown(socket.SHUT_WR)
+
+
+def binding(epoch: str = "epoch-post-reset") -> auth.PhysicalRunBinding:
+    return auth.PhysicalRunBinding(
+        profile_id="activity-1",
+        ast_binding='{"program":[{"height_m":0.8,"kind":"takeoff"},{"kind":"land"}],"semantics":"webeeblocks-ast-v1","version":1}',
+        connection_epoch=epoch,
+    )
+
+
+def test_host_first_exact_post_reset_binding_mints_receipt() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    epoch = Epoch()
+    decision = post_reset.PostResetTeacherDecisionChannel(
+        host_sock,
+        epoch,
+        challenge_id_factory=lambda: "post-reset-challenge",
+    )
+    authorizer = auth.TrustedTeacherAuthorizer()
+    exact = binding()
+    observed = {}
+
+    def peer() -> None:
+        proposal = read_line(teacher_sock)
+        observed.update(proposal)
+        send_line(teacher_sock, decision_for(proposal))
+        teacher_sock.shutdown(socket.SHUT_WR)
+
+    worker = Thread(target=peer, daemon=True)
+    worker.start()
+    receipt = decision.receive_authorization_for_binding(
+        authorizer,
+        exact,
+        decision_timeout_seconds=0.5,
+    )
+    worker.join(timeout=1.0)
+
+    require(observed["profileId"] == exact.profile_id, "host publishes exact profile")
+    require(observed["astBinding"] == exact.ast_binding, "host publishes exact canonical AST")
+    require(
+        observed["connectionEpoch"] == exact.connection_epoch,
+        "host publishes newly live post-reset epoch",
+    )
+    require(observed["executionAuthority"] is False, "proposal never becomes authority")
+    require(type(receipt) is auth.TeacherRunAuthorization, "exact #267 receipt minted")
+    require(receipt.binding == exact and receipt.active, "receipt binds exact post-reset run")
+    require(decision.terminal, "one teacher decision consumes the channel")
+    teacher_sock.close()
+    decision.close()
+
+
+def test_stale_pre_reset_epoch_fails_before_publication() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    teacher_sock.settimeout(0.05)
+    decision = post_reset.PostResetTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    expect_error(
+        lambda: decision.receive_authorization_for_binding(
+            authorizer,
+            binding("epoch-pre-reset"),
+            decision_timeout_seconds=0.1,
+        ),
+        "live connection epoch",
+    )
+    require(not authorizer.has_active_run, "stale pre-reset binding mints no receipt")
+    try:
+        leaked = teacher_sock.recv(1)
+    except socket.timeout:
+        leaked = b""
+    require(leaked == b"", "stale binding is never published to teacher peer")
+    teacher_sock.close()
+    decision.close()
+
+
+def test_teacher_cannot_substitute_host_proposed_binding() -> None:
+    for changes, pattern in (
+        ({"profileId": "activity-2"}, "host-proposed run binding"),
+        ({"astBinding": "different-ast"}, "host-proposed run binding"),
+        ({"connectionEpoch": "epoch-forged"}, "host-proposed run binding"),
+        ({"challengeId": "wrong"}, "challenge correlation"),
+    ):
+        host_sock, teacher_sock = socket.socketpair()
+        decision = post_reset.PostResetTeacherDecisionChannel(host_sock, Epoch())
+        authorizer = auth.TrustedTeacherAuthorizer()
+        worker = Thread(
+            target=teacher_peer,
+            args=(teacher_sock,),
+            kwargs={"changes": changes},
+            daemon=True,
+        )
+        worker.start()
+        expect_error(
+            lambda: decision.receive_authorization_for_binding(
+                authorizer,
+                binding(),
+                decision_timeout_seconds=0.5,
+            ),
+            pattern,
+        )
+        worker.join(timeout=1.0)
+        require(not authorizer.has_active_run, "substitution mints no authority")
+        teacher_sock.close()
+        decision.close()
+
+
+def test_reconnect_denial_and_late_data_fail_closed() -> None:
+    host_sock, teacher_sock = socket.socketpair()
+    epoch = Epoch()
+    decision = post_reset.PostResetTeacherDecisionChannel(host_sock, epoch)
+    authorizer = auth.TrustedTeacherAuthorizer()
+    worker = Thread(
+        target=teacher_peer,
+        args=(teacher_sock,),
+        kwargs={"mutate_epoch": lambda: setattr(epoch, "value", "epoch-after-reconnect")},
+        daemon=True,
+    )
+    worker.start()
+    expect_error(
+        lambda: decision.receive_authorization_for_binding(
+            authorizer,
+            binding(),
+            decision_timeout_seconds=0.5,
+        ),
+        "epoch changed",
+    )
+    worker.join(timeout=1.0)
+    require(not authorizer.has_active_run, "reconnect mints no stale receipt")
+    teacher_sock.close()
+    decision.close()
+
+    host_sock, teacher_sock = socket.socketpair()
+    decision = post_reset.PostResetTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    worker = Thread(
+        target=teacher_peer,
+        args=(teacher_sock,),
+        kwargs={"approved": False},
+        daemon=True,
+    )
+    worker.start()
+    expect_error(
+        lambda: decision.receive_authorization_for_binding(
+            authorizer,
+            binding(),
+            decision_timeout_seconds=0.5,
+        ),
+        "explicitly denied",
+    )
+    worker.join(timeout=1.0)
+    require(not authorizer.has_active_run, "denial mints no receipt")
+    teacher_sock.close()
+    decision.close()
+
+    host_sock, teacher_sock = socket.socketpair()
+    decision = post_reset.PostResetTeacherDecisionChannel(host_sock, Epoch())
+    authorizer = auth.TrustedTeacherAuthorizer()
+    worker = Thread(
+        target=teacher_peer,
+        args=(teacher_sock,),
+        kwargs={"duplicate": True},
+        daemon=True,
+    )
+    worker.start()
+    expect_error(
+        lambda: decision.receive_authorization_for_binding(
+            authorizer,
+            binding(),
+            decision_timeout_seconds=0.5,
+        ),
+        "duplicate or late",
+    )
+    worker.join(timeout=1.0)
+    require(not authorizer.has_active_run, "late/duplicate data mints no receipt")
+    teacher_sock.close()
+    decision.close()
+
+
+def test_protocol_extension_has_no_effect_surface() -> None:
+    source = (PHYSICAL / "post_reset_teacher_decision.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "send_packet(",
+        "HighLevelCommander(",
+        "PowerSwitch(",
+        "stm_power_cycle(",
+        "send_setpoint(",
+        "send_emergency_stop(",
+    ):
+        require(forbidden not in source, "post-reset teacher protocol leaked effect: " + forbidden)
+    require(
+        '"teacher-run-binding-proposal"' in source,
+        "host-first exact binding proposal must be explicit",
+    )
+    require(
+        "TrustedTeacherAuthorizer" in source and "PhysicalRunBinding" in source,
+        "extension must reuse integrated #267 authority primitive",
+    )
+
+
+def main() -> int:
+    test_host_first_exact_post_reset_binding_mints_receipt()
+    test_stale_pre_reset_epoch_fails_before_publication()
+    test_teacher_cannot_substitute_host_proposed_binding()
+    test_reconnect_denial_and_late_data_fail_closed()
+    test_protocol_extension_has_no_effect_surface()
+    print(
+        "PASS post-reset teacher binding bootstrap publishes the exact host-owned new epoch "
+        "on the existing trusted channel and mints only one correlated #267 receipt"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_teacher_run_authorization.py
+++ b/tools/ci/test_teacher_run_authorization.py
@@ -236,9 +236,9 @@ def test_binding_validation() -> None:
         )
 
 
-def test_trusted_teacher_decision_channel_contract() -> None:
+def _run_contract(path: str, marker: str, failure: str) -> None:
     result = subprocess.run(
-        [sys.executable, "tools/ci/test_teacher_decision_channel.py"],
+        [sys.executable, path],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -246,10 +246,23 @@ def test_trusted_teacher_decision_channel_contract() -> None:
     if result.returncode:
         print(result.stdout, file=sys.stderr)
         print(result.stderr, file=sys.stderr)
-        raise AssertionError("trusted teacher decision channel regression failed")
-    require(
-        "PASS trusted teacher decision channel" in result.stdout,
-        "trusted teacher decision channel PASS marker",
+        raise AssertionError(failure)
+    require(marker in result.stdout, marker + " PASS marker")
+
+
+def test_trusted_teacher_decision_channel_contract() -> None:
+    _run_contract(
+        "tools/ci/test_teacher_decision_channel.py",
+        "PASS trusted teacher decision channel",
+        "trusted teacher decision channel regression failed",
+    )
+
+
+def test_post_reset_teacher_binding_contract() -> None:
+    _run_contract(
+        "tools/ci/test_post_reset_teacher_decision.py",
+        "PASS post-reset teacher binding bootstrap",
+        "post-reset teacher binding regression failed",
     )
 
 
@@ -261,6 +274,7 @@ def main() -> int:
     test_receipt_cannot_be_minted_or_restored_from_serialized_identity()
     test_binding_validation()
     test_trusted_teacher_decision_channel_contract()
+    test_post_reset_teacher_binding_contract()
     print(
         "PASS host-only teacher run authorization: one explicit decision binds one exact "
         "profile/AST/epoch run and every effect boundary re-checks it"

--- a/tools/physical/post_reset_teacher_decision.py
+++ b/tools/physical/post_reset_teacher_decision.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Host-first post-reset teacher binding decision on the existing trusted socket.
+
+This is a no-effect protocol prerequisite for the #287 physical-run composition.
+After #266 has established a genuinely new live connection epoch, the trusted
+physical host already owns the exact non-authority profile/canonical-AST binding
+that must be approved. The teacher peer must not guess that host-minted epoch.
+
+``PostResetTeacherDecisionChannel`` therefore reuses the exact launcher-installed
+socket and fail-closed machinery from #288, but the host sends the exact binding
+proposal first. A correlated explicit teacher decision still mints the existing
+#267 process-local receipt through ``TrustedTeacherAuthorizer``. The proposal and
+decision remain ``executionAuthority:false`` data; neither message is a physical
+effect capability.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from teacher_decision_channel import (
+    TeacherDecisionChannelError,
+    TrustedTeacherDecisionChannel,
+    _read_epoch,
+    _require_timeout,
+)
+from teacher_run_authorization import (
+    PhysicalRunBinding,
+    TeacherRunAuthorization,
+    TeacherRunAuthorizationError,
+    TrustedTeacherAuthorizer,
+)
+
+
+class PostResetTeacherDecisionChannel(TrustedTeacherDecisionChannel):
+    """One host-first exact-binding decision on the #288 trusted socket."""
+
+    def receive_authorization_for_binding(
+        self,
+        authorizer: TrustedTeacherAuthorizer,
+        binding: PhysicalRunBinding,
+        *,
+        decision_timeout_seconds: float = 5.0,
+    ) -> TeacherRunAuthorization:
+        """Publish one host-owned post-reset binding, then require explicit approval."""
+        if type(authorizer) is not TrustedTeacherAuthorizer:
+            raise TeacherDecisionChannelError(
+                "exact trusted teacher authorizer is required"
+            )
+        if type(binding) is not PhysicalRunBinding:
+            raise TeacherDecisionChannelError(
+                "exact host-owned physical run binding is required"
+            )
+        timeout = _require_timeout(decision_timeout_seconds)
+
+        with self._lock:
+            if self._terminal:
+                raise TeacherDecisionChannelError(
+                    "teacher decision channel is terminal: "
+                    + (self._terminal_reason or "prior decision consumed")
+                )
+            if self._started:
+                raise TeacherDecisionChannelError(
+                    "teacher decision channel already has an active exchange"
+                )
+            self._started = True
+
+        receipt: TeacherRunAuthorization | None = None
+        try:
+            before_epoch = _read_epoch(self._epoch_reader)
+            if binding.connection_epoch != before_epoch:
+                raise TeacherDecisionChannelError(
+                    "host teacher binding does not match the live connection epoch"
+                )
+
+            request_id = secrets.token_urlsafe(24)
+            challenge_id = self._challenge_id()
+            proposal = {
+                "op": "teacher-run-binding-proposal",
+                "requestId": request_id,
+                "challengeId": challenge_id,
+                "profileId": binding.profile_id,
+                "astBinding": binding.ast_binding,
+                "connectionEpoch": binding.connection_epoch,
+                "executionAuthority": False,
+            }
+            self._send_json_line(proposal, timeout)
+            response = self._recv_json_line(timeout)
+
+            if set(response) != {
+                "op",
+                "requestId",
+                "challengeId",
+                "profileId",
+                "astBinding",
+                "connectionEpoch",
+                "approved",
+                "executionAuthority",
+            }:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has unsupported fields"
+                )
+            if response.get("op") != "teacher-run-decision-result":
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has the wrong operation"
+                )
+            if response.get("requestId") != request_id:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has the wrong request correlation"
+                )
+            if response.get("challengeId") != challenge_id:
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply has the wrong challenge correlation"
+                )
+            if response.get("executionAuthority") is not False:
+                raise TeacherDecisionChannelError(
+                    "teacher decision transport must remain non-authority data"
+                )
+            if (
+                response.get("profileId") != binding.profile_id
+                or response.get("astBinding") != binding.ast_binding
+                or response.get("connectionEpoch") != binding.connection_epoch
+            ):
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply does not match the host-proposed run binding"
+                )
+            approved = response.get("approved")
+            if not isinstance(approved, bool):
+                raise TeacherDecisionChannelError(
+                    "teacher decision reply must contain a boolean approved value"
+                )
+
+            if _read_epoch(self._epoch_reader) != before_epoch:
+                raise TeacherDecisionChannelError(
+                    "connection epoch changed during teacher decision"
+                )
+            if approved is not True:
+                raise TeacherDecisionChannelError(
+                    "teacher explicitly denied this physical run"
+                )
+
+            self._require_peer_write_closed(timeout)
+            if _read_epoch(self._epoch_reader) != before_epoch:
+                raise TeacherDecisionChannelError(
+                    "connection epoch changed while sealing teacher decision"
+                )
+
+            try:
+                receipt = authorizer.authorize_run(
+                    binding,
+                    lambda exact_binding: exact_binding == binding,
+                )
+            except TeacherRunAuthorizationError as exc:
+                raise TeacherDecisionChannelError(
+                    "teacher authorization receipt could not be minted"
+                ) from exc
+
+            if _read_epoch(self._epoch_reader) != before_epoch:
+                try:
+                    authorizer.close_run(
+                        receipt,
+                        "connection epoch changed while minting teacher authorization",
+                    )
+                except TeacherRunAuthorizationError:
+                    receipt.invalidate(
+                        "connection epoch changed while minting teacher authorization"
+                    )
+                raise TeacherDecisionChannelError(
+                    "connection epoch changed while minting teacher authorization"
+                )
+            if (
+                type(receipt) is not TeacherRunAuthorization
+                or receipt.binding != binding
+                or receipt.active is not True
+            ):
+                if type(receipt) is TeacherRunAuthorization:
+                    try:
+                        authorizer.close_run(
+                            receipt,
+                            "invalid teacher authorization receipt",
+                        )
+                    except TeacherRunAuthorizationError:
+                        receipt.invalidate("invalid teacher authorization receipt")
+                raise TeacherDecisionChannelError(
+                    "teacher authorization receipt does not match the approved run"
+                )
+
+            self._finish("teacher decision consumed")
+            return receipt
+        except Exception as exc:
+            if receipt is not None and receipt.active:
+                try:
+                    authorizer.close_run(receipt, "teacher decision failed closed")
+                except TeacherRunAuthorizationError:
+                    receipt.invalidate("teacher decision failed closed")
+            with self._lock:
+                already_terminal = self._terminal
+            if not already_terminal:
+                self._finish(exc)
+            if isinstance(exc, TeacherDecisionChannelError):
+                raise
+            if isinstance(exc, TeacherRunAuthorizationError):
+                raise TeacherDecisionChannelError(str(exc)) from exc
+            raise TeacherDecisionChannelError(
+                "teacher decision failed closed"
+            ) from exc


### PR DESCRIPTION
Adds the smallest no-effect prerequisite identified on #287 after integrated #266/#288.

#266 rotates the connection epoch, while #288's existing teacher-first request requires the peer to already know that exact host-minted post-reset epoch. This slice keeps the same distinct launcher-installed teacher socket and adds a host-first `PostResetTeacherDecisionChannel`: after trusted host composition has a post-reset `PhysicalRunBinding`, it publishes the exact profile/canonical AST/new epoch as `executionAuthority:false`, correlates one explicit teacher decision, seals peer write EOF, rechecks the live epoch throughout, and mints the existing #267 process-local receipt.

Stale pre-reset epoch fails before publication. The teacher peer cannot substitute profile/AST/epoch/correlation. Reconnect, denial and late/duplicate data fail closed. No physical reset/effect API is added, and the existing #288 teacher-first protocol remains unchanged.

Core CI runs the deterministic regressions through the existing teacher-authorization harness.

This PR does not itself perform #266 reset, modify `serve_physical_host.py`, complete #287, or authorize takeoff/flight/testing. It only makes the required post-reset teacher decision protocol executable for the later production-host path.

Refs #287 #266 #288 #267 #157.