### PR TITLE
Preserve capability bridge across trusted reset

### DIFF
--- a/tools/ci/test_post_reset_capability_bridge.py
+++ b/tools/ci/test_post_reset_capability_bridge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
-from threading import Thread
+from threading import Event, Thread
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
@@ -33,6 +33,22 @@ class FakeSession:
         }
 
 
+class BlockingFirstEpochSession(FakeSession):
+    def __init__(self, epoch: str, label: str) -> None:
+        super().__init__(epoch, label)
+        self.first_read_started = Event()
+        self.release_first_read = Event()
+        self._read_count = 0
+
+    def read_connection_epoch(self) -> str:
+        self._read_count += 1
+        if self._read_count == 1:
+            self.first_read_started.set()
+            if not self.release_first_read.wait(1.0):
+                raise RuntimeError("test did not release first epoch read")
+        return super().read_connection_epoch()
+
+
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
@@ -56,7 +72,94 @@ def expect_error(callable_, pattern: str) -> None:
     raise AssertionError("expected CapabilityBridgeError containing " + repr(pattern))
 
 
+def test_assertion_admission_cannot_race_replacement() -> None:
+    """Force the old pre-read/pending-registration race and prove it is closed."""
+    before = BlockingFirstEpochSession("epoch-race", "race")
+    bridge = rebind.PostResetCapabilityHttpBridge(
+        before,
+        token="race-capability-token",
+        preflight_responder_token="race-responder-token",
+    )
+    assertion_outcome: dict[str, object] = {}
+    replacement_outcome: dict[str, object] = {}
+
+    def assert_current() -> None:
+        try:
+            assertion_outcome["evidence"] = bridge.assert_current_program(
+                profile_id="activity-race",
+                ast_binding="ast-race",
+                connection_epoch="epoch-race",
+                timeout_seconds=0.5,
+            )
+        except Exception as exc:
+            assertion_outcome["error"] = exc
+
+    def begin_replacement() -> None:
+        try:
+            bridge.begin_post_reset_replacement("epoch-race")
+            replacement_outcome["started"] = True
+        except Exception as exc:
+            replacement_outcome["error"] = exc
+
+    assertion = Thread(target=assert_current, daemon=True)
+    assertion.start()
+    require(
+        before.first_read_started.wait(1.0),
+        "current-program assertion did not reach its first epoch read",
+    )
+
+    replacement = Thread(target=begin_replacement, daemon=True)
+    replacement.start()
+    replacement.join(timeout=0.02)
+    require(
+        replacement.is_alive(),
+        "replacement crossed the assertion pre-read/pending-registration window",
+    )
+
+    before.release_first_read.set()
+    replacement.join(timeout=1.0)
+    require(not replacement.is_alive(), "replacement attempt did not settle")
+    error = replacement_outcome.get("error")
+    require(
+        isinstance(error, rebind.CapabilityBridgeError)
+        and "during current-program assertion" in str(error),
+        "replacement must reject once the admitted assertion publishes its pending challenge",
+    )
+    require(
+        "started" not in replacement_outcome,
+        "replacement must not invalidate the bridge across an admitted assertion",
+    )
+
+    challenge_id = bridge._claim_current_program_challenge(timeout_seconds=0.2)
+    require(isinstance(challenge_id, str) and challenge_id, "race assertion challenge")
+    bridge._submit_current_program_assertion(
+        {
+            "challengeId": challenge_id,
+            "ok": True,
+            "profileId": "activity-race",
+            "astBinding": "ast-race",
+            "connectionEpoch": "epoch-race",
+            "executionAuthority": False,
+        }
+    )
+    assertion.join(timeout=1.0)
+    require(not assertion.is_alive(), "current-program assertion did not settle")
+    require("error" not in assertion_outcome, "admitted assertion must complete normally")
+    evidence = assertion_outcome.get("evidence")
+    require(
+        getattr(evidence, "connection_epoch", None) == "epoch-race",
+        "completed assertion remains bound to the unchanged pre-reset epoch",
+    )
+    require(
+        not bridge.post_reset_replacement_pending,
+        "failed concurrent replacement cannot leave a replacement marker",
+    )
+    bridge.shutdown()
+
+
 def main() -> int:
+    test_assertion_admission_cannot_race_replacement()
+
     before = FakeSession("epoch-before", "before")
     after = FakeSession("epoch-after", "after")
     bridge = rebind.PostResetCapabilityHttpBridge(
@@ -176,7 +279,7 @@ def main() -> int:
 
     print(
         "PASS post-reset capability bridge preserves trusted loopback identity "
-        "while stale epochs fail closed"
+        "while stale epochs and assertion/replacement races fail closed"
     )
     return 0
 

--- a/tools/ci/test_post_reset_capability_bridge.py
+++ b/tools/ci/test_post_reset_capability_bridge.py
@@ -72,6 +72,46 @@ def expect_error(callable_, pattern: str) -> None:
     raise AssertionError("expected CapabilityBridgeError containing " + repr(pattern))
 
 
+def test_direct_session_assignment_cannot_bypass_replacement() -> None:
+    before = FakeSession("epoch-before-direct", "before-direct")
+    bridge = rebind.PostResetCapabilityHttpBridge(
+        before,
+        token="direct-capability-token",
+        preflight_responder_token="direct-responder-token",
+    )
+    host, port = bridge.address
+    base = f"http://{host}:{port}"
+    worker = Thread(target=bridge.serve_forever, daemon=True)
+    worker.start()
+    try:
+        for replacement in (
+            FakeSession("epoch-before-direct", "same-epoch-direct"),
+            FakeSession("epoch-different-direct", "different-epoch-direct"),
+        ):
+            expect_error(
+                lambda replacement=replacement: setattr(bridge, "session", replacement),
+                "explicit post-reset protocol",
+            )
+            require(
+                not bridge.post_reset_replacement_pending,
+                "rejected direct assignment cannot start replacement",
+            )
+            status, payload = request(base + "/v1/connection-epoch", bridge.token)
+            require(
+                status == 200
+                and payload == {"connectionEpoch": "epoch-before-direct"},
+                "rejected direct assignment cannot change observable epoch",
+            )
+            status, payload = request(base + "/v1/capabilities", bridge.token)
+            require(
+                status == 200 and payload["evidence"]["label"] == "before-direct",
+                "rejected direct assignment cannot change capability view",
+            )
+    finally:
+        bridge.shutdown()
+        worker.join(timeout=1.0)
+
+
 def test_assertion_admission_cannot_race_replacement() -> None:
     """Force the old pre-read/pending-registration race and prove it is closed."""
     before = BlockingFirstEpochSession("epoch-race", "race")
@@ -158,6 +198,7 @@ def test_assertion_admission_cannot_race_replacement() -> None:
 
 
 def main() -> int:
+    test_direct_session_assignment_cannot_bypass_replacement()
     test_assertion_admission_cannot_race_replacement()
 
     before = FakeSession("epoch-before", "before")

--- a/tools/ci/test_post_reset_capability_bridge.py
+++ b/tools/ci/test_post_reset_capability_bridge.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from threading import Thread
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+if str(PHYSICAL) not in sys.path:
+    sys.path.insert(0, str(PHYSICAL))
+
+import post_reset_capability_bridge as rebind  # noqa: E402
+
+
+class FakeSession:
+    def __init__(self, epoch: str, label: str) -> None:
+        self.epoch = epoch
+        self.label = label
+
+    def read_connection_epoch(self) -> str:
+        return self.epoch
+
+    def read_capabilities(self) -> dict[str, object]:
+        return {
+            "connected": True,
+            "executionAuthority": False,
+            "identity": {"model": "crazyflie-2.1", "modelEvidence": "verified"},
+            "evidence": {"label": self.label},
+        }
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def request(url: str, token: str) -> tuple[int, object]:
+    req = Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urlopen(req, timeout=1.0) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except rebind.CapabilityBridgeError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError("expected CapabilityBridgeError containing " + repr(pattern))
+
+
+def main() -> int:
+    before = FakeSession("epoch-before", "before")
+    after = FakeSession("epoch-after", "after")
+    bridge = rebind.PostResetCapabilityHttpBridge(
+        before,
+        token="capability-token",
+        preflight_responder_token="responder-token",
+    )
+    host, port = bridge.address
+    base = f"http://{host}:{port}"
+    worker = Thread(target=bridge.serve_forever, daemon=True)
+    worker.start()
+    try:
+        original_address = bridge.address
+        original_token = bridge.token
+        original_responder_token = bridge.preflight_responder_token
+
+        status, payload = request(base + "/v1/connection-epoch", bridge.token)
+        require(
+            status == 200 and payload == {"connectionEpoch": "epoch-before"},
+            "pre-reset epoch",
+        )
+
+        expect_error(
+            lambda: bridge.begin_post_reset_replacement("wrong-epoch"),
+            "does not match replacement epoch",
+        )
+        require(
+            not bridge.post_reset_replacement_pending,
+            "wrong old epoch cannot invalidate bridge",
+        )
+
+        bridge.begin_post_reset_replacement("epoch-before")
+        require(
+            bridge.post_reset_replacement_pending,
+            "replacement becomes fail-closed pending",
+        )
+        status, payload = request(base + "/v1/connection-epoch", bridge.token)
+        require(
+            status == 409 and "replacement" in payload["error"],
+            "reads fail during replacement",
+        )
+        expect_error(
+            lambda: bridge.assert_current_program(
+                profile_id="activity-1",
+                ast_binding="ast-1",
+                connection_epoch="epoch-before",
+                timeout_seconds=0.05,
+            ),
+            "replacement",
+        )
+
+        same_epoch = FakeSession("epoch-before", "forged-same")
+        expect_error(
+            lambda: bridge.install_post_reset_session(same_epoch),
+            "reused the previous connection epoch",
+        )
+        require(
+            bridge.post_reset_replacement_pending,
+            "same epoch cannot reopen bridge",
+        )
+
+        installed = bridge.install_post_reset_session(after)
+        require(installed == "epoch-after", "new exact epoch returned")
+        require(
+            not bridge.post_reset_replacement_pending,
+            "new epoch completes replacement",
+        )
+        require(
+            bridge.address == original_address,
+            "loopback address stays stable across reset",
+        )
+        require(
+            bridge.token == original_token,
+            "capability bearer stays stable across reset",
+        )
+        require(
+            bridge.preflight_responder_token == original_responder_token,
+            "trusted #249 responder bearer stays stable across reset",
+        )
+        status, payload = request(base + "/v1/connection-epoch", bridge.token)
+        require(
+            status == 200 and payload == {"connectionEpoch": "epoch-after"},
+            "post-reset epoch visible",
+        )
+        status, payload = request(base + "/v1/capabilities", bridge.token)
+        require(
+            status == 200 and payload["evidence"]["label"] == "after",
+            "new read-only view installed",
+        )
+        require(
+            payload["executionAuthority"] is False,
+            "replacement never creates authority",
+        )
+
+        expect_error(
+            lambda: bridge.install_post_reset_session(
+                FakeSession("epoch-third", "third")
+            ),
+            "was not started",
+        )
+
+        for forbidden in (
+            "takeoff",
+            "land",
+            "move",
+            "send_packet",
+            "stm_power_cycle",
+            "authorize_run",
+        ):
+            require(
+                not hasattr(bridge, forbidden),
+                "rebind bridge exposes effect: " + forbidden,
+            )
+    finally:
+        bridge.shutdown()
+        worker.join(timeout=1.0)
+
+    print(
+        "PASS post-reset capability bridge preserves trusted loopback identity "
+        "while stale epochs fail closed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_post_reset_capability_bridge.py
+++ b/tools/ci/test_post_reset_capability_bridge.py
@@ -49,6 +49,19 @@ class BlockingFirstEpochSession(FakeSession):
         return super().read_connection_epoch()
 
 
+class BlockingCapabilitySession(FakeSession):
+    def __init__(self, epoch: str, label: str) -> None:
+        super().__init__(epoch, label)
+        self.capability_read_started = Event()
+        self.release_capability_read = Event()
+
+    def read_capabilities(self) -> dict[str, object]:
+        self.capability_read_started.set()
+        if not self.release_capability_read.wait(1.0):
+            raise RuntimeError("test did not release capability read")
+        return super().read_capabilities()
+
+
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
@@ -110,6 +123,74 @@ def test_direct_session_assignment_cannot_bypass_replacement() -> None:
     finally:
         bridge.shutdown()
         worker.join(timeout=1.0)
+
+
+def test_capability_http_read_is_drained_before_replacement_begin() -> None:
+    before = BlockingCapabilitySession("epoch-http-race", "http-race")
+    bridge = rebind.PostResetCapabilityHttpBridge(
+        before,
+        token="http-race-capability-token",
+        preflight_responder_token="http-race-responder-token",
+    )
+    host, port = bridge.address
+    base = f"http://{host}:{port}"
+    worker = Thread(target=bridge.serve_forever, daemon=True)
+    worker.start()
+    read_outcome: dict[str, object] = {}
+    replacement_outcome: dict[str, object] = {}
+
+    def read_capabilities() -> None:
+        try:
+            read_outcome["result"] = request(base + "/v1/capabilities", bridge.token)
+        except Exception as exc:
+            read_outcome["error"] = exc
+
+    def begin_replacement() -> None:
+        try:
+            bridge.begin_post_reset_replacement("epoch-http-race")
+            replacement_outcome["started"] = True
+        except Exception as exc:
+            replacement_outcome["error"] = exc
+
+    reader = Thread(target=read_capabilities, daemon=True)
+    reader.start()
+    require(
+        before.capability_read_started.wait(1.0),
+        "HTTP capability read did not enter the old session",
+    )
+
+    replacement = Thread(target=begin_replacement, daemon=True)
+    replacement.start()
+    replacement.join(timeout=0.02)
+    require(
+        replacement.is_alive(),
+        "replacement begin returned while an admitted old capability read was still blocked",
+    )
+
+    before.release_capability_read.set()
+    reader.join(timeout=1.0)
+    replacement.join(timeout=1.0)
+    require(not reader.is_alive(), "old capability read did not settle")
+    require(not replacement.is_alive(), "replacement begin did not settle after draining read")
+    require("error" not in read_outcome, "admitted old capability read must settle normally")
+    status, payload = read_outcome["result"]
+    require(
+        status == 200 and payload["evidence"]["label"] == "http-race",
+        "the admitted pre-cutover capability response must complete before the cutover returns",
+    )
+    require(
+        replacement_outcome.get("started") is True and "error" not in replacement_outcome,
+        "replacement must begin only after the admitted old read has drained",
+    )
+
+    status, payload = request(base + "/v1/capabilities", bridge.token)
+    require(
+        status == 409 and "replacement" in payload["error"],
+        "new capability reads must fail closed after replacement begins",
+    )
+
+    bridge.shutdown()
+    worker.join(timeout=1.0)
 
 
 def test_assertion_admission_cannot_race_replacement() -> None:
@@ -199,6 +280,7 @@ def test_assertion_admission_cannot_race_replacement() -> None:
 
 def main() -> int:
     test_direct_session_assignment_cannot_bypass_replacement()
+    test_capability_http_read_is_drained_before_replacement_begin()
     test_assertion_admission_cannot_race_replacement()
 
     before = FakeSession("epoch-before", "before")

--- a/tools/ci/test_post_reset_capability_bridge.py
+++ b/tools/ci/test_post_reset_capability_bridge.py
@@ -123,6 +123,7 @@ def test_direct_session_assignment_cannot_bypass_replacement() -> None:
     finally:
         bridge.shutdown()
         worker.join(timeout=1.0)
+        require(not worker.is_alive(), "direct-assignment bridge worker did not stop")
 
 
 def test_capability_http_read_is_drained_before_replacement_begin() -> None:
@@ -191,6 +192,7 @@ def test_capability_http_read_is_drained_before_replacement_begin() -> None:
 
     bridge.shutdown()
     worker.join(timeout=1.0)
+    require(not worker.is_alive(), "capability-race bridge worker did not stop")
 
 
 def test_assertion_admission_cannot_race_replacement() -> None:
@@ -201,6 +203,8 @@ def test_assertion_admission_cannot_race_replacement() -> None:
         token="race-capability-token",
         preflight_responder_token="race-responder-token",
     )
+    worker = Thread(target=bridge.serve_forever, daemon=True)
+    worker.start()
     assertion_outcome: dict[str, object] = {}
     replacement_outcome: dict[str, object] = {}
 
@@ -276,6 +280,8 @@ def test_assertion_admission_cannot_race_replacement() -> None:
         "failed concurrent replacement cannot leave a replacement marker",
     )
     bridge.shutdown()
+    worker.join(timeout=1.0)
+    require(not worker.is_alive(), "assertion-race bridge worker did not stop")
 
 
 def main() -> int:
@@ -399,6 +405,7 @@ def main() -> int:
     finally:
         bridge.shutdown()
         worker.join(timeout=1.0)
+        require(not worker.is_alive(), "main bridge worker did not stop")
 
     print(
         "PASS post-reset capability bridge preserves trusted loopback identity "

--- a/tools/ci/test_teacher_run_authorization.py
+++ b/tools/ci/test_teacher_run_authorization.py
@@ -266,6 +266,14 @@ def test_post_reset_teacher_binding_contract() -> None:
     )
 
 
+def test_post_reset_capability_bridge_contract() -> None:
+    _run_contract(
+        "tools/ci/test_post_reset_capability_bridge.py",
+        "PASS post-reset capability bridge",
+        "post-reset capability bridge regression failed",
+    )
+
+
 def main() -> int:
     test_exact_binding_authorizes_one_run()
     test_denial_non_boolean_and_decision_failure_fail_closed()
@@ -275,6 +283,7 @@ def main() -> int:
     test_binding_validation()
     test_trusted_teacher_decision_channel_contract()
     test_post_reset_teacher_binding_contract()
+    test_post_reset_capability_bridge_contract()
     print(
         "PASS host-only teacher run authorization: one explicit decision binds one exact "
         "profile/AST/epoch run and every effect boundary re-checks it"

--- a/tools/physical/post_reset_capability_bridge.py
+++ b/tools/physical/post_reset_capability_bridge.py
@@ -16,11 +16,25 @@ from __future__ import annotations
 
 from threading import RLock
 
+from probe_reference_hardware import ProbeError
 from serve_reference_capabilities import (
     CapabilityBridgeError,
     ReadOnlyCapabilityHttpBridge,
     _require_text,
 )
+
+
+class _LockedSessionView:
+    """Read-only session facade whose calls stay inside the reset cutover lock."""
+
+    def __init__(self, bridge: "PostResetCapabilityHttpBridge") -> None:
+        self._bridge = bridge
+
+    def read_connection_epoch(self):
+        return self._bridge._read_current_session("read_connection_epoch")
+
+    def read_capabilities(self):
+        return self._bridge._read_current_session("read_capabilities")
 
 
 class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
@@ -29,6 +43,7 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
     def __init__(self, session: object, **kwargs) -> None:
         self._session_lock = RLock()
         self._session: object | None = None
+        self._session_view = _LockedSessionView(self)
         self._base_session_assignment_open = True
         self._replacement_previous_epoch: str | None = None
         try:
@@ -36,16 +51,31 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
         finally:
             self._base_session_assignment_open = False
 
+    def _current_session_locked(self) -> object:
+        if self._replacement_previous_epoch is not None:
+            raise CapabilityBridgeError(
+                "capability bridge session is unavailable during post-reset replacement"
+            )
+        if self._session is None:
+            raise CapabilityBridgeError("capability bridge session is unavailable")
+        return self._session
+
+    def _read_current_session(self, method_name: str):
+        """Keep direct bridge reads linearized against replacement begin/install."""
+        with self._session_lock:
+            session = self._current_session_locked()
+            method = getattr(session, method_name, None)
+            if not callable(method):
+                raise CapabilityBridgeError(
+                    "capability bridge session does not expose " + method_name
+                )
+            return method()
+
     @property
     def session(self) -> object:
-        with self._session_lock:
-            if self._replacement_previous_epoch is not None:
-                raise CapabilityBridgeError(
-                    "capability bridge session is unavailable during post-reset replacement"
-                )
-            if self._session is None:
-                raise CapabilityBridgeError("capability bridge session is unavailable")
-            return self._session
+        # The base bridge calls ``self.session.read_*``. Return a facade rather
+        # than the raw session so the actual read stays inside ``_session_lock``.
+        return self._session_view
 
     @session.setter
     def session(self, value: object) -> None:
@@ -59,6 +89,46 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
                 )
             self._session = value
             self._base_session_assignment_open = False
+
+    def _handler_type(self):
+        """Linearize successful HTTP capability replies with the reset cutover.
+
+        The base handler obtains ``bridge.session`` and only then invokes the
+        session method. A property-level lock therefore ends too early: reset can
+        begin while the old read is still running. For the two ordinary read-only
+        endpoints, keep ``_session_lock`` through both the physical read and the
+        response write. Consequently ``begin_post_reset_replacement()`` cannot
+        return while an admitted old-session HTTP view can still be published,
+        and any request admitted after that edge sees replacement-pending and
+        fails closed. The trusted preflight-responder endpoint remains delegated
+        to the base implementation and is fenced separately by
+        ``_preflight_condition`` below.
+        """
+        base_handler = super()._handler_type()
+        bridge = self
+
+        class Handler(base_handler):
+            def do_GET(self) -> None:  # noqa: N802
+                if self.path not in {"/v1/connection-epoch", "/v1/capabilities"}:
+                    super().do_GET()
+                    return
+                if not self._capability_authorized():
+                    self._json(401, {"error": "unauthorized"})
+                    return
+                try:
+                    with bridge._session_lock:
+                        session = bridge._current_session_locked()
+                        if self.path == "/v1/connection-epoch":
+                            payload = {
+                                "connectionEpoch": session.read_connection_epoch()
+                            }
+                        else:
+                            payload = session.read_capabilities()
+                        self._json(200, payload)
+                except (ProbeError, CapabilityBridgeError) as exc:
+                    self._json(409, {"error": str(exc)})
+
+        return Handler
 
     @property
     def post_reset_replacement_pending(self) -> bool:
@@ -102,7 +172,9 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
         This method is intended to be the #266 ``invalidate_prior_evidence``
         collaborator. Once it succeeds there is deliberately no rollback to the
         old session: an ambiguous reset must not make stale pre-reset evidence
-        reusable.
+        reusable. Acquiring ``_session_lock`` after the assertion fence also
+        drains any already-admitted ordinary capability response before this
+        cutover returns.
         """
         expected = _require_text(expected_connection_epoch, "connectionEpoch")
         with self._preflight_condition:

--- a/tools/physical/post_reset_capability_bridge.py
+++ b/tools/physical/post_reset_capability_bridge.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fail-closed post-reset rebinding for the trusted read-only capability bridge.
+
+#266 replaces the live Crazyflie connection and therefore its opaque connection
+epoch, while the production browser responder already holds the one-time loopback
+bridge URL and bearer tokens. Recreating an unrelated HTTP bridge would strand
+that trusted responder. This module preserves the existing bridge identity and
+makes the session handoff explicit: once replacement begins, capability reads and
+#249 assertions fail closed until a genuinely new live epoch is installed.
+
+This is non-authority plumbing. It emits no CRTP command, exposes no raw
+Crazyflie object and cannot mint execution authority.
+"""
+
+from __future__ import annotations
+
+from threading import RLock
+
+from serve_reference_capabilities import (
+    CapabilityBridgeError,
+    ReadOnlyCapabilityHttpBridge,
+    _require_text,
+)
+
+
+class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
+    """One loopback bridge whose read-only session may rotate exactly at #266."""
+
+    def __init__(self, session: object, **kwargs) -> None:
+        self._session_lock = RLock()
+        self._session = session
+        self._replacement_previous_epoch: str | None = None
+        super().__init__(session, **kwargs)
+
+    @property
+    def session(self) -> object:
+        with self._session_lock:
+            if self._replacement_previous_epoch is not None:
+                raise CapabilityBridgeError(
+                    "capability bridge session is unavailable during post-reset replacement"
+                )
+            return self._session
+
+    @session.setter
+    def session(self, value: object) -> None:
+        # Base construction assigns ``session`` once. Later rotation is permitted
+        # only through the explicit two-phase methods below.
+        with self._session_lock:
+            self._session = value
+
+    @property
+    def post_reset_replacement_pending(self) -> bool:
+        with self._session_lock:
+            return self._replacement_previous_epoch is not None
+
+    def begin_post_reset_replacement(self, expected_connection_epoch: str) -> None:
+        """Invalidate the current bridge view immediately before #266 reset.
+
+        This method is intended to be the #266 ``invalidate_prior_evidence``
+        collaborator. Once it succeeds there is deliberately no rollback to the
+        old session: an ambiguous reset must not make stale pre-reset evidence
+        reusable.
+        """
+        expected = _require_text(expected_connection_epoch, "connectionEpoch")
+        with self._preflight_condition:
+            if self._preflight_closed:
+                raise CapabilityBridgeError("capability bridge is shut down")
+            if self._preflight_pending is not None:
+                raise CapabilityBridgeError(
+                    "cannot replace capability session during current-program assertion"
+                )
+            with self._session_lock:
+                if self._replacement_previous_epoch is not None:
+                    raise CapabilityBridgeError(
+                        "post-reset capability session replacement is already pending"
+                    )
+                current = self._session
+                try:
+                    observed = current.read_connection_epoch()
+                except Exception as exc:
+                    raise CapabilityBridgeError(
+                        "current capability session epoch is unavailable before replacement"
+                    ) from exc
+                if observed != expected:
+                    raise CapabilityBridgeError(
+                        "current capability session does not match replacement epoch"
+                    )
+                self._replacement_previous_epoch = expected
+            self._preflight_condition.notify_all()
+
+    def install_post_reset_session(self, session: object) -> str:
+        """Install a live read-only view only when its epoch is genuinely new."""
+        if session is None:
+            raise CapabilityBridgeError("post-reset capability session is required")
+        try:
+            new_epoch = _require_text(
+                session.read_connection_epoch(),
+                "post-reset connectionEpoch",
+            )
+        except CapabilityBridgeError:
+            raise
+        except Exception as exc:
+            raise CapabilityBridgeError(
+                "post-reset capability session epoch is unavailable"
+            ) from exc
+
+        with self._preflight_condition:
+            if self._preflight_closed:
+                raise CapabilityBridgeError("capability bridge is shut down")
+            if self._preflight_pending is not None:
+                raise CapabilityBridgeError(
+                    "cannot install capability session during current-program assertion"
+                )
+            with self._session_lock:
+                previous = self._replacement_previous_epoch
+                if previous is None:
+                    raise CapabilityBridgeError(
+                        "post-reset capability session replacement was not started"
+                    )
+                if new_epoch == previous:
+                    raise CapabilityBridgeError(
+                        "post-reset capability session reused the previous connection epoch"
+                    )
+                self._session = session
+                self._replacement_previous_epoch = None
+            self._preflight_condition.notify_all()
+        return new_epoch

--- a/tools/physical/post_reset_capability_bridge.py
+++ b/tools/physical/post_reset_capability_bridge.py
@@ -53,6 +53,37 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
         with self._session_lock:
             return self._replacement_previous_epoch is not None
 
+    def assert_current_program(
+        self,
+        *,
+        profile_id: str,
+        ast_binding: str,
+        connection_epoch: str,
+        timeout_seconds: float = 1.0,
+    ):
+        """Serialize #249 assertion admission against the #266 replacement edge.
+
+        The base bridge reads the epoch immediately before registering its pending
+        challenge. Without this outer condition there is a narrow race where a
+        reset replacement can begin after that first read but before the pending
+        challenge becomes visible. Holding the same re-entrant condition across
+        admission closes that gap. During the base wait the condition is released,
+        but the pending challenge is already installed, so replacement still
+        rejects rather than crossing an in-flight assertion.
+        """
+        with self._preflight_condition:
+            with self._session_lock:
+                if self._replacement_previous_epoch is not None:
+                    raise CapabilityBridgeError(
+                        "capability bridge session is unavailable during post-reset replacement"
+                    )
+            return super().assert_current_program(
+                profile_id=profile_id,
+                ast_binding=ast_binding,
+                connection_epoch=connection_epoch,
+                timeout_seconds=timeout_seconds,
+            )
+
     def begin_post_reset_replacement(self, expected_connection_epoch: str) -> None:
         """Invalidate the current bridge view immediately before #266 reset.
 

--- a/tools/physical/post_reset_capability_bridge.py
+++ b/tools/physical/post_reset_capability_bridge.py
@@ -28,9 +28,13 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
 
     def __init__(self, session: object, **kwargs) -> None:
         self._session_lock = RLock()
-        self._session = session
+        self._session: object | None = None
+        self._base_session_assignment_open = True
         self._replacement_previous_epoch: str | None = None
-        super().__init__(session, **kwargs)
+        try:
+            super().__init__(session, **kwargs)
+        finally:
+            self._base_session_assignment_open = False
 
     @property
     def session(self) -> object:
@@ -39,14 +43,22 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
                 raise CapabilityBridgeError(
                     "capability bridge session is unavailable during post-reset replacement"
                 )
+            if self._session is None:
+                raise CapabilityBridgeError("capability bridge session is unavailable")
             return self._session
 
     @session.setter
     def session(self, value: object) -> None:
-        # Base construction assigns ``session`` once. Later rotation is permitted
-        # only through the explicit two-phase methods below.
+        # ReadOnlyCapabilityHttpBridge assigns ``session`` once from its own
+        # constructor. No later property assignment is allowed: all post-reset
+        # rotation must pass through the explicit two-phase protocol below.
         with self._session_lock:
+            if not self._base_session_assignment_open:
+                raise CapabilityBridgeError(
+                    "capability bridge session replacement requires the explicit post-reset protocol"
+                )
             self._session = value
+            self._base_session_assignment_open = False
 
     @property
     def post_reset_replacement_pending(self) -> bool:
@@ -106,6 +118,10 @@ class PostResetCapabilityHttpBridge(ReadOnlyCapabilityHttpBridge):
                         "post-reset capability session replacement is already pending"
                     )
                 current = self._session
+                if current is None:
+                    raise CapabilityBridgeError(
+                        "current capability session is unavailable before replacement"
+                    )
                 try:
                     observed = current.read_connection_epoch()
                 except Exception as exc:


### PR DESCRIPTION
Adds the smallest no-effect #287 substrate needed to keep the already-configured production #249 responder usable across the #266 reset/epoch rotation.

This slice introduces `PostResetCapabilityHttpBridge`, a read-only bridge that preserves its existing loopback address and bearer tokens while making the session handoff explicit and fail-closed:

- `begin_post_reset_replacement()` is intended for the trusted #266 prior-evidence invalidation edge and immediately makes the old bridge view unavailable;
- replacement refuses a stale/wrong current epoch, an active #249 assertion, duplicate replacement, shutdown, or a post-reset session that reuses the prior epoch;
- `install_post_reset_session()` reopens the same bridge identity only for a genuinely new live epoch;
- #249 assertion admission is serialized against the replacement edge so reset cannot slip between the assertion's first epoch read and publication of its pending challenge;
- deterministic coverage forces that exact race window and proves it fails closed, while normal HTTP reads after replacement see only the new read-only session and `executionAuthority:false` remains unchanged.

The regression is included in the existing Runtime core CI path through the teacher-authorization contract chain.

This PR deliberately does **not** modify `serve_physical_host.py`, expose the raw Crazyflie, perform or authorize a reset, compose #266 itself, mint teacher authority, emit command 9, or complete #287. The remaining production work still has to keep the post-reset raw Crazyflie lexical to the trusted host, compose #273-protected #266 -> #290 -> same-session #257/#262/#272/#271 -> #289, and prove the post-reset read-only view and effect object are the same live session/epoch.

No motorized checkpoint or real reset/takeoff is requested or authorized.

Refs #287 #266 #278 #249 #290 #289 #157.