### PR TITLE
Establish the missing raw inputs for the X3 firmware proof

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -338,11 +338,19 @@ justified by the current evidence.
   estimate from IMU/barometer evidence that excludes suspect ToF can bound
   `delta z` tightly enough that `delta h = delta z_ind - delta c` distinguishes
   terrain, true vertical motion and a mixed event
-- next proof: reanalyse the existing #180/#236/#251 archives before collecting
-  new physical data. Verify provenance/hashes and available columns, use the raw
-  barometer plus IMU/attitude when present, quantify uncertainty/latency, and
-  compare the same frozen calculation across stationary, terrain, vertical and
-  mixed controls with an independent metric reference where one exists
+- archived-input result: #292 made the retained #180/#236/#251 text accessible;
+  the [input audit](../experiments/crazyflie-ukf-surface-range/evidence/analysis-2026-09-11/README.md)
+  verifies all 94 retained files. No CSV contains continuous raw barometer or
+  accelerometer/gyroscope samples; no independent metric vehicle-Z trajectory
+  or measured mixed case is retained. Inactive/conditional diagnostics cannot
+  substitute for these inputs. The independent-displacement proof is UNPROVEN
+- next proof: prepare the missing acquisition and frozen offline calculation
+  support for one bounded props-off information checkpoint, using the existing
+  #251 firmware and unchanged parameters. Verify live log availability, timing,
+  independent metric reference and durable raw publication before requesting it;
+  then compare the same calculation across stationary, terrain, vertical and
+  mixed cases, with explicit uncertainty/latency. The firmware already declares
+  the missing sensor logs; an estimator patch is not justified to obtain them
 - falsification boundary: the current #70 review uses at most 5 cm displacement
   error and at most 1 s after transition end as bounded experimental criteria,
   not classifier thresholds or flight acceptance. A valid counterexample

--- a/experiments/crazyflie-ukf-surface-range/audit_archived_inputs.py
+++ b/experiments/crazyflie-ukf-surface-range/audit_archived_inputs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Inventory #180/#236/#251 bytes and observed inputs; never infer flight PASS.
+
+Run from any directory. Output is derived JSON on stdout; raw evidence is opened
+read-only. Historical scripts and TOC caches are never executed or counted as
+measurements. SOURCE/manifest consistency proves integrity against the retained
+import, not independent authentication of the original capture or archive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+
+
+ROOT = Path(__file__).resolve().parent / "evidence"
+INPUT_GROUPS = {
+    "barometer": ("baro.asl", "baro.pressure", "baro.temp"),
+    "accelerometer": ("acc.x", "acc.y", "acc.z"),
+    "gyroscope": ("gyro.x", "gyro.y", "gyro.z"),
+    "attitude_diagnostic": ("stabilizer.roll", "stabilizer.pitch"),
+}
+PROBES = (
+    "sensorFilter.baroHeight", "sensorFilter.surfBaroD",
+    "sensorFilter.baro0", "sensorFilter.baroDec", "sensorFilter.lateElig",
+)
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def verified_files(directory: Path) -> tuple[dict, dict[str, bytes]]:
+    source = json.loads((directory / "SOURCE.json").read_bytes())
+    entries = source["machine_readable_files"]
+    expected = {entry["path"]: entry for entry in entries}
+    if len(expected) != len(entries) or not expected:
+        raise ValueError(f"{directory.name}: duplicate or empty source inventory")
+    manifest = {}
+    for line in (directory / "MANIFEST.sha256").read_text().splitlines():
+        sha, name = line.split("  ", 1)
+        if name in manifest:
+            raise ValueError(f"duplicate manifest path: {name}")
+        manifest[name] = sha
+    actual = {str(p.relative_to(directory)) for p in (directory / "raw").rglob("*")
+              if p.is_file()}
+    if set(expected) != set(manifest) or set(expected) != actual:
+        raise ValueError(f"{directory.name}: missing/unexpected raw files")
+    files = {}
+    for name, entry in sorted(expected.items()):
+        path = directory / name
+        if not name.startswith("raw/") or ".." in Path(name).parts:
+            raise ValueError(f"invalid raw path: {name}")
+        if path.is_symlink() or not path.resolve().is_relative_to(directory.resolve()):
+            raise ValueError(f"non-local raw path: {name}")
+        data = path.read_bytes()
+        if digest(data) != manifest[name] or digest(data) != entry["sha256"]:
+            raise ValueError(f"digest mismatch: {name}")
+        if len(data) != entry["bytes"]:
+            raise ValueError(f"size mismatch: {name}")
+        files[name] = data
+    return source, files
+
+
+def inventory_csv(name: str, data: bytes) -> dict:
+    reader = csv.DictReader(io.StringIO(data.decode("utf-8"), newline=""))
+    columns = reader.fieldnames
+    if not columns or len(columns) != len(set(columns)):
+        raise ValueError(f"missing/duplicate CSV header: {name}")
+    rows = list(reader)
+    if not rows or any(None in row or None in row.values() for row in rows):
+        raise ValueError(f"empty/malformed CSV: {name}")
+    excluded = any("excluded" in part for part in Path(name).parts)
+    result = {"path": name, "rows": len(rows), "columns": columns,
+              "excluded_from_physical_verdict": excluded}
+    if "event" in columns:
+        result["markers"] = rows
+        return result
+    numeric = {col: [float(row[col]) for row in rows] for col in columns}
+    result["nonfinite_cells"] = sum(not math.isfinite(v)
+                                    for vals in numeric.values() for v in vals)
+    stamp = "cf_timestamp_ms" if "cf_timestamp_ms" in columns else "Timestamp"
+    ts = numeric[stamp]
+    dt = [b - a for a, b in zip(ts, ts[1:])]
+    result["log_clock"] = {
+        "column": stamp, "duration_ms": ts[-1] - ts[0],
+        "median_step_ms": statistics.median(dt) if dt else None,
+        "max_step_ms": max(dt) if dt else None,
+        "nonincreasing_steps": sum(d <= 0 for d in dt),
+        "boundary": "log timestamps, not per-sensor producer timestamps",
+    }
+    result["diagnostic_probes"] = {}
+    for col in PROBES:
+        if col not in numeric:
+            continue
+        vals = [v for v in numeric[col] if math.isfinite(v)]
+        result["diagnostic_probes"][col] = {
+            "finite_samples": len(vals), "distinct_values": len(set(vals)),
+            "minimum": min(vals) if vals else None,
+            "maximum": max(vals) if vals else None,
+        }
+    return result
+
+
+def audit(root: Path) -> dict:
+    checkpoints = []
+    for number in (180, 236, 251):
+        directory = root / f"checkpoint-{number}"
+        source, files = verified_files(directory)
+        if source["checkpoint"] != number:
+            raise ValueError(f"wrong checkpoint identity: {number}")
+        csvs = [inventory_csv(name, data) for name, data in files.items()
+                if name.endswith(".csv")]
+        observed = {col for item in csvs if not item["excluded_from_physical_verdict"]
+                    for col in item["columns"]}
+        missing = {group: [col for col in names if col not in observed]
+                   for group, names in INPUT_GROUPS.items()}
+        checkpoints.append({
+            "checkpoint": number, "verified_files": len(files),
+            "csv_files": len(csvs),
+            "excluded_csv_files": sum(item["excluded_from_physical_verdict"] for item in csvs),
+            "source_archive_sha256": source["source_archive_sha256"],
+            "source_issue_comment": source["source_issue_comment"],
+            "archive_digest_previously_published": source["expected_archive_sha256"] is not None,
+            "manifest_sha256": digest((directory / "MANIFEST.sha256").read_bytes()),
+            "source_json_sha256": digest((directory / "SOURCE.json").read_bytes()),
+            "omissions": source["skipped_files"],
+            "missing_observed_columns": missing,
+            "independent_displacement": "UNPROVEN" if any(
+                missing[group] for group in ("barometer", "accelerometer", "gyroscope")
+            ) else "REQUIRES_SCIENTIFIC_REVIEW",
+            "csv_inventory": csvs,
+        })
+    return {
+        "schema": "webeeblocks.x3.archived-input-inventory.v1",
+        "scope": "retained text import from #292; original binary archives not re-fetched",
+        "checkpoints": checkpoints,
+        "boundary": "Header presence is not signal validity, metric ground truth or acceptance. "
+                    "No imputation, estimator fitting, confidence interval or physical verdict.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-root", type=Path, default=ROOT)
+    args = parser.parse_args()
+    try:
+        report = audit(args.evidence_root)
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        print(f"ARCHIVE_AUDIT_ERROR: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+    return 0  # Successful inventory, never a scientific or human PASS.
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/crazyflie-ukf-surface-range/evidence/README.md
+++ b/experiments/crazyflie-ukf-surface-range/evidence/README.md
@@ -4,6 +4,12 @@ Byte-for-byte UTF-8 copies of the owner-attached checkpoint archives, accessible
 through ordinary Git clones and GitHub file reads. No attachment download is
 needed to inspect the retained CSV data.
 
+The [11 September input audit](analysis-2026-09-11/README.md) verifies all 94
+retained files and establishes the next #70 boundary: continuous raw barometer,
+accelerometer/gyroscope samples and an independent metric reference are absent.
+The independent-displacement question is UNPROVEN from these archives; the
+inactive/conditional barometer diagnostics must not substitute for those inputs.
+
 | Checkpoint | Text files | CSV files | Archive SHA-256 provenance |
 | --- | ---: | ---: | --- |
 | [#180](https://github.com/djibian/webeeblocks/issues/180) | 50 | 36 | Observed digest; no prior archive digest was published |

--- a/experiments/crazyflie-ukf-surface-range/evidence/analysis-2026-09-11/README.md
+++ b/experiments/crazyflie-ukf-surface-range/evidence/analysis-2026-09-11/README.md
@@ -1,0 +1,156 @@
+# X3 archived-input audit — 11 September 2026
+
+**VERIFIED_BY_ARTIFACT_INSPECTION:** #292 resolves access to the retained raw
+text. **UNPROVEN:** these recordings cannot establish independent vertical
+displacement from IMU/barometer measurements. The required measurements were
+not recorded. Do not fit a predictor or infer zero displacement from absent or
+inactive fields.
+
+Evidence state: `main@c65c5561690c5c1703082ae9367e43961d032320`.
+Scientific question and frozen falsification criteria:
+[#70 architecture review](https://github.com/djibian/webeeblocks/issues/70#issuecomment-5606273253).
+This is derived analysis, separate from the original owner verdicts. #70 remains
+Lab-only; no estimator, controller, parameter or flight authority changes.
+
+## Reproduce
+
+From the repository root, using Python 3.10 or later:
+
+```sh
+python3 experiments/crazyflie-ukf-surface-range/audit_archived_inputs.py > /tmp/x3-inventory.json
+cmp /tmp/x3-inventory.json experiments/crazyflie-ukf-surface-range/evidence/analysis-2026-09-11/inventory.json
+```
+
+The script verifies every retained file against both `SOURCE.json` and
+`MANIFEST.sha256`, including sizes, and rejects missing, unexpected or changed
+raw files. It inventories every CSV and keeps excluded streams explicitly
+marked. It never runs a historical capture script, treats a TOC cache as sensor
+samples, resamples missing signals or issues a physical verdict. Exit zero means
+the inventory completed, not that the scientific hypothesis passed.
+
+## Provenance and coverage
+
+| Checkpoint | Tested WebeeBlocks SHA | Verified files | CSVs | Excluded CSVs |
+| --- | --- | ---: | ---: | ---: |
+| #180 | `173b7c5b189b4c4241d7fbde5b1443214dd20a14` | 50 | 36 | 0 |
+| #236 | `8561ec3e9609acc40677b88d98eada3aae0ad954` | 16 | 14 | 2 |
+| #251 | `6562ad827bf0c8bf2c9b609edad36f3e15652133` | 28 | 26 | 6 |
+
+All **94 retained files / 76 CSVs** match the import's hashes and sizes. #180's
+36 CSVs include four START/END marker files. #236's two excluded CSVs record an
+operator-error fast trial; #251's six excluded CSVs are the invalid initial
+precheck. They remain auditable and are not reclassified as valid experiments.
+The nested binary invalid initial series omitted from #236 remains an explicit
+omission in `SOURCE.json`; this audit does not claim to inspect it.
+
+Archive hashes in the generated inventory are the source archive digests recorded
+by #292, not a new download verification. #236/#251 matched owner-published
+digests during that import; #180 had no prior published archive digest. Matching
+local manifests establishes retained-byte integrity, not independent proof of
+capture provenance. Firmware-bundle hashes are different objects and must not be
+substituted for raw-result archive hashes.
+
+## What the traces actually contain
+
+| Required information | #180 | #236 | #251 |
+| --- | --- | --- | --- |
+| Continuous `baro.asl`, `baro.pressure`, `baro.temp` | Absent | Absent | Absent |
+| Accelerometer `acc.x/y/z` | Absent | Absent | Absent |
+| Gyroscope `gyro.x/y/z` | Absent | Absent | Absent |
+| Roll/pitch diagnostic | Present | Absent | Absent |
+| Independent metric vehicle-Z trajectory | Not retained | Not retained | Not retained |
+| Explicit measured mixed terrain/vehicle event | Not retained | Not retained | Not retained |
+
+Header availability is reported from CSVs only. The cached #180 log TOC
+`B411033C.json` lists `baro.*`, `acc.*` and `gyro.*` as available, but none of their
+samples was captured. `motion.deltaX/deltaY` are optical-flow measurements, not
+accelerometer measurements. `stateEstimate.z/vz` are the UKF output influenced
+by ToF and cannot supply the requested independent input.
+
+The potential substitutes are specifically insufficient:
+
+- **#180 `sensorFilter.baroHeight`:** all 4,448 retained samples are exactly
+  zero across calibration/A/B/C. In pinned upstream UKF source, `baroOut` is a
+  static log variable with no assignment; the three S3 applicators do not add
+  one. This is an inactive diagnostic, not zero barometric noise.
+- **`sensorFilter.surfBaroD`:** S3's event-relative value is conditional on its
+  detector path and its reset/restart baseline. It is not a continuous pressure
+  series. It is identically zero in #180/#236/#251 stationary calibrations and
+  in the valid #236 B/C controls. Those zeros cannot estimate sensor uncertainty.
+- **#251 `baro0/baroDec`:** entry and eligible-decision snapshots are held between
+  detector events. A1/A2 never reach `lateElig`; their `baroDec` remains zero.
+  A3 reaches the late path and supplies useful snapshots, but no continuous
+  stationary/vertical/mixed control stream for the same before/after statistic.
+
+The complete-run START/END markers in #180 do not identify the start/end of each
+physical transition. None of the retained result manifests includes a measured
+vehicle-Z trajectory or a synchronized metric reference. The historical human
+observations remain valid in their own scope; clearance or UKF Z must not be
+relabelled as independent vehicle ground truth.
+
+## Scientific consequence
+
+The frozen statistic (0.5 s pre-event median; 0.5 s post-event median from
+0.25–0.75 s after transition end; drift learned only from stationary calibration)
+cannot be computed from the required raw signal. Neither an uncertainty bound
+nor a bias/attitude-aware inertial displacement can be recovered from these
+archives. The same missing inputs prevent evaluating the simple IMU/barometer-
+only world-Z alternative.
+
+Therefore no quantitative comparison against **5 cm / 1 s** is reported. This
+is **UNPROVEN because inputs/reference are missing**, not a counterexample to all
+possible IMU/barometer methods, nor evidence supporting a new terrain model.
+Do not search for windows on A3, reconstruct a continuous barometer from held
+snapshots, reuse ToF-derived VZ, or repeat generic S3-A/B/C to fill this gap.
+
+## Smallest next experiment preparation
+
+The next useful change is acquisition and offline analysis support using the
+existing #251 firmware, with its historical parameters unchanged. A firmware
+estimator patch or a new flash is not justified merely to expose these inputs:
+the pinned firmware already declares them. Verify the live log TOC at setup;
+missing or failed logging must stop preparation before a physical gesture.
+
+Prepare one bounded props-off information checkpoint with:
+
+1. Continuous `baro.asl/pressure/temp`, `acc.x/y/z`, `gyro.x/y/z`, roll/pitch,
+   downward ToF and existing state/diagnostic fields. Preserve device log and
+   host timestamps and explicitly distinguish log time from sensor producer
+   time. Assess cadence, loss, duplicates and cross-block alignment before any
+   inertial claim; ordinary 20 ms log samples do not automatically prove a
+   faithful inertial replay. Each CRTP log block must fit the existing payload
+   budget.
+2. One stationary calibration of about 30 s, followed by one terrain, one true
+   vertical and one mixed out-and-back case, both signs retained. Use a measured
+   platform height H; in the mixed case independently measure vehicle movement
+   near H/2. Keep at least 2 s stationary plateaus.
+3. A metric guide or fixed-camera reference with resolution substantially better
+   than 5 cm, synchronized event boundaries and stated measurement uncertainty.
+   The reference serves analysis only. It must not be inferred from the same ToF
+   or UKF output being evaluated.
+4. An executable, frozen pressure statistic and, only if timing/bias/attitude
+   support it, a separately bounded inertial calculation. All physical cases
+   must traverse the same calculation without the existing UKF gate bypassing
+   the vertical control. Missing inputs, reference or interpretable uncertainty
+   produce UNPROVEN; a valid counterexample refutes the bounded candidate.
+5. Exact request, firmware and capture-tool identity, expected-output validation
+   and Controller-readable durable raw publication. Reuse #296's generic
+   evidence mechanism once available; it is not a scientific dependency. Manual
+   issue attachments alone are not the canonical publication path.
+
+This document is preparation guidance, not an executable checkpoint request.
+The acquisition/calculation support and exact artifact still require preparation
+and independent validation before the trusted checkpoint mechanism can create
+TEST_REQUIRED. Props stay removed; no motorized test follows automatically.
+
+## Inspected primary code
+
+- [Pinned firmware sensor logs and units](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/modules/src/stabilizer.c):
+  `acc.*` in g, filtered `gyro.*` in degrees/s, `baro.asl` in metres,
+  pressure in mbar and temperature in Celsius.
+- [Pinned UKF](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/modules/src/estimator/estimator_ukf.c):
+  `baroOut` and the `baroHeight` logging binding.
+- Local S3 base and timing applicators at the evidence-state SHA above:
+  conditional `surfaceBaroDelta`, SUSPECT baseline/restart and held decision
+  snapshots. These code observations explain the columns; they are not physical
+  proof of an independent estimator.

--- a/experiments/crazyflie-ukf-surface-range/evidence/analysis-2026-09-11/inventory.json
+++ b/experiments/crazyflie-ukf-surface-range/evidence/analysis-2026-09-11/inventory.json
@@ -1,0 +1,2101 @@
+{
+  "boundary": "Header presence is not signal validity, metric ground truth or acceptance. No imputation, estimator fitting, confidence interval or physical verdict.",
+  "checkpoints": [
+    {
+      "archive_digest_previously_published": false,
+      "checkpoint": 180,
+      "csv_files": 36,
+      "csv_inventory": [
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.distPred",
+            "sensorFilter.distMeas",
+            "sensorFilter.baroHeight",
+            "sensorFilter.innoChFlow_x",
+            "sensorFilter.innoChFlow_y",
+            "sensorFilter.innoChTof"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baroHeight": {
+              "distinct_values": 1,
+              "finite_samples": 1115,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/filter.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "event",
+            "cf_timestamp_ms_nearest",
+            "host_monotonic_s"
+          ],
+          "excluded_from_physical_verdict": false,
+          "markers": [
+            {
+              "cf_timestamp_ms_nearest": "92795",
+              "event": "START",
+              "host_monotonic_s": "1886.409487"
+            },
+            {
+              "cf_timestamp_ms_nearest": "115095",
+              "event": "END",
+              "host_monotonic_s": "1908.688841"
+            }
+          ],
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/markers.csv",
+          "rows": 2
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.deltaX",
+            "motion.deltaY",
+            "motion.shutter",
+            "motion.squal"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/motion_a.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.outlierCount",
+            "motion.motion",
+            "motion.std"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/motion_b.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "range.zrange",
+            "stabilizer.roll",
+            "stabilizer.pitch"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/range_attitude.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "stateEstimate.x",
+            "stateEstimate.y",
+            "stateEstimate.z",
+            "stateEstimate.vx",
+            "stateEstimate.vy",
+            "stateEstimate.vz"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/state.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.flowRange",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfClear"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22281.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/surface_a.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfBefore",
+            "sensorFilter.surfAfter",
+            "sensorFilter.surfDelta",
+            "sensorFilter.surfSign"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/surface_b.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfN",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCandInn",
+            "sensorFilter.surfState",
+            "sensorFilter.surfReason"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 88,
+              "finite_samples": 1115,
+              "maximum": 0.032810211181640625,
+              "minimum": -0.4265098571777344
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 22280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-A/surface_c.csv",
+          "rows": 1115
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.distPred",
+            "sensorFilter.distMeas",
+            "sensorFilter.baroHeight",
+            "sensorFilter.innoChFlow_x",
+            "sensorFilter.innoChFlow_y",
+            "sensorFilter.innoChTof"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baroHeight": {
+              "distinct_values": 1,
+              "finite_samples": 1000,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 19980.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/filter.csv",
+          "rows": 1000
+        },
+        {
+          "columns": [
+            "event",
+            "cf_timestamp_ms_nearest",
+            "host_monotonic_s"
+          ],
+          "excluded_from_physical_verdict": false,
+          "markers": [
+            {
+              "cf_timestamp_ms_nearest": "132551",
+              "event": "START",
+              "host_monotonic_s": "1926.129531"
+            },
+            {
+              "cf_timestamp_ms_nearest": "152555",
+              "event": "END",
+              "host_monotonic_s": "1946.128638"
+            }
+          ],
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/markers.csv",
+          "rows": 2
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.deltaX",
+            "motion.deltaY",
+            "motion.shutter",
+            "motion.squal"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 19980.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/motion_a.csv",
+          "rows": 1000
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.outlierCount",
+            "motion.motion",
+            "motion.std"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 19980.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/motion_b.csv",
+          "rows": 1000
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "range.zrange",
+            "stabilizer.roll",
+            "stabilizer.pitch"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 20000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/range_attitude.csv",
+          "rows": 1001
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "stateEstimate.x",
+            "stateEstimate.y",
+            "stateEstimate.z",
+            "stateEstimate.vx",
+            "stateEstimate.vy",
+            "stateEstimate.vz"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 19980.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/state.csv",
+          "rows": 1000
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.flowRange",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfClear"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 20000.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/surface_a.csv",
+          "rows": 1001
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfBefore",
+            "sensorFilter.surfAfter",
+            "sensorFilter.surfDelta",
+            "sensorFilter.surfSign"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 20000.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/surface_b.csv",
+          "rows": 1001
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfN",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCandInn",
+            "sensorFilter.surfState",
+            "sensorFilter.surfReason"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 172,
+              "finite_samples": 1001,
+              "maximum": 0.683502197265625,
+              "minimum": -0.8147354125976562
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 20000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-B/surface_c.csv",
+          "rows": 1001
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.distPred",
+            "sensorFilter.distMeas",
+            "sensorFilter.baroHeight",
+            "sensorFilter.innoChFlow_x",
+            "sensorFilter.innoChFlow_y",
+            "sensorFilter.innoChTof"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baroHeight": {
+              "distinct_values": 1,
+              "finite_samples": 1582,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31620.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/filter.csv",
+          "rows": 1582
+        },
+        {
+          "columns": [
+            "event",
+            "cf_timestamp_ms_nearest",
+            "host_monotonic_s"
+          ],
+          "excluded_from_physical_verdict": false,
+          "markers": [
+            {
+              "cf_timestamp_ms_nearest": "183748",
+              "event": "START",
+              "host_monotonic_s": "1977.290764"
+            },
+            {
+              "cf_timestamp_ms_nearest": "215395",
+              "event": "END",
+              "host_monotonic_s": "2008.922094"
+            }
+          ],
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/markers.csv",
+          "rows": 2
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.deltaX",
+            "motion.deltaY",
+            "motion.shutter",
+            "motion.squal"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31640.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/motion_a.csv",
+          "rows": 1583
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.outlierCount",
+            "motion.motion",
+            "motion.std"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31640.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/motion_b.csv",
+          "rows": 1583
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "range.zrange",
+            "stabilizer.roll",
+            "stabilizer.pitch"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31640.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/range_attitude.csv",
+          "rows": 1583
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "stateEstimate.x",
+            "stateEstimate.y",
+            "stateEstimate.z",
+            "stateEstimate.vx",
+            "stateEstimate.vy",
+            "stateEstimate.vz"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31620.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/state.csv",
+          "rows": 1582
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.flowRange",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfClear"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31640.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/surface_a.csv",
+          "rows": 1583
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfBefore",
+            "sensorFilter.surfAfter",
+            "sensorFilter.surfDelta",
+            "sensorFilter.surfSign"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31640.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/surface_b.csv",
+          "rows": 1583
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfN",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCandInn",
+            "sensorFilter.surfState",
+            "sensorFilter.surfReason"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 167,
+              "finite_samples": 1583,
+              "maximum": 0.497589111328125,
+              "minimum": -0.5413398742675781
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 31640.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/S3-C/surface_c.csv",
+          "rows": 1583
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.distPred",
+            "sensorFilter.distMeas",
+            "sensorFilter.baroHeight",
+            "sensorFilter.innoChFlow_x",
+            "sensorFilter.innoChFlow_y",
+            "sensorFilter.innoChTof"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baroHeight": {
+              "distinct_values": 1,
+              "finite_samples": 751,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/filter.csv",
+          "rows": 751
+        },
+        {
+          "columns": [
+            "event",
+            "cf_timestamp_ms_nearest",
+            "host_monotonic_s"
+          ],
+          "excluded_from_physical_verdict": false,
+          "markers": [
+            {
+              "cf_timestamp_ms_nearest": "62095",
+              "event": "START",
+              "host_monotonic_s": "1855.728856"
+            },
+            {
+              "cf_timestamp_ms_nearest": "77126",
+              "event": "END",
+              "host_monotonic_s": "1870.744344"
+            }
+          ],
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/markers.csv",
+          "rows": 2
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.deltaX",
+            "motion.deltaY",
+            "motion.shutter",
+            "motion.squal"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/motion_a.csv",
+          "rows": 751
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "motion.outlierCount",
+            "motion.motion",
+            "motion.std"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/motion_b.csv",
+          "rows": 751
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "range.zrange",
+            "stabilizer.roll",
+            "stabilizer.pitch"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/range_attitude.csv",
+          "rows": 751
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "stateEstimate.x",
+            "stateEstimate.y",
+            "stateEstimate.z",
+            "stateEstimate.vx",
+            "stateEstimate.vy",
+            "stateEstimate.vz"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15020.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/state.csv",
+          "rows": 752
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.flowRange",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfClear"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/surface_a.csv",
+          "rows": 751
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfBefore",
+            "sensorFilter.surfAfter",
+            "sensorFilter.surfDelta",
+            "sensorFilter.surfSign"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/surface_b.csv",
+          "rows": 751
+        },
+        {
+          "columns": [
+            "cf_timestamp_ms",
+            "host_monotonic_s",
+            "sensorFilter.surfN",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCandInn",
+            "sensorFilter.surfState",
+            "sensorFilter.surfReason"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 1,
+              "finite_samples": 751,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "cf_timestamp_ms",
+            "duration_ms": 15000.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-173b7c5-bundle/results-20ms/calibration/surface_c.csv",
+          "rows": 751
+        }
+      ],
+      "excluded_csv_files": 0,
+      "independent_displacement": "UNPROVEN",
+      "manifest_sha256": "4b9a6cfe64581fb36d533955cbcd47a9c526ae774f6b98d6c33c9cc89a123846",
+      "missing_observed_columns": {
+        "accelerometer": [
+          "acc.x",
+          "acc.y",
+          "acc.z"
+        ],
+        "attitude_diagnostic": [],
+        "barometer": [
+          "baro.asl",
+          "baro.pressure",
+          "baro.temp"
+        ],
+        "gyroscope": [
+          "gyro.x",
+          "gyro.y",
+          "gyro.z"
+        ]
+      },
+      "omissions": [],
+      "source_archive_sha256": "7b13d7d6e8cd69b1cfd95451f61af2063797bc2716b3648b625c27c8caac122d",
+      "source_issue_comment": "https://github.com/djibian/webeeblocks/issues/180#issuecomment-5586166222",
+      "source_json_sha256": "3d1b48bb2c17e1ea0331ac4a6ca3215fc1ca2519cf856e095fa55c02b5e80073",
+      "verified_files": 50
+    },
+    {
+      "archive_digest_previously_published": true,
+      "checkpoint": 236,
+      "csv_files": 14,
+      "csv_inventory": [
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 17900.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/excluded/S3_CORE_236-20260908T22-35-57.csv",
+          "rows": 896
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 1,
+              "finite_samples": 874,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 17460.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/excluded/S3_DETECTOR_236-20260908T22-35-57.csv",
+          "rows": 874
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 21760.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_CORE_236-20260908T22-16-14.csv",
+          "rows": 1089
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 26680.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_CORE_236-20260908T22-20-53.csv",
+          "rows": 1335
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 22780.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_CORE_236-20260908T22-26-25.csv",
+          "rows": 1140
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 19820.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_CORE_236-20260908T22-28-49.csv",
+          "rows": 992
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25120.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_CORE_236-20260908T22-38-15.csv",
+          "rows": 1257
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25880.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_CORE_236-20260908T22-43-38.csv",
+          "rows": 1295
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 1,
+              "finite_samples": 1107,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 22120.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_DETECTOR_236-20260908T22-16-15.csv",
+          "rows": 1107
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 79,
+              "finite_samples": 1329,
+              "maximum": 0.1093606948852539,
+              "minimum": -0.3991670608520508
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 26560.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_DETECTOR_236-20260908T22-20-53.csv",
+          "rows": 1329
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 36,
+              "finite_samples": 1060,
+              "maximum": 0.1421680450439453,
+              "minimum": -0.21325397491455078
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 21180.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_DETECTOR_236-20260908T22-26-25.csv",
+          "rows": 1060
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 1,
+              "finite_samples": 990,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 19780.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_DETECTOR_236-20260908T22-28-50.csv",
+          "rows": 990
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 1,
+              "finite_samples": 1227,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 24520.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_DETECTOR_236-20260908T22-38-15.csv",
+          "rows": 1227
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 133,
+              "finite_samples": 1288,
+              "maximum": 0.5194635391235352,
+              "minimum": -0.22965764999389648
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25740.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/S3-8561ec3-checkpoint-236-evidence/valid/S3_DETECTOR_236-20260908T22-43-39.csv",
+          "rows": 1288
+        }
+      ],
+      "excluded_csv_files": 2,
+      "independent_displacement": "UNPROVEN",
+      "manifest_sha256": "998801f09180726585524caf883ec9a123efb34107ab0c0a6a9fe74dbd724c69",
+      "missing_observed_columns": {
+        "accelerometer": [
+          "acc.x",
+          "acc.y",
+          "acc.z"
+        ],
+        "attitude_diagnostic": [
+          "stabilizer.roll",
+          "stabilizer.pitch"
+        ],
+        "barometer": [
+          "baro.asl",
+          "baro.pressure",
+          "baro.temp"
+        ],
+        "gyroscope": [
+          "gyro.x",
+          "gyro.y",
+          "gyro.z"
+        ]
+      },
+      "omissions": [
+        {
+          "bytes": 104135,
+          "path": "S3-8561ec3-checkpoint-236-evidence/original/S3-8561ec3-results.tar.gz",
+          "reason": "non-UTF-8/binary",
+          "sha256": "46affd93964a358c10d9cc7344de41ad6af1f97d49012a1c030c5b9c80d38b44"
+        }
+      ],
+      "source_archive_sha256": "d47dd2b4e83e87c3fd8fa5576f720355a858879ac0d0c27550831dbcaaf1fccb",
+      "source_issue_comment": "https://github.com/djibian/webeeblocks/issues/236#issuecomment-5591721995",
+      "source_json_sha256": "f234a08fc0f4e4b67ff4bbcee163bd38ed00a161ad99ca939bef6bffb9cbb225",
+      "verified_files": 16
+    },
+    {
+      "archive_digest_previously_published": true,
+      "checkpoint": 251,
+      "csv_files": 26,
+      "csv_inventory": [
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 26120.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/00_precheck_excluded/S3_CORE_236-20260909T15-32-57.csv",
+          "rows": 1307
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 178,
+              "finite_samples": 1311,
+              "maximum": 0.39643287658691406,
+              "minimum": -0.2651996612548828
+            }
+          },
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 26200.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/00_precheck_excluded/S3_DETECTOR_236-20260909T15-32-57.csv",
+          "rows": 1311
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAgeD",
+            "sensorFilter.baroLagD",
+            "sensorFilter.baroSeenD",
+            "sensorFilter.tofAgeD",
+            "sensorFilter.vzDec"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25840.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/00_precheck_excluded/X3_DECISION-20260909T15-32-59.csv",
+          "rows": 1293
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge0",
+            "sensorFilter.baroLag0",
+            "sensorFilter.baroSeen0",
+            "sensorFilter.tofAge0",
+            "sensorFilter.vz0"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25380.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/00_precheck_excluded/X3_ENTRY-20260909T15-32-59.csv",
+          "rows": 1270
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baro0",
+            "sensorFilter.baroDDec",
+            "sensorFilter.baroDec",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baro0": {
+              "distinct_values": 1,
+              "finite_samples": 1262,
+              "maximum": 0.5212669372558594,
+              "minimum": 0.5212669372558594
+            },
+            "sensorFilter.baroDec": {
+              "distinct_values": 1,
+              "finite_samples": 1262,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25220.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/00_precheck_excluded/X3_EVIDENCE-20260909T15-33-00.csv",
+          "rows": 1262
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge",
+            "sensorFilter.baroLag",
+            "sensorFilter.baroSeen",
+            "sensorFilter.lateElig",
+            "sensorFilter.tofAge"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.lateElig": {
+              "distinct_values": 1,
+              "finite_samples": 1271,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": true,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 25400.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/00_precheck_excluded/X3_NOW-20260909T15-33-01.csv",
+          "rows": 1271
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 18480.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/01_calibration_valid/S3_CORE_236-20260909T15-43-16.csv",
+          "rows": 925
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 1,
+              "finite_samples": 907,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 18120.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/01_calibration_valid/S3_DETECTOR_236-20260909T15-43-17.csv",
+          "rows": 907
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 18600.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A1/S3_CORE_236-20260909T17-14-00.csv",
+          "rows": 931
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfOffset",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 129,
+              "finite_samples": 888,
+              "maximum": 0.30074214935302734,
+              "minimum": -0.2023172378540039
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 17740.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A1/S3_DETECTOR_236-20260909T17-14-01.csv",
+          "rows": 888
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAgeD",
+            "sensorFilter.baroLagD",
+            "sensorFilter.baroSeenD",
+            "sensorFilter.tofAgeD",
+            "sensorFilter.vzDec"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 16100.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A1/X3_DECISION-20260909T17-14-02.csv",
+          "rows": 806
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge0",
+            "sensorFilter.baroLag0",
+            "sensorFilter.baroSeen0",
+            "sensorFilter.tofAge0",
+            "sensorFilter.vz0"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 15240.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A1/X3_ENTRY-20260909T17-14-03.csv",
+          "rows": 763
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baro0",
+            "sensorFilter.baroDDec",
+            "sensorFilter.baroDec",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baro0": {
+              "distinct_values": 3,
+              "finite_samples": 715,
+              "maximum": 0.7462234497070312,
+              "minimum": 0.0
+            },
+            "sensorFilter.baroDec": {
+              "distinct_values": 1,
+              "finite_samples": 715,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 14280.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A1/X3_EVIDENCE-20260909T17-14-03.csv",
+          "rows": 715
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge",
+            "sensorFilter.baroLag",
+            "sensorFilter.baroSeen",
+            "sensorFilter.lateElig",
+            "sensorFilter.tofAge"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.lateElig": {
+              "distinct_values": 1,
+              "finite_samples": 664,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 13260.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A1/X3_NOW-20260909T17-14-04.csv",
+          "rows": 664
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 16700.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A2/S3_CORE_236-20260909T17-24-24.csv",
+          "rows": 836
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfCandInn",
+            "sensorFilter.surfClear",
+            "sensorFilter.surfN",
+            "sensorFilter.surfOffset"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 116,
+              "finite_samples": 840,
+              "maximum": 0.17771053314208984,
+              "minimum": -0.33628368377685547
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 16780.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A2/S3_DETECTOR_236-20260909T17-24-24.csv",
+          "rows": 840
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAgeD",
+            "sensorFilter.baroLagD",
+            "sensorFilter.baroSeenD",
+            "sensorFilter.tofAgeD",
+            "sensorFilter.vzDec"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 16640.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A2/X3_DECISION-20260909T17-24-25.csv",
+          "rows": 833
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge0",
+            "sensorFilter.baroLag0",
+            "sensorFilter.baroSeen0",
+            "sensorFilter.tofAge0",
+            "sensorFilter.vz0"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 16940.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A2/X3_ENTRY-20260909T17-24-26.csv",
+          "rows": 848
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baro0",
+            "sensorFilter.baroDDec",
+            "sensorFilter.baroDec",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baro0": {
+              "distinct_values": 3,
+              "finite_samples": 867,
+              "maximum": 0.0,
+              "minimum": -0.16376972198486328
+            },
+            "sensorFilter.baroDec": {
+              "distinct_values": 1,
+              "finite_samples": 867,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 17320.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A2/X3_EVIDENCE-20260909T17-24-26.csv",
+          "rows": 867
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge",
+            "sensorFilter.baroLag",
+            "sensorFilter.baroSeen",
+            "sensorFilter.lateElig",
+            "sensorFilter.tofAge"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.lateElig": {
+              "distinct_values": 1,
+              "finite_samples": 873,
+              "maximum": 0.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 17440.0,
+            "max_step_ms": 21.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A2/X3_NOW-20260909T17-24-26.csv",
+          "rows": 873
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "range.zrange",
+            "sensorFilter.innoChTof",
+            "stateEstimate.vz",
+            "stateEstimate.z"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 21060.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A3/S3_CORE_236-20260909T17-30-49.csv",
+          "rows": 1054
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.flowLocal",
+            "sensorFilter.surfBaroD",
+            "sensorFilter.surfCand",
+            "sensorFilter.surfCandInn",
+            "sensorFilter.surfClear",
+            "sensorFilter.surfN",
+            "sensorFilter.surfOffset"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.surfBaroD": {
+              "distinct_values": 146,
+              "finite_samples": 1053,
+              "maximum": 0.2187213897705078,
+              "minimum": -0.47025108337402344
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 21040.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A3/S3_DETECTOR_236-20260909T17-30-50.csv",
+          "rows": 1053
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAgeD",
+            "sensorFilter.baroLagD",
+            "sensorFilter.baroSeenD",
+            "sensorFilter.tofAgeD",
+            "sensorFilter.vzDec"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 19880.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A3/X3_DECISION-20260909T17-30-50.csv",
+          "rows": 995
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge0",
+            "sensorFilter.baroLag0",
+            "sensorFilter.baroSeen0",
+            "sensorFilter.tofAge0",
+            "sensorFilter.vz0"
+          ],
+          "diagnostic_probes": {},
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 19680.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A3/X3_ENTRY-20260909T17-30-51.csv",
+          "rows": 985
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baro0",
+            "sensorFilter.baroDDec",
+            "sensorFilter.baroDec",
+            "sensorFilter.surfReason",
+            "sensorFilter.surfState"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.baro0": {
+              "distinct_values": 3,
+              "finite_samples": 983,
+              "maximum": 0.0,
+              "minimum": -0.12953853607177734
+            },
+            "sensorFilter.baroDec": {
+              "distinct_values": 47,
+              "finite_samples": 983,
+              "maximum": 0.08918285369873047,
+              "minimum": -0.45488643646240234
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 19640.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A3/X3_EVIDENCE-20260909T17-30-51.csv",
+          "rows": 983
+        },
+        {
+          "columns": [
+            "Timestamp",
+            "sensorFilter.baroAge",
+            "sensorFilter.baroLag",
+            "sensorFilter.baroSeen",
+            "sensorFilter.lateElig",
+            "sensorFilter.tofAge"
+          ],
+          "diagnostic_probes": {
+            "sensorFilter.lateElig": {
+              "distinct_values": 2,
+              "finite_samples": 981,
+              "maximum": 1.0,
+              "minimum": 0.0
+            }
+          },
+          "excluded_from_physical_verdict": false,
+          "log_clock": {
+            "boundary": "log timestamps, not per-sensor producer timestamps",
+            "column": "Timestamp",
+            "duration_ms": 19600.0,
+            "max_step_ms": 20.0,
+            "median_step_ms": 20.0,
+            "nonincreasing_steps": 0
+          },
+          "nonfinite_cells": 0,
+          "path": "raw/A3/X3_NOW-20260909T17-30-52.csv",
+          "rows": 981
+        }
+      ],
+      "excluded_csv_files": 6,
+      "independent_displacement": "UNPROVEN",
+      "manifest_sha256": "da74bf84fd73e4c4c6438ef53eaf48c9abd38721a5682c37e20eee0c6da89a9b",
+      "missing_observed_columns": {
+        "accelerometer": [
+          "acc.x",
+          "acc.y",
+          "acc.z"
+        ],
+        "attitude_diagnostic": [
+          "stabilizer.roll",
+          "stabilizer.pitch"
+        ],
+        "barometer": [
+          "baro.asl",
+          "baro.pressure",
+          "baro.temp"
+        ],
+        "gyroscope": [
+          "gyro.x",
+          "gyro.y",
+          "gyro.z"
+        ]
+      },
+      "omissions": [],
+      "source_archive_sha256": "996a79be8783de18ad26e8687322cc9ef7ff2bda1fa8331f4320f3389dd00ba7",
+      "source_issue_comment": "https://github.com/djibian/webeeblocks/issues/251#issuecomment-5604542710",
+      "source_json_sha256": "a8876546abf12d168ac41b1290cf5fcb7ee743c7946fb542606db61f2923d64f",
+      "verified_files": 28
+    }
+  ],
+  "schema": "webeeblocks.x3.archived-input-inventory.v1",
+  "scope": "retained text import from #292; original binary archives not re-fetched"
+}


### PR DESCRIPTION
The #70 architecture review requires archived IMU/barometer evidence to be inspected before another firmware candidate or physical test. #292 made the retained traces accessible, so the former access limitation no longer explains the missing proof.

This change verifies all 94 retained files against both import manifests, inventories all 76 CSVs while preserving exclusions, and records the reproducible derived result: continuous raw barometer, accelerometer and gyroscope samples are absent. All 4,448 #180 baroHeight samples are zero from an inactive log; S3 event-relative and held snapshots cannot substitute for a continuous independent signal. No independent metric vehicle-Z trajectory or measured mixed case is retained.

The scientific result is UNPROVEN, not a new physical FAIL/PASS. The report and smallest X3 roadmap update make the next boundary explicit: acquisition plus a frozen offline calculation/reference, using the existing #251 firmware and unchanged parameters. The pinned firmware already exposes the missing sensor logs; no estimator patch is justified merely to obtain them. #296 remains the separate generic evidence-publication workstream.

Validation: regenerated inventory is byte-identical; all retained hashes and sizes verified; changed, missing and unexpected raw-file controls are rejected. The audit emits no inferred physical verdict and executes no historical capture code. git diff --check passes. No firmware, Runtime, CI/checkpoint mechanism or motor behavior is changed; no checkpoint is requested.

Refs #70 #292. Independent review must verify the scientific scope and source/manifest provenance under current main AGENTS.md.