### PR TITLE
Automate durable physical-test evidence publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           python3 tools/ci/test_repository_hygiene.py
           python3 tools/ci/test_windows_release_contract.py
           python3 tools/ci/test_controller_contract.py
+          python3 tools/ci/test_evidence_publication.py
       - name: Select required suites
         id: scope
         run: >-

--- a/docs/CONTROLLER_NOTIFICATIONS.md
+++ b/docs/CONTROLLER_NOTIFICATIONS.md
@@ -29,6 +29,23 @@ provenance/digest and procedure are ready. Enabled profiles are:
 
 Any unknown profile is rejected until its preparation is implemented explicitly.
 
+## Raw output publication
+
+When an enabled or future checkpoint produces bounded CSV/text/log output, the
+canonical data path is Git-backed evidence, not a browser-only issue attachment.
+Use the repository-controlled profile plus
+`tools/evidence/publish_test_evidence.py` as described in
+[`TEST_EVIDENCE.md`](TEST_EVIDENCE.md). AI/tooling should invoke that bridge when
+it can access the files; on a physical test machine it may guide the same
+deterministic local command.
+
+The helper binds the exact request and tested SHA, preserves raw bytes, records
+sizes/SHA-256/provenance, verifies a manifest, and race-safely pushes a new
+evidence branch without force or overwrite. A Controller then opens the short
+Draft PR. Publication leaves `human_verdict` null: PASS/FAIL/NOT_NEEDED remains a
+separate owner-authoritative action. Manual `github.com/user-attachments` uploads
+may remain optional convenience copies but are non-canonical.
+
 ## Human concurrency and idempotence
 
 There may be only one unresolved TEST_REQUIRED globally. There is no queue. If a

--- a/docs/TEST_EVIDENCE.md
+++ b/docs/TEST_EVIDENCE.md
@@ -68,7 +68,12 @@ python3 tools/evidence/publish_test_evidence.py \
 
 Verification fails closed on a missing, unexpected, modified, size-mismatched or
 digest-mismatched raw file, malformed metadata/profile, changed manifest, invalid
-tested commit, or byte-preservation attributes.
+tested commit, or byte-preservation attributes. It also requires the bundled
+`PROFILE.json` bytes and digest to match the repository-controlled registered
+profile for that versioned id; a self-consistent evidence directory cannot widen
+its own file/size contract. `raw/`, `EVIDENCE.json`, `PROFILE.json`,
+`MANIFEST.sha256` and `.gitattributes` must be real in-tree files/directories,
+not symlink indirections to checkout-dependent external content.
 
 ## Publish without a manual attachment
 

--- a/docs/TEST_EVIDENCE.md
+++ b/docs/TEST_EVIDENCE.md
@@ -1,0 +1,119 @@
+# Durable physical-test evidence
+
+Issue #296 defines the canonical path for future bounded CSV/text/log evidence.
+Raw files produced by a physical checkpoint should become ordinary Git content;
+a browser-only `github.com/user-attachments` upload may be convenient transport,
+but it is not canonical project evidence.
+
+The publication path is:
+
+`exact request -> local output directory -> materialize/verify -> new evidence branch -> Draft PR -> human verdict`
+
+`tools/evidence/publish_test_evidence.py` is the deterministic local bridge. It
+does not run a physical test and it never records `PASS`, `FAIL` or `NOT_NEEDED`.
+
+## Registering a test-output profile
+
+Each reusable output shape is a repository-controlled JSON file under
+`tools/evidence/profiles/`. A profile declares:
+
+- a stable versioned profile id;
+- `required_globs`, each of which must match at least one produced file;
+- `allowed_globs`, outside of which publication fails closed;
+- `max_files` and `max_total_bytes` bounds.
+
+Adding a profile is sufficient to describe a new bounded output shape; no
+experiment-specific importer workflow is required. Version an incompatible
+profile rather than silently changing the meaning of evidence already published
+under an older id.
+
+The initial `physical-csv-text-v1` profile requires at least one CSV and allows
+bounded CSV, text, JSON and log files.
+
+## Materialize and verify locally
+
+The source directory is never modified or removed. From a checkout that contains
+the exact tested commit:
+
+```sh
+python3 tools/evidence/publish_test_evidence.py \
+  --repo-root . materialize \
+  --source /path/to/test-output \
+  --destination experiments/<experiment>/evidence/checkpoint-<N>-<sha12> \
+  --profile physical-csv-text-v1 \
+  --target-sha <exact-tested-40-char-sha> \
+  --checkpoint-ref issue-<N> \
+  --purpose checkpoint \
+  --request https://github.com/djibian/webeeblocks/issues/<N>#issuecomment-<ID> \
+  --provenance '<one-line capture command or equally precise production description>'
+```
+
+The resulting directory contains:
+
+- `raw/` — byte-for-byte copies of the registered source files;
+- `PROFILE.json` — the exact profile contract used for this capture;
+- `EVIDENCE.json` — exact SHA/request/profile/purpose/capture provenance, sizes,
+  digests, and an explicit `human_verdict: null`;
+- `MANIFEST.sha256` — an independently checkable raw-file SHA-256 manifest;
+- `.gitattributes` — `raw/** -text`, so Git does not normalize CRLF measurement
+  bytes or turn them into whitespace failures.
+
+A fresh Controller or operator can verify an evidence directory with:
+
+```sh
+python3 tools/evidence/publish_test_evidence.py \
+  --repo-root . verify \
+  --evidence-dir experiments/<experiment>/evidence/checkpoint-<N>-<sha12>
+```
+
+Verification fails closed on a missing, unexpected, modified, size-mismatched or
+digest-mismatched raw file, malformed metadata/profile, changed manifest, invalid
+tested commit, or byte-preservation attributes.
+
+## Publish without a manual attachment
+
+When tooling/AI has access to the local files and authenticated Git push is
+available, use `publish` instead of manually staging an archive:
+
+```sh
+python3 tools/evidence/publish_test_evidence.py \
+  --repo-root . publish \
+  --source /path/to/test-output \
+  --destination experiments/<experiment>/evidence/checkpoint-<N>-<sha12> \
+  --profile physical-csv-text-v1 \
+  --target-sha <exact-tested-40-char-sha> \
+  --checkpoint-ref issue-<N> \
+  --purpose checkpoint \
+  --request https://github.com/djibian/webeeblocks/issues/<N>#issuecomment-<ID> \
+  --provenance '<one-line capture command or equally precise production description>' \
+  --base-sha <exact-current-main-sha> \
+  --base-ref main \
+  --branch evidence/issue-<N>-<sha12>
+```
+
+Publication requires a clean checkout exactly at `--base-sha`, reconstructs the
+remote `main` SHA, refuses an already-existing evidence branch, creates the local
+branch, materializes and re-verifies the evidence, commits only that destination,
+rechecks remote `main` and the destination branch immediately before push, and
+uses a normal non-force push. It then verifies that the remote branch resolves to
+the exact created commit.
+
+If the remote base moves, the evidence branch appears concurrently, push is
+rejected, or remote verification is ambiguous, the command reports failure and
+keeps the local source/evidence for recovery. It never deletes raw source data.
+
+After a successful push, the Controller/AI opens a short Draft PR from the
+reported branch to `main`, links the exact checkpoint/request, and lets normal
+governance/independent review validate the evidence mechanism and content. The
+branch plus PR are project state; no Controller ownership marker is needed.
+
+## Authority boundary
+
+Raw publication is machine evidence, not a real-world acceptance verdict.
+`human_verdict` is deliberately fixed to `null`; this helper has no command-line
+surface that can publish `PASS`, `FAIL` or `NOT_NEEDED`. Those remain separate,
+owner-authoritative actions bound to the applicable TEST_REQUIRED request.
+
+Derived analysis should live separately from `raw/` and cite the immutable
+evidence set. A correction or recapture uses a new destination/branch; the tool
+will not overwrite an existing decision-relevant publication.

--- a/docs/TEST_EVIDENCE.md
+++ b/docs/TEST_EVIDENCE.md
@@ -94,13 +94,16 @@ python3 tools/evidence/publish_test_evidence.py \
 Publication requires a clean checkout exactly at `--base-sha`, reconstructs the
 remote `main` SHA, refuses an already-existing evidence branch, creates the local
 branch, materializes and re-verifies the evidence, commits only that destination,
-rechecks remote `main` and the destination branch immediately before push, and
-uses a normal non-force push. It then verifies that the remote branch resolves to
-the exact created commit.
+and rechecks remote `main` and the destination branch immediately before push.
+The push carries an explicit empty expected `--force-with-lease` for the exact
+destination ref: this is an atomic create-if-absent compare-and-swap, not authority
+to overwrite an existing branch. It then verifies that the remote branch resolves
+to the exact created commit.
 
-If the remote base moves, the evidence branch appears concurrently, push is
-rejected, or remote verification is ambiguous, the command reports failure and
-keeps the local source/evidence for recovery. It never deletes raw source data.
+If the remote base moves, the evidence branch appears concurrently (including in
+the final check→push gap), the atomic ref creation is rejected, or remote
+verification is ambiguous, the command reports failure and keeps the local
+source/evidence for recovery. It never deletes raw source data.
 
 After a successful push, the Controller/AI opens a short Draft PR from the
 reported branch to `main`, links the exact checkpoint/request, and lets normal

--- a/tools/ci/test_evidence_publication.py
+++ b/tools/ci/test_evidence_publication.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 MODULE = ROOT / "tools" / "evidence" / "publish_test_evidence.py"
@@ -263,6 +264,62 @@ def test_publish_creates_new_remote_branch_and_refuses_race(tmp: Path) -> None:
     )
     assert not (racer / race_destination).exists()
     assert run("git", "rev-parse", "HEAD", cwd=racer).stdout.strip() == base
+
+    # Reproduce the actual check→push TOCTOU: create the destination ref only
+    # after publish() has completed its final absence reconstruction, immediately
+    # before the underlying push process starts. The empty expected lease must
+    # reject even a would-be fast-forward and preserve the concurrent ref.
+    toctou = tmp / "repo-toctou"
+    run("git", "clone", "-q", "-b", "main", str(remote), str(toctou))
+    run("git", "config", "user.name", "Evidence Test", cwd=toctou)
+    run("git", "config", "user.email", "evidence@example.invalid", cwd=toctou)
+    toctou_base = run("git", "rev-parse", "HEAD", cwd=toctou).stdout.strip()
+    assert toctou_base == base
+    toctou_source, _ = fixture_source(tmp / "toctou-source-root")
+    toctou_branch = "evidence/issue-128-" + base[:12]
+    original_run_git = evidence.run_git
+    injected = {"done": False}
+
+    def racing_run_git(repo_root, *args, **kwargs):
+        if args and args[0] == "push" and not injected["done"]:
+            injected["done"] = True
+            run(
+                "git",
+                f"--git-dir={remote}",
+                "update-ref",
+                f"refs/heads/{toctou_branch}",
+                base,
+            )
+        return original_run_git(repo_root, *args, **kwargs)
+
+    with patch.object(evidence, "run_git", side_effect=racing_run_git):
+        expect_error(
+            lambda: evidence.publish(
+                repo_root=toctou,
+                source=toctou_source,
+                destination="experiments/fixture/evidence/checkpoint-toctou",
+                profile_id="physical-csv-text-v1",
+                target_sha=base,
+                checkpoint_ref="issue-128",
+                purpose="checkpoint",
+                request="https://github.com/djibian/webeeblocks/issues/128",
+                provenance="fixture injected check-push race",
+                base_sha=base,
+                base_ref="main",
+                branch=toctou_branch,
+                remote="origin",
+            ),
+            "atomic evidence branch creation failed",
+        )
+    assert injected["done"]
+    preserved = run(
+        "git",
+        "ls-remote",
+        "--heads",
+        str(remote),
+        f"refs/heads/{toctou_branch}",
+    ).stdout.split()[0]
+    assert preserved == base
 
 
 def main() -> int:

--- a/tools/ci/test_evidence_publication.py
+++ b/tools/ci/test_evidence_publication.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = ROOT / "tools" / "evidence" / "publish_test_evidence.py"
+PROFILE = ROOT / "tools" / "evidence" / "profiles" / "physical-csv-text-v1.json"
+
+spec = importlib.util.spec_from_file_location("publish_test_evidence", MODULE)
+assert spec and spec.loader
+evidence = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(evidence)
+
+
+def run(*args: str, cwd: Path | None = None, check: bool = True, text: bool = True):
+    process = subprocess.run(
+        list(args),
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=text,
+    )
+    if check and process.returncode:
+        stderr = process.stderr if text else process.stderr.decode("utf-8", "replace")
+        raise AssertionError(f"{' '.join(args)} failed: {stderr}")
+    return process
+
+
+def init_repo(root: Path, remote: Path | None = None) -> str:
+    run("git", "init", "-q", "-b", "main", str(root))
+    run("git", "config", "user.name", "Evidence Test", cwd=root)
+    run("git", "config", "user.email", "evidence@example.invalid", cwd=root)
+    profile_target = root / "tools" / "evidence" / "profiles"
+    profile_target.mkdir(parents=True)
+    shutil.copyfile(PROFILE, profile_target / PROFILE.name)
+    (root / "README.md").write_text("fixture\n", encoding="utf-8")
+    run("git", "add", ".", cwd=root)
+    run("git", "commit", "-q", "-m", "fixture base", cwd=root)
+    sha = run("git", "rev-parse", "HEAD", cwd=root).stdout.strip()
+    if remote is not None:
+        run("git", "init", "-q", "--bare", str(remote))
+        run("git", "remote", "add", "origin", str(remote), cwd=root)
+        run("git", "push", "-q", "-u", "origin", "main", cwd=root)
+    return sha
+
+
+def fixture_source(root: Path) -> tuple[Path, bytes]:
+    source = root / "source"
+    source.mkdir(parents=True)
+    raw = b"time,value\r\n0,1\r\n1,2\r\n"
+    (source / "trace.csv").write_bytes(raw)
+    (source / "operator.txt").write_bytes(b"captured without verdict\r\n")
+    return source, raw
+
+
+def expect_error(callable_, contains: str) -> None:
+    try:
+        callable_()
+    except evidence.EvidenceError as exc:
+        assert contains in str(exc), (contains, str(exc))
+        return
+    raise AssertionError(f"expected EvidenceError containing {contains!r}")
+
+
+def test_materialize_and_verify_preserve_raw_bytes(tmp: Path) -> None:
+    repo = tmp / "repo-materialize"
+    repo.mkdir()
+    base = init_repo(repo)
+    source, raw = fixture_source(tmp / "materialize-source-root")
+
+    destination = "experiments/fixture/evidence/checkpoint-123"
+    path = evidence.materialize(
+        repo_root=repo,
+        source=source,
+        destination=destination,
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-123",
+        purpose="checkpoint",
+        request="https://github.com/djibian/webeeblocks/issues/123#issuecomment-1",
+        provenance="fixture logger --csv trace.csv",
+    )
+    assert (path / "raw" / "trace.csv").read_bytes() == raw
+    metadata = evidence.verify(repo_root=repo, evidence_dir=path)
+    assert metadata["binding"]["target_sha"] == base
+    assert metadata["binding"]["checkpoint_ref"] == "issue-123"
+    assert metadata["capture"]["provenance"] == "fixture logger --csv trace.csv"
+    assert metadata["human_verdict"] is None
+    assert (path / "PROFILE.json").read_bytes() == PROFILE.read_bytes()
+    record = next(item for item in metadata["raw_files"] if item["path"] == "raw/trace.csv")
+    assert record["size"] == len(raw)
+    assert record["sha256"] == evidence.sha256_bytes(raw)
+    assert (path / "MANIFEST.sha256").read_text(encoding="utf-8").count("\n") == 2
+
+    # Raw CRLF must remain exact after Git stages it under the generated attributes.
+    run("git", "add", destination, cwd=repo)
+    blob = run(
+        "git",
+        "show",
+        f":{destination}/raw/trace.csv",
+        cwd=repo,
+        text=False,
+    ).stdout
+    assert blob == raw
+
+
+def test_fail_closed_inputs_and_mutation(tmp: Path) -> None:
+    repo = tmp / "repo-fail"
+    repo.mkdir()
+    base = init_repo(repo)
+
+    missing_source = tmp / "missing-source"
+    missing_source.mkdir()
+    (missing_source / "note.txt").write_bytes(b"no csv\r\n")
+    expect_error(
+        lambda: evidence.materialize(
+            repo_root=repo,
+            source=missing_source,
+            destination="evidence/missing",
+            profile_id="physical-csv-text-v1",
+            target_sha=base,
+            checkpoint_ref="issue-124",
+            purpose="checkpoint",
+            request="issue-124",
+            provenance="fixture missing-csv capture",
+        ),
+        "required evidence",
+    )
+    assert not (repo / "evidence" / "missing").exists()
+
+    unexpected_source = tmp / "unexpected-source"
+    unexpected_source.mkdir()
+    (unexpected_source / "trace.csv").write_bytes(b"x\r\n")
+    (unexpected_source / "payload.bin").write_bytes(b"\x00\x01")
+    expect_error(
+        lambda: evidence.materialize(
+            repo_root=repo,
+            source=unexpected_source,
+            destination="evidence/unexpected",
+            profile_id="physical-csv-text-v1",
+            target_sha=base,
+            checkpoint_ref="issue-125",
+            purpose="checkpoint",
+            request="issue-125",
+            provenance="fixture unexpected-file capture",
+        ),
+        "unexpected evidence",
+    )
+    assert not (repo / "evidence" / "unexpected").exists()
+
+    source, _ = fixture_source(tmp / "mutated-source-root")
+    path = evidence.materialize(
+        repo_root=repo,
+        source=source,
+        destination="evidence/mutated",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126",
+        purpose="checkpoint",
+        request="issue-126",
+        provenance="fixture mutation capture",
+    )
+    (path / "raw" / "trace.csv").write_bytes(b"tampered\n")
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=path),
+        "size mismatch",
+    )
+
+    manifest_source, _ = fixture_source(tmp / "manifest-source-root")
+    manifest_path = evidence.materialize(
+        repo_root=repo,
+        source=manifest_source,
+        destination="evidence/manifest-tamper",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126b",
+        purpose="checkpoint",
+        request="issue-126b",
+        provenance="fixture manifest-tamper capture",
+    )
+    (manifest_path / "MANIFEST.sha256").write_text(
+        "0" * 64 + "  raw/trace.csv\n", encoding="utf-8"
+    )
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=manifest_path),
+        "MANIFEST.sha256",
+    )
+
+
+def test_publish_creates_new_remote_branch_and_refuses_race(tmp: Path) -> None:
+    remote = tmp / "remote.git"
+    repo = tmp / "repo-publish"
+    repo.mkdir()
+    base = init_repo(repo, remote)
+    source, raw = fixture_source(tmp / "publish-source-root")
+
+    result = evidence.publish(
+        repo_root=repo,
+        source=source,
+        destination="experiments/fixture/evidence/checkpoint-127",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-127",
+        purpose="checkpoint",
+        request="https://github.com/djibian/webeeblocks/issues/127",
+        provenance="fixture publish capture",
+        base_sha=base,
+        base_ref="main",
+        branch="evidence/issue-127-" + base[:12],
+        remote="origin",
+    )
+    remote_sha = run(
+        "git",
+        "ls-remote",
+        "--heads",
+        str(remote),
+        "refs/heads/" + result["branch"],
+    ).stdout.split()[0]
+    assert remote_sha == result["commit_sha"]
+    stored = run(
+        "git",
+        f"--git-dir={remote}",
+        "show",
+        f"{remote_sha}:experiments/fixture/evidence/checkpoint-127/raw/trace.csv",
+        text=False,
+    ).stdout
+    assert stored == raw
+
+    # A fresh clean clone observes the existing branch before any materialization
+    # and refuses to overwrite it.
+    racer = tmp / "repo-racer"
+    run("git", "clone", "-q", "-b", "main", str(remote), str(racer))
+    run("git", "config", "user.name", "Evidence Test", cwd=racer)
+    run("git", "config", "user.email", "evidence@example.invalid", cwd=racer)
+    racer_base = run("git", "rev-parse", "HEAD", cwd=racer).stdout.strip()
+    assert racer_base == base
+    race_source, _ = fixture_source(tmp / "race-source-root")
+    race_destination = "experiments/fixture/evidence/checkpoint-race"
+    expect_error(
+        lambda: evidence.publish(
+            repo_root=racer,
+            source=race_source,
+            destination=race_destination,
+            profile_id="physical-csv-text-v1",
+            target_sha=base,
+            checkpoint_ref="issue-127",
+            purpose="checkpoint",
+            request="https://github.com/djibian/webeeblocks/issues/127",
+            provenance="fixture race capture",
+            base_sha=base,
+            base_ref="main",
+            branch=result["branch"],
+            remote="origin",
+        ),
+        "already exists",
+    )
+    assert not (racer / race_destination).exists()
+    assert run("git", "rev-parse", "HEAD", cwd=racer).stdout.strip() == base
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="webeeblocks-evidence-test-") as temp:
+        tmp = Path(temp)
+        test_materialize_and_verify_preserve_raw_bytes(tmp)
+        test_fail_closed_inputs_and_mutation(tmp)
+        test_publish_creates_new_remote_branch_and_refuses_race(tmp)
+    print(
+        "PASS raw test evidence is byte-preserving, manifest-bound, "
+        "fail-closed and race-safe to publish"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_evidence_publication.py
+++ b/tools/ci/test_evidence_publication.py
@@ -70,7 +70,7 @@ def expect_error(callable_, contains: str) -> None:
     raise AssertionError(f"expected EvidenceError containing {contains!r}")
 
 
-def rewrite_bundled_profile_limit(path: Path, key: str, value: int) -> None:
+def rewrite_bundled_profile_limit(path: Path, key: str, value: int) -> bytes:
     profile_path = path / "PROFILE.json"
     profile = json.loads(profile_path.read_text(encoding="utf-8"))
     profile[key] = value
@@ -80,6 +80,20 @@ def rewrite_bundled_profile_limit(path: Path, key: str, value: int) -> None:
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     metadata["profile"]["sha256"] = evidence.sha256_bytes(profile_raw)
     metadata_path.write_bytes(evidence.metadata_bytes(metadata))
+    return profile_raw
+
+
+def rewrite_registered_profile_limit(repo: Path, key: str, value: int) -> None:
+    profile_path = repo / "tools" / "evidence" / "profiles" / PROFILE.name
+    profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    profile[key] = value
+    profile_path.write_text(
+        json.dumps(profile, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def restore_registered_profile(repo: Path) -> None:
+    shutil.copyfile(PROFILE, repo / "tools" / "evidence" / "profiles" / PROFILE.name)
 
 
 def test_materialize_and_verify_preserve_raw_bytes(tmp: Path) -> None:
@@ -219,10 +233,12 @@ def test_fail_closed_inputs_and_mutation(tmp: Path) -> None:
         provenance="fixture max-files verifier capture",
     )
     rewrite_bundled_profile_limit(files_path, "max_files", 1)
+    rewrite_registered_profile_limit(repo, "max_files", 1)
     expect_error(
         lambda: evidence.verify(repo_root=repo, evidence_dir=files_path),
         "max_files",
     )
+    restore_registered_profile(repo)
 
     bytes_source, _ = fixture_source(tmp / "max-bytes-source-root")
     bytes_path = evidence.materialize(
@@ -240,9 +256,76 @@ def test_fail_closed_inputs_and_mutation(tmp: Path) -> None:
     total_bytes = sum(item["size"] for item in bytes_metadata["raw_files"])
     assert total_bytes > 1
     rewrite_bundled_profile_limit(bytes_path, "max_total_bytes", total_bytes - 1)
+    rewrite_registered_profile_limit(repo, "max_total_bytes", total_bytes - 1)
     expect_error(
         lambda: evidence.verify(repo_root=repo, evidence_dir=bytes_path),
         "max_total_bytes",
+    )
+    restore_registered_profile(repo)
+
+    # A self-consistent bundled profile may not widen the repository-controlled
+    # registered contract merely by rebinding its digest in EVIDENCE.json.
+    widened_source, _ = fixture_source(tmp / "widened-profile-source-root")
+    widened_path = evidence.materialize(
+        repo_root=repo,
+        source=widened_source,
+        destination="evidence/widened-profile",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126e",
+        purpose="checkpoint",
+        request="issue-126e",
+        provenance="fixture widened-profile tamper",
+    )
+    original_profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+    rewrite_bundled_profile_limit(
+        widened_path, "max_files", int(original_profile["max_files"]) + 100
+    )
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=widened_path),
+        "registered profile",
+    )
+
+    # Durable evidence must not be supplied through checkout-dependent symlink
+    # indirection, even when the external bytes and metadata still match.
+    raw_link_source, _ = fixture_source(tmp / "raw-link-source-root")
+    raw_link_path = evidence.materialize(
+        repo_root=repo,
+        source=raw_link_source,
+        destination="evidence/raw-link",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126f",
+        purpose="checkpoint",
+        request="issue-126f",
+        provenance="fixture raw-directory symlink tamper",
+    )
+    external_raw = tmp / "external-raw"
+    shutil.move(raw_link_path / "raw", external_raw)
+    (raw_link_path / "raw").symlink_to(external_raw, target_is_directory=True)
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=raw_link_path),
+        "real directory",
+    )
+
+    top_link_source, _ = fixture_source(tmp / "top-link-source-root")
+    top_link_path = evidence.materialize(
+        repo_root=repo,
+        source=top_link_source,
+        destination="evidence/top-link",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126g",
+        purpose="checkpoint",
+        request="issue-126g",
+        provenance="fixture top-level symlink tamper",
+    )
+    external_metadata = tmp / "external-EVIDENCE.json"
+    shutil.move(top_link_path / "EVIDENCE.json", external_metadata)
+    (top_link_path / "EVIDENCE.json").symlink_to(external_metadata)
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=top_link_path),
+        "real regular file",
     )
 
 

--- a/tools/ci/test_evidence_publication.py
+++ b/tools/ci/test_evidence_publication.py
@@ -70,6 +70,18 @@ def expect_error(callable_, contains: str) -> None:
     raise AssertionError(f"expected EvidenceError containing {contains!r}")
 
 
+def rewrite_bundled_profile_limit(path: Path, key: str, value: int) -> None:
+    profile_path = path / "PROFILE.json"
+    profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    profile[key] = value
+    profile_raw = (json.dumps(profile, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    profile_path.write_bytes(profile_raw)
+    metadata_path = path / "EVIDENCE.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["profile"]["sha256"] = evidence.sha256_bytes(profile_raw)
+    metadata_path.write_bytes(evidence.metadata_bytes(metadata))
+
+
 def test_materialize_and_verify_preserve_raw_bytes(tmp: Path) -> None:
     repo = tmp / "repo-materialize"
     repo.mkdir()
@@ -192,6 +204,45 @@ def test_fail_closed_inputs_and_mutation(tmp: Path) -> None:
     expect_error(
         lambda: evidence.verify(repo_root=repo, evidence_dir=manifest_path),
         "MANIFEST.sha256",
+    )
+
+    files_source, _ = fixture_source(tmp / "max-files-source-root")
+    files_path = evidence.materialize(
+        repo_root=repo,
+        source=files_source,
+        destination="evidence/max-files",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126c",
+        purpose="checkpoint",
+        request="issue-126c",
+        provenance="fixture max-files verifier capture",
+    )
+    rewrite_bundled_profile_limit(files_path, "max_files", 1)
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=files_path),
+        "max_files",
+    )
+
+    bytes_source, _ = fixture_source(tmp / "max-bytes-source-root")
+    bytes_path = evidence.materialize(
+        repo_root=repo,
+        source=bytes_source,
+        destination="evidence/max-bytes",
+        profile_id="physical-csv-text-v1",
+        target_sha=base,
+        checkpoint_ref="issue-126d",
+        purpose="checkpoint",
+        request="issue-126d",
+        provenance="fixture max-bytes verifier capture",
+    )
+    bytes_metadata = json.loads((bytes_path / "EVIDENCE.json").read_text(encoding="utf-8"))
+    total_bytes = sum(item["size"] for item in bytes_metadata["raw_files"])
+    assert total_bytes > 1
+    rewrite_bundled_profile_limit(bytes_path, "max_total_bytes", total_bytes - 1)
+    expect_error(
+        lambda: evidence.verify(repo_root=repo, evidence_dir=bytes_path),
+        "max_total_bytes",
     )
 
 

--- a/tools/evidence/profiles/physical-csv-text-v1.json
+++ b/tools/evidence/profiles/physical-csv-text-v1.json
@@ -1,0 +1,15 @@
+{
+  "allowed_globs": [
+    "**/*.csv",
+    "**/*.txt",
+    "**/*.json",
+    "**/*.log"
+  ],
+  "max_files": 256,
+  "max_total_bytes": 25000000,
+  "profile": "physical-csv-text-v1",
+  "required_globs": [
+    "**/*.csv"
+  ],
+  "schema": 1
+}

--- a/tools/evidence/publish_test_evidence.py
+++ b/tools/evidence/publish_test_evidence.py
@@ -607,7 +607,9 @@ def publish(
         if not SHA_RE.fullmatch(commit_sha):
             raise EvidenceError("publication commit did not resolve exactly")
 
-        # Reconstruct the remote immediately before the external effect.
+        # Reconstruct the remote immediately before the external effect. The lease
+        # below is the atomic create-if-absent check; the preceding read is only an
+        # early diagnostic and is never relied on as the write authority.
         if remote_branch_sha(repo_root, remote, base_ref) != base_sha:
             raise EvidenceError(
                 "remote base moved during publication; local evidence is retained"
@@ -619,13 +621,14 @@ def publish(
             repo_root,
             "push",
             "--porcelain",
+            f"--force-with-lease=refs/heads/{branch}:",
             remote,
             f"HEAD:refs/heads/{branch}",
             check=False,
         )
         if push.returncode:
             raise EvidenceError(
-                "race-safe evidence push failed; local evidence is retained: "
+                "atomic evidence branch creation failed; local evidence is retained: "
                 + push.stderr.strip()
             )
         published_sha = remote_branch_sha(repo_root, remote, branch)
@@ -676,7 +679,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     publish_parser = subparsers.add_parser(
         "publish",
-        help="materialize and push a new immutable evidence branch without force",
+        help="materialize and atomically create a new immutable evidence branch",
     )
     add_evidence_args(publish_parser)
     publish_parser.add_argument("--base-sha", required=True)

--- a/tools/evidence/publish_test_evidence.py
+++ b/tools/evidence/publish_test_evidence.py
@@ -300,7 +300,10 @@ def materialize(
 
 def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
     repo_root = repo_root.resolve()
-    evidence_dir = evidence_dir.resolve()
+    lexical_evidence_dir = evidence_dir.absolute()
+    if lexical_evidence_dir.is_symlink():
+        raise EvidenceError("evidence directory symlink is forbidden")
+    evidence_dir = lexical_evidence_dir.resolve()
     if not evidence_dir.is_dir():
         raise EvidenceError(f"evidence directory does not exist: {evidence_dir}")
     try:
@@ -311,6 +314,15 @@ def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
     metadata_path = evidence_dir / "EVIDENCE.json"
     manifest_path = evidence_dir / "MANIFEST.sha256"
     attributes_path = evidence_dir / ".gitattributes"
+    bundled_profile_path = evidence_dir / "PROFILE.json"
+    for path, label in (
+        (metadata_path, "EVIDENCE.json"),
+        (manifest_path, "MANIFEST.sha256"),
+        (attributes_path, ".gitattributes"),
+        (bundled_profile_path, "PROFILE.json"),
+    ):
+        if path.is_symlink() or not path.is_file():
+            raise EvidenceError(f"{label} must be a real regular file")
     try:
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -388,13 +400,21 @@ def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
     expected_registry = (PROFILE_ROOT / f"{profile_id}.json").as_posix()
     if profile_meta["registry_path"] != expected_registry:
         raise EvidenceError("profile registry path binding mismatch")
+    registered_profile, registered_profile_sha, registered_profile_raw = load_profile(
+        repo_root, profile_id
+    )
     try:
-        bundled_profile_raw = (evidence_dir / "PROFILE.json").read_bytes()
+        bundled_profile_raw = bundled_profile_path.read_bytes()
         bundled_profile = json.loads(bundled_profile_raw.decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise EvidenceError("bundled PROFILE.json is missing or invalid") from exc
     if sha256_bytes(bundled_profile_raw) != profile_meta["sha256"]:
         raise EvidenceError("bundled PROFILE.json digest mismatch")
+    if (
+        bundled_profile_raw != registered_profile_raw
+        or profile_meta["sha256"] != registered_profile_sha
+    ):
+        raise EvidenceError("bundled PROFILE.json does not match registered profile")
     if not isinstance(bundled_profile, dict):
         raise EvidenceError("bundled PROFILE.json must be an object")
     unknown = set(bundled_profile) - PROFILE_KEYS
@@ -423,7 +443,7 @@ def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
         or bundled_profile["max_total_bytes"] <= 0
     ):
         raise EvidenceError("bundled PROFILE.json contract mismatch")
-    profile = bundled_profile
+    profile = registered_profile
 
     try:
         attributes = attributes_path.read_text(encoding="utf-8")
@@ -463,8 +483,8 @@ def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
 
     raw_root = evidence_dir / "raw"
     actual_paths: list[str] = []
-    if not raw_root.is_dir():
-        raise EvidenceError("raw evidence directory is missing")
+    if raw_root.is_symlink() or not raw_root.is_dir():
+        raise EvidenceError("raw evidence directory must be a real directory")
     for path in raw_root.rglob("*"):
         if path.is_symlink():
             raise EvidenceError(f"raw evidence symlink is forbidden: {path}")

--- a/tools/evidence/publish_test_evidence.py
+++ b/tools/evidence/publish_test_evidence.py
@@ -473,6 +473,10 @@ def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
     actual_paths.sort()
     if expected_paths != sorted(expected_paths) or actual_paths != expected_paths:
         raise EvidenceError("raw evidence file set does not match EVIDENCE.json")
+    if len(actual_paths) > int(profile["max_files"]):
+        raise EvidenceError("raw evidence exceeds profile max_files")
+    if sum(int(record["size"]) for record in records) > int(profile["max_total_bytes"]):
+        raise EvidenceError("raw evidence exceeds profile max_total_bytes")
 
     relatives = [item[4:] for item in actual_paths]
     allowed = list(profile["allowed_globs"])

--- a/tools/evidence/publish_test_evidence.py
+++ b/tools/evidence/publish_test_evidence.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python3
+"""Materialize and race-safely publish raw physical-test evidence.
+
+The tool deliberately does not record a human PASS/FAIL/NOT_NEEDED verdict.
+It preserves raw bytes, binds them to an exact request and tested commit, and can
+publish a new Git branch without overwriting an existing publication.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import subprocess
+import sys
+from typing import Iterable
+
+SCHEMA_VERSION = 1
+TOOL_PATH = "tools/evidence/publish_test_evidence.py"
+PROFILE_ROOT = Path("tools/evidence/profiles")
+ATTRIBUTES = (
+    "raw/** -text "
+    "whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol\n"
+)
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+SLUG_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+BRANCH_RE = re.compile(r"evidence/[A-Za-z0-9][A-Za-z0-9._/-]{0,180}")
+PROFILE_KEYS = {
+    "schema",
+    "profile",
+    "required_globs",
+    "allowed_globs",
+    "max_files",
+    "max_total_bytes",
+}
+
+
+class EvidenceError(RuntimeError):
+    """Fail-closed evidence preparation or publication error."""
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_git(
+    repo_root: Path,
+    *args: str,
+    check: bool = True,
+    text: bool = True,
+) -> subprocess.CompletedProcess:
+    process = subprocess.run(
+        ["git", "-C", os.fspath(repo_root), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=text,
+    )
+    if check and process.returncode:
+        stderr = process.stderr if text else process.stderr.decode("utf-8", "replace")
+        raise EvidenceError(
+            f"git {' '.join(args)} failed ({process.returncode}): {stderr.strip()}"
+        )
+    return process
+
+
+def require_git_commit(repo_root: Path, sha: str) -> None:
+    if not SHA_RE.fullmatch(sha):
+        raise EvidenceError("target SHA must be an exact lowercase 40-character SHA")
+    result = run_git(repo_root, "cat-file", "-e", f"{sha}^{{commit}}", check=False)
+    if result.returncode:
+        raise EvidenceError(f"target SHA is not an available Git commit: {sha}")
+
+
+def profile_path(repo_root: Path, profile_id: str) -> Path:
+    if not SLUG_RE.fullmatch(profile_id):
+        raise EvidenceError("invalid evidence profile identifier")
+    return repo_root / PROFILE_ROOT / f"{profile_id}.json"
+
+
+def load_profile(repo_root: Path, profile_id: str) -> tuple[dict[str, object], str, bytes]:
+    path = profile_path(repo_root, profile_id)
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceError(f"evidence profile is unavailable: {path}") from exc
+    try:
+        profile = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError(f"evidence profile is not valid UTF-8 JSON: {path}") from exc
+    if not isinstance(profile, dict):
+        raise EvidenceError("evidence profile must be a JSON object")
+    unknown = set(profile) - PROFILE_KEYS
+    missing = PROFILE_KEYS - set(profile)
+    if unknown or missing:
+        raise EvidenceError(
+            f"evidence profile fields mismatch; missing={sorted(missing)} "
+            f"unknown={sorted(unknown)}"
+        )
+    if profile["schema"] != SCHEMA_VERSION or profile["profile"] != profile_id:
+        raise EvidenceError("evidence profile schema/id mismatch")
+    required = profile["required_globs"]
+    allowed = profile["allowed_globs"]
+    if (
+        not isinstance(required, list)
+        or not required
+        or not all(isinstance(item, str) and item for item in required)
+        or not isinstance(allowed, list)
+        or not allowed
+        or not all(isinstance(item, str) and item for item in allowed)
+    ):
+        raise EvidenceError("profile glob lists must be non-empty string arrays")
+    for key in ("max_files", "max_total_bytes"):
+        value = profile[key]
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise EvidenceError(f"profile {key} must be a positive integer")
+    return profile, sha256_bytes(raw), raw
+
+
+def _matches(relpath: str, pattern: str) -> bool:
+    # PurePath.match("**/*.csv") does not consistently express "root or nested"
+    # across Python versions, so "**/" is explicitly treated as zero-or-more dirs.
+    path = PurePosixPath(relpath)
+    if path.match(pattern) or fnmatch.fnmatchcase(relpath, pattern):
+        return True
+    return pattern.startswith("**/") and (
+        path.match(pattern[3:]) or fnmatch.fnmatchcase(relpath, pattern[3:])
+    )
+
+
+def discover_source_files(source: Path, profile: dict[str, object]) -> list[Path]:
+    if not source.is_dir():
+        raise EvidenceError(f"source directory does not exist: {source}")
+    paths: list[Path] = []
+    for path in source.rglob("*"):
+        if path.is_symlink():
+            raise EvidenceError(f"source symlink is forbidden: {path}")
+        if path.is_file():
+            paths.append(path)
+    paths.sort(key=lambda item: item.relative_to(source).as_posix())
+
+    if len(paths) > int(profile["max_files"]):
+        raise EvidenceError("source exceeds profile max_files")
+    total = sum(path.stat().st_size for path in paths)
+    if total > int(profile["max_total_bytes"]):
+        raise EvidenceError("source exceeds profile max_total_bytes")
+
+    allowed = list(profile["allowed_globs"])
+    required = list(profile["required_globs"])
+    relatives = [path.relative_to(source).as_posix() for path in paths]
+
+    unexpected = [
+        rel for rel in relatives if not any(_matches(rel, pattern) for pattern in allowed)
+    ]
+    if unexpected:
+        raise EvidenceError(f"unexpected evidence files: {unexpected}")
+
+    missing = [
+        pattern
+        for pattern in required
+        if not any(_matches(rel, pattern) for rel in relatives)
+    ]
+    if missing:
+        raise EvidenceError(f"required evidence patterns have no match: {missing}")
+    return paths
+
+
+def resolve_destination(repo_root: Path, destination: str) -> Path:
+    destination_path = Path(destination)
+    if destination_path.is_absolute() or not destination_path.parts:
+        raise EvidenceError("destination must be a non-empty repository-relative path")
+    if any(part in {"", ".", "..", ".git"} for part in destination_path.parts):
+        raise EvidenceError("destination contains a forbidden path component")
+    repo_real = repo_root.resolve()
+    dest_real = (repo_root / destination_path).resolve()
+    try:
+        dest_real.relative_to(repo_real)
+    except ValueError as exc:
+        raise EvidenceError("destination escapes repository root") from exc
+    return dest_real
+
+
+def manifest_text(records: Iterable[dict[str, object]]) -> str:
+    return "".join(f"{item['sha256']}  {item['path']}\n" for item in records)
+
+
+def metadata_bytes(metadata: dict[str, object]) -> bytes:
+    return (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def materialize(
+    *,
+    repo_root: Path,
+    source: Path,
+    destination: str,
+    profile_id: str,
+    target_sha: str,
+    checkpoint_ref: str,
+    purpose: str,
+    request: str,
+    provenance: str,
+) -> Path:
+    repo_root = repo_root.resolve()
+    source = source.resolve()
+    require_git_commit(repo_root, target_sha)
+    if not SLUG_RE.fullmatch(checkpoint_ref):
+        raise EvidenceError("checkpoint ref must be a stable slug")
+    if purpose not in {"checkpoint", "release"}:
+        raise EvidenceError("purpose must be checkpoint or release")
+    if not request.strip() or "\n" in request or "\r" in request or len(request) > 2048:
+        raise EvidenceError("request must be one non-empty durable reference line")
+    if (
+        not provenance.strip()
+        or "\n" in provenance
+        or "\r" in provenance
+        or len(provenance) > 4096
+    ):
+        raise EvidenceError("provenance must be one non-empty capture-description line")
+
+    profile, profile_sha, profile_raw = load_profile(repo_root, profile_id)
+    source_files = discover_source_files(source, profile)
+    destination_path = resolve_destination(repo_root, destination)
+    if destination_path.exists():
+        raise EvidenceError(f"destination already exists; refusing overwrite: {destination}")
+
+    raw_root = destination_path / "raw"
+    records: list[dict[str, object]] = []
+    try:
+        raw_root.mkdir(parents=True, exist_ok=False)
+        for source_path in source_files:
+            rel = source_path.relative_to(source)
+            target = raw_root / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source_path, target)
+            source_size = source_path.stat().st_size
+            copied_size = target.stat().st_size
+            source_sha = sha256_file(source_path)
+            copied_sha = sha256_file(target)
+            if source_size != copied_size or source_sha != copied_sha:
+                raise EvidenceError(f"byte-for-byte copy verification failed: {rel.as_posix()}")
+            records.append(
+                {
+                    "path": f"raw/{rel.as_posix()}",
+                    "sha256": copied_sha,
+                    "size": copied_size,
+                }
+            )
+
+        (destination_path / "PROFILE.json").write_bytes(profile_raw)
+        metadata = {
+            "binding": {
+                "checkpoint_ref": checkpoint_ref,
+                "purpose": purpose,
+                "request": request,
+                "target_sha": target_sha,
+            },
+            "capture": {"provenance": provenance},
+            "human_verdict": None,
+            "kind": "webeeblocks-raw-test-evidence",
+            "producer": {
+                "format_version": SCHEMA_VERSION,
+                "tool": TOOL_PATH,
+            },
+            "profile": {
+                "id": profile_id,
+                "registry_path": (PROFILE_ROOT / f"{profile_id}.json").as_posix(),
+                "sha256": profile_sha,
+            },
+            "raw_files": records,
+            "schema": SCHEMA_VERSION,
+        }
+        (destination_path / "EVIDENCE.json").write_bytes(metadata_bytes(metadata))
+        (destination_path / "MANIFEST.sha256").write_text(
+            manifest_text(records), encoding="utf-8", newline="\n"
+        )
+        (destination_path / ".gitattributes").write_text(
+            ATTRIBUTES, encoding="utf-8", newline="\n"
+        )
+        verify(repo_root=repo_root, evidence_dir=destination_path)
+    except BaseException:
+        # A failed materialization is never durable evidence. Removing only the
+        # newly-created destination is safe; the source is intentionally untouched.
+        if destination_path.exists():
+            shutil.rmtree(destination_path)
+        raise
+    return destination_path
+
+
+def verify(*, repo_root: Path, evidence_dir: Path) -> dict[str, object]:
+    repo_root = repo_root.resolve()
+    evidence_dir = evidence_dir.resolve()
+    if not evidence_dir.is_dir():
+        raise EvidenceError(f"evidence directory does not exist: {evidence_dir}")
+    try:
+        evidence_dir.relative_to(repo_root)
+    except ValueError as exc:
+        raise EvidenceError("evidence directory must be inside repository root") from exc
+
+    metadata_path = evidence_dir / "EVIDENCE.json"
+    manifest_path = evidence_dir / "MANIFEST.sha256"
+    attributes_path = evidence_dir / ".gitattributes"
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError("EVIDENCE.json is missing or invalid") from exc
+    if not isinstance(metadata, dict):
+        raise EvidenceError("EVIDENCE.json must be an object")
+    if set(metadata) != {
+        "binding",
+        "capture",
+        "human_verdict",
+        "kind",
+        "producer",
+        "profile",
+        "raw_files",
+        "schema",
+    }:
+        raise EvidenceError("EVIDENCE.json top-level contract mismatch")
+    if (
+        metadata["schema"] != SCHEMA_VERSION
+        or metadata["kind"] != "webeeblocks-raw-test-evidence"
+        or metadata["human_verdict"] is not None
+        or metadata["producer"]
+        != {"format_version": SCHEMA_VERSION, "tool": TOOL_PATH}
+    ):
+        raise EvidenceError("EVIDENCE.json semantic contract mismatch")
+    capture = metadata["capture"]
+    if (
+        not isinstance(capture, dict)
+        or set(capture) != {"provenance"}
+        or not isinstance(capture["provenance"], str)
+        or not capture["provenance"].strip()
+        or "\n" in capture["provenance"]
+        or "\r" in capture["provenance"]
+        or len(capture["provenance"]) > 4096
+    ):
+        raise EvidenceError("capture provenance contract mismatch")
+
+    binding = metadata["binding"]
+    if not isinstance(binding, dict) or set(binding) != {
+        "checkpoint_ref",
+        "purpose",
+        "request",
+        "target_sha",
+    }:
+        raise EvidenceError("evidence binding contract mismatch")
+    checkpoint_ref = binding["checkpoint_ref"]
+    target_sha = binding["target_sha"]
+    purpose = binding["purpose"]
+    request = binding["request"]
+    if not isinstance(checkpoint_ref, str) or not SLUG_RE.fullmatch(checkpoint_ref):
+        raise EvidenceError("invalid durable checkpoint binding")
+    if purpose not in {"checkpoint", "release"}:
+        raise EvidenceError("invalid durable purpose binding")
+    if (
+        not isinstance(request, str)
+        or not request.strip()
+        or "\n" in request
+        or "\r" in request
+        or len(request) > 2048
+    ):
+        raise EvidenceError("invalid durable request binding")
+    if not isinstance(target_sha, str):
+        raise EvidenceError("invalid durable target SHA binding")
+    require_git_commit(repo_root, target_sha)
+
+    profile_meta = metadata["profile"]
+    if (
+        not isinstance(profile_meta, dict)
+        or set(profile_meta) != {"id", "registry_path", "sha256"}
+    ):
+        raise EvidenceError("profile binding contract mismatch")
+    profile_id = profile_meta["id"]
+    if not isinstance(profile_id, str) or not SLUG_RE.fullmatch(profile_id):
+        raise EvidenceError("invalid profile identifier binding")
+    expected_registry = (PROFILE_ROOT / f"{profile_id}.json").as_posix()
+    if profile_meta["registry_path"] != expected_registry:
+        raise EvidenceError("profile registry path binding mismatch")
+    try:
+        bundled_profile_raw = (evidence_dir / "PROFILE.json").read_bytes()
+        bundled_profile = json.loads(bundled_profile_raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError("bundled PROFILE.json is missing or invalid") from exc
+    if sha256_bytes(bundled_profile_raw) != profile_meta["sha256"]:
+        raise EvidenceError("bundled PROFILE.json digest mismatch")
+    if not isinstance(bundled_profile, dict):
+        raise EvidenceError("bundled PROFILE.json must be an object")
+    unknown = set(bundled_profile) - PROFILE_KEYS
+    missing = PROFILE_KEYS - set(bundled_profile)
+    if unknown or missing:
+        raise EvidenceError("bundled PROFILE.json fields mismatch")
+    if (
+        bundled_profile["schema"] != SCHEMA_VERSION
+        or bundled_profile["profile"] != profile_id
+    ):
+        raise EvidenceError("bundled PROFILE.json schema/id mismatch")
+    required = bundled_profile["required_globs"]
+    allowed = bundled_profile["allowed_globs"]
+    if (
+        not isinstance(required, list)
+        or not required
+        or not all(isinstance(item, str) and item for item in required)
+        or not isinstance(allowed, list)
+        or not allowed
+        or not all(isinstance(item, str) and item for item in allowed)
+        or not isinstance(bundled_profile["max_files"], int)
+        or isinstance(bundled_profile["max_files"], bool)
+        or bundled_profile["max_files"] <= 0
+        or not isinstance(bundled_profile["max_total_bytes"], int)
+        or isinstance(bundled_profile["max_total_bytes"], bool)
+        or bundled_profile["max_total_bytes"] <= 0
+    ):
+        raise EvidenceError("bundled PROFILE.json contract mismatch")
+    profile = bundled_profile
+
+    try:
+        attributes = attributes_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise EvidenceError("evidence .gitattributes is missing") from exc
+    if attributes != ATTRIBUTES:
+        raise EvidenceError("evidence .gitattributes does not preserve raw bytes")
+
+    records = metadata["raw_files"]
+    if not isinstance(records, list):
+        raise EvidenceError("raw_files must be an array")
+    expected_paths: list[str] = []
+    for record in records:
+        if (
+            not isinstance(record, dict)
+            or set(record) != {"path", "sha256", "size"}
+            or not isinstance(record["path"], str)
+            or not record["path"].startswith("raw/")
+            or not isinstance(record["sha256"], str)
+            or not re.fullmatch(r"[0-9a-f]{64}", record["sha256"])
+            or not isinstance(record["size"], int)
+            or isinstance(record["size"], bool)
+            or record["size"] < 0
+        ):
+            raise EvidenceError("invalid raw_files record")
+        rel = PurePosixPath(record["path"])
+        if any(part in {"", ".", ".."} for part in rel.parts):
+            raise EvidenceError("invalid raw evidence path")
+        file_path = evidence_dir.joinpath(*rel.parts)
+        if file_path.is_symlink() or not file_path.is_file():
+            raise EvidenceError(f"raw evidence file missing or non-regular: {record['path']}")
+        if file_path.stat().st_size != record["size"]:
+            raise EvidenceError(f"raw evidence size mismatch: {record['path']}")
+        if sha256_file(file_path) != record["sha256"]:
+            raise EvidenceError(f"raw evidence digest mismatch: {record['path']}")
+        expected_paths.append(record["path"])
+
+    raw_root = evidence_dir / "raw"
+    actual_paths: list[str] = []
+    if not raw_root.is_dir():
+        raise EvidenceError("raw evidence directory is missing")
+    for path in raw_root.rglob("*"):
+        if path.is_symlink():
+            raise EvidenceError(f"raw evidence symlink is forbidden: {path}")
+        if path.is_file():
+            actual_paths.append(f"raw/{path.relative_to(raw_root).as_posix()}")
+    actual_paths.sort()
+    if expected_paths != sorted(expected_paths) or actual_paths != expected_paths:
+        raise EvidenceError("raw evidence file set does not match EVIDENCE.json")
+
+    relatives = [item[4:] for item in actual_paths]
+    allowed = list(profile["allowed_globs"])
+    required = list(profile["required_globs"])
+    if any(not any(_matches(rel, pattern) for pattern in allowed) for rel in relatives):
+        raise EvidenceError("raw evidence violates current profile allowed_globs")
+    if any(not any(_matches(rel, pattern) for rel in relatives) for pattern in required):
+        raise EvidenceError("raw evidence violates current profile required_globs")
+
+    try:
+        manifest = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise EvidenceError("MANIFEST.sha256 is missing") from exc
+    if manifest != manifest_text(records):
+        raise EvidenceError("MANIFEST.sha256 does not exactly match metadata")
+
+    allowed_top = {"EVIDENCE.json", "MANIFEST.sha256", "PROFILE.json", ".gitattributes", "raw"}
+    actual_top = {path.name for path in evidence_dir.iterdir()}
+    if actual_top != allowed_top:
+        raise EvidenceError("unexpected top-level evidence content")
+    return metadata
+
+
+def ensure_clean_base(repo_root: Path, base_sha: str) -> None:
+    require_git_commit(repo_root, base_sha)
+    head = run_git(repo_root, "rev-parse", "HEAD").stdout.strip()
+    if head != base_sha:
+        raise EvidenceError(f"working tree HEAD {head} is not requested base {base_sha}")
+    status = run_git(
+        repo_root, "status", "--porcelain=v1", "--untracked-files=all"
+    ).stdout
+    if status:
+        raise EvidenceError("working tree must be clean before publication")
+
+
+def remote_branch_sha(repo_root: Path, remote: str, branch: str) -> str | None:
+    result = run_git(
+        repo_root,
+        "ls-remote",
+        "--heads",
+        remote,
+        f"refs/heads/{branch}",
+        check=False,
+    )
+    if result.returncode:
+        raise EvidenceError(
+            f"cannot reconstruct remote branch state for {remote}/{branch}: "
+            f"{result.stderr.strip()}"
+        )
+    line = result.stdout.strip()
+    if not line:
+        return None
+    fields = line.split()
+    if len(fields) != 2 or fields[1] != f"refs/heads/{branch}" or not SHA_RE.fullmatch(fields[0]):
+        raise EvidenceError("unexpected git ls-remote response")
+    return fields[0]
+
+
+def publish(
+    *,
+    repo_root: Path,
+    source: Path,
+    destination: str,
+    profile_id: str,
+    target_sha: str,
+    checkpoint_ref: str,
+    purpose: str,
+    request: str,
+    provenance: str,
+    base_sha: str,
+    base_ref: str,
+    branch: str,
+    remote: str,
+) -> dict[str, str]:
+    repo_root = repo_root.resolve()
+    if not SHA_RE.fullmatch(base_sha):
+        raise EvidenceError("base SHA must be an exact lowercase 40-character SHA")
+    if not BRANCH_RE.fullmatch(branch) or ".." in branch or "//" in branch:
+        raise EvidenceError("publication branch must be a safe evidence/... branch")
+    if not remote or any(char.isspace() for char in remote):
+        raise EvidenceError("invalid Git remote name")
+    if not SLUG_RE.fullmatch(base_ref):
+        raise EvidenceError("base ref must be a simple branch name")
+
+    ensure_clean_base(repo_root, base_sha)
+    if remote_branch_sha(repo_root, remote, base_ref) != base_sha:
+        raise EvidenceError("remote base moved or does not match the exact requested base SHA")
+    if remote_branch_sha(repo_root, remote, branch) is not None:
+        raise EvidenceError("remote publication branch already exists; refusing overwrite")
+
+    # Create the local branch before touching the evidence destination. This leaves
+    # no untracked partial evidence if branch creation itself fails.
+    run_git(repo_root, "switch", "-c", branch, base_sha)
+    evidence_path: Path | None = None
+    try:
+        evidence_path = materialize(
+            repo_root=repo_root,
+            source=source,
+            destination=destination,
+            profile_id=profile_id,
+            target_sha=target_sha,
+            checkpoint_ref=checkpoint_ref,
+            purpose=purpose,
+            request=request,
+            provenance=provenance,
+        )
+        rel_destination = evidence_path.relative_to(repo_root).as_posix()
+        run_git(repo_root, "add", "--", rel_destination)
+
+        staged_names = [
+            line
+            for line in run_git(
+                repo_root, "diff", "--cached", "--name-only", "--diff-filter=ACMR"
+            ).stdout.splitlines()
+            if line
+        ]
+        prefix = rel_destination.rstrip("/") + "/"
+        if not staged_names or any(
+            name != rel_destination and not name.startswith(prefix)
+            for name in staged_names
+        ):
+            raise EvidenceError("staged publication contains changes outside evidence destination")
+
+        # The evidence-local .gitattributes makes CRLF raw files binary for Git
+        # whitespace purposes without changing their bytes.
+        run_git(repo_root, "diff", "--cached", "--check")
+        verify(repo_root=repo_root, evidence_dir=evidence_path)
+
+        message = f"Publish raw evidence {checkpoint_ref} for {target_sha[:12]}"
+        run_git(repo_root, "commit", "-m", message)
+        commit_sha = run_git(repo_root, "rev-parse", "HEAD").stdout.strip()
+        if not SHA_RE.fullmatch(commit_sha):
+            raise EvidenceError("publication commit did not resolve exactly")
+
+        # Reconstruct the remote immediately before the external effect.
+        if remote_branch_sha(repo_root, remote, base_ref) != base_sha:
+            raise EvidenceError(
+                "remote base moved during publication; local evidence is retained"
+            )
+        if remote_branch_sha(repo_root, remote, branch) is not None:
+            raise EvidenceError("remote publication branch appeared concurrently; refusing overwrite")
+
+        push = run_git(
+            repo_root,
+            "push",
+            "--porcelain",
+            remote,
+            f"HEAD:refs/heads/{branch}",
+            check=False,
+        )
+        if push.returncode:
+            raise EvidenceError(
+                "race-safe evidence push failed; local evidence is retained: "
+                + push.stderr.strip()
+            )
+        published_sha = remote_branch_sha(repo_root, remote, branch)
+        if published_sha != commit_sha:
+            raise EvidenceError(
+                "remote publication verification is ambiguous; local evidence is retained"
+            )
+        return {
+            "branch": branch,
+            "commit_sha": commit_sha,
+            "destination": rel_destination,
+            "target_sha": target_sha,
+        }
+    except BaseException:
+        # Never delete source or an already-created local evidence branch here.
+        # Its durable/remote state may be unknown after a failed push.
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="repository working tree (default: current directory)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_evidence_args(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--source", required=True)
+        command.add_argument("--destination", required=True)
+        command.add_argument("--profile", required=True)
+        command.add_argument("--target-sha", required=True)
+        command.add_argument("--checkpoint-ref", required=True)
+        command.add_argument("--purpose", choices=("checkpoint", "release"), required=True)
+        command.add_argument("--request", required=True)
+        command.add_argument("--provenance", required=True)
+
+    materialize_parser = subparsers.add_parser(
+        "materialize", help="copy, bind, hash and locally verify one evidence set"
+    )
+    add_evidence_args(materialize_parser)
+
+    verify_parser = subparsers.add_parser(
+        "verify", help="verify one already-materialized evidence set"
+    )
+    verify_parser.add_argument("--evidence-dir", required=True)
+
+    publish_parser = subparsers.add_parser(
+        "publish",
+        help="materialize and push a new immutable evidence branch without force",
+    )
+    add_evidence_args(publish_parser)
+    publish_parser.add_argument("--base-sha", required=True)
+    publish_parser.add_argument("--base-ref", default="main")
+    publish_parser.add_argument("--branch", required=True)
+    publish_parser.add_argument("--remote", default="origin")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(args.repo_root)
+    try:
+        if args.command == "verify":
+            metadata = verify(
+                repo_root=repo_root,
+                evidence_dir=repo_root / args.evidence_dir,
+            )
+            print(
+                json.dumps(
+                    {
+                        "verified": True,
+                        "target_sha": metadata["binding"]["target_sha"],
+                        "profile": metadata["profile"]["id"],
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+
+        common = {
+            "repo_root": repo_root,
+            "source": Path(args.source),
+            "destination": args.destination,
+            "profile_id": args.profile,
+            "target_sha": args.target_sha,
+            "checkpoint_ref": args.checkpoint_ref,
+            "purpose": args.purpose,
+            "request": args.request,
+            "provenance": args.provenance,
+        }
+        if args.command == "materialize":
+            path = materialize(**common)
+            print(
+                json.dumps(
+                    {
+                        "materialized": path.relative_to(repo_root.resolve()).as_posix(),
+                        "target_sha": args.target_sha,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+
+        result = publish(
+            **common,
+            base_sha=args.base_sha,
+            base_ref=args.base_ref,
+            branch=args.branch,
+            remote=args.remote,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except EvidenceError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the generic future evidence path requested by #296 without changing physical-test authority or synthesizing human results.

The new `tools/evidence/publish_test_evidence.py` local bridge consumes a registered output profile and exact local test-output directory, preserves raw bytes, binds the evidence to the exact checkpoint/request and tested Git SHA, records file sizes and SHA-256 digests, bundles the exact profile contract, writes a machine-verifiable `MANIFEST.sha256`, and verifies the materialized copy before publication. The initial `physical-csv-text-v1` profile covers bounded CSV/text/JSON/log evidence and requires at least one CSV; future bounded output shapes use a new repository-controlled versioned profile rather than silently widening an existing evidence contract. Fresh verification requires the bundled profile bytes/digest to match that registered profile exactly.

The verifier is fail-closed not only on paths, digests and profile bounds but also on storage provenance: the evidence directory and required top-level contract artifacts must be real in-tree objects, `raw/` must be a real non-symlink directory, and symlinks anywhere under `raw/` are rejected. Decision-relevant bytes therefore cannot be supplied through checkout-dependent external indirection.

The `publish` path is deliberately optimistic and fail-closed: it requires a clean checkout on an exact base SHA, reconstructs remote `main`, refuses an already-existing evidence branch, commits only the evidence destination, and rechecks remote base/branch state immediately before publication. The actual destination-ref creation is an atomic create-if-absent CAS using an explicit empty-expected `--force-with-lease=refs/heads/<branch>:`; a branch created in the final check→push gap is rejected even when an ordinary push would have been a valid fast-forward. Exact post-push ref verification remains mandatory, and failed or ambiguous publication keeps the local source/evidence without overwriting concurrent work.

`tools/ci/test_evidence_publication.py` provides deterministic coverage for CRLF/raw-byte preservation through Git staging, exact SHA/request/provenance binding, missing and unexpected evidence rejection, post-copy mutation/digest detection, manifest tampering, profile file/byte bounds, rejection of a self-consistent but more permissive bundled profile, rejection of raw-directory and top-level contract-file symlink indirection, successful remote publication, ordinary pre-existing-branch refusal, and an injected check→push race that creates the destination ref after the final absence read and proves that ref is preserved. The existing CI Gate select contract runs this test; no new workflow, trigger, permission, notification or human-test queue is introduced.

`docs/TEST_EVIDENCE.md` makes Git-backed raw evidence the canonical future path and manual `github.com/user-attachments` non-canonical. `docs/CONTROLLER_NOTIFICATIONS.md` documents the publication bridge while preserving the existing single `TEST_REQUIRED` boundary. Published `EVIDENCE.json` fixes `human_verdict` to `null`; PASS/FAIL/NOT_NEEDED remain separate owner-authoritative actions bound to the applicable request/candidate.

This is governance/evidence-mechanism work explicitly requested by #296, so the `.github/workflows/ci.yml` trust-boundary change is intentionally narrow and requires the stricter independent review applicable to checkpoint/evidence mechanisms before integration.

Closes #296. Refs #70 #292.