### PR TITLE
Capture independent X3 sensor inputs on unchanged firmware

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/INDEPENDENT_INPUT_CAPTURE.md
+++ b/experiments/crazyflie-ukf-surface-range/INDEPENDENT_INPUT_CAPTURE.md
@@ -1,0 +1,106 @@
+# X3 independent-input acquisition support
+
+The integrated [archive audit](evidence/analysis-2026-09-11/README.md) establishes
+that the old recordings lack continuous pressure and IMU samples. This collector
+fills the acquisition part of that gap using the existing #251 firmware. It
+does not implement or validate an independent vertical estimator.
+
+## Exact firmware and recorded signals
+
+The expected binary is the #251 artifact's `cf2.bin`, 250,176 bytes:
+
+`67d71f2fc74c06001bb141ed6206b0d06df23497a48f498531c3aba192f0b738`
+
+It was independently read from [artifact 10089812000](https://github.com/djibian/webeeblocks/actions/runs/34314942011/artifacts/10089812000)
+and the enclosing ZIP matched checkpoint #251's published SHA-256
+`c7b9b9143118fb7572e7b23a7f61e9936f220a1eb5f56e98ea39852f52c39cc3`.
+The authoritative artifact ID/digest are in
+[#251's result](https://github.com/djibian/webeeblocks/issues/251#issuecomment-5604562996).
+The collector checks the local binary; the operator confirms its installation.
+This is explicitly not remote firmware attestation. No flash is performed.
+
+| CSV block | Period | Signals | Fetch payload |
+| --- | ---: | --- | ---: |
+| `barometer` | 20 ms | `baro.asl`, `pressure`, `temp` | 12 bytes |
+| `imu` | 10 ms | `acc.x/y/z`, `gyro.x/y/z` | 24 bytes |
+| `pose` | 20 ms | downward range, roll/pitch, UKF Z/VZ | 20 bytes |
+| `detector` | 20 ms | S3 state/reason/offset/barometer delta, local Flow flag, late eligibility | 24 bytes |
+
+Every field is fetched as a float; each block fits cflib's 26-byte log payload.
+Units remain the pinned firmware units: barometer altitude in m, pressure in
+mbar, temperature in Celsius; accelerometer in g; filtered gyro in degrees/s;
+downward range in mm; roll/pitch in degrees; UKF Z in m and VZ in m/s. Diagnostic
+UKF outputs must not become independent displacement inputs.
+
+Both the 24-bit device log timestamp and host monotonic receipt time are retained
+for every row. Log time does not identify a sensor's producer time, and fetching
+acceleration/gyro in one block does not prove simultaneous sensor acquisition.
+The chosen cadence is an acquisition configuration, not proof that inertial
+integration or a 5 cm / 1 s bound is achievable. No missing row is interpolated.
+
+## Machine checks and output
+
+```sh
+python3 experiments/crazyflie-ukf-surface-range/capture_independent_inputs.py --describe
+python3 experiments/crazyflie-ukf-surface-range/test_capture_independent_inputs.py
+```
+
+These commands require no cflib, radio or physical action. Tests use explicitly
+synthetic links/telemetry and exercise the complete acquisition lifecycle plus
+missing streams, wrong configuration/binary, invalid rows, timestamp wrap versus
+duplicates, connection/parameter timeout, interruption and log-stop failure. They
+do not prove live throughput.
+
+For an eventual prepared checkpoint, the trusted procedure supplies the exact
+checkpoint URL and request SHA, the proven cflib runtime, this exact script and
+the exact local firmware file. The recording CLI additionally requires one
+explicit radio URI, a new output directory, duration (30–300 s), and explicit
+`--props-removed --installed-bin-confirmed`. The script checks all required live
+log names and reads the unchanged #251 parameters before declaring recording
+ready. It allows 30 s for the asynchronous connection/parameter download after
+opening the driver, then 5 s for every stream to become observable. These are
+protocol wait bounds, not a hard process deadline for OS/USB/file operations.
+It writes no parameter, estimator reset or commander request. Normal
+cflib close retains its documented safety-zero setpoint behavior.
+
+Output includes four CSVs and immutable start/ready/result metadata. Startup
+samples stay in the raw files; `recording-ready.json` is a receipt-clock marker,
+not an independently measured physical event boundary. Missing/malformed values
+stay visible in their raw row and make the capture incomplete. A gap over five
+configured log periods, duplicate/backward timestamp, stopped stream, transport
+failure, interruption or uncertain cleanup cannot yield `CAPTURED`. Smaller
+gaps are recorded in the per-stream maximum and remain part of later data-quality
+analysis. A forward 24-bit timestamp wrap is distinguished from a backward clock.
+
+`CAPTURED` means acquisition completed, never physical PASS, scientific adequacy
+or durable publication. A crash may leave only partial files; absence of a final
+result is incomplete/unknown. Existing output directories are never overwritten.
+
+## Remaining prerequisites before TEST_REQUIRED
+
+This change is a complete acquisition component; no new test is requested here.
+The following checkpoint preparation still remains:
+
+- Freeze and execute the offline pressure statistic/calculation and its tests,
+  including explicit handling of calibration drift, uncertainty and metric
+  reference validity. Do not tune it on new terrain outcomes.
+- Prepare the measured stationary/terrain/vertical/mixed procedure, synchronized
+  reference and event boundaries. A 30 s calibration and both signs of each
+  physical case are retained; the same analysis path must process every case.
+- Package and validate the exact runtime and supports in the trusted checkpoint
+  preparation. The collector's module hashes identify two observed modules;
+  they are deliberately not presented as a complete dependency lock. The live
+  cadence/availability remains unproven until the bounded props-off capture.
+- Provide the generic Controller-readable raw-publication path from #296 when
+  available, or another already authorized durable project path. This collector
+  does not implement a second attachment/import mechanism and never deletes or
+  uploads raw files. A manually attached archive alone is not canonical evidence.
+
+Preserve the local-range Flow split, all #251 parameters and the no-motorized
+boundary. No estimator or controller change follows from successful acquisition.
+
+## Inspected API sources
+
+- [Firmware log names/units](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/modules/src/stabilizer.c).
+- [Pinned cflib LogConfig/TOC/log lifecycle](https://github.com/bitcraze/crazyflie-lib-python/blob/45fdb784c9d13074c42835f3b5ac1d12133bf873/cflib/crazyflie/log.py).
+- [Pinned cflib asynchronous connection/parameter-ready and close lifecycle](https://github.com/bitcraze/crazyflie-lib-python/blob/45fdb784c9d13074c42835f3b5ac1d12133bf873/cflib/crazyflie/__init__.py).

--- a/experiments/crazyflie-ukf-surface-range/capture_independent_inputs.py
+++ b/experiments/crazyflie-ukf-surface-range/capture_independent_inputs.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Record missing X3 sensor inputs on the unchanged #251 firmware, props off.
+
+This is acquisition support, not a checkpoint request, estimator or physical
+verdict. Imports cflib only for an explicit recording. Never flashes, changes
+parameters, resets the estimator or invokes a commander. cflib's normal link
+close can still emit its documented safety-zero setpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import sys
+import threading
+import time
+
+
+FIRMWARE_TARGET = "6562ad827bf0c8bf2c9b609edad36f3e15652133"
+FIRMWARE_BIN_SHA256 = "67d71f2fc74c06001bb141ed6206b0d06df23497a48f498531c3aba192f0b738"
+PARAMETERS = {
+    "stabilizer.estimator": 3, "ukf.qualityGateTof": 20,
+    "ukf.baroNoise": 6.25, "ukf.surfaceOffsetS3": 1,
+}
+# Every variable is fetched as a 32-bit float: at most 24 of 26 payload bytes.
+# A log timestamp is NOT a per-sensor producer timestamp. No synchronized IMU
+# integration claim follows from this choice of log periods.
+BLOCKS = {
+    "barometer": (20, ("baro.asl", "baro.pressure", "baro.temp")),
+    "imu": (10, ("acc.x", "acc.y", "acc.z", "gyro.x", "gyro.y", "gyro.z")),
+    "pose": (20, ("range.zrange", "stabilizer.roll", "stabilizer.pitch",
+                  "stateEstimate.z", "stateEstimate.vz")),
+    "detector": (20, ("sensorFilter.surfState", "sensorFilter.surfReason",
+                      "sensorFilter.surfOffset", "sensorFilter.surfBaroD",
+                      "sensorFilter.flowLocal", "sensorFilter.lateElig")),
+}
+TIMESTAMP_MODULUS = 1 << 24
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def require_inputs(cf: object) -> dict[str, str]:
+    missing = [name for _, names in BLOCKS.values() for name in names
+               if cf.log.toc.get_element_by_complete_name(name) is None]
+    if missing:
+        raise ValueError("required live log variables missing: " + ", ".join(missing))
+    observed = {}
+    for name, expected in PARAMETERS.items():
+        raw = cf.param.get_value(name)
+        observed[name] = str(raw)
+        if isinstance(raw, bool) or float(raw) != expected:
+            raise ValueError(f"unchanged #251 parameter required: {name}")
+    return observed
+
+
+class Recorder:
+    """Append observed samples; keep incomplete/invalid captures for inspection."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.lock = threading.Lock()
+        self.error: str | None = None
+        self.closed = False
+        self.streams = {}
+        self.writers = {}
+        self.stats = {}
+        for name, (_, columns) in BLOCKS.items():
+            stream = (root / f"{name}.csv").open("x", newline="", encoding="utf-8")
+            writer = csv.writer(stream)
+            writer.writerow(("cf_timestamp_ms", "host_monotonic_s", *columns))
+            stream.flush()
+            self.streams[name] = stream
+            self.writers[name] = writer
+            self.stats[name] = {"rows": 0, "last_timestamp_ms": None,
+                                "last_host_s": None, "max_gap_ms": 0,
+                                "nonincreasing_timestamps": 0, "invalid_rows": 0}
+
+    def fail(self, reason: str) -> None:
+        with self.lock:
+            if self.error is None:
+                self.error = reason
+
+    def callback(self, name: str):
+        def received(timestamp, data, _config):
+            host_s = time.monotonic()
+            with self.lock:
+                if self.closed:
+                    return
+                stats = self.stats[name]
+                _, columns = BLOCKS[name]
+                values = [data.get(column) for column in columns]
+                # Retain the observed invalid row before marking it unusable.
+                try:
+                    self.writers[name].writerow((timestamp, repr(host_s), *values))
+                    self.streams[name].flush()
+                except OSError as exc:
+                    self.error = self.error or f"{name}: output write failed: {exc}"
+                    return
+                stats["rows"] += 1
+                valid = (isinstance(timestamp, int) and not isinstance(timestamp, bool)
+                         and 0 <= timestamp < TIMESTAMP_MODULUS
+                         and all(isinstance(v, (int, float)) and not isinstance(v, bool)
+                                 and math.isfinite(v) for v in values))
+                if not valid:
+                    stats["invalid_rows"] += 1
+                    self.error = self.error or f"{name}: missing/malformed/non-finite sample"
+                    return
+                previous = stats["last_timestamp_ms"]
+                if previous is not None:
+                    gap = (timestamp - previous) % TIMESTAMP_MODULUS
+                    if gap == 0 or gap >= TIMESTAMP_MODULUS // 2:
+                        stats["nonincreasing_timestamps"] += 1
+                        self.error = self.error or f"{name}: duplicate/backward log timestamp"
+                    else:
+                        stats["max_gap_ms"] = max(stats["max_gap_ms"], gap)
+                        if gap > 5 * BLOCKS[name][0]:
+                            self.error = self.error or f"{name}: log gap exceeds five periods"
+                stats["last_timestamp_ms"] = timestamp
+                stats["last_host_s"] = host_s
+        return received
+
+    def check_streams(self, *, startup: bool = False) -> bool:
+        with self.lock:
+            if self.error:
+                raise RuntimeError(self.error)
+            now = time.monotonic()
+            ready = all(s["rows"] >= 2 for s in self.stats.values())
+            if not startup and any(s["last_host_s"] is None or now - s["last_host_s"] > 1
+                                   for s in self.stats.values()):
+                raise RuntimeError("one or more required log streams stopped")
+            return ready
+
+    def close(self) -> None:
+        with self.lock:
+            self.closed = True
+            for stream in self.streams.values():
+                stream.close()
+
+
+def write_json_once(path: Path, value: object) -> None:
+    with path.open("x", encoding="utf-8") as stream:
+        json.dump(value, stream, indent=2, sort_keys=True, allow_nan=False)
+        stream.write("\n")
+
+
+def record(args) -> int:
+    if not args.props_removed or not args.installed_bin_confirmed:
+        raise ValueError("props removal and installation of the supplied exact binary must be confirmed")
+    if file_digest(args.firmware_bin) != FIRMWARE_BIN_SHA256:
+        raise ValueError("the supplied firmware file is not the exact #251 cf2.bin")
+    if not re.fullmatch(r"radio://[0-9]+/[0-9]+/(250K|1M|2M)(/[0-9A-Fa-f]+)?", args.uri):
+        raise ValueError("one explicit Crazyradio URI is required")
+    if not re.fullmatch(r"https://github.com/djibian/webeeblocks/issues/[1-9][0-9]*", args.checkpoint_url):
+        raise ValueError("an exact existing checkpoint issue URL is required")
+    if not re.fullmatch(r"[0-9a-f]{40}", args.request_sha):
+        raise ValueError("the exact checkpoint request SHA is required")
+    if not 30 <= args.seconds <= 300:
+        raise ValueError("capture duration must be 30–300 seconds")
+
+    import cflib
+    import cflib.crtp
+    from cflib.crazyflie import Crazyflie
+    from cflib.crazyflie.log import LogConfig
+
+    args.output.mkdir(parents=True, exist_ok=False)
+    write_json_once(args.output / "capture-start.json", {
+        "schema": "webeeblocks.x3.sensor-capture.v1",
+        "checkpoint_url": args.checkpoint_url, "request_sha": args.request_sha,
+        "test_profile": "s3-props-off", "purpose": "checkpoint",
+        "tested_firmware_source_sha": FIRMWARE_TARGET,
+        "verified_local_firmware_bin_sha256": FIRMWARE_BIN_SHA256,
+        "installed_firmware_identity": "operator-confirmed; not remote attestation",
+        "props_removed_operator_confirmation": True,
+        "capture_script_sha256": file_digest(Path(__file__)),
+        "cflib_module_sha256": file_digest(Path(cflib.__file__)),
+        "cflib_logging_module_sha256": file_digest(Path(sys.modules["cflib.crazyflie.log"].__file__)),
+        "runtime_boundary": "module fingerprints are not a complete dependency/runtime lock",
+        "started_host_monotonic_s": time.monotonic(), "duration_seconds": args.seconds,
+        "blocks": BLOCKS, "uri": args.uri,
+        "time_boundary": "device log and host receipt times; no sensor producer times",
+        "physical_verdict": None,
+    })
+    recorder = Recorder(args.output)
+    configs = []
+    outcome = "INCOMPLETE"
+    error = None
+    try:
+        cflib.crtp.init_drivers()
+        cf = Crazyflie(rw_cache=None)
+        fully_connected = threading.Event()
+        cf.fully_connected.add_callback(lambda *_: fully_connected.set())
+        cf.connection_failed.add_callback(lambda _, msg: recorder.fail(f"connection failed: {msg}"))
+        cf.connection_lost.add_callback(lambda *_: recorder.fail("Crazyradio connection lost"))
+        try:
+            cf.open_link(args.uri)
+            deadline = time.monotonic() + 30
+            while not fully_connected.is_set():
+                recorder.check_streams(startup=True)
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("connection/parameter download did not complete within 30 s")
+                time.sleep(0.02)
+            recorder.check_streams(startup=True)
+            observed = require_inputs(cf)
+            write_json_once(args.output / "observed-parameters.json", observed)
+            try:
+                for name, (period, columns) in BLOCKS.items():
+                    config = LogConfig("X3_" + name, period)
+                    for column in columns:
+                        config.add_variable(column, "float")
+                    cf.log.add_config(config)
+                    config.data_received_cb.add_callback(recorder.callback(name))
+                    config.error_cb.add_callback(lambda conf, msg: recorder.fail(f"{conf.name}: {msg}"))
+                    configs.append(config)
+                    config.start()
+                deadline = time.monotonic() + 5
+                while not recorder.check_streams(startup=True):
+                    if time.monotonic() >= deadline:
+                        raise RuntimeError("required streams did not become observable within 5 s")
+                    time.sleep(0.02)
+                # Startup samples stay in the raw files. This timestamp identifies
+                # readiness, not the physical start/end of a movement.
+                ready_at = time.monotonic()
+                write_json_once(args.output / "recording-ready.json", {"host_monotonic_s": ready_at})
+                print("ENREGISTREMENT : suivez uniquement la procédure du checkpoint ; hélices retirées.", flush=True)
+                while time.monotonic() - ready_at < args.seconds:
+                    recorder.check_streams()
+                    time.sleep(0.02)
+                recorder.check_streams()
+                outcome = "CAPTURED"
+            finally:
+                for config in configs:
+                    try:
+                        config.stop()
+                    except Exception as exc:
+                        recorder.fail(f"log stop failed: {exc}")
+        finally:
+            cf.close_link()
+    except (Exception, KeyboardInterrupt) as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        recorder.close()
+        if error or recorder.error:
+            outcome = "INCOMPLETE"
+        write_json_once(args.output / "capture-result.json", {
+            "capture_status": outcome, "error": error or recorder.error,
+            "streams": recorder.stats, "physical_verdict": None,
+            "boundary": "capture completion is not scientific sufficiency or durable publication",
+        })
+    print(f"{outcome}: {args.output}")
+    return 0 if outcome == "CAPTURED" else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--describe", action="store_true", help="show log plan without importing cflib")
+    parser.add_argument("--uri")
+    parser.add_argument("--checkpoint-url")
+    parser.add_argument("--request-sha")
+    parser.add_argument("--firmware-bin", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--seconds", type=int, default=150)
+    parser.add_argument("--props-removed", action="store_true")
+    parser.add_argument("--installed-bin-confirmed", action="store_true")
+    args = parser.parse_args()
+    if args.describe:
+        print(json.dumps({"blocks": BLOCKS, "parameters": PARAMETERS,
+                          "firmware_target": FIRMWARE_TARGET,
+                          "firmware_bin_sha256": FIRMWARE_BIN_SHA256}, indent=2))
+        return 0
+    if not all((args.uri, args.checkpoint_url, args.request_sha, args.firmware_bin, args.output)):
+        parser.error("recording requires URI, checkpoint URL/SHA, exact firmware file and new output directory")
+    try:
+        return record(args)
+    except (OSError, ValueError, ImportError) as exc:
+        print(f"CAPTURE_ERROR: {exc}; retain any partial output for inspection", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/crazyflie-ukf-surface-range/test_capture_independent_inputs.py
+++ b/experiments/crazyflie-ukf-surface-range/test_capture_independent_inputs.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Deterministic acquisition tests. All telemetry/links here are synthetic."""
+
+import contextlib
+import csv
+import hashlib
+import io
+import json
+from pathlib import Path
+import tempfile
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+import capture_independent_inputs as capture
+
+
+class Event:
+    def __init__(self):
+        self.callbacks = []
+
+    def add_callback(self, callback):
+        self.callbacks.append(callback)
+
+    def emit(self, *args):
+        for callback in self.callbacks:
+            callback(*args)
+
+
+class AcquisitionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+    def test_required_live_signals_and_unchanged_parameters(self):
+        available = {v for _, names in capture.BLOCKS.values() for v in names}
+        values = {k: str(v) for k, v in capture.PARAMETERS.items()}
+        cf = SimpleNamespace(
+            log=SimpleNamespace(toc=SimpleNamespace(get_element_by_complete_name=lambda n: n if n in available else None)),
+            param=SimpleNamespace(get_value=lambda n: values[n]),
+        )
+        self.assertEqual(capture.require_inputs(cf), values)
+        available.remove("baro.asl")
+        with self.assertRaisesRegex(ValueError, "baro.asl"):
+            capture.require_inputs(cf)
+        available.add("baro.asl")
+        values["ukf.qualityGateTof"] = "100"
+        with self.assertRaisesRegex(ValueError, "unchanged"):
+            capture.require_inputs(cf)
+        self.assertTrue(all(4 * len(names) <= 26 and period % 10 == 0
+                            for period, names in capture.BLOCKS.values()))
+
+    def test_invalid_samples_preserved_and_timestamp_wrap_distinguished(self):
+        recorder = capture.Recorder(self.root)
+        cb = recorder.callback("barometer")
+        data = {"baro.asl": 10.0, "baro.pressure": 1013.0, "baro.temp": 20.0}
+        cb((1 << 24) - 10, data, None)
+        cb(10, data, None)  # genuine forward 24-bit wrap, 20 ms
+        self.assertIsNone(recorder.error)
+        cb(10, data, None)  # duplicate, not a new sensor observation
+        self.assertIn("duplicate", recorder.error)
+        cb(30, {"baro.asl": float("nan")}, None)
+        recorder.close()
+        with (self.root / "barometer.csv").open() as stream:
+            rows = list(csv.DictReader(stream))
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[-1]["baro.asl"], "nan")
+        self.assertEqual(rows[-1]["baro.pressure"], "")
+        self.assertEqual(recorder.stats["barometer"]["invalid_rows"], 1)
+        self.assertEqual(recorder.stats["barometer"]["max_gap_ms"], 20)
+
+    def test_large_gap_and_stopped_stream_are_incomplete(self):
+        recorder = capture.Recorder(self.root)
+        self.addCleanup(recorder.close)
+        with patch.object(capture.time, "monotonic", return_value=100.0):
+            for name, (period, columns) in capture.BLOCKS.items():
+                callback = recorder.callback(name)
+                data = dict.fromkeys(columns, 0.0)
+                callback(1000, data, None)
+                callback(1000 + period, data, None)
+            self.assertTrue(recorder.check_streams())
+        with patch.object(capture.time, "monotonic", return_value=101.1):
+            with self.assertRaisesRegex(RuntimeError, "stopped"):
+                recorder.check_streams()
+        recorder.callback("barometer")(1140, dict.fromkeys(capture.BLOCKS["barometer"][1], 0.0), None)
+        with self.assertRaisesRegex(RuntimeError, "gap"):
+            recorder.check_streams()
+        self.assertEqual(recorder.stats["barometer"]["max_gap_ms"], 120)
+
+    def fake_record(self, *, omit=None, interrupt=False, bad_stop=False, no_connection=False):
+        configs = []
+        clock = [1000.0]
+        class Config:
+            def __init__(self, name, period):
+                self.name, self.period, self.columns = name, period, []
+                self.data_received_cb, self.error_cb = Event(), Event()
+                self.active = False
+                configs.append(self)
+            def add_variable(self, name, fetch_as):
+                assert fetch_as == "float"
+                self.columns.append(name)
+            def start(self):
+                self.active = True
+            def stop(self):
+                self.active = False
+                if bad_stop:
+                    raise RuntimeError("synthetic log stop failure")
+        class CF:
+            def __init__(self, **_):
+                self.connection_lost, self.connection_failed, self.fully_connected = Event(), Event(), Event()
+                self.log = SimpleNamespace(
+                    toc=SimpleNamespace(get_element_by_complete_name=lambda _: object()),
+                    add_config=lambda _: None,
+                )
+                self.param = SimpleNamespace(get_value=lambda n: str(capture.PARAMETERS[n]))
+            def open_link(self, uri):
+                if not no_connection:
+                    self.fully_connected.emit(uri)
+            def close_link(self):
+                pass
+        def sleep(seconds):
+            clock[0] += seconds
+            if interrupt and clock[0] > 1000.2:
+                raise KeyboardInterrupt("synthetic interruption")
+            stamp = round(clock[0] * 1000) % (1 << 24)
+            for conf in configs:
+                if conf.active and conf.name != omit:
+                    conf.data_received_cb.emit(stamp, {v: 0.0 for v in conf.columns}, conf)
+        modules = {n: ModuleType(n) for n in (
+            "cflib", "cflib.crtp", "cflib.crazyflie", "cflib.crazyflie.log",
+        )}
+        modules["cflib"].__file__ = __file__
+        modules["cflib"].crtp = modules["cflib.crtp"]
+        modules["cflib.crtp"].init_drivers = lambda: None
+        modules["cflib.crazyflie"].Crazyflie = CF
+        modules["cflib.crazyflie.log"].LogConfig = Config
+        modules["cflib.crazyflie.log"].__file__ = __file__
+        binary = self.root / "synthetic.bin"
+        binary.write_bytes(b"SYNTHETIC FIRMWARE FIXTURE, NOT A FLIGHT ARTIFACT")
+        args = SimpleNamespace(
+            props_removed=True, installed_bin_confirmed=True, firmware_bin=binary,
+            uri="radio://0/80/2M", checkpoint_url="https://github.com/djibian/webeeblocks/issues/251",
+            request_sha=capture.FIRMWARE_TARGET,
+            output=self.root / "capture", seconds=30,
+        )
+        with patch.dict("sys.modules", modules), patch.object(capture.time, "monotonic", lambda: clock[0]), \
+             patch.object(capture.time, "sleep", sleep), \
+             patch.object(capture, "FIRMWARE_BIN_SHA256", hashlib.sha256(binary.read_bytes()).hexdigest()), \
+             contextlib.redirect_stdout(io.StringIO()):
+            result = capture.record(args)
+        return result, json.loads((args.output / "capture-result.json").read_text())
+
+    def test_complete_acquisition_is_not_a_physical_verdict(self):
+        code, result = self.fake_record()
+        self.assertEqual(code, 0)
+        self.assertEqual(result["capture_status"], "CAPTURED")
+        self.assertIsNone(result["physical_verdict"])
+        self.assertTrue(all(s["rows"] > 100 for s in result["streams"].values()))
+        self.assertEqual(len(list((self.root / "capture").glob("*.csv"))), 4)
+
+    def test_missing_stream_retains_incomplete_output(self):
+        code, result = self.fake_record(omit="X3_barometer")
+        self.assertEqual(code, 1)
+        self.assertEqual(result["capture_status"], "INCOMPLETE")
+        self.assertEqual(result["streams"]["barometer"]["rows"], 0)
+        self.assertGreater(result["streams"]["imu"]["rows"], 0)
+        self.assertFalse((self.root / "capture" / "recording-ready.json").exists())
+
+    def test_connection_or_parameter_download_timeout_is_incomplete(self):
+        code, result = self.fake_record(no_connection=True)
+        self.assertEqual(code, 1)
+        self.assertIn("within 30 s", result["error"])
+        self.assertEqual(result["capture_status"], "INCOMPLETE")
+        self.assertTrue(all(s["rows"] == 0 for s in result["streams"].values()))
+        self.assertFalse((self.root / "capture" / "recording-ready.json").exists())
+
+    def test_interruption_and_uncertain_stop_cannot_report_completion(self):
+        code, result = self.fake_record(interrupt=True)
+        self.assertEqual(code, 1)
+        self.assertEqual(result["capture_status"], "INCOMPLETE")
+        self.assertIn("KeyboardInterrupt", result["error"])
+
+    def test_log_stop_error_is_retained(self):
+        code, result = self.fake_record(bad_stop=True)
+        self.assertEqual(code, 1)
+        self.assertEqual(result["capture_status"], "INCOMPLETE")
+        self.assertIn("stop", result["error"])
+
+    def test_wrong_binary_or_missing_confirmation_cannot_open_link(self):
+        binary = self.root / "wrong.bin"
+        binary.write_bytes(b"wrong")
+        args = SimpleNamespace(props_removed=False, installed_bin_confirmed=True, firmware_bin=binary)
+        with self.assertRaisesRegex(ValueError, "confirmed"):
+            capture.record(args)
+        args.props_removed = True
+        with self.assertRaisesRegex(ValueError, "exact #251"):
+            capture.record(args)
+        # These failures occur before cflib is imported and before output creation.
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The #297 archive audit established that retained #180/#236/#251 traces contain neither continuous raw barometer nor IMU samples. This PR supplies the acquisition component for the independent-displacement question in #70, using the unchanged #251 firmware.

`capture_independent_inputs.py` records four bounded log blocks (barometer, IMU, pose and S3 diagnostics), retaining device and host receipt timestamps and every observed raw row. It requires the exact locally hashed #251 binary, explicit props-removed/installation confirmations, a checkpoint issue/request SHA, live log names and unchanged parameters. Connection/parameter readiness and stream startup have explicit protocol wait bounds. Missing streams, malformed/nonfinite data, timestamp errors, excessive gaps, interruption and uncertain cleanup retain incomplete output; acquisition completion never emits a physical verdict.

`INDEPENDENT_INPUT_CAPTURE.md` binds the freshly inspected artifact/binary digests and pinned cflib/firmware APIs, and states the limits: operator-confirmed installation is not remote attestation; two module hashes are not a complete runtime lock; log timestamps do not prove sensor producer synchronization or scientific adequacy. The collector does not flash, write parameters, reset the estimator or invoke a commander. The stock cflib close path retains its safety-zero setpoint behavior.

Validation: nine deterministic tests pass locally, exercising the complete acquisition lifecycle with synthetic links/telemetry, invalid/missing inputs, 24-bit timestamp wrap versus duplicates, gaps/stalls, connection/parameter timeout, interruption and stop failure. `--describe` works without cflib or hardware; `git diff --check` passes. These local tests are not live-throughput evidence and are not claimed as a new CI oracle.

The acquisition change originated at `f681639ed463a8a0ea3903e89919436d7f0c8ba6` and is now offered on current main at exact candidate `d959ae7c65c0c8af9ae8adda4677ee9dd6c23132`. Frozen offline calculation/reference, full runtime/support packaging and durable generic raw publication still must be prepared and validated before a new TEST_REQUIRED. No checkpoint is requested here, and no estimator/Runtime/CI/checkpoint mechanism is changed. #296/#298 remain the separate generic publication work.

Refs #70 #297.