### PR TITLE
Freeze descriptive X3 pressure-window calculation

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/FROZEN_PRESSURE_PROBE.md
+++ b/experiments/crazyflie-ukf-surface-range/FROZEN_PRESSURE_PROBE.md
@@ -1,0 +1,90 @@
+# Frozen descriptive pressure probe
+
+This executes the pressure-only statistic specified by
+[#70's architecture review](https://github.com/djibian/webeeblocks/issues/70#issuecomment-5606273253).
+The archived-input audit establishes that the retained traces cannot supply its
+continuous inputs. No new physical result is derived here. The probe is an
+offline calculation component, not the complete IMU/barometer predictor or a
+prepared checkpoint.
+
+For every annotated stationary, terrain, vertical and mixed episode, the exact
+same function computes `median(B+) - median(B-)`. B− is `[start−0.5, start)`;
+B+ is `[end+0.25, end+0.75)`. There is no S3/UKF eligibility branch. Labels do not
+change the computation; they do not establish physical truth. The statistic
+uses raw firmware `baro.asl`, never UKF Z/VZ or an S3 conditional snapshot.
+
+A centered least-squares line is fitted only to the supplied prior stationary
+calibration of at least 30 s. Both the raw contrast and the comparison after
+subtracting `slope × observed median-timestamp separation` are retained. This
+uses the actual sampled times instead of assuming the sampling grid coincides
+with nominal window centers. Event outcomes
+cannot change that fit, the windows or any parameter.
+
+Calibration comparisons use the same window width and separation as each event.
+Their complete before/after spans do not overlap. Every pair and its signed
+residual remain in the output. The residual extrema describe only this finite
+calibration: non-overlap does **not** prove independence, and low-rate drift and
+sensor autocorrelation remain relevant. Pair count is not an effective
+independent sample count. No Gaussian error, standard error, 95/99% confidence
+or future uncertainty bound is inferred from these counts/extrema. The effective
+count and predictive bound stay null and the scientific result stays UNPROVEN.
+
+## Inputs and execution
+
+The specification is a JSON file with this shape (times and names are illustrative,
+not measured data):
+
+```json
+{
+  "schema": "webeeblocks.x3.pressure-probe-input.v1",
+  "barometer": {"path": "barometer.csv", "sha256": "<exact 64-hex digest>"},
+  "calibration": {"start_s": 0, "end_s": 30},
+  "events": [
+    {"id": "terrain-entry", "kind": "terrain", "start_s": 34, "end_s": 35}
+  ]
+}
+```
+
+The CSV columns are `cf_timestamp_ms,host_monotonic_s,baro.asl,baro.pressure,baro.temp`.
+Additional columns are not used. Time zero is the first barometer device log
+timestamp, with genuine forward 24-bit wraps unwrapped; the host clock is retained
+and checked but never substituted for device time. Physical event annotations
+must later come from an independently synchronized reference. Startup/readiness
+or S3 decisions do not supply those boundaries.
+
+```sh
+python3 experiments/crazyflie-ukf-surface-range/test_frozen_pressure_probe.py
+python3 experiments/crazyflie-ukf-surface-range/frozen_pressure_probe.py input.json --output pressure-result.json
+```
+
+The file entry point verifies the exact input digest and confines the input path
+to the specification directory, preserves source bytes, fingerprints the script
+and specification and creates a new result file exclusively. Empty/non-finite
+inputs, ambiguous timestamps, receipt-clock reversal, gaps over 40 ms, windows
+with fewer than 20 rows per 0.5 s or edge coverage worse than 40 ms fail closed.
+These fixed checks establish minimal sampled-window coverage, not sensor producer
+cadence or independent observations. Episodes must be ordered, with at least 2 s
+between calibration/episodes; the physical stillness of these plateaus is not
+verified by arithmetic. No missing sample is synthesized.
+
+The synthetic tests establish signed arithmetic, identical paths for all labels,
+calibration isolation from changed terrain values, matched non-overlapping pairs,
+input integrity and rejection of missing coverage/clock errors. They are local
+component tests, not a new CI or physical oracle.
+
+## Remaining scientific boundary
+
+`COMPUTED` establishes only that this descriptive calculation ran. Every result
+keeps `independent_displacement_verdict: UNPROVEN` and `physical_verdict: null`.
+The end+0.75 s window endpoint is not an end-to-end latency measurement. In
+particular, this component neither compares an independent metric Z reference,
+integrates IMU signals nor computes/validates terrain Δh.
+
+Before any new checkpoint, the complete preparation still needs the exact
+acquisition/runtime, synchronized metric reference and annotations, an executable
+independent predictor with its validity/uncertainty limits, and durable raw
+publication. Faithful inertial replay requires verified producer timing, bias and
+attitude treatment; log receipt times and ToF-derived estimator outputs cannot
+silently fill those gaps. Failure of this frozen probe must not trigger a search
+for windows tuned to the same terrain outcomes. Preserve the #251 firmware and
+parameters, the Flow local-range split and the props-off boundary.

--- a/experiments/crazyflie-ukf-surface-range/frozen_pressure_probe.py
+++ b/experiments/crazyflie-ukf-surface-range/frozen_pressure_probe.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Frozen descriptive pressure probe for #70; never a physical/estimator verdict."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+from pathlib import Path
+import re
+from statistics import median
+
+
+WINDOW_S = 0.5
+POST_DELAY_S = 0.25
+MAX_GAP_S = 0.04
+MIN_WINDOW_ROWS = 20
+KINDS = ("stationary", "terrain", "vertical", "mixed")
+MODULUS = 1 << 24
+
+
+def finite(value, name):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"{name}: finite number required")
+    return float(value)
+
+
+def read_barometer(raw: bytes) -> list[tuple[float, float]]:
+    """Preserve raw bytes outside this function; unwrap only the device log clock."""
+    reader = csv.DictReader(io.StringIO(raw.decode("utf-8"), newline=""))
+    required = {"cf_timestamp_ms", "host_monotonic_s", "baro.asl", "baro.pressure", "baro.temp"}
+    if not reader.fieldnames or len(set(reader.fieldnames)) != len(reader.fieldnames) or not required <= set(reader.fieldnames):
+        raise ValueError("continuous barometer and device/receipt clocks required")
+    samples = []
+    previous = previous_host = None
+    elapsed_ms = 0
+    for row in reader:
+        if None in row or any(value is None for value in row.values()):
+            raise ValueError("malformed CSV row")
+        stamp = int(row["cf_timestamp_ms"])
+        host = finite(float(row["host_monotonic_s"]), "host timestamp")
+        values = [finite(float(row[name]), name) for name in ("baro.asl", "baro.pressure", "baro.temp")]
+        if not 0 <= stamp < MODULUS or (previous_host is not None and host <= previous_host):
+            raise ValueError("invalid device or nonincreasing receipt timestamp")
+        if previous is not None:
+            gap = (stamp - previous) % MODULUS
+            if gap == 0 or gap >= MODULUS // 2 or gap / 1000 > MAX_GAP_S + 1e-9:
+                raise ValueError("duplicate/backward timestamp or barometer gap over 40 ms")
+            elapsed_ms += gap
+        samples.append((elapsed_ms / 1000, values[0]))
+        previous, previous_host = stamp, host
+    if not samples:
+        raise ValueError("empty barometer stream")
+    return samples
+
+
+def window(samples, start, end):
+    # Half-open windows avoid counting one boundary sample twice.
+    selected = [(t, y) for t, y in samples if start <= t < end]
+    minimum = math.ceil((end - start) / WINDOW_S * MIN_WINDOW_ROWS - 1e-9)
+    if len(selected) < minimum or selected[0][0] - start > MAX_GAP_S + 1e-9 or end - selected[-1][0] > MAX_GAP_S + 1e-9:
+        raise ValueError("insufficient observed samples/edge coverage for a fixed window")
+    return selected
+
+
+def contrast(samples, before_start, after_start, slope):
+    before = window(samples, before_start, before_start + WINDOW_S)
+    after = window(samples, after_start, after_start + WINDOW_S)
+    raw = median(y for _, y in after) - median(y for _, y in before)
+    observed_separation = median(t for t, _ in after) - median(t for t, _ in before)
+    drift = slope * observed_separation
+    return {"before_s": [before_start, before_start + WINDOW_S],
+            "after_s": [after_start, after_start + WINDOW_S],
+            "rows_before": len(before), "rows_after": len(after),
+            "observed_median_time_separation_s": observed_separation,
+            "raw_delta_m": raw, "calibration_drift_m": drift,
+            "drift_corrected_delta_m": raw - drift}
+
+
+def analyze(samples, specification):
+    if specification.get("schema") != "webeeblocks.x3.pressure-probe-input.v1":
+        raise ValueError("unknown pressure probe input schema")
+    calibration = specification["calibration"]
+    c0 = finite(calibration["start_s"], "calibration start")
+    c1 = finite(calibration["end_s"], "calibration end")
+    if c0 < 0 or c1 - c0 < 30:
+        raise ValueError("at least 30 s of prior stationary calibration required")
+    baseline = window(samples, c0, c1)
+    # Centered ordinary least squares. No IID standard error is inferred.
+    tmean = sum(t - c0 for t, _ in baseline) / len(baseline)
+    ymean = sum(y for _, y in baseline) / len(baseline)
+    slope = sum((t - c0 - tmean) * (y - ymean) for t, y in baseline) / sum((t - c0 - tmean) ** 2 for t, _ in baseline)
+    events = specification["events"]
+    if not events:
+        raise ValueError("at least one complete annotated episode required")
+    results, identifiers = [], set()
+    previous_end = c1
+    for event in events:
+        identifier, kind = event["id"], event["kind"]
+        if not isinstance(identifier, str) or not identifier.strip() or identifier in identifiers or kind not in KINDS:
+            raise ValueError("unique event ID and known descriptive kind required")
+        identifiers.add(identifier)
+        start = finite(event["start_s"], "event start")
+        end = finite(event["end_s"], "event end")
+        if start < previous_end + 2 or end <= start:
+            raise ValueError("ordered episodes with at least 2 s plateaus and positive duration required")
+        previous_end = end
+        # Every kind passes through this identical calculation; no UKF gate.
+        before_start, after_start = start - WINDOW_S, end + POST_DELAY_S
+        measured = contrast(samples, before_start, after_start, slope)
+        separation = after_start - before_start
+        span = separation + WINDOW_S
+        pairs = []
+        for index in range(math.floor((c1 - c0 + 1e-9) / span)):
+            pair_start = c0 + index * span
+            pairs.append(contrast(samples, pair_start, pair_start + separation, slope))
+        residuals = [p["drift_corrected_delta_m"] for p in pairs]
+        results.append({"id": identifier, "kind": kind, "start_s": start, "end_s": end,
+                        "pressure_contrast": measured, "matched_calibration_pairs": pairs,
+                        "empirical_residual_min_m": min(residuals) if residuals else None,
+                        "empirical_residual_max_m": max(residuals) if residuals else None,
+                        "pair_count": len(pairs), "effective_independent_count": None,
+                        "uncertainty_bound_m": None,
+                        "uncertainty_status": "UNPROVEN: finite calibration extrema are not a predictive bound"})
+    return {"schema": "webeeblocks.x3.pressure-probe-result.v1", "status": "COMPUTED",
+            "calibration_s": [c0, c1], "calibration_slope_m_per_s": slope,
+            "calibration_rows": len(baseline), "events": results,
+            "observed_kinds": sorted({e["kind"] for e in results}),
+            "independent_displacement_verdict": "UNPROVEN", "physical_verdict": None,
+            "scope": "descriptive pressure statistic; no IMU fusion, metric-reference verdict, terrain decision or confidence level",
+            "timing_boundary": "window endpoint is end+0.75 s in log time, not a proven end-to-end latency"}
+
+
+def run(spec_path: Path):
+    spec_bytes = spec_path.read_bytes()
+    spec = json.loads(spec_bytes)
+    source = spec["barometer"]
+    path = Path(source["path"])
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError("barometer path must stay inside the input directory")
+    root = spec_path.parent.resolve()
+    path = (root / path).resolve()
+    if not path.is_relative_to(root) or not path.is_file():
+        raise ValueError("barometer input missing or outside the input directory")
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    if not isinstance(source["sha256"], str) or not re.fullmatch(r"[0-9a-f]{64}", source["sha256"]) or digest != source["sha256"]:
+        raise ValueError("barometer input digest mismatch")
+    result = analyze(read_barometer(raw), spec)
+    result["input_provenance"] = {"specification_sha256": hashlib.sha256(spec_bytes).hexdigest(),
+                                  "barometer_sha256": digest, "barometer_bytes": len(raw),
+                                  "probe_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest()}
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("specification", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        result = run(args.specification)
+        serialized = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        with args.output.open("x", encoding="utf-8") as stream:
+            stream.write(serialized)
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        parser.exit(1, f"UNPROVEN: {exc}; preserve raw inputs and any partial output\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/crazyflie-ukf-surface-range/test_frozen_pressure_probe.py
+++ b/experiments/crazyflie-ukf-surface-range/test_frozen_pressure_probe.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Synthetic arithmetic/data-quality controls, not physical X3 evidence."""
+
+import copy
+import csv
+import hashlib
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import frozen_pressure_probe as probe
+
+
+def fixture():
+    spec = {"schema": "webeeblocks.x3.pressure-probe-input.v1",
+            "calibration": {"start_s": 0, "end_s": 30},
+            "events": [{"id": kind, "kind": kind, "start_s": 34 + 6 * i,
+                        "end_s": 35 + 6 * i} for i, kind in enumerate(probe.KINDS)]}
+    # Deliberately synthetic linear pressure drift plus a +0.20 m transition.
+    samples = []
+    for i in range(3201):
+        t = i * 0.02
+        z = 100 + 0.002 * t
+        for event in spec["events"]:
+            z += 0.2 * max(0, min(1, t - event["start_s"]))
+        samples.append((t, z))
+    return samples, spec
+
+
+class PressureProbeTests(unittest.TestCase):
+    def test_fixed_windows_signed_contrast_and_shared_path(self):
+        samples, spec = fixture()
+        result = probe.analyze(samples, spec)
+        self.assertAlmostEqual(result["calibration_slope_m_per_s"], 0.002)
+        for event in result["events"]:
+            self.assertAlmostEqual(event["pressure_contrast"]["drift_corrected_delta_m"], 0.2)
+            # Medians land at start-0.26 and end+0.50 on this 20 ms grid.
+            self.assertAlmostEqual(event["pressure_contrast"]["raw_delta_m"], 0.20352)
+            self.assertEqual(event["pressure_contrast"]["after_s"][1], event["end_s"] + 0.75)
+            self.assertIsNone(event["uncertainty_bound_m"])
+            self.assertIsNone(event["effective_independent_count"])
+        negative = probe.analyze([(t, -y) for t, y in samples], spec)
+        self.assertAlmostEqual(negative["events"][-1]["pressure_contrast"]["drift_corrected_delta_m"], -0.2)
+        self.assertIsNone(result["physical_verdict"])
+        self.assertEqual(result["independent_displacement_verdict"], "UNPROVEN")
+
+    def test_terrain_values_cannot_train_calibration_or_windows(self):
+        samples, spec = fixture()
+        original = probe.analyze(samples, spec)
+        altered = probe.analyze([(t, y + (1000 if t >= 35 else 0)) for t, y in samples], spec)
+        self.assertEqual(original["calibration_slope_m_per_s"], altered["calibration_slope_m_per_s"])
+        for a, b in zip(original["events"], altered["events"]):
+            self.assertEqual(a["matched_calibration_pairs"], b["matched_calibration_pairs"])
+            self.assertEqual(a["pressure_contrast"]["before_s"], b["pressure_contrast"]["before_s"])
+
+    def test_matched_pairs_preserve_separation_and_do_not_overlap(self):
+        samples, spec = fixture()
+        event = probe.analyze(samples, spec)["events"][0]
+        previous_end = 0
+        for pair in event["matched_calibration_pairs"]:
+            self.assertGreaterEqual(pair["before_s"][0], previous_end)
+            self.assertAlmostEqual(pair["after_s"][0] - pair["before_s"][0], 1.75)
+            previous_end = pair["after_s"][1]
+            self.assertLessEqual(previous_end, 30)
+
+    def test_missing_coverage_and_invalid_episode_cannot_compute(self):
+        samples, spec = fixture()
+        with self.assertRaisesRegex(ValueError, "coverage"):
+            probe.analyze([(t, y) for t, y in samples if not 33.5 <= t < 34], spec)
+        for change in ({"start_s": 20}, {"end_s": float("nan")}, {"kind": "gate-bypass"}):
+            invalid = copy.deepcopy(spec)
+            invalid["events"][0].update(change)
+            with self.assertRaises(ValueError):
+                probe.analyze(samples, invalid)
+
+    def test_csv_clock_wrap_and_bad_samples(self):
+        header = "cf_timestamp_ms,host_monotonic_s,baro.asl,baro.pressure,baro.temp\n"
+        raw = header + f"{(1 << 24) - 10},100,1,1000,20\n10,100.02,2,1000,20\n"
+        self.assertEqual(probe.read_barometer(raw.encode()), [(0.0, 1.0), (0.02, 2.0)])
+        for invalid in (raw.replace("10,100.02", "9,99"), raw.replace("2,1000,20", "nan,1000,20"),
+                        raw + "10,100.04,2,1000,20\n", raw.replace("10,100.02", "110,100.12")):
+            with self.assertRaises(ValueError):
+                probe.read_barometer(invalid.encode())
+
+    def test_full_file_path_preserves_bytes_and_binds_digests(self):
+        samples, spec = fixture()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stream = io.StringIO(newline="")
+            writer = csv.writer(stream)
+            writer.writerow(("cf_timestamp_ms", "host_monotonic_s", "baro.asl", "baro.pressure", "baro.temp"))
+            for t, y in samples:
+                writer.writerow((round(t * 1000), 1000 + t, y, 1000, 20))
+            raw = stream.getvalue().encode()
+            source = root / "barometer.csv"
+            source.write_bytes(raw)
+            spec["barometer"] = {"path": source.name, "sha256": hashlib.sha256(raw).hexdigest()}
+            path = root / "spec.json"
+            path.write_text(json.dumps(spec))
+            result = probe.run(path)
+            self.assertEqual(source.read_bytes(), raw)
+            self.assertEqual(result["input_provenance"]["barometer_sha256"], spec["barometer"]["sha256"])
+            source.write_bytes(raw + b"\n")
+            with self.assertRaisesRegex(ValueError, "digest"):
+                probe.run(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The #70 architecture review fixed a simple pressure statistic before further physical acquisition, but the repository had no executable implementation of it. This PR supplies that bounded offline component independently of the #299 collector; it does not import or stack on that candidate.

`frozen_pressure_probe.py` uses the same function for every stationary/terrain/vertical/mixed episode: median altitude during [end+0.25,end+0.75) minus median altitude during [start−0.5,start). It reads continuous raw `baro.asl`, never UKF Z/VZ or S3 conditional diagnostics. A centered linear drift fit uses only at least 30 seconds of prior stationary calibration; raw and drift-compared results remain separate. The drift comparison uses the observed median-timestamp separation so sampling-grid phase is explicit.

For each episode, the output preserves matched-separation calibration pairs with non-overlapping complete spans. Their signed residual extrema remain descriptive: non-overlap does not establish independence, pair count is not effective sample count, and no confidence level or predictive uncertainty bound is invented. Every result retains `independent_displacement_verdict: UNPROVEN` and `physical_verdict: null`.

The file entry point binds exact CSV/specification/script hashes, preserves raw bytes, rejects path escape, missing input, digest mismatch, bad/ambiguous clocks and insufficient fixed-window coverage, and writes a new output exclusively. The documentation specifies the schema, frozen windows, data-quality limits and remaining synchronized metric-reference, faithful IMU propagation, runtime and publication boundaries. The end+0.75 s window is not claimed as proven end-to-end latency.

Validation: six deterministic local tests pass, covering signed arithmetic, identical paths for all four labels, isolation of calibration from altered terrain values, non-overlapping matched pairs, missing coverage, invalid episodes, timestamp wrap/errors and exact file-byte provenance. `git diff --check` passes. These tests use synthetic data and are not a new CI/physical oracle; no archived trace has the indispensable raw signals needed for this calculation.

The pressure-analysis change originated at `beae8b70b88778618e6ac8039693cabf0e6eb598` and is now refreshed onto current `main@9b21eb5a7083b3524e47e962864cde9cab333016` at exact candidate `1b8a8283fb591a788fd8b5bf3217deb0e01973c5`. The refresh integrates #276's already-reviewed physical-effect result without modifying the three pressure-analysis files. This completes the descriptive pressure-calculation unit, not the full independent predictor or checkpoint preparation. No threshold/window search, estimator patch, Runtime/CI/governance change, physical request or motorized action.

Refs #70 #297 #299 #276.