### PR TITLE
Qualify real Webots Qt file-dialog display and cancellation

### DIFF
--- a/tools/ci/firefox_qt_provider/README.md
+++ b/tools/ci/firefox_qt_provider/README.md
@@ -1,0 +1,65 @@
+# One Qt provider qualification for #87
+
+Research only. Do not merge this harness. The architecture decision in
+[#87](https://github.com/djibian/webeeblocks/issues/87#issuecomment-5607115679)
+requests one qualification of the useful provider, not more C8–C26 reductions.
+
+The existing `crazyflie-runtime-wwi` preparation calls this harness only on
+`research/firefox-qt-provider-qualification`. It adds no workflow or dependency
+on another candidate, changes no CI selection/oracle/timeout, and preserves the
+ordinary job's product checks. Its evidence is included by the existing always-on
+`crazyflie-runtime-wwi-r2025a` artifact upload. A green synthetic oracle test is not
+a live qualification.
+
+The harness reproduces the pinned R2025a desktop archive and official runtime
+recipe used in the preserved controls. It downloads the exact C10 provider and
+`runtime.ini`, verifies all four Git blobs, and adds only a research dialog hook
+to a temporary copy. Both C++ units are compiled `-fPIC`, then linked as PIE.
+The executable must contain the real factory, `QCoreApplication::instance()`,
+qobject/metaobject paths and called dialog hook; `readelf` must show no Qt COPY
+relocation and no added RPATH/RUNPATH. Linked and live libraries must resolve to
+the Webots bundle. There is no standalone arm, dummy provider, debugger, system Qt,
+QPA/DISPLAY switch or project-file operation.
+
+One minimal supervisor/controller is launched by official Webots under the
+preserved Xvfb/software-rendering environment. It calls `wb_robot_init()`, invokes
+the real provider and enters `QFileDialog::exec()`. A Qt timer captures the exposed
+window as PNG. An independent Xlib/XTEST observer verifies the exact controller
+executable and its ancestry under the launched Webots process, the window's title,
+`_NET_WM_PID`, `IsViewable` geometry and focus before sending one Escape press and
+release. It never calls `reject()` or fabricates an accepted dialog result.
+
+After `Rejected`, the controller must return from the provider, execute eight
+real Webots steps (0.256 s of simulation time), receive the preserved broker's
+capabilities response with `operationsReady:false`, destroy the provider and
+complete. This proves a return to the controller loop; it does **not** claim a
+browser WWI round-trip or Open/Save/Save As implementation. The isolated directory
+sentinel and file inventory must remain unchanged.
+
+Pre-registered interpretation:
+
+- PASS: all static/provenance preconditions, Qt screenshot, independently bound
+  X11 exposure/cancellation and ordered controller return evidence hold, Webots
+  exits normally and the test-file inventory is unchanged.
+- FAIL: with the qualified executable and real provider reached, a fatal failure
+  occurs; or a complete observed sequence demonstrates changed project files,
+  unsuccessful completion or no actual simulation advancement.
+- UNPROVEN: preparation, launch, runtime identity or indispensable observations
+  are missing/ambiguous. A missing frame or malformed observer is never a pass.
+
+The 15 s dialog deadline and 45 s launch bound are diagnostic limits, not product
+latency claims. Preserve whatever result this single qualification produces and
+stop; do not start another causal-discriminator chain or silently retune it.
+Full Firefox same-file semantics and Windows compatibility remain unproven even
+if this provider qualification succeeds.
+
+Local checks:
+
+```sh
+python3 tools/ci/firefox_qt_provider/test_qualification.py
+bash -n tools/ci/run_firefox_qt_provider_qualification.sh
+```
+
+API references: [Qt 6.5 QFileDialog](https://doc.qt.io/qt-6.5/qfiledialog.html),
+[QWindow exposure](https://doc.qt.io/qt-6.5/qwindow.html#isExposed),
+[XTEST](https://xorg.freedesktop.org/archive/X11R7.7/doc/libXtst/xtestlib.html).

--- a/tools/ci/firefox_qt_provider/dialog_qualification.hpp
+++ b/tools/ci/firefox_qt_provider/dialog_qualification.hpp
@@ -1,0 +1,47 @@
+// Added only to a hash-checked temporary copy of the preserved C10 provider.
+#include <QtCore/QTimer>
+#include <QtGui/QScreen>
+#include <QtGui/QWindow>
+#include <QtGui/QPixmap>
+#include <cstdlib>
+#include <unistd.h>
+
+static void qualify_dialog(QFileDialog &dialog) {
+  const QString title = QString("WebeeBlocks Q87 qualification %1").arg(::getpid());
+  dialog.setWindowTitle(title);
+  dialog.setFileMode(QFileDialog::ExistingFile);
+  dialog.setDirectory(QString::fromUtf8(std::getenv("Q87_FILES")));
+  // No QPA/platform option or native-dialog substitution is introduced.
+  bool exposed = false;
+  QTimer witness;
+  QObject::connect(&witness, &QTimer::timeout, [&]() {
+    QWindow *window = dialog.windowHandle();
+    if (!exposed && dialog.isVisible() && window && window->isExposed()) {
+      const QPixmap pixels = window->screen()->grabWindow(dialog.winId());
+      const QString output = QString::fromUtf8(std::getenv("Q87_EVIDENCE")) + "/dialog.png";
+      if (pixels.isNull() || !pixels.save(output, "PNG")) _exit(125);
+      exposed = true;
+      std::printf("Q87 DIALOG_EXPOSED pid=%ld wid=%lu width=%d height=%d\n",
+                  static_cast<long>(::getpid()), static_cast<unsigned long>(dialog.winId()),
+                  pixels.width(), pixels.height());
+      std::fflush(stdout);
+    }
+  });
+  QTimer deadline;
+  deadline.setSingleShot(true);
+  QObject::connect(&deadline, &QTimer::timeout, []() {
+    std::fputs("Q87 DIALOG_TIMEOUT\n", stderr);
+    std::fflush(stderr);
+    _exit(126);
+  });
+  witness.start(50);
+  deadline.start(15000);
+  std::puts("Q87 DIALOG_EXEC");
+  std::fflush(stdout);
+  const int result = dialog.exec();
+  witness.stop();
+  deadline.stop();
+  if (!exposed || result != QDialog::Rejected) throw std::runtime_error("dialog did not complete through observed cancellation");
+  std::puts("Q87 DIALOG_CANCELLED result=Rejected");
+  std::fflush(stdout);
+}

--- a/tools/ci/firefox_qt_provider/probe.cpp
+++ b/tools/ci/firefox_qt_provider/probe.cpp
@@ -1,0 +1,63 @@
+// Research-only controller. No student program or project-file operation.
+#include "file_broker_c.h"
+#include <webots/robot.h>
+#include <webots/supervisor.h>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <execinfo.h>
+#include <initializer_list>
+#include <unistd.h>
+
+static void fatal(int signal) {
+  const char *mark = "Q87 FATAL\n";
+  ::write(STDERR_FILENO, mark, std::strlen(mark));
+  void *frames[64];
+  int count = ::backtrace(frames, 64);
+  ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+  _exit(128 + signal);
+}
+
+int main() {
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  void *warmup[1]; (void)::backtrace(warmup, 1);
+  struct sigaction action {};
+  action.sa_handler = fatal;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = SA_RESETHAND;
+  for (int signal : {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE})
+    if (sigaction(signal, &action, nullptr)) return 120;
+  const char *evidence = std::getenv("Q87_EVIDENCE");
+  if (!evidence) return 121;
+  char filename[4096];
+  if (std::snprintf(filename, sizeof(filename), "%s/controller.pid", evidence) >= static_cast<int>(sizeof(filename))) return 121;
+  FILE *pid = std::fopen(filename, "wx");
+  if (!pid) return 121;
+  std::fprintf(pid, "%ld\n", static_cast<long>(::getpid()));
+  std::fclose(pid);
+  std::printf("Q87 BEFORE_WB_INIT pid=%ld\n", static_cast<long>(::getpid()));
+  wb_robot_init();
+  std::puts("Q87 WB_INIT_RETURN");
+  std::puts("Q87 PROVIDER_CALLED");
+  WbFileBroker *broker = wb_file_broker_create_qt();
+  if (!broker) return 122;
+  std::puts("Q87 PROVIDER_RETURNED");
+  const double before = wb_robot_get_time();
+  for (int step = 0; step < 8; ++step) {
+    if (wb_robot_step(32) == -1) return 123;
+  }
+  const double after = wb_robot_get_time();
+  if (!(after > before)) return 123;
+  std::printf("Q87 LOOP_RETURN steps=8 before=%.6f after=%.6f\n", before, after);
+  char response[1024];
+  if (!wb_file_broker_handle_message(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 1 CAPABILITIES", response, sizeof(response))) return 124;
+  if (!std::strstr(response, "\"operationsReady\":false")) return 124;
+  std::puts("Q87 CAPABILITIES_RETURN operationsReady=false");
+  wb_file_broker_destroy(broker);
+  std::puts("Q87 PROVIDER_DESTROYED");
+  wb_supervisor_simulation_quit(0);
+  wb_robot_cleanup();
+  std::puts("Q87 CONTROLLER_COMPLETE");
+  return 0;
+}

--- a/tools/ci/firefox_qt_provider/qualify.py
+++ b/tools/ci/firefox_qt_provider/qualify.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Single research qualification of the real C10 provider in official Webots."""
+
+from __future__ import annotations
+
+import ctypes as C
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def prepare(project, evidence):
+    source = project / "controllers/qt_provider_probe/file_broker.cpp"
+    original = source.read_text()
+    assert original.count("namespace {") == 1
+    assert original.count("    std::fflush(stdout);") == 1
+    patched = original.replace("namespace {", '#include "dialog_qualification.hpp"\n\nnamespace {')
+    patched = patched.replace("    std::fflush(stdout);", "    std::fflush(stdout);\n    qualify_dialog(*mDialog);")
+    source.write_text(patched)
+    (evidence / "provider-original.cpp").write_text(original)
+    (evidence / "provider-qualified.cpp").write_text(patched)
+    (project / "worlds/qualification.wbt").write_text('''#VRML_SIM R2025a utf8
+WorldInfo { basicTimeStep 32 }
+Viewpoint { position 1 1 1 }
+Robot {
+  name "Q87 provider qualification"
+  controller "qt_provider_probe"
+  supervisor TRUE
+  window "<none>"
+}
+''')
+
+
+def inspect(project, evidence, webots):
+    relocations = (evidence / "relocations.txt").read_text()
+    dynamic = (evidence / "dynamic.txt").read_text()
+    symbols = (evidence / "symbols.txt").read_text()
+    closure = (evidence / "ldd.txt").read_text()
+    copies = [line for line in relocations.splitlines() if "R_X86_64_COPY" in line]
+    assert not any(re.search(r"\bQ[A-Za-z]|Qt_6", line) for line in copies), copies
+    assert not re.search(r"\((RPATH|RUNPATH)\)", dynamic), dynamic
+    for name in ("QCoreApplication::instance()", "qobject_cast<QApplication*>",
+                 "QApplication::staticMetaObject", "webeeblocks::createQtFileDialogProvider()",
+                 "wb_file_broker_create_qt", "qualify_dialog(QFileDialog&)"):
+        assert name in symbols, name
+    assert "not found" not in closure, closure
+    for library in ("libQt6Core.so.6", "libQt6Gui.so.6", "libQt6Widgets.so.6"):
+        assert f"{library} => {webots}/lib/webots/{library}" in closure, library
+    assert f"libController.so => {webots}/lib/controller/libController.so" in closure
+    binary = project / "controllers/qt_provider_probe/qt_provider_probe"
+    write_json(evidence / "static-proof.json", {
+        "qt_copy_relocations": [], "required_provider_roots_retained": True,
+        "runtime_paths_added": False, "bundled_qt_and_controller_resolved": True,
+        "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+        "github_event_sha": os.environ.get("GITHUB_SHA"),
+        "candidate_sha": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+    })
+
+
+class Attributes(C.Structure):
+    _fields_ = [(name, kind) for name, kind in (
+        ("x", C.c_int), ("y", C.c_int), ("width", C.c_int), ("height", C.c_int),
+        ("border_width", C.c_int), ("depth", C.c_int), ("visual", C.c_void_p), ("root", C.c_ulong),
+        ("window_class", C.c_int), ("bit_gravity", C.c_int), ("win_gravity", C.c_int),
+        ("backing_store", C.c_int), ("backing_planes", C.c_ulong), ("backing_pixel", C.c_ulong),
+        ("save_under", C.c_int), ("colormap", C.c_ulong), ("map_installed", C.c_int),
+        ("map_state", C.c_int), ("all_event_masks", C.c_long), ("your_event_mask", C.c_long),
+        ("do_not_propagate_mask", C.c_long), ("override_redirect", C.c_int), ("screen", C.c_void_p))]
+
+
+class XObserver:
+    """Observe only the exact test controller's dialog in this private Xvfb."""
+
+    def __init__(self):
+        self.x = C.CDLL("libX11.so.6")
+        self.xt = C.CDLL("libXtst.so.6")
+        pointer, window, integer = C.c_void_p, C.c_ulong, C.c_int
+        self.bind(self.x, "XOpenDisplay", pointer, C.c_char_p)
+        self.bind(self.x, "XDefaultRootWindow", window, pointer)
+        self.bind(self.x, "XQueryTree", integer, pointer, window, C.POINTER(window), C.POINTER(window), C.POINTER(C.POINTER(window)), C.POINTER(C.c_uint))
+        self.bind(self.x, "XGetWindowAttributes", integer, pointer, window, C.POINTER(Attributes))
+        self.bind(self.x, "XFetchName", integer, pointer, window, C.POINTER(C.c_char_p))
+        self.bind(self.x, "XInternAtom", window, pointer, C.c_char_p, integer)
+        self.bind(self.x, "XGetWindowProperty", integer, pointer, window, window, C.c_long, C.c_long, integer,
+                  window, C.POINTER(window), C.POINTER(integer), C.POINTER(C.c_ulong), C.POINTER(C.c_ulong), C.POINTER(pointer))
+        self.bind(self.x, "XFree", integer, pointer)
+        self.bind(self.x, "XSetInputFocus", integer, pointer, window, integer, window)
+        self.bind(self.x, "XGetInputFocus", integer, pointer, C.POINTER(window), C.POINTER(integer))
+        self.bind(self.x, "XSync", integer, pointer, integer)
+        self.bind(self.x, "XKeysymToKeycode", C.c_ubyte, pointer, window)
+        self.bind(self.xt, "XTestFakeKeyEvent", integer, pointer, C.c_uint, integer, C.c_ulong)
+        self.bind(self.xt, "XTestQueryExtension", integer, pointer, C.POINTER(integer), C.POINTER(integer), C.POINTER(integer), C.POINTER(integer))
+        self.display = self.x.XOpenDisplay(None)
+        if not self.display:
+            raise RuntimeError("the preserved Xvfb display is unavailable")
+        args = [integer() for _ in range(4)]
+        if not self.xt.XTestQueryExtension(self.display, *(C.byref(a) for a in args)):
+            raise RuntimeError("XTEST is unavailable; no substitute cancellation")
+        self.root = self.x.XDefaultRootWindow(self.display)
+        self.pid_atom = self.x.XInternAtom(self.display, b"_NET_WM_PID", 0)
+
+    @staticmethod
+    def bind(library, name, result, *arguments):
+        function = getattr(library, name)
+        function.restype, function.argtypes = result, arguments
+
+    def windows(self):
+        root, parent, children, count = C.c_ulong(), C.c_ulong(), C.POINTER(C.c_ulong)(), C.c_uint()
+        if not self.x.XQueryTree(self.display, self.root, C.byref(root), C.byref(parent), C.byref(children), C.byref(count)):
+            raise RuntimeError("X11 window enumeration failed")
+        try:
+            return [children[i] for i in range(count.value)]
+        finally:
+            if children:
+                self.x.XFree(children)
+
+    def mapped_dialog(self, pid):
+        for window in self.windows():
+            title = C.c_char_p()
+            if not self.x.XFetchName(self.display, window, C.byref(title)) or not title:
+                continue
+            try:
+                matches = title.value == f"WebeeBlocks Q87 qualification {pid}".encode()
+            finally:
+                self.x.XFree(title)
+            if not matches:
+                continue
+            actual_type, format_, count, remaining, data = C.c_ulong(), C.c_int(), C.c_ulong(), C.c_ulong(), C.c_void_p()
+            result = self.x.XGetWindowProperty(self.display, window, self.pid_atom, 0, 1, 0, 6,
+                                               C.byref(actual_type), C.byref(format_), C.byref(count), C.byref(remaining), C.byref(data))
+            try:
+                if result or actual_type.value != 6 or format_.value != 32 or count.value != 1 or remaining.value != 0 or not data:
+                    continue
+                if C.cast(data, C.POINTER(C.c_ulong))[0] != pid:
+                    continue
+            finally:
+                if data:
+                    self.x.XFree(data)
+            attributes = Attributes()
+            if self.x.XGetWindowAttributes(self.display, window, C.byref(attributes)) and attributes.map_state == 2:
+                if attributes.width >= 200 and attributes.height >= 100:
+                    return {"window": window, "pid": pid, "map_state": "IsViewable",
+                            "width": attributes.width, "height": attributes.height}
+        return None
+
+    def cancel(self, witness):
+        window = witness["window"]
+        if self.mapped_dialog(witness["pid"]) != witness:
+            raise RuntimeError("dialog changed before the cancellation effect")
+        self.x.XSetInputFocus(self.display, window, 2, 0)
+        self.x.XSync(self.display, 0)
+        focus, revert = C.c_ulong(), C.c_int()
+        self.x.XGetInputFocus(self.display, C.byref(focus), C.byref(revert))
+        if focus.value != window:
+            raise RuntimeError("exact dialog focus was not established")
+        key = self.x.XKeysymToKeycode(self.display, 0xff1b)
+        if not key or not self.xt.XTestFakeKeyEvent(self.display, key, 1, 0):
+            raise RuntimeError("Escape key press not accepted by XTEST")
+        if not self.xt.XTestFakeKeyEvent(self.display, key, 0, 0):
+            raise RuntimeError("Escape key release not accepted by XTEST")
+        self.x.XSync(self.display, 0)
+        return {**witness, "cancel": "XTEST_ESCAPE", "focus_verified": True,
+                "host_monotonic_s": time.monotonic()}
+
+
+def descendant(pid, ancestor):
+    for _ in range(12):
+        if pid == ancestor:
+            return True
+        status = Path(f"/proc/{pid}/status").read_text()
+        pid = int(re.search(r"^PPid:\s*(\d+)", status, re.M)[1])
+        if pid <= 1:
+            break
+    return False
+
+
+def evaluate(log, witness, code, unchanged, png_present):
+    required = ["Q87 WB_INIT_RETURN", "Q87 PROVIDER_CALLED", "QT_APP_INITIALIZED", "QFILEDIALOG_CONSTRUCTED",
+                "Q87 DIALOG_EXEC", "Q87 DIALOG_EXPOSED", "Q87 DIALOG_CANCELLED result=Rejected",
+                "Q87 PROVIDER_RETURNED", "Q87 LOOP_RETURN steps=8", "Q87 CAPABILITIES_RETURN operationsReady=false",
+                "Q87 PROVIDER_DESTROYED", "Q87 CONTROLLER_COMPLETE"]
+    cursor = -1
+    for marker in required:
+        cursor = log.find(marker, cursor + 1)
+        if cursor < 0:
+            if "Q87 FATAL" in log and "Q87 PROVIDER_CALLED" in log:
+                return "FAIL"
+            return "UNPROVEN"
+    exposed = re.search(r"Q87 DIALOG_EXPOSED pid=(\d+) wid=(\d+)", log)
+    if not witness or not exposed or witness.get("cancel") != "XTEST_ESCAPE" or not witness.get("focus_verified") or witness.get("map_state") != "IsViewable":
+        return "UNPROVEN"
+    if int(exposed[1]) != witness["pid"] or int(exposed[2]) != witness["window"] or not png_present:
+        return "UNPROVEN"
+    if not unchanged or code != 0 or "Q87 FATAL" in log:
+        return "FAIL"
+    movement = re.search(r"Q87 LOOP_RETURN steps=8 before=([0-9.]+) after=([0-9.]+)", log)
+    if not movement:
+        return "UNPROVEN"
+    advance = float(movement[2]) - float(movement[1])
+    if not math.isfinite(advance) or not 0.255 <= advance <= 0.257:
+        return "FAIL"
+    return "PASS"
+
+
+def snapshot(directory):
+    return {str(p.relative_to(directory)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in directory.rglob("*") if p.is_file()}
+
+
+def run(project, evidence, webots):
+    static = json.loads((evidence / "static-proof.json").read_text())
+    binary = (project / "controllers/qt_provider_probe/qt_provider_probe").resolve()
+    if hashlib.sha256(binary.read_bytes()).hexdigest() != static["binary_sha256"]:
+        raise RuntimeError("characterized controller binary changed")
+    observer = XObserver()
+    before = snapshot(project / "files")
+    witness, error, process_proof = None, None, None
+    with (evidence / "webots.log").open("w") as log:
+        process = subprocess.Popen([str(webots / "webots"), "--stdout", "--stderr", "--batch", "--mode=realtime",
+                                    str(project / "worlds/qualification.wbt")], stdout=log, stderr=subprocess.STDOUT)
+        deadline = time.monotonic() + 45
+        try:
+            while process.poll() is None and time.monotonic() < deadline:
+                pid_file = evidence / "controller.pid"
+                if not witness and pid_file.exists() and pid_file.read_text().strip():
+                    pid = int(pid_file.read_text())
+                    proc = Path(f"/proc/{pid}")
+                    if proc.exists():
+                        if (proc / "exe").resolve() != binary or not descendant(pid, process.pid):
+                            raise RuntimeError("PID is not the exact official-Webots-launched probe")
+                        process_proof = {"pid": pid, "binary": str(binary), "webots_ancestor_pid": process.pid}
+                        mapped = observer.mapped_dialog(pid)
+                        if mapped and (evidence / "dialog.png").exists():
+                            maps = (proc / "maps").read_text()
+                            (evidence / "controller-maps.txt").write_text(maps)
+                            qt_paths = {line.split()[-1] for line in maps.splitlines() if "libQt6" in line or "libqxcb.so" in line}
+                            if not qt_paths or not all(path.startswith(str(webots / "lib/webots") + "/") for path in qt_paths):
+                                raise RuntimeError("live Qt/QPA maps differ from the pinned bundle")
+                            if not any("libqxcb.so" in path for path in qt_paths):
+                                raise RuntimeError("xcb plugin mapping not observed")
+                            witness = observer.cancel(mapped)
+                            write_json(evidence / "x11-witness.json", witness)
+                time.sleep(0.05)
+            if process.poll() is None:
+                error = "official Webots/probe did not complete within 45 s"
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=3)
+    text = (evidence / "webots.log").read_text()
+    unchanged = snapshot(project / "files") == before
+    png = evidence / "dialog.png"
+    png_present = png.exists() and png.stat().st_size > 100
+    result = evaluate(text, witness, process.returncode, unchanged, png_present)
+    if error and result == "PASS":
+        result = "UNPROVEN"
+    if process_proof is None:
+        result = "UNPROVEN"
+    write_json(evidence / "result.json", {"result": result, "scope": "Qt provider display/cancel/return only",
+        "static_proof": static, "process_proof": process_proof, "x11_witness": witness,
+        "project_files_unchanged": unchanged, "webots_exit": process.returncode, "error": error,
+        "display": os.environ.get("DISPLAY"), "qpa_override": os.environ.get("QT_QPA_PLATFORM"),
+        "full_firefox_parity": "UNPROVEN"})
+    print(text)
+    print("Q87_QUALIFICATION_RESULT=" + result)
+    return 0 if result == "PASS" else 1
+
+
+if __name__ == "__main__":
+    mode, project, evidence, *remaining = sys.argv[1:]
+    project, evidence = Path(project), Path(evidence)
+    if mode == "prepare":
+        prepare(project, evidence)
+    elif mode == "inspect":
+        inspect(project, evidence, Path(remaining[0]))
+    elif mode == "run":
+        raise SystemExit(run(project, evidence, Path(remaining[0])))
+    else:
+        raise SystemExit("unknown qualification mode")

--- a/tools/ci/firefox_qt_provider/test_qualification.py
+++ b/tools/ci/firefox_qt_provider/test_qualification.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Negative oracle controls; these fixtures are not a live-dialog qualification."""
+
+from pathlib import Path
+import tempfile
+import unittest
+
+import qualify
+
+
+LOG = """Q87 WB_INIT_RETURN
+Q87 PROVIDER_CALLED
+WEBEEBLOCKS_FILE_BROKER_V1 QT_APP_INITIALIZED
+WEBEEBLOCKS_FILE_BROKER_V1 QFILEDIALOG_CONSTRUCTED
+Q87 DIALOG_EXEC
+Q87 DIALOG_EXPOSED pid=321 wid=987 width=600 height=400
+Q87 DIALOG_CANCELLED result=Rejected
+Q87 PROVIDER_RETURNED
+Q87 LOOP_RETURN steps=8 before=0.000000 after=0.256000
+Q87 CAPABILITIES_RETURN operationsReady=false
+Q87 PROVIDER_DESTROYED
+Q87 CONTROLLER_COMPLETE
+"""
+WITNESS = {"pid": 321, "window": 987, "map_state": "IsViewable",
+           "focus_verified": True, "cancel": "XTEST_ESCAPE"}
+
+
+class OracleTests(unittest.TestCase):
+    def test_complete_synthetic_record_and_refuting_outcomes(self):
+        self.assertEqual(qualify.evaluate(LOG, WITNESS, 0, True, True), "PASS")
+        self.assertEqual(qualify.evaluate(LOG, WITNESS, 1, True, True), "FAIL")
+        self.assertEqual(qualify.evaluate(LOG, WITNESS, 0, False, True), "FAIL")
+        self.assertEqual(qualify.evaluate(LOG.replace("0.256000", "0.000000"), WITNESS, 0, True, True), "FAIL")
+        self.assertEqual(qualify.evaluate("Q87 WB_INIT_RETURN\nQ87 PROVIDER_CALLED\nQ87 FATAL\n", None, 139, True, False), "FAIL")
+
+    def test_constructed_or_programmatic_cancel_cannot_replace_real_exposure(self):
+        for missing in ("Q87 DIALOG_EXPOSED", "Q87 DIALOG_CANCELLED", "Q87 PROVIDER_RETURNED", "Q87 LOOP_RETURN"):
+            truncated = "\n".join(line for line in LOG.splitlines() if missing not in line)
+            self.assertEqual(qualify.evaluate(truncated, WITNESS, 0, True, True), "UNPROVEN")
+        for patch in ({"pid": 322}, {"window": 988}, {"focus_verified": False},
+                      {"map_state": "IsUnmapped"}, {"cancel": "direct-reject-call"}):
+            witness = {**WITNESS, **patch}
+            self.assertEqual(qualify.evaluate(LOG, witness, 0, True, True), "UNPROVEN")
+        self.assertEqual(qualify.evaluate(LOG, WITNESS, 0, True, False), "UNPROVEN")
+
+    def test_event_order_and_unknown_launcher_are_not_success(self):
+        reverse = "\n".join(reversed(LOG.splitlines()))
+        self.assertEqual(qualify.evaluate(reverse, WITNESS, 0, True, True), "UNPROVEN")
+        self.assertEqual(qualify.evaluate("", None, 0, True, False), "UNPROVEN")
+
+    def test_preparation_keeps_provider_factory_and_adds_only_dialog_hook(self):
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory) / "project"
+            evidence = Path(directory) / "evidence"
+            controller = project / "controllers/qt_provider_probe"
+            controller.mkdir(parents=True)
+            (project / "worlds").mkdir()
+            evidence.mkdir()
+            original = "namespace {\nvoid constructor() {\n    std::fflush(stdout);\n}\n}\n"
+            (controller / "file_broker.cpp").write_text(original)
+            qualify.prepare(project, evidence)
+            actual = (controller / "file_broker.cpp").read_text()
+            self.assertEqual((evidence / "provider-original.cpp").read_text(), original)
+            self.assertEqual(actual.count("qualify_dialog(*mDialog);"), 1)
+            self.assertIn('controller "qt_provider_probe"', (project / "worlds/qualification.wbt").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/prepare_crazyflie_runtime_wwi.py
+++ b/tools/ci/prepare_crazyflie_runtime_wwi.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import json
+import os
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -140,3 +142,12 @@ script = r'''
 
 html_path.write_text(html + '\n' + script, encoding='utf-8')
 print('Prepared Blockly Robot Window runtime WWI harness.')
+
+# Research-only qualification requested by #87. Ordinary product evidence above
+# and the remainder of the existing CI job are unchanged. Never merge this hook.
+if os.environ.get('GITHUB_HEAD_REF') == 'research/firefox-qt-provider-qualification':
+    subprocess.run(
+        ['bash', str(ROOT / 'tools/ci/run_firefox_qt_provider_qualification.sh')],
+        cwd=ROOT,
+        check=True,
+    )

--- a/tools/ci/run_firefox_qt_provider_qualification.sh
+++ b/tools/ci/run_firefox_qt_provider_qualification.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(pwd)"
+evidence="$root/ci-artifacts/crazyflie-runtime-wwi/firefox-qt-provider"
+mkdir -p "$evidence"
+exec > >(tee "$evidence/preparation.log") 2>&1
+trap 'code=$?; if [ "$code" -ne 0 ] && [ ! -f "$evidence/result.json" ]; then printf "{\"result\":\"UNPROVEN\",\"reason\":\"preparation or harness incomplete\",\"exit_code\":%s}\n" "$code" > "$evidence/result.json"; fi' EXIT
+
+recipe="$RUNNER_TEMP/q87-linux-runtime-dependencies.sh"
+curl --fail --location --retry 3 --output "$recipe" \
+  https://raw.githubusercontent.com/cyberbotics/webots/R2025a/scripts/install/linux_runtime_dependencies.sh
+test "$(git hash-object "$recipe")" = 4593476be2c985580a0e1738671f4b5bae81f669
+sudo env CI=true bash "$recipe"
+archive="$RUNNER_TEMP/webots-R2025a-x86-64.tar.bz2"
+curl --fail --location --retry 3 --output "$archive" \
+  https://github.com/cyberbotics/webots/releases/download/R2025a/webots-R2025a-x86-64.tar.bz2
+echo "c5127fb4206c57a5ae5523f1b7f3da8b670bc8926d9ae08595e139f226f38c38  $archive" | sha256sum --check
+tar -xjf "$archive" -C "$RUNNER_TEMP"
+webots="$RUNNER_TEMP/webots"
+project="$RUNNER_TEMP/q87-provider-project"
+controller="$project/controllers/qt_provider_probe"
+mkdir -p "$controller" "$project/worlds" "$project/files"
+printf 'Q87 project-file sentinel: no Open or Save operation\n' > "$project/files/untouched.wbb"
+
+frozen=fa78eb7dc8fd423abfd7e656a3bbf8c3e7e26c1c
+for file in file_broker.cpp file_broker.hpp file_broker_c.h runtime.ini; do
+  curl --fail --location --retry 3 --output "$controller/$file" \
+    "https://raw.githubusercontent.com/djibian/webeeblocks/$frozen/controllers/crazyflie_runtime_v2/$file"
+done
+test "$(git hash-object "$controller/file_broker.cpp")" = 241e6e6aaec32ceaeaa2693fad337a774757b895
+test "$(git hash-object "$controller/file_broker.hpp")" = 9e50d286344f680cb0cc254f4d68f4434a9e409a
+test "$(git hash-object "$controller/file_broker_c.h")" = d51074ba660b131f3c9df67d0ceef404c204f079
+test "$(git hash-object "$controller/runtime.ini")" = 27cbdb180b6f1aa4ed6a871bd9cb3ed147b29b6a
+git hash-object "$controller"/file_broker.* "$controller/runtime.ini" > "$evidence/frozen-blobs.txt"
+cp tools/ci/firefox_qt_provider/probe.cpp tools/ci/firefox_qt_provider/dialog_qualification.hpp "$controller/"
+python3 tools/ci/firefox_qt_provider/qualify.py prepare "$project" "$evidence"
+
+flags=(-std=c++17 -fPIC -g -O0 -I"$controller" -I"$webots/include/controller/c"
+  -isystem "$webots/include/qt" -isystem "$webots/include/qt/QtCore"
+  -isystem "$webots/include/qt/QtGui" -isystem "$webots/include/qt/QtWidgets")
+g++ "${flags[@]}" -c "$controller/probe.cpp" -o "$controller/probe.o"
+g++ "${flags[@]}" -c "$controller/file_broker.cpp" -o "$controller/file_broker.o"
+g++ -fPIC -pie "$controller/probe.o" "$controller/file_broker.o" \
+  -L"$webots/lib/webots" -L"$webots/lib/controller" \
+  -Wl,-rpath-link,"$webots/lib/webots" -Wl,-rpath-link,"$webots/lib/controller" \
+  -Wl,-Map,"$evidence/link.map" -lQt6Widgets -lQt6Gui -lQt6Core -lController \
+  -o "$controller/qt_provider_probe"
+readelf -rW --demangle "$controller/qt_provider_probe" > "$evidence/relocations.txt"
+readelf -d "$controller/qt_provider_probe" > "$evidence/dynamic.txt"
+nm -C "$controller/qt_provider_probe" > "$evidence/symbols.txt"
+LD_LIBRARY_PATH="$webots/lib/webots:$webots/lib/controller" ldd "$controller/qt_provider_probe" > "$evidence/ldd.txt"
+sha256sum "$controller/qt_provider_probe" "$controller/file_broker.cpp" "$controller/probe.cpp" \
+  "$controller/dialog_qualification.hpp" "$controller/runtime.ini" "$webots/lib/controller/libController.so" \
+  "$webots/lib/webots/libQt6Core.so.6" "$webots/lib/webots/libQt6Gui.so.6" \
+  "$webots/lib/webots/libQt6Widgets.so.6" > "$evidence/build.sha256"
+g++ --version > "$evidence/compiler.txt"
+python3 tools/ci/firefox_qt_provider/qualify.py inspect "$project" "$evidence" "$webots"
+
+# One real provider qualification. No standalone/copy-relocation crash arms.
+env WEBOTS_HOME="$webots" QT_PLUGIN_PATH="$webots/lib/webots/qt/plugins" \
+  LIBGL_ALWAYS_SOFTWARE=true Q87_EVIDENCE="$evidence" Q87_FILES="$project/files" \
+  timeout -k 5s 60s xvfb-run -a \
+  python3 tools/ci/firefox_qt_provider/qualify.py run "$project" "$evidence" "$webots"


### PR DESCRIPTION
Research-only implementation of the single real-provider qualification selected in #87 (architecture decision comment 5607115679). Do not merge this harness; preserve the bounded result on #87, then close it. This does not claim Firefox same-file semantics.

Exact candidate: `c71548670a6a681b78fc9ffee3944eb6f1536828`.

The harness reuses the pinned R2025a desktop archive/runtime recipe and hash-checked C10 provider/runtime.ini. Both C++ translation units are compiled as PIC and the resulting executable is inspected: no Qt COPY relocation or added RPATH/RUNPATH; the real provider factory, QCoreApplication::instance(), qobject/metaobject paths and called dialog hook must remain. No C8–C26 crash/control arms are rerun.

Official Webots launches one minimal supervisor/controller. It calls wb_robot_init(), invokes the actual preserved provider and displays its QFileDialog. Qt must observe exposure and save a non-empty screenshot. A separate Xlib/XTEST observer verifies the exact controller executable/PID ancestry, window title, _NET_WM_PID, IsViewable geometry and focus before one Escape press/release. After Rejected, the provider must return, the controller must advance eight real Webots steps, the existing capabilities handler must remain operationsReady:false, and destruction/completion must succeed. The isolated project-file inventory is checked unchanged. The loop evidence is not presented as a browser WWI round-trip.

The branch-specific hook stays inside the existing crazyflie-runtime-wwi preparation surface, as in the preserved research mechanism. It adds no workflow, weakens no selector/oracle, changes no timeout/QPA/DISPLAY, installs no debugger/system Qt and leaves the ordinary product checks intact. The existing always-on diagnostic artifact upload preserves its files.

Pre-registered result: PASS only with all static, mapped-window, real-cancellation and return evidence; FAIL for a reached-provider fatal failure or complete observations refuting completion/unchanged files/actual advancement; UNPROVEN when indispensable setup, identity or observation evidence is unavailable. Even PASS leaves project-file operations and Windows qualification unproven. Stop after this qualification; no further causal-discriminator chain.

Local validation: four negative oracle/preparation tests, 14 controller-contract tests and 21 workflow-contract tests pass; Python and shell syntax checks and git diff --check pass. Synthetic tests do not establish the live-dialog result.

Refs #87.