### PR TITLE
Prepare exact terminal physical landing semantics

### DIFF
--- a/tools/ci/test_physical_program_sequence.py
+++ b/tools/ci/test_physical_program_sequence.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import struct
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 PHYSICAL = ROOT / "tools" / "physical"
 sys.path.insert(0, str(PHYSICAL))
 
+import landing_command as landing  # noqa: E402
 import physical_program_sequence as sequence  # noqa: E402
 
 
@@ -38,6 +40,15 @@ def expect_error(callable_, pattern: str) -> None:
     raise AssertionError(f"expected PhysicalProgramSequenceError containing {pattern!r}")
 
 
+def expect_landing_error(value: object, pattern: str) -> None:
+    try:
+        landing.derive_bound_landing_command(value)
+    except landing.LandingCommandError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected LandingCommandError containing {pattern!r}")
+
+
 def sample_ast() -> str:
     return canonical(
         [
@@ -49,9 +60,17 @@ def sample_ast() -> str:
     )
 
 
+def advance_to_landing(domain: sequence.PhysicalProgramSequence) -> None:
+    first = domain.reserve_next_motion()
+    domain.complete_motion(first)
+    second = domain.reserve_next_motion()
+    domain.complete_motion(second)
+
+
 def test_exact_order_and_claim_identity() -> None:
     domain = sequence.PhysicalProgramSequence(sample_ast())
     require(domain.next_index == 1, "sequence must begin immediately after completed takeoff")
+    require(not domain.completed, "fresh post-takeoff sequence cannot be complete")
 
     first = domain.reserve_next_motion()
     motion = domain.motion_for_claim(first)
@@ -60,7 +79,7 @@ def test_exact_order_and_claim_identity() -> None:
         "first in-flight motion must come from exact AST index 1",
     )
     expect_error(domain.reserve_next_motion, "pending")
-    expect_error(lambda: domain.complete_motion(object()), "exact pending")
+    expect_error(lambda: domain.complete_motion(object()), "motion claim")
 
     domain.complete_motion(first)
     require(domain.next_index == 2, "causal completion alone advances the cursor")
@@ -75,9 +94,27 @@ def test_exact_order_and_claim_identity() -> None:
     require(domain.next_index == 2, "definitive no-effect/rejection cannot skip a statement")
     retry = domain.reserve_next_motion()
     require(domain.motion_for_claim(retry) == turn, "released statement must remain next")
+    domain.complete_motion(retry)
+
+    require(domain.next_index == 3, "completed motions must expose exact terminal landing")
+    landing_claim = domain.reserve_terminal_landing()
+    require(
+        domain.landing_for_claim(landing_claim) == sequence.SequencedTerminalLanding(3),
+        "terminal landing must preserve exact AST index",
+    )
+    expect_error(domain.reserve_next_motion, "pending")
+    expect_error(lambda: domain.complete_landing(object()), "landing claim")
+
+    domain.release_unemitted(landing_claim)
+    require(domain.next_index == 3, "rejected/unemitted landing cannot advance the cursor")
+    landing_retry = domain.reserve_terminal_landing()
+    domain.complete_landing(landing_retry)
+    require(domain.next_index == 4, "causal landing completion advances past final statement")
+    require(domain.completed, "exact program completes only after terminal landing completion")
+    expect_error(domain.reserve_terminal_landing, "not the next")
 
 
-def test_caller_cannot_select_motion_or_index() -> None:
+def test_caller_cannot_select_motion_index_or_landing() -> None:
     domain = sequence.PhysicalProgramSequence(sample_ast())
     try:
         domain.reserve_next_motion({"kind": "turn", "angle_deg": -90})
@@ -86,6 +123,14 @@ def test_caller_cannot_select_motion_or_index() -> None:
     else:
         raise AssertionError("caller-selected motion unexpectedly entered sequencing API")
 
+    try:
+        domain.reserve_terminal_landing({"height_m": 0.1})
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("caller-selected landing unexpectedly entered sequencing API")
+
+    expect_error(domain.reserve_terminal_landing, "not the next")
     claim = domain.reserve_next_motion()
     require(
         domain.motion_for_claim(claim).kind == "move",
@@ -93,16 +138,25 @@ def test_caller_cannot_select_motion_or_index() -> None:
     )
 
 
-def test_ambiguous_effect_is_terminal() -> None:
-    domain = sequence.PhysicalProgramSequence(sample_ast())
-    claim = domain.reserve_next_motion()
-    domain.mark_ambiguous(claim, "accepted effect completion became uncertain")
-    require(domain.terminal, "ambiguous emitted effect must make sequencing terminal")
-    require(domain.next_index == 1, "ambiguity cannot manufacture completion")
-    expect_error(domain.reserve_next_motion, "terminal")
+def test_ambiguous_motion_or_landing_is_terminal() -> None:
+    motion_domain = sequence.PhysicalProgramSequence(sample_ast())
+    claim = motion_domain.reserve_next_motion()
+    motion_domain.mark_ambiguous(claim, "accepted effect completion became uncertain")
+    require(motion_domain.terminal, "ambiguous emitted motion must make sequencing terminal")
+    require(motion_domain.next_index == 1, "ambiguity cannot manufacture completion")
+    expect_error(motion_domain.reserve_next_motion, "terminal")
+
+    landing_domain = sequence.PhysicalProgramSequence(sample_ast())
+    advance_to_landing(landing_domain)
+    landing_claim = landing_domain.reserve_terminal_landing()
+    landing_domain.mark_ambiguous(landing_claim, "landing completion became uncertain")
+    require(landing_domain.terminal, "ambiguous emitted landing must make sequencing terminal")
+    require(not landing_domain.completed, "ambiguous landing cannot manufacture program completion")
+    require(landing_domain.next_index == 3, "ambiguous landing cannot advance final cursor")
+    expect_error(landing_domain.reserve_terminal_landing, "terminal")
 
 
-def test_unsupported_or_malformed_next_statement_fails_closed() -> None:
+def test_complete_envelope_is_validated_before_flight() -> None:
     for statement in (
         {"kind": "land"},
         {"kind": "vertical", "direction": "up", "distance_m": 0.2},
@@ -118,8 +172,7 @@ def test_unsupported_or_malformed_next_statement_fails_closed() -> None:
                 {"kind": "land"},
             ]
         )
-        domain = sequence.PhysicalProgramSequence(ast)
-        expect_error(domain.reserve_next_motion, "next")
+        expect_error(lambda ast=ast: sequence.PhysicalProgramSequence(ast), "next")
 
 
 def test_exact_canonical_ast_and_flight_boundaries_are_required() -> None:
@@ -144,15 +197,97 @@ def test_exact_canonical_ast_and_flight_boundaries_are_required() -> None:
     expect_error(lambda: sequence.PhysicalProgramSequence(wrong_last), "end")
 
 
+def test_exact_bound_command_10_landing_semantics() -> None:
+    binding = sample_ast()
+    command = landing.derive_bound_landing_command(binding)
+    require(command.ast_binding == binding, "landing command preserves exact AST binding")
+    require(command.descent_m == 0.8, "landing descent derives exact bound takeoff height")
+    require(
+        len(command.request) == struct.calcsize("<BBf?f?f"),
+        "command 10 packet size matches pinned firmware layout",
+    )
+    fields = struct.unpack("<BBf?f?f", command.request)
+    require(fields[0] == 10, "command id is LAND_WITH_VELOCITY")
+    require(fields[1] == 0, "landing group mask is zero")
+    require(abs(fields[2] - 0.8) < 1e-6, "relative descent is exact takeoff height")
+    require(fields[3] is True, "landing height is relative and positive downward")
+    require(fields[4] == 0.0, "ignored yaw payload stays neutral")
+    require(fields[5] is True, "current yaw is preserved")
+    require(abs(fields[6] - 0.5) < 1e-6, "explicit landing velocity is 0.5 m/s")
+
+    boundary_only = canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.5},
+            {"kind": "land"},
+        ]
+    )
+    require(
+        landing.derive_bound_landing_command(boundary_only).descent_m == 0.5,
+        "boundary-only exact program derives the same relative landing policy",
+    )
+
+
+def test_landing_command_fails_closed_on_unsupported_envelope() -> None:
+    unsupported = canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "vertical", "direction": "down", "distance_m": 0.2},
+            {"kind": "land"},
+        ]
+    )
+    expect_landing_error(unsupported, "next")
+
+    malformed_final = canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "land", "height_m": 0.0},
+        ]
+    )
+    expect_landing_error(malformed_final, "end")
+
+    too_high = canonical(
+        [
+            {"kind": "takeoff", "height_m": 1.6},
+            {"kind": "land"},
+        ]
+    )
+    expect_landing_error(too_high, "bounds")
+
+
+def test_landing_command_has_no_effect_or_caller_parameter_surface() -> None:
+    source = (PHYSICAL / "landing_command.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "send_packet(",
+        "HighLevelCommander(",
+        "PowerSwitch(",
+        "teacher_decision",
+        "caller_height",
+        "caller_velocity",
+        "COMMAND_STOP",
+    ):
+        require(forbidden not in source, "pure landing semantics leaked authority: " + forbidden)
+
+    try:
+        landing.derive_bound_landing_command(sample_ast(), 0.2)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("caller-selected landing distance entered pure command API")
+
+
 def main() -> int:
     test_exact_order_and_claim_identity()
-    test_caller_cannot_select_motion_or_index()
-    test_ambiguous_effect_is_terminal()
-    test_unsupported_or_malformed_next_statement_fails_closed()
+    test_caller_cannot_select_motion_index_or_landing()
+    test_ambiguous_motion_or_landing_is_terminal()
+    test_complete_envelope_is_validated_before_flight()
     test_exact_canonical_ast_and_flight_boundaries_are_required()
+    test_exact_bound_command_10_landing_semantics()
+    test_landing_command_fails_closed_on_unsupported_envelope()
+    test_landing_command_has_no_effect_or_caller_parameter_surface()
     print(
-        "PASS exact physical-program sequencing derives the next in-flight motion from the "
-        "teacher-bound canonical AST and advances only on causal completion"
+        "PASS exact physical-program sequencing validates the complete supported envelope, "
+        "exposes only the exact terminal land after prior causal completion, and derives "
+        "pinned command 10 solely from the teacher-bound canonical AST"
     )
     return 0
 

--- a/tools/ci/test_physical_program_sequence.py
+++ b/tools/ci/test_physical_program_sequence.py
@@ -240,7 +240,7 @@ def test_landing_command_fails_closed_on_unsupported_envelope() -> None:
     malformed_final = canonical(
         [
             {"kind": "takeoff", "height_m": 0.8},
-            {"kind": "land", "height_m": 0.0},
+            {"kind": "land", "extra": True},
         ]
     )
     expect_landing_error(malformed_final, "end")

--- a/tools/physical/landing_command.py
+++ b/tools/physical/landing_command.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Pure exact-AST -> typed terminal HighLevel landing request semantics.
+
+This module is deliberately non-authority and emits no CRTP packet. It consumes
+only the exact canonical ``astBinding`` already bound by the trusted physical
+host and derives the one terminal ``land`` statement after validating the whole
+currently supported physical program envelope through
+:class:`physical_program_sequence.PhysicalProgramSequence`.
+
+The resulting request is the pinned Crazyflie firmware
+``COMMAND_LAND_WITH_VELOCITY`` packet (command 10). The bounded physical slice
+supports no vertical motion between takeoff and land, so landing descends by the
+exact teacher-bound absolute takeoff height relative to the current high-level
+setpoint. With command 9's absolute takeoff contract and no intervening vertical
+effects, this deterministically targets the estimator-zero landing level without
+exposing an independent caller-selected landing height. The command preserves
+current yaw and uses the firmware's explicit safe-default 0.5 m/s landing
+velocity.
+
+No caller-supplied height, velocity, yaw, raw packet bytes, teacher decision,
+session object or other effect authority is accepted here. A later trusted
+physical-host consumer must still compose this pure request with
+#267/#266/#262/#257/#264/#272/#271/#273 and fresh #278/#249 provenance
+immediately before emission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import struct
+
+import physical_program_sequence
+import takeoff_command
+
+LAND_WITH_VELOCITY_COMMAND = 10
+LAND_GROUP_MASK = 0
+LAND_VELOCITY_M_S = 0.5
+_LAND_PACKET = struct.Struct("<BBf?f?f")
+
+
+class LandingCommandError(RuntimeError):
+    """Fail-closed error for an unavailable exact-bound landing request."""
+
+
+@dataclass(frozen=True)
+class BoundLandingCommand:
+    """Pure typed command derived from one exact canonical student AST binding."""
+
+    ast_binding: str
+    descent_m: float
+    request: bytes
+
+
+def derive_bound_landing_command(ast_binding: object) -> BoundLandingCommand:
+    """Derive command 10 solely from the exact supported canonical AST."""
+    try:
+        sequence = physical_program_sequence.PhysicalProgramSequence(ast_binding)
+        takeoff = takeoff_command.derive_bound_takeoff_command(sequence.ast_binding)
+    except (
+        physical_program_sequence.PhysicalProgramSequenceError,
+        takeoff_command.TakeoffCommandError,
+    ) as exc:
+        raise LandingCommandError(str(exc)) from exc
+
+    request = _LAND_PACKET.pack(
+        LAND_WITH_VELOCITY_COMMAND,
+        LAND_GROUP_MASK,
+        takeoff.height_m,
+        True,  # relative downward distance; firmware LAND semantics define + as down
+        0.0,  # ignored because current yaw is explicitly preserved
+        True,
+        LAND_VELOCITY_M_S,
+    )
+    return BoundLandingCommand(
+        ast_binding=sequence.ast_binding,
+        descent_m=takeoff.height_m,
+        request=request,
+    )

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
-"""Exact-AST sequencing state for trusted physical in-flight effects.
+"""Exact-AST sequencing state for trusted physical flight effects.
 
-The #287 takeoff consumer deliberately derives its effect from the first
-statement in the exact teacher-authorized canonical AST. Later physical effects
-must preserve that property: a bounded caller-selected motion is not equivalent
+The #287 takeoff consumer derives its effect from the first statement in the
+exact teacher-authorized canonical AST. Later effects must preserve that
+property: a bounded caller-selected motion or landing request is not equivalent
 to the next statement of the authorized program.
 
-This module provides the small non-effect state machine needed by #276. It
-starts only after a caller has already established the first takeoff statement by
-other trusted means, reserves exactly the next top-level move/turn statement,
-and advances only after the trusted effect consumer reports definitive causal
-completion. A rejected/unemitted attempt may be released without advancing;
-an ambiguous emitted outcome makes the sequence terminal.
+This module provides the small non-effect state machine needed by the physical
+host. It starts only after a caller has already established the first takeoff
+statement by other trusted means, eagerly validates the complete currently
+supported envelope (move/turn statements followed by one exact terminal land),
+reserves exactly the next statement, and advances only after the trusted effect
+consumer reports definitive causal completion. A rejected/unemitted attempt may
+be released without advancing; an ambiguous emitted outcome makes the sequence
+terminal.
 
 It emits no CRTP command and accepts no caller-selected motion, program index,
-completion proof or authority object.
+landing parameter, completion proof or authority object.
 """
 
 from __future__ import annotations
@@ -41,11 +43,25 @@ class SequencedInflightMotion:
     angle_deg: float | None
 
 
+@dataclass(frozen=True, slots=True)
+class SequencedTerminalLanding:
+    """The one exact terminal landing boundary of the immutable canonical AST."""
+
+    index: int
+
+
 class _MotionClaim:
     __slots__ = ("motion",)
 
     def __init__(self, motion: SequencedInflightMotion) -> None:
         self.motion = motion
+
+
+class _LandingClaim:
+    __slots__ = ("landing",)
+
+    def __init__(self, landing: SequencedTerminalLanding) -> None:
+        self.landing = landing
 
 
 class PhysicalProgramSequence:
@@ -73,10 +89,19 @@ class PhysicalProgramSequence:
             raise PhysicalProgramSequenceError(
                 "physical AST must end with the exact landing statement"
             )
+
         self._ast_binding = ast_binding
         self._program = tuple(program)
+
+        # This production slice supports only horizontal move / turn between the
+        # exact takeoff and terminal landing boundaries. Validate the complete
+        # envelope before reset/takeoff, rather than discovering an unsupported
+        # statement only after the aircraft is already flying.
+        for index in range(1, len(self._program) - 1):
+            self._motion_at(index)
+
         self._next_index = 1
-        self._pending: _MotionClaim | None = None
+        self._pending: _MotionClaim | _LandingClaim | None = None
         self._terminal_reason: str | None = None
         self._lock = Lock()
 
@@ -98,6 +123,15 @@ class PhysicalProgramSequence:
     def terminal_reason(self) -> str | None:
         with self._lock:
             return self._terminal_reason
+
+    @property
+    def completed(self) -> bool:
+        with self._lock:
+            return (
+                self._terminal_reason is None
+                and self._pending is None
+                and self._next_index == len(self._program)
+            )
 
     def _motion_at(self, index: int) -> SequencedInflightMotion:
         if index >= len(self._program) - 1:
@@ -165,7 +199,7 @@ class PhysicalProgramSequence:
             ) from exc
 
         raise PhysicalProgramSequenceError(
-            "next exact AST statement is not a #276 horizontal/turn effect"
+            "next exact AST statement is not a supported horizontal/turn effect"
         )
 
     def reserve_next_motion(self) -> object:
@@ -177,7 +211,7 @@ class PhysicalProgramSequence:
                 )
             if self._pending is not None:
                 raise PhysicalProgramSequenceError(
-                    "physical program already has a pending in-flight effect"
+                    "physical program already has a pending effect"
                 )
             motion = self._motion_at(self._next_index)
             claim = _MotionClaim(motion)
@@ -188,7 +222,7 @@ class PhysicalProgramSequence:
         with self._lock:
             if claim is not self._pending or not isinstance(claim, _MotionClaim):
                 raise PhysicalProgramSequenceError(
-                    "exact pending physical-program claim is required"
+                    "exact pending physical-program motion claim is required"
                 )
             return claim.motion
 
@@ -197,19 +231,75 @@ class PhysicalProgramSequence:
         with self._lock:
             if claim is not self._pending or not isinstance(claim, _MotionClaim):
                 raise PhysicalProgramSequenceError(
-                    "exact pending physical-program claim is required"
+                    "exact pending physical-program motion claim is required"
                 )
             if claim.motion.index != self._next_index:
                 raise PhysicalProgramSequenceError(
-                    "pending physical-program claim no longer matches the cursor"
+                    "pending physical-program motion claim no longer matches the cursor"
+                )
+            self._next_index += 1
+            self._pending = None
+
+    def reserve_terminal_landing(self) -> object:
+        """Reserve the exact final land only when all prior motions completed."""
+        with self._lock:
+            if self._terminal_reason is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is terminal: " + self._terminal_reason
+                )
+            if self._pending is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending effect"
+                )
+            final_index = len(self._program) - 1
+            if self._next_index != final_index:
+                raise PhysicalProgramSequenceError(
+                    "terminal landing is not the next exact physical statement"
+                )
+            statement = self._program[final_index]
+            if (
+                not isinstance(statement, dict)
+                or set(statement) != {"kind"}
+                or statement.get("kind") != "land"
+            ):
+                raise PhysicalProgramSequenceError(
+                    "exact terminal landing statement is unavailable"
+                )
+            claim = _LandingClaim(SequencedTerminalLanding(final_index))
+            self._pending = claim
+            return claim
+
+    def landing_for_claim(self, claim: object) -> SequencedTerminalLanding:
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _LandingClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program landing claim is required"
+                )
+            return claim.landing
+
+    def complete_landing(self, claim: object) -> None:
+        """Advance past the exact terminal land only after causal completion."""
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _LandingClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program landing claim is required"
+                )
+            if (
+                claim.landing.index != self._next_index
+                or self._next_index != len(self._program) - 1
+            ):
+                raise PhysicalProgramSequenceError(
+                    "pending terminal landing claim no longer matches the cursor"
                 )
             self._next_index += 1
             self._pending = None
 
     def release_unemitted(self, claim: object) -> None:
-        """Release a definitively unemitted/rejected motion without advancing."""
+        """Release one definitively unemitted/rejected effect without advancing."""
         with self._lock:
-            if claim is not self._pending or not isinstance(claim, _MotionClaim):
+            if claim is not self._pending or not isinstance(
+                claim, (_MotionClaim, _LandingClaim)
+            ):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program claim is required"
                 )
@@ -222,7 +312,9 @@ class PhysicalProgramSequence:
                 "ambiguous physical-program outcome requires a reason"
             )
         with self._lock:
-            if claim is not self._pending or not isinstance(claim, _MotionClaim):
+            if claim is not self._pending or not isinstance(
+                claim, (_MotionClaim, _LandingClaim)
+            ):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program claim is required"
                 )


### PR DESCRIPTION
Establishes the no-effect prerequisite for the remaining controlled terminal landing slice of #157, on top of the integrated exact-program physical host path.

`PhysicalProgramSequence` now validates the complete currently supported post-takeoff envelope (horizontal move / turn only) at construction time, before reset or takeoff can be attempted. It exposes one opaque terminal-landing claim only after every prior exact motion has causally completed. Definitive no-effect/rejection keeps the same terminal statement pending; an ambiguous emitted landing makes sequencing terminal rather than manufacturing completion; only causal landing completion advances past the final statement.

The new pure `landing_command.py` derives pinned firmware `COMMAND_LAND_WITH_VELOCITY` (10) solely from the teacher-bound canonical AST. Because this bounded physical slice admits no intervening vertical effect, it uses the exact bound absolute takeoff height as a relative downward landing distance, preserves current yaw and fixes the explicit firmware safe-default landing velocity at 0.5 m/s. There is no caller-supplied height, velocity, yaw, raw packet, teacher/session object or CRTP send surface.

The existing `test_physical_program_sequence.py` gate now covers exact terminal reservation/completion identity, caller-substitution rejection, motion/landing ambiguity, eager rejection of unsupported middle statements, and the exact command-10 packet/provenance semantics. It remains on the existing Runtime core CI path; no workflow or authority boundary is added.

This PR deliberately does **not** emit a landing command and does not claim an executable normal-completion path yet. A later trusted host consumer must still compose fresh #278/#249 provenance, #267 teacher authority, #266/#262 session/watchdog state, #257 supervisor evidence, #272 SafeLink, #271 acknowledgement freshness, #273 exclusion, and #264 controlled-landing completion around the exact terminal claim. No motorized checkpoint is requested or authorized.

Refs #157 #264 #276 #289 #295.