### PR TITLE
Complete trusted terminal landing composition

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -133,6 +133,10 @@ def main():
     if physical_setpoint_transport_test.returncode:
         print('FAIL trusted one-shot SETPOINT_HL effect transport',file=sys.stderr);print(physical_setpoint_transport_test.stdout,file=sys.stderr);print(physical_setpoint_transport_test.stderr,file=sys.stderr);return physical_setpoint_transport_test.returncode
     print(physical_setpoint_transport_test.stdout.strip())
+    controlled_landing_transport_test=subprocess.run([sys.executable,'tools/ci/test_controlled_landing_transport.py'],text=True,capture_output=True)
+    if controlled_landing_transport_test.returncode:
+        print('FAIL trusted controlled terminal landing transport',file=sys.stderr);print(controlled_landing_transport_test.stdout,file=sys.stderr);print(controlled_landing_transport_test.stderr,file=sys.stderr);return controlled_landing_transport_test.returncode
+    print(controlled_landing_transport_test.stdout.strip())
     physical_host_inflight_test=subprocess.run([sys.executable,'tools/ci/test_physical_host_inflight_sequence.py'],text=True,capture_output=True)
     if physical_host_inflight_test.returncode:
         print('FAIL actual physical-host exact-program in-flight composition',file=sys.stderr);print(physical_host_inflight_test.stdout,file=sys.stderr);print(physical_host_inflight_test.stderr,file=sys.stderr);return physical_host_inflight_test.returncode

--- a/tools/ci/test_controlled_landing_transport.py
+++ b/tools/ci/test_controlled_landing_transport.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from math import isclose
+from pathlib import Path
+from types import SimpleNamespace
+import struct
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(CI))
+sys.path.insert(0, str(PHYSICAL))
+
+import controlled_landing_transport as landing_transport  # noqa: E402
+import landing_completion  # noqa: E402
+import physical_execution_domain as execution  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
+import test_physical_setpoint_hl_transport as base  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except Exception as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected failure containing {pattern!r}")
+
+
+def canonical(height_m: float = 0.8) -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": height_m, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+class HostBoundLandingTransport(landing_transport.TrustedControlledLandingTransport):
+    def __init__(self, *, bridge, **kwargs) -> None:
+        self._test_bridge = bridge
+        super().__init__(**kwargs)
+
+    def _read_current_binding(self):
+        binding = self.teacher_binding
+        try:
+            evidence = self._test_bridge.assert_current_program(
+                profile_id=binding.profile_id,
+                ast_binding=binding.ast_binding,
+                connection_epoch=binding.connection_epoch,
+                timeout_seconds=0.25,
+            )
+        except Exception as exc:
+            raise landing_transport.ControlledLandingTransportError(
+                "integrated current-program re-assertion failed"
+            ) from exc
+        if type(evidence) is not base.capability_bridge.CurrentProgramPreflightEvidence:
+            raise landing_transport.ControlledLandingTransportError(
+                "invalid current-program evidence"
+            )
+        if (
+            evidence.execution_authority is not False
+            or evidence.profile_id != binding.profile_id
+            or evidence.ast_binding != binding.ast_binding
+            or evidence.connection_epoch != binding.connection_epoch
+        ):
+            raise landing_transport.ControlledLandingTransportError(
+                "current-program binding mismatch"
+            )
+        return binding
+
+
+class CompletionStub:
+    def __init__(self, epoch: str, *, error: Exception | None = None) -> None:
+        self.bound_connection_epoch = epoch
+        self.error = error
+        self.capture_calls = 0
+        self.await_calls = 0
+        self.baseline = landing_completion.PreLandingFlightEvidence(epoch, 0)
+
+    def capture_pre_land_flight(self, *, timeout_seconds: float = 0.2):
+        del timeout_seconds
+        self.capture_calls += 1
+        return self.baseline
+
+    def await_completion(self, baseline, **kwargs):
+        del kwargs
+        self.await_calls += 1
+        require(baseline is self.baseline, "landing completion must consume exact baseline")
+        if self.error is not None:
+            raise self.error
+        return landing_completion.LandingCompletionEvidence(
+            connection_epoch=self.bound_connection_epoch,
+            observations=1,
+            supervisor_state=SimpleNamespace(
+                blocking_fault=False,
+                is_flying=False,
+                hl_control_active=False,
+                hl_traj_finished=True,
+            ),
+        )
+
+
+def make_transport(label: str, cf: base.FakeCrazyflie, *, completion_error=None):
+    fixture = base.Fixture(label, cf)
+    binding = teacher.PhysicalRunBinding(
+        profile_id="activity-1",
+        ast_binding=canonical(),
+        connection_epoch=fixture.epoch(),
+    )
+    authorizer = teacher.TrustedTeacherAuthorizer()
+    authorization = authorizer.authorize_run(binding, lambda exact: exact == binding)
+    fixture.current_binding = binding
+    kwargs = dict(fixture.kwargs)
+    kwargs["teacher_authorization"] = authorization
+    transport = HostBoundLandingTransport(
+        bridge=fixture.bridge,
+        connection_epoch_reader=fixture.epoch,
+        **kwargs,
+    )
+    completion = CompletionStub(fixture.epoch(), error=completion_error)
+    transport._landing_observer = completion
+    return fixture, transport, completion
+
+
+def unpack_landing(cf: base.FakeCrazyflie):
+    require(len(cf.send_calls) == 1, "terminal landing must emit exactly one packet")
+    data = bytes(cf.send_calls[0][0][0].data)
+    return struct.unpack("<BBf?f?f", data)
+
+
+landing_transport._DEFAULT_REPLY_TIMEOUT_SECONDS = 0.01
+
+
+def test_accepted_exact_ast_landing_completes_inactive() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture, transport, completion = make_transport("landing-accepted", cf)
+    try:
+        result = transport.send_controlled_landing()
+        require(result.accepted is True, "zero firmware status must be accepted")
+        require(fixture.domain.phase == execution.INACTIVE, "fresh #264 completion must establish inactive")
+        require(completion.capture_calls == 1, "one pre-land flight baseline is required")
+        require(completion.await_calls == 1, "positive acknowledgement must require landing completion")
+        command, group, height, relative, yaw, current_yaw, velocity = unpack_landing(cf)
+        require(command == 10 and group == 0, "only pinned command-10 single-Crazyflie landing is allowed")
+        require(isclose(height, 0.8, rel_tol=0, abs_tol=1e-6), "landing descent must derive exact takeoff height")
+        require(relative is True, "landing command must use relative downward distance")
+        require(isclose(yaw, 0.0, rel_tol=0, abs_tol=1e-9) and current_yaw is True, "landing must preserve current yaw")
+        require(isclose(velocity, 0.5, rel_tol=0, abs_tol=1e-6), "landing velocity must be explicit pinned safe default")
+        try:
+            transport.send_controlled_landing(height_m=0.2)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("caller-selected landing semantics unexpectedly exist")
+    finally:
+        fixture.close()
+
+
+def test_definitive_rejection_restores_flying_without_completion() -> None:
+    cf = base.FakeCrazyflie(reply_status=7)
+    fixture, transport, completion = make_transport("landing-rejected", cf)
+    try:
+        result = transport.send_controlled_landing()
+        require(result.accepted is False and result.status == 7, "non-zero firmware status must be definitive rejection")
+        require(fixture.domain.phase == execution.FLYING, "definitive rejection must restore prior flying phase")
+        require(completion.capture_calls == 1, "fresh pre-land evidence remains required before emission")
+        require(completion.await_calls == 0, "rejected landing must not consume completion authority")
+        require(len(cf.send_calls) == 1, "rejected landing must not be retried")
+    finally:
+        fixture.close()
+
+
+def test_acknowledgement_ambiguity_poisoned_without_retry() -> None:
+    cf = base.FakeCrazyflie(reply_status=None)
+    fixture, transport, completion = make_transport("landing-timeout", cf)
+    try:
+        expect_error(transport.send_controlled_landing, "acknowledgement timeout")
+        require(fixture.domain.phase == execution.RECOVERY_REQUIRED, "ambiguous emitted landing must require recovery")
+        require(fixture.ack.poisoned is True, "ambiguous landing acknowledgement must poison epoch freshness")
+        require(completion.await_calls == 0, "unknown acknowledgement cannot enter completion")
+        require(len(cf.send_calls) == 1, "ambiguous landing must never retry")
+    finally:
+        fixture.close()
+
+
+def test_completion_uncertainty_requires_recovery() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture, transport, completion = make_transport(
+        "landing-completion-uncertain",
+        cf,
+        completion_error=landing_completion.LandingCompletionError("completion unavailable"),
+    )
+    try:
+        expect_error(transport.send_controlled_landing, "completion unavailable")
+        require(completion.await_calls == 1, "accepted landing must consume completion observer")
+        require(fixture.domain.phase == execution.RECOVERY_REQUIRED, "uncertain accepted landing completion must require recovery")
+        require(len(cf.send_calls) == 1, "completion uncertainty must not retry physical landing")
+    finally:
+        fixture.close()
+
+
+def main() -> int:
+    test_accepted_exact_ast_landing_completes_inactive()
+    test_definitive_rejection_restores_flying_without_completion()
+    test_acknowledgement_ambiguity_poisoned_without_retry()
+    test_completion_uncertainty_requires_recovery()
+    print(
+        "PASS controlled terminal landing derives command 10 from the exact program, "
+        "sends once after callback registration, distinguishes rejection/ambiguity, "
+        "and requires fresh completion before inactive"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(CI))
 sys.path.insert(0, str(PHYSICAL))
 HOST = PHYSICAL / "serve_physical_host.py"
 
+import controlled_landing_transport  # noqa: E402
 import setpoint_hl_transport  # noqa: E402
 import test_physical_host_activation as base  # noqa: E402
 import yaw_observer  # noqa: E402
@@ -36,6 +37,21 @@ def canonical_ast(final_statement: dict[str, object] | None = None) -> str:
                 {"angle_deg": -25, "kind": "turn"},
                 {"direction": "forward", "distance_m": 0.3, "kind": "move"},
                 final,
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def direct_landing_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {"kind": "land"},
             ],
             "semantics": "webeeblocks-ast-v1",
             "version": 1,
@@ -76,17 +92,20 @@ class FakeInflightTransportBase:
         watchdog_guard: object,
         supervisor_reader: object,
     ) -> None:
+        del acknowledgement_domain, safelink_guard, supervisor_reader
         require(powered_session.session is crazyflie, "in-flight exact powered session")
         require(execution_domain.phase == base.physical_execution_domain.FLYING, "takeoff must complete first")
         self.teacher_binding = teacher_authorization.binding
         self.bound_connection_epoch = powered_session.connection_epoch
         self._crazyflie = crazyflie
         self._watchdog = watchdog_guard
+        self._execution_domain = execution_domain
 
     def _read_current_binding(self):
         raise AssertionError("host-local provenance override is required")
 
     def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
+        del timing_policy
         require(yaw_reader is not None and yaw_reader.is_open, "fresh yaw observer must be opened lazily for moves")
         require(yaw_reader.bound_crazyflie is self._crazyflie, "yaw exact Crazyflie")
         require(self._watchdog.active, "same-session watchdog remains live")
@@ -96,6 +115,7 @@ class FakeInflightTransportBase:
         return SimpleNamespace(accepted=True, status=0)
 
     def send_turn(self, *, angle_deg, timing_policy):
+        del timing_policy
         require(self._watchdog.active, "same-session watchdog remains live")
         binding = self._read_current_binding()
         require(binding == self.teacher_binding, "fresh #249 matches exact teacher run")
@@ -103,14 +123,40 @@ class FakeInflightTransportBase:
         return SimpleNamespace(accepted=True, status=0)
 
 
+class FakeLandingTransportBase(FakeInflightTransportBase):
+    def __init__(self, *, connection_epoch_reader, execution_domain, **kwargs) -> None:
+        super().__init__(execution_domain=execution_domain, **kwargs)
+        require(
+            connection_epoch_reader() == self.bound_connection_epoch,
+            "landing transport must bind the exact live epoch",
+        )
+
+    def send_controlled_landing(self):
+        require(self._watchdog.active, "watchdog must remain live through terminal landing")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact landing run")
+        base.EVENTS.append(("terminal-land", binding.connection_epoch))
+        with self._execution_domain.effect_transaction(lambda: None) as effect:
+            effect.mark_emitted()
+            permit = effect.mark_accepted()
+        self._execution_domain.complete_accepted_effect(
+            permit,
+            base.physical_execution_domain.INACTIVE,
+            lambda: True,
+        )
+        return SimpleNamespace(accepted=True, status=0)
+
+
 def install_fakes() -> None:
     base.install_fakes()
     # ``physical_run_activation`` was imported by the reusable #293 fixture
-    # before these substitutions, so patch its exact globals as well as the
-    # modules future imports would see.
+    # before these substitutions, so patch its exact globals as well as modules
+    # future imports would see.
     base.activation.TrustedSetpointHlTransport = FakeInflightTransportBase
+    base.activation.TrustedControlledLandingTransport = FakeLandingTransportBase
     base.activation.FreshYawObserver = FakeYawObserver
     setpoint_hl_transport.TrustedSetpointHlTransport = FakeInflightTransportBase
+    controlled_landing_transport.TrustedControlledLandingTransport = FakeLandingTransportBase
     yaw_observer.FreshYawObserver = FakeYawObserver
 
 
@@ -126,7 +172,11 @@ def read_line(stream) -> dict[str, object]:
     return value
 
 
-def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]:
+def run_host_sequence(
+    ast_binding: str | None = None,
+    *,
+    exact_steps: int = 3,
+) -> list[dict[str, object]]:
     caller_host, caller_peer = socket.socketpair()
     caller_stream = caller_peer.makefile("r", encoding="utf-8")
     browser_read, browser_write = os.pipe()
@@ -173,7 +223,7 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
     )
     replies = [read_line(caller_stream)]
 
-    # Caller-selected semantics are rejected before the exact-program operation.
+    # Caller-selected semantics are rejected before every exact-program effect.
     send_line(
         caller_peer,
         {
@@ -185,11 +235,18 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
     )
     replies.append(read_line(caller_stream))
 
-    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-1"})
-    replies.append(read_line(caller_stream))
-    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-2"})
-    replies.append(read_line(caller_stream))
-    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-land"})
+    for index in range(exact_steps):
+        send_line(
+            caller_peer,
+            {"op": "execute-next-inflight", "requestId": f"step-{index + 1}"},
+        )
+        replies.append(read_line(caller_stream))
+
+    # A completed exact program cannot consume the terminal land twice.
+    send_line(
+        caller_peer,
+        {"op": "execute-next-inflight", "requestId": "post-complete"},
+    )
     replies.append(read_line(caller_stream))
 
     caller_peer.shutdown(socket.SHUT_WR)
@@ -217,20 +274,22 @@ def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
     )
 
 
-def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
+def test_actual_host_completes_exact_program_through_terminal_landing() -> None:
     base.EVENTS.clear()
     install_fakes()
     replies = run_host_sequence()
 
     require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation stays diagnostic")
-    require(replies[1]["ok"] is False, "caller-supplied motion fields must be rejected")
+    require(replies[1]["ok"] is False, "caller-supplied effect fields must be rejected")
     require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
     require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
     require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
-    require(replies[4]["ok"] is False, "landing remains outside this bounded #276 slice")
+    require(replies[4] == {"executionAuthority": False, "ok": True, "requestId": "step-3"}, "exact terminal land executes")
+    require(replies[5]["ok"] is False, "completed exact program cannot repeat terminal landing")
 
     move_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-move"]
     turn_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-turn"]
+    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
     require(
         turn_events == [("inflight-turn", -25.0, "epoch-after")],
         "caller substitution must not change the exact first authorized effect",
@@ -239,48 +298,82 @@ def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
         move_events == [("inflight-move", "forward", 0.3, "epoch-after")],
         "second in-flight effect must follow exact canonical AST order",
     )
+    require(
+        land_events == [("terminal-land", "epoch-after")],
+        "terminal landing must be consumed exactly once on the same run/epoch",
+    )
 
     takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
     turn_index = base.EVENTS.index(turn_events[0])
     yaw_open_index = base.EVENTS.index(("yaw-open", "epoch-after"))
     move_index = base.EVENTS.index(move_events[0])
+    land_index = base.EVENTS.index(land_events[0])
     require(
-        takeoff_index < turn_index < yaw_open_index < move_index,
-        "#260 yaw must stay unopened for a turn and open only before the exact horizontal move",
+        takeoff_index < turn_index < yaw_open_index < move_index < land_index,
+        "actual host must preserve takeoff -> turn -> move -> terminal land order",
     )
     require(
         any(event == ("current-program", "epoch-after") for event in base.EVENTS[takeoff_index:turn_index]),
         "fresh host-local #278/#249 must guard the first in-flight effect",
     )
+    require(
+        any(event == ("current-program", "epoch-after") for event in base.EVENTS[move_index:land_index]),
+        "fresh host-local #278/#249 must guard terminal landing",
+    )
     require(("yaw-close", "epoch-after") in base.EVENTS, "host teardown closes #260 observer")
+
+
+def test_actual_host_can_land_immediately_after_takeoff() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    replies = run_host_sequence(direct_landing_ast(), exact_steps=1)
+
+    require(replies[0]["ok"] is True, "direct takeoff/land run validates")
+    require(replies[1]["ok"] is False, "caller-selected landing fields remain impossible")
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact direct terminal land executes")
+    require(replies[3]["ok"] is False, "direct terminal land cannot be consumed twice")
+    require(
+        [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
+        == [("terminal-land", "epoch-after")],
+        "zero-motion exact program lands exactly once",
+    )
+    require(
+        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move"} for event in base.EVENTS),
+        "zero-motion exact program must not manufacture an in-flight move",
+    )
 
 
 def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
     base.EVENTS.clear()
     install_fakes()
     malformed = canonical_ast({"kind": "land", "extra": True})
-    replies = run_host_sequence(malformed)
+    replies = run_host_sequence(malformed, exact_steps=1)
 
     require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation remains diagnostic before activation")
     require(replies[2]["ok"] is False, "malformed terminal must make exact activation unavailable")
     require(
         ("transport-send", "epoch-after") not in base.EVENTS,
-        "malformed terminal must be rejected by #295 before the takeoff effect",
+        "malformed terminal must be rejected by exact sequencing before takeoff",
     )
     require(
-        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move"} for event in base.EVENTS),
-        "malformed terminal must never be skipped into an in-flight effect",
+        not any(
+            isinstance(event, tuple)
+            and event[0] in {"inflight-turn", "inflight-move", "terminal-land"}
+            for event in base.EVENTS
+        ),
+        "malformed terminal must never reach any physical program effect",
     )
 
 
 def main() -> int:
     test_started_activation_wait_is_outside_lifecycle_lock()
-    test_actual_host_uses_exact_program_sequence_after_takeoff()
+    test_actual_host_completes_exact_program_through_terminal_landing()
+    test_actual_host_can_land_immediately_after_takeoff()
     test_actual_host_rejects_malformed_terminal_before_takeoff()
     print(
         "PASS actual physical host sequencing: validate/activation handoff is race-free; "
-        "successful takeoff hands the same run/epoch to shared #295 exact-AST turn/move execution; "
-        "#260 yaw opens only for horizontal motion; malformed landing boundaries fail before takeoff"
+        "successful takeoff hands the same exact run/epoch through ordered turn/move and one "
+        "terminal landing; direct takeoff/land completes; duplicate/malformed land fails closed"
     )
     return 0
 

--- a/tools/ci/test_physical_program_sequence.py
+++ b/tools/ci/test_physical_program_sequence.py
@@ -77,7 +77,40 @@ def test_exact_order_and_claim_identity() -> None:
     require(domain.motion_for_claim(retry) == turn, "released statement must remain next")
 
 
-def test_caller_cannot_select_motion_or_index() -> None:
+def test_terminal_landing_is_exact_one_shot_program_boundary() -> None:
+    domain = sequence.PhysicalProgramSequence(sample_ast())
+    expect_error(domain.reserve_terminal_landing, "not the next")
+
+    first = domain.reserve_next_motion()
+    domain.complete_motion(first)
+    second = domain.reserve_next_motion()
+    domain.complete_motion(second)
+
+    expect_error(domain.reserve_next_motion, "final landing")
+    landing_claim = domain.reserve_terminal_landing()
+    landing = domain.landing_for_claim(landing_claim)
+    require(
+        landing == sequence.SequencedTerminalLanding(3),
+        "terminal land must be derived from the exact final AST index",
+    )
+    expect_error(domain.reserve_terminal_landing, "pending")
+    expect_error(lambda: domain.complete_landing(object()), "exact pending")
+
+    domain.release_unemitted(landing_claim)
+    require(domain.next_index == 3, "definitive rejected landing cannot advance completion")
+    retry = domain.reserve_terminal_landing()
+    require(
+        domain.landing_for_claim(retry) == landing,
+        "definitively unemitted terminal landing must remain exactly next",
+    )
+    domain.complete_landing(retry)
+    require(domain.completed, "trusted terminal landing completion must close the sequence")
+    require(domain.next_index == 4, "completed landing must consume the exact final statement")
+    expect_error(domain.reserve_terminal_landing, "already completed")
+    expect_error(domain.reserve_next_motion, "already completed")
+
+
+def test_caller_cannot_select_motion_or_landing_parameters() -> None:
     domain = sequence.PhysicalProgramSequence(sample_ast())
     try:
         domain.reserve_next_motion({"kind": "turn", "angle_deg": -90})
@@ -85,6 +118,13 @@ def test_caller_cannot_select_motion_or_index() -> None:
         pass
     else:
         raise AssertionError("caller-selected motion unexpectedly entered sequencing API")
+
+    try:
+        domain.reserve_terminal_landing({"height_m": 0.0})
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("caller-selected landing unexpectedly entered sequencing API")
 
     claim = domain.reserve_next_motion()
     require(
@@ -100,6 +140,18 @@ def test_ambiguous_effect_is_terminal() -> None:
     require(domain.terminal, "ambiguous emitted effect must make sequencing terminal")
     require(domain.next_index == 1, "ambiguity cannot manufacture completion")
     expect_error(domain.reserve_next_motion, "terminal")
+
+    landing_domain = sequence.PhysicalProgramSequence(
+        canonical([
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "land"},
+        ])
+    )
+    landing_claim = landing_domain.reserve_terminal_landing()
+    landing_domain.mark_ambiguous(landing_claim, "landing completion uncertain")
+    require(landing_domain.terminal, "ambiguous landing must make sequence terminal")
+    require(not landing_domain.completed, "ambiguous landing must not manufacture completion")
+    expect_error(landing_domain.reserve_terminal_landing, "terminal")
 
 
 def test_unsupported_or_malformed_next_statement_fails_closed() -> None:
@@ -120,6 +172,7 @@ def test_unsupported_or_malformed_next_statement_fails_closed() -> None:
         )
         domain = sequence.PhysicalProgramSequence(ast)
         expect_error(domain.reserve_next_motion, "next")
+        expect_error(domain.reserve_terminal_landing, "not the next")
 
 
 def test_exact_canonical_ast_and_flight_boundaries_are_required() -> None:
@@ -146,13 +199,14 @@ def test_exact_canonical_ast_and_flight_boundaries_are_required() -> None:
 
 def main() -> int:
     test_exact_order_and_claim_identity()
-    test_caller_cannot_select_motion_or_index()
+    test_terminal_landing_is_exact_one_shot_program_boundary()
+    test_caller_cannot_select_motion_or_landing_parameters()
     test_ambiguous_effect_is_terminal()
     test_unsupported_or_malformed_next_statement_fails_closed()
     test_exact_canonical_ast_and_flight_boundaries_are_required()
     print(
-        "PASS exact physical-program sequencing derives the next in-flight motion from the "
-        "teacher-bound canonical AST and advances only on causal completion"
+        "PASS exact physical-program sequencing derives move/turn plus one terminal land "
+        "from the teacher-bound canonical AST and advances only on causal completion"
     )
     return 0
 

--- a/tools/physical/controlled_landing_transport.py
+++ b/tools/physical/controlled_landing_transport.py
@@ -1,37 +1,33 @@
 #!/usr/bin/env python3
-"""Trusted controlled terminal LAND_2 effect for the physical Crazyflie.
+"""Trusted exact-program controlled terminal landing for the physical Crazyflie.
 
 This module extends the integrated #276 host-local SETPOINT_HL trust root with
-one fixed-policy terminal landing primitive for #304. It exposes no altitude,
-duration, yaw, raw-byte or retry surface: the only command is pinned cflib
-``COMMAND_LAND_2`` to absolute 0.0 m over 2.0 s while preserving current yaw.
+one terminal landing effect for #304.  Landing semantics are not selected here:
+``landing_command`` derives the pinned firmware ``COMMAND_LAND_WITH_VELOCITY``
+request solely from the exact teacher-bound canonical AST already validated by
+#305.  There is no caller altitude, duration, velocity, yaw, raw-byte or retry
+surface.
 
-Authority remains the exact #276 composition. Fresh current-program provenance,
-teacher binding, powered session, watchdog, supervisor state, SafeLink and
-acknowledgement freshness are checked at the effect boundary. Positive firmware
-acknowledgement is not completion: the private #279 permit is consumed only
-after the integrated #264 observer establishes a later same-epoch finished,
-non-flying, high-level-inactive state. Importing this module performs no effect.
+Authority remains the exact integrated physical-host composition.  Fresh
+current-program provenance, teacher binding, powered session, watchdog,
+supervisor state, SafeLink and acknowledgement freshness are checked at the
+effect boundary.  Positive firmware acknowledgement is not completion: the
+private #279 permit is consumed only after the integrated #264 observer
+establishes a later same-epoch finished, non-flying, high-level-inactive state.
+Importing this module performs no physical effect.
 """
 
 from __future__ import annotations
 
-import struct
 from threading import Event, Lock
 from typing import Callable
 
 import high_level_ack
+import landing_command
 import landing_completion
 import physical_execution_domain
 import setpoint_hl_transport
 
-_COMMAND_LAND_2 = 8
-_LAND_GROUP_MASK = 0
-_LAND_ABSOLUTE_HEIGHT_M = 0.0
-_LAND_TARGET_YAW_RAD = 0.0
-_LAND_USE_CURRENT_YAW = True
-_LAND_DURATION_SECONDS = 2.0
-_LAND_PACKET = struct.Struct("<BBff?f")
 _DEFAULT_REPLY_TIMEOUT_SECONDS = 0.2
 _LANDING_COMPLETION_TIMEOUT_SECONDS = 8.0
 
@@ -40,41 +36,8 @@ class ControlledLandingTransportError(setpoint_hl_transport.SetpointHlTransportE
     """Fail-closed trusted controlled-landing transport error."""
 
 
-def _landing_request() -> bytes:
-    return _LAND_PACKET.pack(
-        _COMMAND_LAND_2,
-        _LAND_GROUP_MASK,
-        _LAND_ABSOLUTE_HEIGHT_M,
-        _LAND_TARGET_YAW_RAD,
-        _LAND_USE_CURRENT_YAW,
-        _LAND_DURATION_SECONDS,
-    )
-
-
-def _validate_landing_request(value: object) -> bytes:
-    if isinstance(value, bytearray):
-        data = bytes(value)
-    elif isinstance(value, bytes):
-        data = value
-    else:
-        raise ControlledLandingTransportError("validated LAND_2 request must be bytes")
-    if len(data) != _LAND_PACKET.size:
-        raise ControlledLandingTransportError("LAND_2 payload size does not match pinned cflib")
-    command, group_mask, height, yaw, use_current_yaw, duration = _LAND_PACKET.unpack(data)
-    if command != _COMMAND_LAND_2 or group_mask != _LAND_GROUP_MASK:
-        raise ControlledLandingTransportError("only the fixed single-Crazyflie LAND_2 policy is available")
-    if (
-        height != _LAND_ABSOLUTE_HEIGHT_M
-        or yaw != _LAND_TARGET_YAW_RAD
-        or use_current_yaw is not _LAND_USE_CURRENT_YAW
-        or duration != _LAND_DURATION_SECONDS
-    ):
-        raise ControlledLandingTransportError("LAND_2 request differs from trusted host landing policy")
-    return data
-
-
 class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlTransport):
-    """#276 transport plus one host-policy terminal LAND_2 effect."""
+    """#276 authority composition plus one exact-AST terminal landing effect."""
 
     def __init__(
         self,
@@ -147,24 +110,49 @@ class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlT
             self._force_landing_completion_uncertainty(permit)
             raise
 
+    def _derive_exact_landing_request(self, ast_binding: str) -> bytes:
+        try:
+            command = landing_command.derive_bound_landing_command(ast_binding)
+        except landing_command.LandingCommandError as exc:
+            raise ControlledLandingTransportError(
+                "exact teacher-bound terminal landing request is unavailable"
+            ) from exc
+        if command.ast_binding != ast_binding:
+            raise ControlledLandingTransportError(
+                "derived landing request does not match the exact teacher-bound AST"
+            )
+        if not isinstance(command.request, bytes):
+            raise ControlledLandingTransportError(
+                "derived terminal landing request is not exact packet bytes"
+            )
+        return command.request
+
     def send_controlled_landing(self) -> high_level_ack.HighLevelAckResult:
-        """Emit the fixed host-policy terminal landing exactly once."""
-        request = _validate_landing_request(_landing_request())
+        """Emit the exact teacher-bound terminal landing once, with no retry."""
         result: high_level_ack.HighLevelAckResult | None = None
         completion_permit: physical_execution_domain.AcceptedEffectCompletionPermit | None = None
         baseline: landing_completion.PreLandingFlightEvidence | None = None
 
         with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            # Derive command 10 only after the trusted exclusion and initial fresh
+            # host-local current-program assertion have established eligibility.
+            initial_binding = self._read_current_binding()
+            self._assert_binding_authority(initial_binding)
+            request = self._derive_exact_landing_request(initial_binding.ast_binding)
             packet = setpoint_hl_transport._default_packet_factory(request)
             self._validate_packet(packet, request)
 
-            # Preserve #276 ordering: fresh host-owned current-program assertion,
-            # fresh finished-flight state, another authority check, then SafeLink.
-            final_binding = self._read_current_binding()
-            self._assert_binding_authority(final_binding)
+            # Match #276's final-boundary discipline, strengthened with a second
+            # host-owned current-program assertion after the blocking fresh #257/
+            # #264 observations and immediately before SafeLink/ack/emission.
             self._read_fresh_finished_flying()
             baseline = self._landing_observer.capture_pre_land_flight()
+            final_binding = self._read_current_binding()
             self._assert_binding_authority(final_binding)
+            if final_binding != initial_binding:
+                raise ControlledLandingTransportError(
+                    "current physical program changed during landing preparation"
+                )
             self._safelink.assert_ready()
 
             with self._ack.transaction(request) as acknowledgement:
@@ -222,11 +210,13 @@ class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlT
                             pass
 
         if result is None:
-            raise ControlledLandingTransportError("LAND_2 acknowledgement result is unavailable")
+            raise ControlledLandingTransportError(
+                "terminal landing acknowledgement result is unavailable"
+            )
         if result.accepted:
             if completion_permit is None or baseline is None:
                 raise ControlledLandingTransportError(
-                    "accepted LAND_2 effect lacks private completion state"
+                    "accepted terminal landing lacks private completion state"
                 )
             self._await_landing_completion(completion_permit, baseline)
         return result

--- a/tools/physical/controlled_landing_transport.py
+++ b/tools/physical/controlled_landing_transport.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Trusted controlled terminal LAND_2 effect for the physical Crazyflie.
+
+This module extends the integrated #276 host-local SETPOINT_HL trust root with
+one fixed-policy terminal landing primitive for #304. It exposes no altitude,
+duration, yaw, raw-byte or retry surface: the only command is pinned cflib
+``COMMAND_LAND_2`` to absolute 0.0 m over 2.0 s while preserving current yaw.
+
+Authority remains the exact #276 composition. Fresh current-program provenance,
+teacher binding, powered session, watchdog, supervisor state, SafeLink and
+acknowledgement freshness are checked at the effect boundary. Positive firmware
+acknowledgement is not completion: the private #279 permit is consumed only
+after the integrated #264 observer establishes a later same-epoch finished,
+non-flying, high-level-inactive state. Importing this module performs no effect.
+"""
+
+from __future__ import annotations
+
+import struct
+from threading import Event, Lock
+from typing import Callable
+
+import high_level_ack
+import landing_completion
+import physical_execution_domain
+import setpoint_hl_transport
+
+_COMMAND_LAND_2 = 8
+_LAND_GROUP_MASK = 0
+_LAND_ABSOLUTE_HEIGHT_M = 0.0
+_LAND_TARGET_YAW_RAD = 0.0
+_LAND_USE_CURRENT_YAW = True
+_LAND_DURATION_SECONDS = 2.0
+_LAND_PACKET = struct.Struct("<BBff?f")
+_DEFAULT_REPLY_TIMEOUT_SECONDS = 0.2
+_LANDING_COMPLETION_TIMEOUT_SECONDS = 8.0
+
+
+class ControlledLandingTransportError(setpoint_hl_transport.SetpointHlTransportError):
+    """Fail-closed trusted controlled-landing transport error."""
+
+
+def _landing_request() -> bytes:
+    return _LAND_PACKET.pack(
+        _COMMAND_LAND_2,
+        _LAND_GROUP_MASK,
+        _LAND_ABSOLUTE_HEIGHT_M,
+        _LAND_TARGET_YAW_RAD,
+        _LAND_USE_CURRENT_YAW,
+        _LAND_DURATION_SECONDS,
+    )
+
+
+def _validate_landing_request(value: object) -> bytes:
+    if isinstance(value, bytearray):
+        data = bytes(value)
+    elif isinstance(value, bytes):
+        data = value
+    else:
+        raise ControlledLandingTransportError("validated LAND_2 request must be bytes")
+    if len(data) != _LAND_PACKET.size:
+        raise ControlledLandingTransportError("LAND_2 payload size does not match pinned cflib")
+    command, group_mask, height, yaw, use_current_yaw, duration = _LAND_PACKET.unpack(data)
+    if command != _COMMAND_LAND_2 or group_mask != _LAND_GROUP_MASK:
+        raise ControlledLandingTransportError("only the fixed single-Crazyflie LAND_2 policy is available")
+    if (
+        height != _LAND_ABSOLUTE_HEIGHT_M
+        or yaw != _LAND_TARGET_YAW_RAD
+        or use_current_yaw is not _LAND_USE_CURRENT_YAW
+        or duration != _LAND_DURATION_SECONDS
+    ):
+        raise ControlledLandingTransportError("LAND_2 request differs from trusted host landing policy")
+    return data
+
+
+class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlTransport):
+    """#276 transport plus one host-policy terminal LAND_2 effect."""
+
+    def __init__(
+        self,
+        *,
+        connection_epoch_reader: Callable[[], str],
+        **kwargs,
+    ) -> None:
+        if not callable(connection_epoch_reader):
+            raise ControlledLandingTransportError(
+                "live connection epoch reader is required for controlled landing"
+            )
+        super().__init__(**kwargs)
+        self._landing_observer = landing_completion.ControlledLandingCompletionObserver(
+            self._supervisor,
+            connection_epoch_reader,
+        )
+        if self._landing_observer.bound_connection_epoch != self.bound_connection_epoch:
+            raise ControlledLandingTransportError(
+                "landing completion observer belongs to a different connection epoch"
+            )
+
+    def _force_landing_completion_uncertainty(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+    ) -> None:
+        if self.execution_domain.phase == physical_execution_domain.AWAITING_COMPLETION:
+            try:
+                self.execution_domain.complete_accepted_effect(
+                    permit,
+                    physical_execution_domain.INACTIVE,
+                    lambda: False,
+                )
+            except physical_execution_domain.PhysicalExecutionDomainError:
+                pass
+
+    def _await_landing_completion(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+        baseline: landing_completion.PreLandingFlightEvidence,
+    ) -> None:
+        if type(permit) is not physical_execution_domain.AcceptedEffectCompletionPermit:
+            raise ControlledLandingTransportError(
+                "exact accepted-effect completion permit is required for landing"
+            )
+        try:
+            self._watchdog.assert_live()
+            evidence = self._landing_observer.await_completion(
+                baseline,
+                total_timeout_seconds=_LANDING_COMPLETION_TIMEOUT_SECONDS,
+            )
+            self._watchdog.assert_live()
+
+            def prove_completion() -> bool:
+                self._watchdog.assert_live()
+                state = evidence.supervisor_state
+                return (
+                    evidence.connection_epoch == self.bound_connection_epoch
+                    and getattr(state, "blocking_fault", None) is False
+                    and getattr(state, "is_flying", None) is False
+                    and getattr(state, "hl_control_active", None) is False
+                    and getattr(state, "hl_traj_finished", None) is True
+                )
+
+            self.execution_domain.complete_accepted_effect(
+                permit,
+                physical_execution_domain.INACTIVE,
+                prove_completion,
+            )
+        except Exception:
+            self._force_landing_completion_uncertainty(permit)
+            raise
+
+    def send_controlled_landing(self) -> high_level_ack.HighLevelAckResult:
+        """Emit the fixed host-policy terminal landing exactly once."""
+        request = _validate_landing_request(_landing_request())
+        result: high_level_ack.HighLevelAckResult | None = None
+        completion_permit: physical_execution_domain.AcceptedEffectCompletionPermit | None = None
+        baseline: landing_completion.PreLandingFlightEvidence | None = None
+
+        with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            packet = setpoint_hl_transport._default_packet_factory(request)
+            self._validate_packet(packet, request)
+
+            # Preserve #276 ordering: fresh host-owned current-program assertion,
+            # fresh finished-flight state, another authority check, then SafeLink.
+            final_binding = self._read_current_binding()
+            self._assert_binding_authority(final_binding)
+            self._read_fresh_finished_flying()
+            baseline = self._landing_observer.capture_pre_land_flight()
+            self._assert_binding_authority(final_binding)
+            self._safelink.assert_ready()
+
+            with self._ack.transaction(request) as acknowledgement:
+                reply_event = Event()
+                reply_lock = Lock()
+                first_reply: list[bytes] = []
+
+                def on_reply(reply_packet: object) -> None:
+                    try:
+                        data = bytes(getattr(reply_packet, "data"))
+                    except Exception:
+                        data = b""
+                    with reply_lock:
+                        if first_reply:
+                            return
+                        first_reply.append(data)
+                        reply_event.set()
+
+                def read_reply() -> bytes | None:
+                    with reply_lock:
+                        return first_reply[0] if first_reply else None
+
+                add_callback = getattr(self._cf, "add_port_callback", None)
+                remove_callback = getattr(self._cf, "remove_port_callback", None)
+                send_packet = getattr(self._cf, "send_packet", None)
+                if not callable(add_callback) or not callable(remove_callback) or not callable(send_packet):
+                    raise ControlledLandingTransportError(
+                        "Crazyflie SETPOINT_HL callback/send surface is unavailable"
+                    )
+                callback_installed = False
+                try:
+                    add_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)
+                    callback_installed = True
+                    acknowledgement.mark_emitted()
+                    effect.mark_emitted()
+                    send_packet(packet)
+                    try:
+                        reply = self._wait_for_reply(
+                            reply_event,
+                            read_reply,
+                            _DEFAULT_REPLY_TIMEOUT_SECONDS,
+                        )
+                    except Exception as exc:
+                        acknowledgement.fail_ambiguous(str(exc))
+                    result = acknowledgement.resolve_reply(reply)
+                    if result.accepted:
+                        completion_permit = effect.mark_accepted()
+                    else:
+                        effect.mark_definitive_rejection()
+                finally:
+                    if callback_installed:
+                        try:
+                            remove_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)
+                        except Exception:
+                            pass
+
+        if result is None:
+            raise ControlledLandingTransportError("LAND_2 acknowledgement result is unavailable")
+        if result.accepted:
+            if completion_permit is None or baseline is None:
+                raise ControlledLandingTransportError(
+                    "accepted LAND_2 effect lacks private completion state"
+                )
+            self._await_landing_completion(completion_permit, baseline)
+        return result

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
-"""Exact-AST sequencing state for trusted physical in-flight effects.
+"""Exact-AST sequencing state for trusted physical effects.
 
-The #287 takeoff consumer deliberately derives its effect from the first
-statement in the exact teacher-authorized canonical AST. Later physical effects
-must preserve that property: a bounded caller-selected motion is not equivalent
-to the next statement of the authorized program.
+The #287 takeoff consumer derives its effect from the first statement in the
+exact teacher-authorized canonical AST. Later physical effects must preserve
+that property: a bounded caller-selected effect is not equivalent to the next
+statement of the authorized program.
 
-This module provides the small non-effect state machine needed by #276. It
-starts only after a caller has already established the first takeoff statement by
-other trusted means, reserves exactly the next top-level move/turn statement,
-and advances only after the trusted effect consumer reports definitive causal
-completion. A rejected/unemitted attempt may be released without advancing;
-an ambiguous emitted outcome makes the sequence terminal.
+The sequence starts after causal takeoff, reserves move/turn effects in exact
+order, and now also exposes the one exact terminal ``land`` boundary required by
+#304. It advances only after the trusted consumer reports definitive causal
+completion. A rejected/unemitted attempt may be released without advancing; an
+ambiguous emitted outcome makes the sequence terminal.
 
-It emits no CRTP command and accepts no caller-selected motion, program index,
-completion proof or authority object.
+It emits no CRTP command and accepts no caller-selected motion, landing
+parameter, program index, completion proof or authority object.
 """
 
 from __future__ import annotations
@@ -41,11 +40,26 @@ class SequencedInflightMotion:
     angle_deg: float | None
 
 
+@dataclass(frozen=True, slots=True)
+class SequencedTerminalLanding:
+    """The one exact terminal landing derived from the immutable canonical AST."""
+
+    index: int
+    kind: str = "land"
+
+
 class _MotionClaim:
     __slots__ = ("motion",)
 
     def __init__(self, motion: SequencedInflightMotion) -> None:
         self.motion = motion
+
+
+class _LandingClaim:
+    __slots__ = ("landing",)
+
+    def __init__(self, landing: SequencedTerminalLanding) -> None:
+        self.landing = landing
 
 
 class PhysicalProgramSequence:
@@ -76,8 +90,9 @@ class PhysicalProgramSequence:
         self._ast_binding = ast_binding
         self._program = tuple(program)
         self._next_index = 1
-        self._pending: _MotionClaim | None = None
+        self._pending: _MotionClaim | _LandingClaim | None = None
         self._terminal_reason: str | None = None
+        self._completed = False
         self._lock = Lock()
 
     @property
@@ -98,6 +113,23 @@ class PhysicalProgramSequence:
     def terminal_reason(self) -> str | None:
         with self._lock:
             return self._terminal_reason
+
+    @property
+    def completed(self) -> bool:
+        with self._lock:
+            return self._completed
+
+    def _require_reservable(self) -> None:
+        if self._terminal_reason is not None:
+            raise PhysicalProgramSequenceError(
+                "physical program sequence is terminal: " + self._terminal_reason
+            )
+        if self._completed:
+            raise PhysicalProgramSequenceError("physical program sequence is already completed")
+        if self._pending is not None:
+            raise PhysicalProgramSequenceError(
+                "physical program already has a pending effect"
+            )
 
     def _motion_at(self, index: int) -> SequencedInflightMotion:
         if index >= len(self._program) - 1:
@@ -169,16 +201,9 @@ class PhysicalProgramSequence:
         )
 
     def reserve_next_motion(self) -> object:
-        """Reserve the exact next motion; no caller motion/index is accepted."""
+        """Reserve the exact next move/turn; no caller motion/index is accepted."""
         with self._lock:
-            if self._terminal_reason is not None:
-                raise PhysicalProgramSequenceError(
-                    "physical program sequence is terminal: " + self._terminal_reason
-                )
-            if self._pending is not None:
-                raise PhysicalProgramSequenceError(
-                    "physical program already has a pending in-flight effect"
-                )
+            self._require_reservable()
             motion = self._motion_at(self._next_index)
             claim = _MotionClaim(motion)
             self._pending = claim
@@ -188,28 +213,78 @@ class PhysicalProgramSequence:
         with self._lock:
             if claim is not self._pending or not isinstance(claim, _MotionClaim):
                 raise PhysicalProgramSequenceError(
-                    "exact pending physical-program claim is required"
+                    "exact pending physical-program motion claim is required"
                 )
             return claim.motion
 
     def complete_motion(self, claim: object) -> None:
-        """Advance only after the trusted consumer proves causal completion."""
+        """Advance only after the trusted consumer proves causal motion completion."""
         with self._lock:
             if claim is not self._pending or not isinstance(claim, _MotionClaim):
                 raise PhysicalProgramSequenceError(
-                    "exact pending physical-program claim is required"
+                    "exact pending physical-program motion claim is required"
                 )
             if claim.motion.index != self._next_index:
                 raise PhysicalProgramSequenceError(
-                    "pending physical-program claim no longer matches the cursor"
+                    "pending physical-program motion claim no longer matches the cursor"
                 )
             self._next_index += 1
             self._pending = None
 
-    def release_unemitted(self, claim: object) -> None:
-        """Release a definitively unemitted/rejected motion without advancing."""
+    def reserve_terminal_landing(self) -> object:
+        """Reserve the exact terminal land only when every prior motion completed."""
         with self._lock:
-            if claim is not self._pending or not isinstance(claim, _MotionClaim):
+            self._require_reservable()
+            landing_index = len(self._program) - 1
+            if self._next_index != landing_index:
+                raise PhysicalProgramSequenceError(
+                    "terminal landing is not the next exact physical statement"
+                )
+            statement = self._program[landing_index]
+            if (
+                not isinstance(statement, dict)
+                or set(statement) != {"kind"}
+                or statement.get("kind") != "land"
+            ):
+                raise PhysicalProgramSequenceError(
+                    "terminal physical landing statement is malformed"
+                )
+            landing = SequencedTerminalLanding(index=landing_index)
+            claim = _LandingClaim(landing)
+            self._pending = claim
+            return claim
+
+    def landing_for_claim(self, claim: object) -> SequencedTerminalLanding:
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _LandingClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program landing claim is required"
+                )
+            return claim.landing
+
+    def complete_landing(self, claim: object) -> None:
+        """Consume the terminal land only after trusted causal landing completion."""
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _LandingClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program landing claim is required"
+                )
+            if claim.landing.index != self._next_index:
+                raise PhysicalProgramSequenceError(
+                    "pending physical-program landing claim no longer matches the cursor"
+                )
+            if self._next_index != len(self._program) - 1:
+                raise PhysicalProgramSequenceError(
+                    "terminal landing completion is out of exact program order"
+                )
+            self._next_index += 1
+            self._pending = None
+            self._completed = True
+
+    def release_unemitted(self, claim: object) -> None:
+        """Release a definitively unemitted/rejected effect without advancing."""
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, (_MotionClaim, _LandingClaim)):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program claim is required"
                 )
@@ -222,7 +297,7 @@ class PhysicalProgramSequence:
                 "ambiguous physical-program outcome requires a reason"
             )
         with self._lock:
-            if claim is not self._pending or not isinstance(claim, _MotionClaim):
+            if claim is not self._pending or not isinstance(claim, (_MotionClaim, _LandingClaim)):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program claim is required"
                 )

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -133,6 +133,34 @@ class PhysicalProgramSequence:
                 and self._next_index == len(self._program)
             )
 
+    @property
+    def next_effect_kind(self) -> str:
+        """Expose only the exact next validated effect kind for trusted dispatch."""
+        with self._lock:
+            if self._terminal_reason is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is terminal: " + self._terminal_reason
+                )
+            if self._pending is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending effect"
+                )
+            if self._next_index >= len(self._program):
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is already completed"
+                )
+            statement = self._program[self._next_index]
+            if not isinstance(statement, dict):
+                raise PhysicalProgramSequenceError(
+                    "next physical statement is malformed"
+                )
+            kind = statement.get("kind")
+            if kind not in {"move", "turn", "land"}:
+                raise PhysicalProgramSequenceError(
+                    "next exact AST statement is outside the validated physical envelope"
+                )
+            return kind
+
     def _motion_at(self, index: int) -> SequencedInflightMotion:
         if index >= len(self._program) - 1:
             raise PhysicalProgramSequenceError(

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Trusted #287 host adapter for one production causal physical run activation.
+"""Trusted #287/#304 host adapter for one production causal physical run.
 
 The running #283 host supplies the already host-validated profile/canonical-AST
 binding, its one live reset-aware #278 bridge, the distinct launcher-installed
 teacher socket and the shared #273 execution domain.  The generic takeoff
 lifecycle remains in ``production_takeoff_run``.  The exact canonical AST is
-validated against the integrated #295 sequencing boundary before any reset or
+validated against the integrated #305 sequencing boundary before any reset or
 flight effect; after the exact takeoff has causally completed, the same sequence
-owns each bounded #276 move/turn reservation and outcome.
+owns each bounded #276 move/turn reservation and the exact terminal #304 landing.
 
 Importing this module performs no physical effect.
 """
@@ -16,8 +16,12 @@ from __future__ import annotations
 
 import socket
 
+from controlled_landing_transport import (
+    ControlledLandingTransportError,
+    TrustedControlledLandingTransport,
+)
 from high_level_timing import HighLevelTimingPolicy
-from physical_execution_domain import FLYING, PhysicalExecutionDomain
+from physical_execution_domain import FLYING, INACTIVE, PhysicalExecutionDomain
 from physical_program_sequence import PhysicalProgramSequence, PhysicalProgramSequenceError
 from post_reset_teacher_decision import PostResetTeacherDecisionChannel
 from powered_session_authority import (
@@ -130,9 +134,9 @@ def activate_validated_run(
     """Activate one exact host-validated run and return its trusted run controller.
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
-    motion parameters.  It reserves only the next supported top-level move/turn
-    from the exact post-reset #267 binding through the integrated #295 sequence,
-    and keeps the #276 positive provenance path lexical to this adapter's
+    effect parameters. It reserves only the exact next validated move/turn or
+    terminal land from the post-reset #267 binding through the integrated #305
+    sequence, and keeps all positive provenance paths lexical to this adapter's
     host-owned bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
@@ -147,8 +151,7 @@ def activate_validated_run(
         raise PhysicalRunActivationError("current-program assertion timeout must be positive")
 
     # Validate the complete exact-program envelope before any reset or physical
-    # effect. In particular this inherits #295's exact terminal {kind: land}
-    # boundary instead of maintaining a second, weaker parser in #276.
+    # effect, including the exact terminal land boundary.
     try:
         sequence = PhysicalProgramSequence(staged_binding.ast_binding)
     except PhysicalProgramSequenceError as exc:
@@ -338,14 +341,28 @@ def activate_validated_run(
                 raise SetpointHlTransportError(str(exc)) from exc
             return binding
 
+    class _HostBoundLandingTransport(TrustedControlledLandingTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            binding = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise ControlledLandingTransportError(str(exc)) from exc
+            return binding
+
     timing_policy = HighLevelTimingPolicy()
 
     class _ActivatedRunController:
-        __slots__ = ("_yaw_reader", "_transport")
+        __slots__ = ("_yaw_reader", "_transport", "_landing_transport")
 
         def __init__(self) -> None:
             self._yaw_reader = None
             self._transport = None
+            self._landing_transport = None
 
         @property
         def active_run(self):
@@ -371,6 +388,27 @@ def activate_validated_run(
             self._transport = transport
             return transport
 
+        def _ensure_landing_transport(self):
+            if self._landing_transport is not None:
+                return self._landing_transport
+            transport = _HostBoundLandingTransport(
+                crazyflie=active_run.crazyflie,
+                execution_domain=active_run.execution_domain,
+                acknowledgement_domain=active_run.acknowledgement_domain,
+                safelink_guard=active_run.safelink_guard,
+                teacher_authorization=active_run.teacher_authorization,
+                powered_session=active_run.powered_session,
+                watchdog_guard=active_run.watchdog_guard,
+                supervisor_reader=active_run.supervisor_reader,
+                connection_epoch_reader=session.read_connection_epoch,
+            )
+            if transport.bound_connection_epoch != session.read_connection_epoch():
+                raise PhysicalRunActivationError(
+                    "#304 landing transport is not bound to the exact active host epoch"
+                )
+            self._landing_transport = transport
+            return transport
+
         def _ensure_yaw_reader(self):
             if self._yaw_reader is not None:
                 return self._yaw_reader
@@ -385,15 +423,14 @@ def activate_validated_run(
         def _release_or_poison_sequence(self, claim: object, reason: str) -> None:
             # Before-emission/definitive failures restore #273 to flying and are
             # retryable without advancing. Any other phase means an effect may
-            # have crossed the boundary or completion certainty was lost; #295
-            # must become terminal rather than manufacturing a retry.
+            # have crossed the boundary or completion certainty was lost; the
+            # exact sequence must become terminal instead of manufacturing retry.
             if active_run.execution_domain.phase == FLYING:
                 sequence.release_unemitted(claim)
             else:
                 sequence.mark_ambiguous(claim, reason)
 
-        def execute_next_inflight(self):
-            """Advance one exact AST move/turn; accepts no caller semantic data."""
+        def _execute_next_motion(self):
             claim = sequence.reserve_next_motion()
             motion = sequence.motion_for_claim(claim)
             try:
@@ -451,6 +488,64 @@ def activate_validated_run(
                     "trusted in-flight transport returned no definitive acknowledgement"
                 )
             return result
+
+        def _execute_terminal_landing(self):
+            claim = sequence.reserve_terminal_landing()
+            sequence.landing_for_claim(claim)
+            try:
+                result = self._ensure_landing_transport().send_controlled_landing()
+            except Exception:
+                self._release_or_poison_sequence(
+                    claim,
+                    "terminal landing outcome is not definitively retryable",
+                )
+                raise
+
+            accepted = getattr(result, "accepted", None)
+            if accepted is True:
+                if active_run.execution_domain.phase != INACTIVE:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "accepted terminal landing did not causally establish inactive state",
+                    )
+                    raise PhysicalRunActivationError(
+                        "accepted terminal landing completion is not causally established"
+                    )
+                sequence.complete_landing(claim)
+                if sequence.completed is not True:
+                    raise PhysicalRunActivationError(
+                        "terminal landing did not complete the exact physical program"
+                    )
+            elif accepted is False:
+                if active_run.execution_domain.phase != FLYING:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "rejected terminal landing did not restore the flying phase",
+                    )
+                    raise PhysicalRunActivationError(
+                        "definitive terminal landing rejection did not restore flight state"
+                    )
+                sequence.release_unemitted(claim)
+            else:
+                sequence.mark_ambiguous(
+                    claim,
+                    "trusted terminal landing transport returned an indeterminate result",
+                )
+                raise PhysicalRunActivationError(
+                    "trusted terminal landing transport returned no definitive acknowledgement"
+                )
+            return result
+
+        def execute_next_inflight(self):
+            """Advance one exact AST effect; accepts no caller semantic data."""
+            next_kind = sequence.next_effect_kind
+            if next_kind == "land":
+                return self._execute_terminal_landing()
+            if next_kind in {"move", "turn"}:
+                return self._execute_next_motion()
+            raise PhysicalRunActivationError(
+                "next exact physical statement is outside the validated execution envelope"
+            )
 
         def shutdown(self) -> None:
             yaw_error = None


### PR DESCRIPTION
Completes the remaining #304 trusted controlled-landing path on top of integrated #305.

The production physical host now consumes terminal landing through the same parameter-free `execute-next-inflight` operation used for exact move/turn progression. `PhysicalProgramSequence` exposes only the exact next validated effect kind, and `physical_run_activation` dispatches the one terminal `{kind:"land"}` only after all prior exact motions have completed. The ordinary caller supplies no altitude, velocity, duration, yaw, packet bytes, provenance or landing authority; duplicate execution after exact-program completion fails closed.

`TrustedControlledLandingTransport` derives pinned firmware `COMMAND_LAND_WITH_VELOCITY` (command 10) only from the exact teacher-bound canonical AST via integrated `landing_command`: relative descent equals the exact takeoff height, current yaw is preserved, and explicit velocity is 0.5 m/s. The transport stays inside the #283/#276 host trust root, performs fresh host-owned current-program assertions, fresh #257/#264 pre-land observation, rechecks the exact binding immediately before SafeLink/#271 emission, registers the reply callback before exactly one no-retry send, and keeps the #262 watchdog/session live through completion. Positive acknowledgement is insufficient: the private #279 permit plus fresh same-epoch #264 completion must establish finished, non-flying, high-level-inactive state before #273 returns to inactive and the terminal sequence claim advances. Definitive rejection leaves the terminal statement unconsumed and restores the flying phase; acknowledgement or completion ambiguity requires recovery and creates no application retry path.

Deterministic coverage now includes the transport-level accepted/rejected/acknowledgement-ambiguous/completion-uncertain boundaries and the actual production-host takeoff→turn→move→land sequence, direct takeoff→land sequence, caller-substitution rejection, duplicate terminal-land rejection and malformed-terminal rejection before takeoff. The Runtime core harness executes both the controlled-landing transport oracle and the production-host sequence oracle.

This remains a deterministic implementation slice only. It authorizes no motorized test, real-flight qualification or `TEST_REQUIRED` checkpoint.

Refs #304 #157 #305 #276 #264.