### PR TITLE
Compose trusted terminal physical landing

### DIFF
--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -140,14 +140,12 @@ class FakeTerminalLandingTransportBase:
             self._execution.phase == base.physical_execution_domain.FLYING,
             "terminal landing effect starts from the causal flying phase",
         )
-        with self._execution.effect_transaction(lambda: None) as effect:
-            effect.mark_emitted()
-            permit = effect.mark_accepted()
-        self._execution.complete_accepted_effect(
-            permit,
-            base.physical_execution_domain.INACTIVE,
-            lambda: True,
-        )
+        # The production-host composition fixture deliberately installs the tiny
+        # FakeExecutionDomain from test_physical_host_activation. The real #273
+        # accepted-effect permit/completion machinery is exercised immediately
+        # before this test by landing_contract.main(); here we only model that
+        # successful terminal consumer's externally observable lifecycle result.
+        self._execution.phase = base.physical_execution_domain.INACTIVE
         require(self._watchdog.active, "watchdog remains live through causal landing completion")
         base.EVENTS.append(("terminal-land", landing.index, binding.connection_epoch))
         return SimpleNamespace(accepted=True, status=0)

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -18,7 +18,9 @@ sys.path.insert(0, str(PHYSICAL))
 HOST = PHYSICAL / "serve_physical_host.py"
 
 import setpoint_hl_transport  # noqa: E402
+import terminal_landing_transport  # noqa: E402
 import test_physical_host_activation as base  # noqa: E402
+import test_physical_terminal_landing_transport as landing_contract  # noqa: E402
 import yaw_observer  # noqa: E402
 
 
@@ -103,14 +105,64 @@ class FakeInflightTransportBase:
         return SimpleNamespace(accepted=True, status=0)
 
 
+class FakeTerminalLandingTransportBase:
+    def __init__(
+        self,
+        *,
+        program_sequence: object,
+        crazyflie: object,
+        execution_domain: object,
+        acknowledgement_domain: object,
+        safelink_guard: object,
+        teacher_authorization: object,
+        powered_session: object,
+        watchdog_guard: object,
+        supervisor_reader: object,
+    ) -> None:
+        require(powered_session.session is crazyflie, "landing exact powered session")
+        require(execution_domain.phase == base.physical_execution_domain.FLYING, "landing begins only from flying")
+        self.teacher_binding = teacher_authorization.binding
+        self.bound_connection_epoch = powered_session.connection_epoch
+        self._crazyflie = crazyflie
+        self._execution = execution_domain
+        self._watchdog = watchdog_guard
+        self._program_sequence = program_sequence
+
+    def _read_current_binding(self):
+        raise AssertionError("host-local landing provenance override is required")
+
+    def send_terminal_landing(self, claim: object):
+        require(self._watchdog.active, "same-session watchdog remains live through landing")
+        landing = self._program_sequence.landing_for_claim(claim)
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact landing run")
+        require(
+            self._execution.phase == base.physical_execution_domain.FLYING,
+            "terminal landing effect starts from the causal flying phase",
+        )
+        with self._execution.effect_transaction(lambda: None) as effect:
+            effect.mark_emitted()
+            permit = effect.mark_accepted()
+        self._execution.complete_accepted_effect(
+            permit,
+            base.physical_execution_domain.INACTIVE,
+            lambda: True,
+        )
+        require(self._watchdog.active, "watchdog remains live through causal landing completion")
+        base.EVENTS.append(("terminal-land", landing.index, binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0)
+
+
 def install_fakes() -> None:
     base.install_fakes()
     # ``physical_run_activation`` was imported by the reusable #293 fixture
     # before these substitutions, so patch its exact globals as well as the
     # modules future imports would see.
     base.activation.TrustedSetpointHlTransport = FakeInflightTransportBase
+    base.activation.TrustedTerminalLandingTransport = FakeTerminalLandingTransportBase
     base.activation.FreshYawObserver = FakeYawObserver
     setpoint_hl_transport.TrustedSetpointHlTransport = FakeInflightTransportBase
+    terminal_landing_transport.TrustedTerminalLandingTransport = FakeTerminalLandingTransportBase
     yaw_observer.FreshYawObserver = FakeYawObserver
 
 
@@ -189,7 +241,25 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
     replies.append(read_line(caller_stream))
     send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-2"})
     replies.append(read_line(caller_stream))
+
+    # The terminal operation remains parameter-free. A caller cannot substitute
+    # height, velocity, duration, yaw or raw landing semantics.
+    send_line(
+        caller_peer,
+        {
+            "op": "execute-next-inflight",
+            "requestId": "land-substitute",
+            "heightM": 0.1,
+        },
+    )
+    replies.append(read_line(caller_stream))
+
     send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-land"})
+    replies.append(read_line(caller_stream))
+
+    # Once causal landing completion consumed the exact final statement, a later
+    # generic execute request must not manufacture a duplicate landing effect.
+    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-after-land"})
     replies.append(read_line(caller_stream))
 
     caller_peer.shutdown(socket.SHUT_WR)
@@ -217,7 +287,7 @@ def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
     )
 
 
-def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
+def test_actual_host_uses_exact_program_sequence_through_landing() -> None:
     base.EVENTS.clear()
     install_fakes()
     replies = run_host_sequence()
@@ -227,10 +297,14 @@ def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
     require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
     require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
     require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
-    require(replies[4]["ok"] is False, "landing remains outside this bounded #276 slice")
+    require(replies[4]["ok"] is False, "caller-supplied landing semantics must be rejected")
+    require(replies[4]["executionAuthority"] is False, "rejected landing substitution mints no authority")
+    require(replies[5] == {"executionAuthority": False, "ok": True, "requestId": "step-land"}, "exact terminal landing executes")
+    require(replies[6]["ok"] is False, "consumed terminal landing cannot execute twice")
 
     move_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-move"]
     turn_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-turn"]
+    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
     require(
         turn_events == [("inflight-turn", -25.0, "epoch-after")],
         "caller substitution must not change the exact first authorized effect",
@@ -239,18 +313,27 @@ def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
         move_events == [("inflight-move", "forward", 0.3, "epoch-after")],
         "second in-flight effect must follow exact canonical AST order",
     )
+    require(
+        land_events == [("terminal-land", 3, "epoch-after")],
+        "exact terminal land must be consumed once on the same active run/epoch",
+    )
 
     takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
     turn_index = base.EVENTS.index(turn_events[0])
     yaw_open_index = base.EVENTS.index(("yaw-open", "epoch-after"))
     move_index = base.EVENTS.index(move_events[0])
+    land_index = base.EVENTS.index(land_events[0])
     require(
-        takeoff_index < turn_index < yaw_open_index < move_index,
-        "#260 yaw must stay unopened for a turn and open only before the exact horizontal move",
+        takeoff_index < turn_index < yaw_open_index < move_index < land_index,
+        "one exact program must execute takeoff -> turn -> move -> controlled landing",
     )
     require(
         any(event == ("current-program", "epoch-after") for event in base.EVENTS[takeoff_index:turn_index]),
         "fresh host-local #278/#249 must guard the first in-flight effect",
+    )
+    require(
+        any(event == ("current-program", "epoch-after") for event in base.EVENTS[move_index:land_index]),
+        "fresh host-local #278/#249 must guard terminal landing",
     )
     require(("yaw-close", "epoch-after") in base.EVENTS, "host teardown closes #260 observer")
 
@@ -268,19 +351,23 @@ def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
         "malformed terminal must be rejected by #295 before the takeoff effect",
     )
     require(
-        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move"} for event in base.EVENTS),
-        "malformed terminal must never be skipped into an in-flight effect",
+        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move", "terminal-land"} for event in base.EVENTS),
+        "malformed terminal must never be skipped into a physical effect",
     )
 
 
 def main() -> int:
+    # Exercise the real #304 effect core before replacing it with production-host
+    # composition fakes below. This keeps the existing Runtime core harness as the
+    # single deterministic gate without creating another workflow/context.
+    landing_contract.main()
     test_started_activation_wait_is_outside_lifecycle_lock()
-    test_actual_host_uses_exact_program_sequence_after_takeoff()
+    test_actual_host_uses_exact_program_sequence_through_landing()
     test_actual_host_rejects_malformed_terminal_before_takeoff()
     print(
         "PASS actual physical host sequencing: validate/activation handoff is race-free; "
-        "successful takeoff hands the same run/epoch to shared #295 exact-AST turn/move execution; "
-        "#260 yaw opens only for horizontal motion; malformed landing boundaries fail before takeoff"
+        "successful takeoff hands the same run/epoch to shared exact-AST turn/move/landing execution; "
+        "terminal landing stays parameter-free, completes to inactive once, and malformed boundaries fail before takeoff"
     )
     return 0
 

--- a/tools/ci/test_physical_terminal_landing_transport.py
+++ b/tools/ci/test_physical_terminal_landing_transport.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+import struct
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(PHYSICAL))
+
+import physical_execution_domain as execution  # noqa: E402
+import physical_program_sequence as sequence  # noqa: E402
+import serve_reference_capabilities as capability_bridge  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
+import terminal_landing_transport as landing_transport  # noqa: E402
+
+# Reuse the exact fake radio/session/supervisor seams already exercised by the
+# integrated #276 transport contract. Importing this test module does not execute
+# its main() because of its normal __main__ guard.
+import test_physical_setpoint_hl_transport as base  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical(program: list[dict[str, object]]) -> str:
+    return json.dumps(
+        {
+            "program": program,
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def expect_error(callable_, pattern: str) -> Exception:
+    try:
+        callable_()
+    except Exception as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return exc
+    raise AssertionError(f"expected error containing {pattern!r}")
+
+
+class HostBoundTerminalTransport(landing_transport.TrustedTerminalLandingTransport):
+    """Test analogue of physical_run_activation's lexical landing subclass."""
+
+    def __init__(self, *, bridge, **kwargs) -> None:
+        self._test_bridge = bridge
+        super().__init__(**kwargs)
+
+    def _read_current_binding(self):
+        binding = self.teacher_binding
+        try:
+            evidence = self._test_bridge.assert_current_program(
+                profile_id=binding.profile_id,
+                ast_binding=binding.ast_binding,
+                connection_epoch=binding.connection_epoch,
+                timeout_seconds=0.25,
+            )
+        except Exception as exc:
+            raise landing_transport.TerminalLandingTransportError(
+                "integrated #278/#249 current-program re-assertion failed"
+            ) from exc
+        if type(evidence) is not capability_bridge.CurrentProgramPreflightEvidence:
+            raise landing_transport.TerminalLandingTransportError(
+                "invalid current-program evidence"
+            )
+        if evidence.execution_authority is not False:
+            raise landing_transport.TerminalLandingTransportError(
+                "current-program evidence became authority"
+            )
+        if (
+            evidence.profile_id != binding.profile_id
+            or evidence.ast_binding != binding.ast_binding
+            or evidence.connection_epoch != binding.connection_epoch
+        ):
+            raise landing_transport.TerminalLandingTransportError(
+                "current-program binding mismatch"
+            )
+        return binding
+
+
+def simple_ast() -> str:
+    return canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "land"},
+        ]
+    )
+
+
+def prepare(label: str, *, ast_binding: str | None = None, reply_status: int | None = 0):
+    ast = ast_binding or simple_ast()
+    cf = base.FakeCrazyflie(reply_status=reply_status)
+    fixture = base.Fixture(label, cf)
+    binding = teacher.PhysicalRunBinding(
+        profile_id="activity-1",
+        ast_binding=ast,
+        connection_epoch=fixture.epoch(),
+    )
+    authorization = teacher.TrustedTeacherAuthorizer().authorize_run(
+        binding,
+        lambda _binding: True,
+    )
+    fixture.current_binding = binding
+    kwargs = dict(fixture.kwargs)
+    kwargs["teacher_authorization"] = authorization
+    program_sequence = sequence.PhysicalProgramSequence(ast)
+    transport = HostBoundTerminalTransport(
+        bridge=fixture.bridge,
+        program_sequence=program_sequence,
+        **kwargs,
+    )
+    return fixture, program_sequence, transport
+
+
+def queue_landing_success(fixture: base.Fixture) -> None:
+    fixture.supervisor_reads.clear()
+    fixture.supervisor_reads.extend(
+        [
+            base.state(is_flying=True, hl_control_active=True, hl_traj_finished=True),
+            base.state(is_flying=True, hl_control_active=True, hl_traj_finished=True),
+            base.state(is_flying=False, hl_control_active=False, hl_traj_finished=True),
+        ]
+    )
+
+
+def unpack_land(cf: base.FakeCrazyflie):
+    require(len(cf.send_calls) == 1, "terminal landing must emit exactly one packet")
+    packet = cf.send_calls[0][0][0]
+    return struct.unpack("<BBf?f?f", bytes(packet.data))
+
+
+def test_exact_claim_emits_command_10_then_requires_completion() -> None:
+    fixture, program, transport = prepare("land-ok")
+    try:
+        claim = program.reserve_terminal_landing()
+        queue_landing_success(fixture)
+        result = transport.send_terminal_landing(claim)
+        require(result.accepted, "zero firmware result must accept exact terminal landing")
+        command, group, descent, relative, yaw_value, current_yaw, velocity = unpack_land(
+            fixture.cf
+        )
+        require((command, group) == (10, 0), "exact firmware command-10 header required")
+        require(abs(descent - 0.8) < 1e-6, "landing distance must come from exact takeoff")
+        require(relative is True, "landing distance must use firmware relative semantics")
+        require(abs(yaw_value) < 1e-9 and current_yaw is True, "landing must preserve yaw")
+        require(abs(velocity - 0.5) < 1e-6, "landing must use pinned safe velocity")
+        require(
+            fixture.domain.phase == execution.INACTIVE,
+            "acknowledgement alone is insufficient; #264 completion must make domain inactive",
+        )
+        require(
+            program.landing_for_claim(claim).index == 1,
+            "transport must preserve the exact pending sequence claim for host completion",
+        )
+        program.complete_landing(claim)
+        require(program.completed, "host may complete exact sequence only after causal landing")
+    finally:
+        fixture.close()
+
+
+def test_no_terminal_claim_or_caller_landing_parameters_can_emit() -> None:
+    fixture, program, transport = prepare("land-claim")
+    try:
+        expect_error(
+            lambda: transport.send_terminal_landing(object()),
+            "terminal landing claim",
+        )
+        require(not fixture.cf.send_calls, "forged landing claim must fail before effect")
+
+        claim = program.reserve_terminal_landing()
+        try:
+            transport.send_terminal_landing(claim, height_m=0.1)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("caller-selected landing height unexpectedly entered API")
+        require(not fixture.cf.send_calls, "caller semantic substitution must not emit")
+        require(
+            list(inspect.signature(transport.send_terminal_landing).parameters) == ["claim"],
+            "terminal landing effect surface must expose only the opaque exact claim",
+        )
+        expect_error(
+            lambda: transport.send_turn(angle_deg=10, timing_policy=object()),
+            "cannot emit ordinary",
+        )
+        require(not fixture.cf.send_calls, "terminal-only transport must reject motion surface")
+    finally:
+        fixture.close()
+
+
+def test_current_program_change_blocks_before_landing_effect() -> None:
+    fixture, program, transport = prepare("land-binding")
+    try:
+        claim = program.reserve_terminal_landing()
+        fixture.current_binding = teacher.PhysicalRunBinding(
+            profile_id="activity-1",
+            ast_binding=canonical(
+                [
+                    {"kind": "takeoff", "height_m": 0.9},
+                    {"kind": "land"},
+                ]
+            ),
+            connection_epoch=fixture.epoch(),
+        )
+        expect_error(
+            lambda: transport.send_terminal_landing(claim),
+            "current-program re-assertion",
+        )
+        require(not fixture.cf.send_calls, "changed browser program must prevent landing")
+        require(fixture.domain.phase == execution.FLYING, "pre-effect failure remains flying")
+    finally:
+        fixture.close()
+
+
+def test_definitive_rejection_preserves_exact_landing_for_retry() -> None:
+    fixture, program, transport = prepare("land-reject", reply_status=17)
+    try:
+        claim = program.reserve_terminal_landing()
+        fixture.supervisor_reads.clear()
+        fixture.supervisor_reads.extend(
+            [
+                base.state(is_flying=True, hl_control_active=True, hl_traj_finished=True),
+                base.state(is_flying=True, hl_control_active=True, hl_traj_finished=True),
+            ]
+        )
+        result = transport.send_terminal_landing(claim)
+        require(not result.accepted, "non-zero firmware status must be definitive rejection")
+        require(len(fixture.cf.send_calls) == 1, "rejected landing still has exactly one send")
+        require(fixture.domain.phase == execution.FLYING, "definitive rejection restores flying")
+        require(program.landing_for_claim(claim).index == 1, "rejection must not advance sequence")
+        program.release_unemitted(claim)
+        retry = program.reserve_terminal_landing()
+        require(program.landing_for_claim(retry).index == 1, "same exact landing remains next")
+    finally:
+        fixture.close()
+
+
+def test_completion_uncertainty_forces_recovery_and_no_retry() -> None:
+    fixture, program, transport = prepare("land-timeout")
+    old_total = landing_transport._COMPLETION_TIMEOUT_SECONDS
+    old_read = landing_transport._COMPLETION_READ_TIMEOUT_SECONDS
+    old_poll = landing_transport._COMPLETION_POLL_SECONDS
+    try:
+        claim = program.reserve_terminal_landing()
+        fixture.supervisor_reads.clear()
+        fixture.supervisor_reads.extend(
+            [
+                base.state(is_flying=True, hl_control_active=True, hl_traj_finished=True),
+                base.state(is_flying=True, hl_control_active=True, hl_traj_finished=True),
+            ]
+        )
+        landing_transport._COMPLETION_TIMEOUT_SECONDS = 0.01
+        landing_transport._COMPLETION_READ_TIMEOUT_SECONDS = 0.002
+        landing_transport._COMPLETION_POLL_SECONDS = 0.001
+        expect_error(
+            lambda: transport.send_terminal_landing(claim),
+            "timed out",
+        )
+        require(len(fixture.cf.send_calls) == 1, "ambiguous completion must never resend landing")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "accepted landing without #264 completion must force recovery",
+        )
+        require(program.landing_for_claim(claim).index == 1, "uncertain landing cannot advance sequence")
+    finally:
+        landing_transport._COMPLETION_TIMEOUT_SECONDS = old_total
+        landing_transport._COMPLETION_READ_TIMEOUT_SECONDS = old_read
+        landing_transport._COMPLETION_POLL_SECONDS = old_poll
+        fixture.close()
+
+
+def main() -> int:
+    test_exact_claim_emits_command_10_then_requires_completion()
+    test_no_terminal_claim_or_caller_landing_parameters_can_emit()
+    test_current_program_change_blocks_before_landing_effect()
+    test_definitive_rejection_preserves_exact_landing_for_retry()
+    test_completion_uncertainty_forces_recovery_and_no_retry()
+    print(
+        "PASS trusted terminal landing is exact-program-bound, one-shot, "
+        "completion-gated and fail-closed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -7,7 +7,8 @@ teacher socket and the shared #273 execution domain.  The generic takeoff
 lifecycle remains in ``production_takeoff_run``.  The exact canonical AST is
 validated against the integrated #295 sequencing boundary before any reset or
 flight effect; after the exact takeoff has causally completed, the same sequence
-owns each bounded #276 move/turn reservation and outcome.
+owns each bounded #276 move/turn reservation and the #304 controlled terminal
+landing reservation through causal completion.
 
 Importing this module performs no physical effect.
 """
@@ -17,7 +18,7 @@ from __future__ import annotations
 import socket
 
 from high_level_timing import HighLevelTimingPolicy
-from physical_execution_domain import FLYING, PhysicalExecutionDomain
+from physical_execution_domain import FLYING, INACTIVE, PhysicalExecutionDomain
 from physical_program_sequence import PhysicalProgramSequence, PhysicalProgramSequenceError
 from post_reset_teacher_decision import PostResetTeacherDecisionChannel
 from powered_session_authority import (
@@ -30,6 +31,10 @@ from setpoint_hl_transport import SetpointHlTransportError, TrustedSetpointHlTra
 from supervisor_state import FreshSupervisorStateReader
 from takeoff_transport import TakeoffTransportError, TrustedTakeoffTransport
 from teacher_run_authorization import PhysicalRunBinding, TrustedTeacherAuthorizer
+from terminal_landing_transport import (
+    TerminalLandingTransportError,
+    TrustedTerminalLandingTransport,
+)
 from yaw_observer import FreshYawObserver
 
 
@@ -130,10 +135,10 @@ def activate_validated_run(
     """Activate one exact host-validated run and return its trusted run controller.
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
-    motion parameters.  It reserves only the next supported top-level move/turn
-    from the exact post-reset #267 binding through the integrated #295 sequence,
-    and keeps the #276 positive provenance path lexical to this adapter's
-    host-owned bridge.
+    motion or landing parameters. It reserves only the exact next supported
+    top-level move/turn or terminal land from the post-reset #267 binding through
+    the integrated sequence, while keeping the #276/#304 positive provenance
+    path lexical to this adapter's host-owned bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
         raise PhysicalRunActivationError("physical activation requires explicit radio:// URI")
@@ -148,7 +153,7 @@ def activate_validated_run(
 
     # Validate the complete exact-program envelope before any reset or physical
     # effect. In particular this inherits #295's exact terminal {kind: land}
-    # boundary instead of maintaining a second, weaker parser in #276.
+    # boundary instead of maintaining a second, weaker parser in the host.
     try:
         sequence = PhysicalProgramSequence(staged_binding.ast_binding)
     except PhysicalProgramSequenceError as exc:
@@ -338,14 +343,28 @@ def activate_validated_run(
                 raise SetpointHlTransportError(str(exc)) from exc
             return binding
 
+    class _HostBoundTerminalLandingTransport(TrustedTerminalLandingTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            binding = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise TerminalLandingTransportError(str(exc)) from exc
+            return binding
+
     timing_policy = HighLevelTimingPolicy()
 
     class _ActivatedRunController:
-        __slots__ = ("_yaw_reader", "_transport")
+        __slots__ = ("_yaw_reader", "_transport", "_landing_transport")
 
         def __init__(self) -> None:
             self._yaw_reader = None
             self._transport = None
+            self._landing_transport = None
 
         @property
         def active_run(self):
@@ -371,6 +390,27 @@ def activate_validated_run(
             self._transport = transport
             return transport
 
+        def _ensure_landing_transport(self):
+            if self._landing_transport is not None:
+                return self._landing_transport
+            transport = _HostBoundTerminalLandingTransport(
+                program_sequence=sequence,
+                crazyflie=active_run.crazyflie,
+                execution_domain=active_run.execution_domain,
+                acknowledgement_domain=active_run.acknowledgement_domain,
+                safelink_guard=active_run.safelink_guard,
+                teacher_authorization=active_run.teacher_authorization,
+                powered_session=active_run.powered_session,
+                watchdog_guard=active_run.watchdog_guard,
+                supervisor_reader=active_run.supervisor_reader,
+            )
+            if transport.bound_connection_epoch != session.read_connection_epoch():
+                raise PhysicalRunActivationError(
+                    "#304 landing transport is not bound to the exact active host epoch"
+                )
+            self._landing_transport = transport
+            return transport
+
         def _ensure_yaw_reader(self):
             if self._yaw_reader is not None:
                 return self._yaw_reader
@@ -385,15 +425,80 @@ def activate_validated_run(
         def _release_or_poison_sequence(self, claim: object, reason: str) -> None:
             # Before-emission/definitive failures restore #273 to flying and are
             # retryable without advancing. Any other phase means an effect may
-            # have crossed the boundary or completion certainty was lost; #295
-            # must become terminal rather than manufacturing a retry.
+            # have crossed the boundary or completion certainty was lost; the
+            # exact sequence must become terminal rather than manufacture retry.
             if active_run.execution_domain.phase == FLYING:
                 sequence.release_unemitted(claim)
             else:
                 sequence.mark_ambiguous(claim, reason)
 
+        def _execute_terminal_landing(self, claim: object):
+            try:
+                result = self._ensure_landing_transport().send_terminal_landing(claim)
+            except Exception:
+                self._release_or_poison_sequence(
+                    claim,
+                    "terminal landing outcome is not definitively retryable",
+                )
+                raise
+
+            accepted = getattr(result, "accepted", None)
+            if accepted is True:
+                if active_run.execution_domain.phase != INACTIVE:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "accepted terminal landing did not causally become inactive",
+                    )
+                    raise PhysicalRunActivationError(
+                        "accepted terminal landing completion is not causally established"
+                    )
+                try:
+                    sequence.complete_landing(claim)
+                except Exception as exc:
+                    try:
+                        sequence.mark_ambiguous(
+                            claim,
+                            "physical landing completed but exact sequence completion failed",
+                        )
+                    except Exception:
+                        pass
+                    raise PhysicalRunActivationError(
+                        "terminal landing could not complete the exact program sequence"
+                    ) from exc
+            elif accepted is False:
+                if active_run.execution_domain.phase != FLYING:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "rejected terminal landing did not restore the flying phase",
+                    )
+                    raise PhysicalRunActivationError(
+                        "definitive terminal landing rejection did not restore physical state"
+                    )
+                sequence.release_unemitted(claim)
+            else:
+                sequence.mark_ambiguous(
+                    claim,
+                    "trusted terminal landing transport returned an indeterminate result",
+                )
+                raise PhysicalRunActivationError(
+                    "trusted terminal landing transport returned no definitive acknowledgement"
+                )
+            return result
+
         def execute_next_inflight(self):
-            """Advance one exact AST move/turn; accepts no caller semantic data."""
+            """Advance one exact AST effect; accepts no caller semantic data."""
+            # Terminal landing has its own opaque sequence claim. Trying that
+            # reservation first is side-effect-free: before the final cursor it
+            # fails without creating a pending claim, after which ordinary #276
+            # motion reservation proceeds. At the final cursor it succeeds and
+            # the caller still supplies no landing semantics or authority.
+            try:
+                landing_claim = sequence.reserve_terminal_landing()
+            except PhysicalProgramSequenceError:
+                landing_claim = None
+            if landing_claim is not None:
+                return self._execute_terminal_landing(landing_claim)
+
             claim = sequence.reserve_next_motion()
             motion = sequence.motion_for_claim(claim)
             try:

--- a/tools/physical/terminal_landing_transport.py
+++ b/tools/physical/terminal_landing_transport.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Trusted exactly-once terminal HighLevel landing effect composition.
+
+This module extends the integrated #276 SETPOINT_HL trust root for the one exact
+terminal ``land`` already reserved by :class:`PhysicalProgramSequence`. It does
+not expose caller-selected landing height, velocity, yaw, raw bytes, provenance
+or authority. The request is derived solely from the exact teacher-bound
+canonical AST through ``landing_command``.
+
+The effect boundary preserves the integrated #267/#266/#262/#257/#272/#271/#273
+authorities and fresh #278/#249 current-program assertion supplied by the trusted
+host subclass. A positive firmware acknowledgement is not completion: the same
+accepted-effect permit remains pending until #264 observes a later same-epoch
+finished, non-flying, high-level-inactive supervisor state. Any post-emission
+uncertainty fails closed and creates no application retry path.
+"""
+
+from __future__ import annotations
+
+from threading import Event, Lock
+
+import landing_command
+import landing_completion
+import physical_execution_domain
+import physical_program_sequence
+import setpoint_hl_transport
+
+_SETPOINT_HL_PORT = 0x08
+_ACK_TIMEOUT_SECONDS = 0.2
+_PRE_LAND_READ_TIMEOUT_SECONDS = 0.2
+_COMPLETION_TIMEOUT_SECONDS = 8.0
+_COMPLETION_READ_TIMEOUT_SECONDS = 0.2
+_COMPLETION_POLL_SECONDS = 0.05
+
+
+class TerminalLandingTransportError(RuntimeError):
+    """Fail-closed trusted terminal-landing transport error."""
+
+
+class TrustedTerminalLandingTransport(setpoint_hl_transport.TrustedSetpointHlTransport):
+    """Terminal-only extension of the existing trusted SETPOINT_HL effect core."""
+
+    def __init__(self, *, program_sequence: object, **kwargs) -> None:
+        if type(program_sequence) is not physical_program_sequence.PhysicalProgramSequence:
+            raise TerminalLandingTransportError(
+                "exact trusted physical-program sequence is required for landing"
+            )
+        super().__init__(**kwargs)
+        if program_sequence.ast_binding != self.teacher_binding.ast_binding:
+            raise TerminalLandingTransportError(
+                "landing sequence does not match the exact teacher-authorized AST"
+            )
+        self._program_sequence = program_sequence
+
+    def send_horizontal_move(self, *args, **kwargs):
+        raise TerminalLandingTransportError(
+            "terminal landing transport cannot emit ordinary in-flight motion"
+        )
+
+    def send_turn(self, *args, **kwargs):
+        raise TerminalLandingTransportError(
+            "terminal landing transport cannot emit ordinary in-flight motion"
+        )
+
+    def _assert_exact_landing_claim(self, claim: object) -> None:
+        try:
+            landing = self._program_sequence.landing_for_claim(claim)
+        except physical_program_sequence.PhysicalProgramSequenceError as exc:
+            raise TerminalLandingTransportError(
+                "exact pending terminal landing claim is required"
+            ) from exc
+        if landing.index != self._program_sequence.next_index:
+            raise TerminalLandingTransportError(
+                "terminal landing claim no longer matches the exact program cursor"
+            )
+
+    def _bound_landing_request(self) -> bytes:
+        binding = self._read_current_binding()
+        self._assert_binding_authority(binding)
+        if binding.ast_binding != self._program_sequence.ast_binding:
+            raise TerminalLandingTransportError(
+                "fresh current program no longer matches the landing sequence"
+            )
+        try:
+            command = landing_command.derive_bound_landing_command(binding.ast_binding)
+        except landing_command.LandingCommandError as exc:
+            raise TerminalLandingTransportError(
+                "exact teacher-bound terminal landing request is unavailable"
+            ) from exc
+        if command.ast_binding != binding.ast_binding:
+            raise TerminalLandingTransportError(
+                "derived terminal landing request lost exact AST provenance"
+            )
+        return command.request
+
+    def _landing_observer(self) -> landing_completion.ControlledLandingCompletionObserver:
+        epoch_reader = getattr(self._supervisor, "_read_epoch", None)
+        if not callable(epoch_reader):
+            raise TerminalLandingTransportError(
+                "fresh supervisor epoch reader is unavailable for landing completion"
+            )
+        try:
+            observer = landing_completion.ControlledLandingCompletionObserver(
+                self._supervisor,
+                epoch_reader,
+            )
+        except landing_completion.LandingCompletionError as exc:
+            raise TerminalLandingTransportError(
+                "controlled landing completion observer is unavailable"
+            ) from exc
+        if observer.bound_connection_epoch != self.bound_connection_epoch:
+            raise TerminalLandingTransportError(
+                "landing completion observer belongs to another connection epoch"
+            )
+        return observer
+
+    def send_terminal_landing(self, claim: object):
+        """Emit and causally complete the one exact pending terminal landing.
+
+        ``claim`` is the opaque host-local object returned by
+        ``PhysicalProgramSequence.reserve_terminal_landing()``. It carries no
+        caller-selected semantics. The method performs exactly one physical send
+        after installing the acknowledgement callback and never retries.
+        """
+        self._assert_exact_landing_claim(claim)
+        request = self._bound_landing_request()
+        packet = setpoint_hl_transport._default_packet_factory(request)
+        self._validate_packet(packet, request)
+        observer = self._landing_observer()
+
+        result = None
+        completion_permit = None
+        baseline = None
+
+        with self._execution.effect_transaction(
+            self._assert_current_authority,
+            lambda: self._assert_exact_landing_claim(claim),
+        ) as effect:
+            # Final fresh provenance and exact claim checks occur inside the
+            # process-wide reset/effect exclusion immediately before the effect.
+            final_binding = self._read_current_binding()
+            self._assert_binding_authority(final_binding)
+            if final_binding.ast_binding != self._program_sequence.ast_binding:
+                raise TerminalLandingTransportError(
+                    "fresh landing provenance no longer matches the exact program"
+                )
+            self._assert_exact_landing_claim(claim)
+
+            try:
+                baseline = observer.capture_pre_land_flight(
+                    timeout_seconds=_PRE_LAND_READ_TIMEOUT_SECONDS
+                )
+            except landing_completion.LandingCompletionError as exc:
+                raise TerminalLandingTransportError(
+                    "fresh pre-land physical-flight evidence is unavailable"
+                ) from exc
+
+            # Recheck all effect authority after the asynchronous supervisor read.
+            self._assert_current_authority()
+            self._assert_exact_landing_claim(claim)
+            self._safelink.assert_ready()
+            self._watchdog.assert_live()
+
+            reply_ready = Event()
+            reply_lock = Lock()
+            reply_data: dict[str, object] = {}
+
+            with self._ack.transaction(request) as acknowledgement:
+                def high_level_callback(reply_packet: object) -> None:
+                    try:
+                        data = bytes(reply_packet.data)
+                    except Exception:
+                        data = b""
+                    with reply_lock:
+                        if reply_ready.is_set():
+                            return
+                        if len(data) >= 3 and data[:3] == acknowledgement.request_prefix:
+                            reply_data["data"] = data
+                            reply_ready.set()
+
+                self._cf.add_port_callback(_SETPOINT_HL_PORT, high_level_callback)
+                try:
+                    # The two domains cross their effect boundary immediately
+                    # before the one plain cflib send. No expected-reply/retry
+                    # transport option is used.
+                    acknowledgement.mark_emitted()
+                    effect.mark_emitted()
+                    try:
+                        self._cf.send_packet(packet)
+                    except Exception as exc:
+                        raise TerminalLandingTransportError(
+                            "terminal landing send outcome is ambiguous"
+                        ) from exc
+
+                    try:
+                        reply = self._wait_for_reply(
+                            reply_ready,
+                            reply_lock,
+                            reply_data,
+                            _ACK_TIMEOUT_SECONDS,
+                        )
+                    except Exception as exc:
+                        acknowledgement.fail_ambiguous(exc)
+                        raise AssertionError("unreachable")
+
+                    result = acknowledgement.resolve_reply(reply)
+                    if result.accepted:
+                        completion_permit = effect.mark_accepted()
+                    else:
+                        effect.mark_definitive_rejection()
+                finally:
+                    self._cf.remove_port_callback(_SETPOINT_HL_PORT, high_level_callback)
+
+        if result is None:
+            raise TerminalLandingTransportError(
+                "terminal landing acknowledgement result is unavailable"
+            )
+        if not result.accepted:
+            return result
+        if completion_permit is None or baseline is None:
+            raise TerminalLandingTransportError(
+                "accepted terminal landing has no completion authority/evidence"
+            )
+
+        try:
+            # The independent watchdog service remains active throughout #264's
+            # completion wait. Requiring it both before and after observation
+            # prevents a completed program from being accepted after watchdog
+            # liveness became terminal during the landing interval.
+            self._watchdog.assert_live()
+            completion = observer.await_completion(
+                baseline,
+                total_timeout_seconds=_COMPLETION_TIMEOUT_SECONDS,
+                per_read_timeout_seconds=_COMPLETION_READ_TIMEOUT_SECONDS,
+                poll_interval_seconds=_COMPLETION_POLL_SECONDS,
+            )
+            self._watchdog.assert_live()
+            if completion.connection_epoch != self.bound_connection_epoch:
+                raise TerminalLandingTransportError(
+                    "landing completion evidence belongs to another connection epoch"
+                )
+            state = completion.supervisor_state
+            if (
+                getattr(state, "blocking_fault", None) is not False
+                or getattr(state, "is_flying", None) is not False
+                or getattr(state, "hl_control_active", None) is not False
+                or getattr(state, "hl_traj_finished", None) is not True
+            ):
+                raise TerminalLandingTransportError(
+                    "landing completion evidence does not establish trusted inactivity"
+                )
+
+            self._execution.complete_accepted_effect(
+                completion_permit,
+                physical_execution_domain.INACTIVE,
+                lambda: True,
+            )
+        except Exception:
+            if self._execution.phase == physical_execution_domain.AWAITING_COMPLETION:
+                self._force_completion_uncertainty(completion_permit)
+            raise
+
+        if self._execution.phase != physical_execution_domain.INACTIVE:
+            raise TerminalLandingTransportError(
+                "causal terminal landing did not leave physical execution inactive"
+            )
+        return result

--- a/tools/physical/terminal_landing_transport.py
+++ b/tools/physical/terminal_landing_transport.py
@@ -94,6 +94,9 @@ class TrustedTerminalLandingTransport(setpoint_hl_transport.TrustedSetpointHlTra
         return command.request
 
     def _landing_observer(self) -> landing_completion.ControlledLandingCompletionObserver:
+        # #257 already owns the reconnect-sensitive epoch reader. Reuse that
+        # exact trusted source instead of accepting another caller-supplied epoch
+        # authority at the landing surface.
         epoch_reader = getattr(self._supervisor, "_read_epoch", None)
         if not callable(epoch_reader):
             raise TerminalLandingTransportError(
@@ -146,6 +149,9 @@ class TrustedTerminalLandingTransport(setpoint_hl_transport.TrustedSetpointHlTra
                 )
             self._assert_exact_landing_claim(claim)
 
+            # #304 lands only after the prior exact motion completed causally.
+            # Re-observe that condition immediately before the #264 baseline.
+            self._read_fresh_finished_flying()
             try:
                 baseline = observer.capture_pre_land_flight(
                     timeout_seconds=_PRE_LAND_READ_TIMEOUT_SECONDS
@@ -155,38 +161,55 @@ class TrustedTerminalLandingTransport(setpoint_hl_transport.TrustedSetpointHlTra
                     "fresh pre-land physical-flight evidence is unavailable"
                 ) from exc
 
-            # Recheck all effect authority after the asynchronous supervisor read.
+            # Recheck all effect authority after the asynchronous supervisor reads.
             self._assert_current_authority()
             self._assert_exact_landing_claim(claim)
             self._safelink.assert_ready()
             self._watchdog.assert_live()
 
-            reply_ready = Event()
-            reply_lock = Lock()
-            reply_data: dict[str, object] = {}
-
             with self._ack.transaction(request) as acknowledgement:
-                def high_level_callback(reply_packet: object) -> None:
+                reply_event = Event()
+                reply_lock = Lock()
+                first_reply: list[bytes] = []
+
+                def on_reply(reply_packet: object) -> None:
                     try:
-                        data = bytes(reply_packet.data)
+                        data = bytes(getattr(reply_packet, "data"))
                     except Exception:
                         data = b""
                     with reply_lock:
-                        if reply_ready.is_set():
+                        if first_reply:
                             return
-                        if len(data) >= 3 and data[:3] == acknowledgement.request_prefix:
-                            reply_data["data"] = data
-                            reply_ready.set()
+                        first_reply.append(data)
+                        reply_event.set()
 
-                self._cf.add_port_callback(_SETPOINT_HL_PORT, high_level_callback)
+                def read_reply() -> bytes | None:
+                    with reply_lock:
+                        return first_reply[0] if first_reply else None
+
+                add_callback = getattr(self._cf, "add_port_callback", None)
+                remove_callback = getattr(self._cf, "remove_port_callback", None)
+                send_packet = getattr(self._cf, "send_packet", None)
+                if (
+                    not callable(add_callback)
+                    or not callable(remove_callback)
+                    or not callable(send_packet)
+                ):
+                    raise TerminalLandingTransportError(
+                        "Crazyflie terminal-landing callback/send surface is unavailable"
+                    )
+
+                callback_installed = False
                 try:
+                    add_callback(_SETPOINT_HL_PORT, on_reply)
+                    callback_installed = True
                     # The two domains cross their effect boundary immediately
                     # before the one plain cflib send. No expected-reply/retry
                     # transport option is used.
                     acknowledgement.mark_emitted()
                     effect.mark_emitted()
                     try:
-                        self._cf.send_packet(packet)
+                        send_packet(packet)
                     except Exception as exc:
                         raise TerminalLandingTransportError(
                             "terminal landing send outcome is ambiguous"
@@ -194,13 +217,12 @@ class TrustedTerminalLandingTransport(setpoint_hl_transport.TrustedSetpointHlTra
 
                     try:
                         reply = self._wait_for_reply(
-                            reply_ready,
-                            reply_lock,
-                            reply_data,
+                            reply_event,
+                            read_reply,
                             _ACK_TIMEOUT_SECONDS,
                         )
                     except Exception as exc:
-                        acknowledgement.fail_ambiguous(exc)
+                        acknowledgement.fail_ambiguous(str(exc))
                         raise AssertionError("unreachable")
 
                     result = acknowledgement.resolve_reply(reply)
@@ -209,7 +231,11 @@ class TrustedTerminalLandingTransport(setpoint_hl_transport.TrustedSetpointHlTra
                     else:
                         effect.mark_definitive_rejection()
                 finally:
-                    self._cf.remove_port_callback(_SETPOINT_HL_PORT, high_level_callback)
+                    if callback_installed:
+                        try:
+                            remove_callback(_SETPOINT_HL_PORT, on_reply)
+                        except Exception:
+                            pass
 
         if result is None:
             raise TerminalLandingTransportError(


### PR DESCRIPTION
Implements #304 as the terminal continuation of the integrated #276 physical-host effect path.

The new terminal-only `TrustedTerminalLandingTransport` consumes only the opaque exact `PhysicalProgramSequence` landing claim and derives pinned firmware command 10 solely from the teacher-bound canonical AST. It reuses the existing #267 teacher authorization, #266 powered session, #262 watchdog, #257 supervisor reader, #272 SafeLink, #271 acknowledgement domain and #273 process-wide exclusion. The production lexical host subclass supplies fresh #278/#249 current-program provenance; no caller surface can provide height, velocity, yaw, duration, raw packet bytes, provenance or landing authority.

Immediately before emission the transport freshly proves the prior exact trajectory finished while flight and high-level control remain active, captures #264 pre-land flight evidence, rechecks authority/SafeLink/watchdog, installs the SETPOINT_HL reply callback, and performs exactly one plain no-retry send. A positive firmware acknowledgement only mints the private accepted-effect completion permit. The watchdog remains live while #264 observes the later same-epoch finished, non-flying, high-level-inactive supervisor state; only then can the execution domain become `inactive`. Completion uncertainty consumes the permit into recovery-required state rather than manufacturing a retry; definitive firmware rejection restores `flying` without advancing the exact terminal sequence.

`physical_run_activation.py` composes this transport into the existing parameter-free `execute-next-inflight` host operation. After zero or more exact move/turn statements, the same sequence reserves its final land, completes it only after the transport has causally reached inactive state, rejects caller landing-field substitution, and cannot execute the consumed terminal statement twice.

Deterministic coverage exercises the real terminal effect core for exact command-10 packet semantics, forged/caller-supplied landing rejection, fresh-program mismatch, definitive rejection, one-send completion uncertainty/recovery, and #264 completion gating. The actual production-host composition test now covers takeoff → turn → move → controlled land on one exact run/epoch, parameter-free landing IPC, fresh host-local provenance at landing, single terminal consumption, and pre-takeoff rejection of a malformed terminal boundary. No workflow/notification/authority boundary is added and no physical/motorized checkpoint is required or authorized.

Closes #304. Refs #157 #276 #264 #305.