### PR TITLE
Compose trusted terminal controlled landing

### DIFF
--- a/tools/ci/test_physical_controlled_landing_transport.py
+++ b/tools/ci/test_physical_controlled_landing_transport.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import struct
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(PHYSICAL))
+
+import controlled_landing_transport as landing_transport  # noqa: E402
+import physical_execution_domain as execution  # noqa: E402
+import serve_reference_capabilities as capability_bridge  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
+import test_physical_setpoint_hl_transport as base  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, error_type, pattern: str) -> None:
+    try:
+        callable_()
+    except error_type as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected {error_type.__name__} containing {pattern!r}")
+
+
+def canonical_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+class TestHostBoundLandingTransport(landing_transport.TrustedControlledLandingTransport):
+    def __init__(self, *, bridge, **kwargs) -> None:
+        self._test_bridge = bridge
+        super().__init__(**kwargs)
+
+    def _read_current_binding(self):
+        binding = self.teacher_binding
+        try:
+            evidence = self._test_bridge.assert_current_program(
+                profile_id=binding.profile_id,
+                ast_binding=binding.ast_binding,
+                connection_epoch=binding.connection_epoch,
+                timeout_seconds=0.25,
+            )
+        except Exception as exc:
+            raise landing_transport.ControlledLandingTransportError(
+                "integrated #278/#249 current-program re-assertion failed"
+            ) from exc
+        if type(evidence) is not capability_bridge.CurrentProgramPreflightEvidence:
+            raise landing_transport.ControlledLandingTransportError(
+                "invalid current-program evidence"
+            )
+        if evidence.execution_authority is not False:
+            raise landing_transport.ControlledLandingTransportError(
+                "current-program evidence became authority"
+            )
+        if (
+            evidence.profile_id != binding.profile_id
+            or evidence.ast_binding != binding.ast_binding
+            or evidence.connection_epoch != binding.connection_epoch
+        ):
+            raise landing_transport.ControlledLandingTransportError(
+                "current-program binding mismatch"
+            )
+        return binding
+
+
+def make_fixture(label: str, *, reply_status: int | None = 0):
+    cf = base.FakeCrazyflie(reply_status=reply_status)
+    fixture = base.Fixture(label, cf)
+    binding = teacher.PhysicalRunBinding(
+        profile_id="activity-landing",
+        ast_binding=canonical_ast(),
+        connection_epoch=fixture.epoch(),
+    )
+    authorizer = teacher.TrustedTeacherAuthorizer()
+    authorization = authorizer.authorize_run(binding, lambda _binding: True)
+    fixture.binding = binding
+    fixture.current_binding = binding
+    fixture.authorization = authorization
+    fixture.kwargs["teacher_authorization"] = authorization
+    fixture.supervisor_reads.clear()
+    transport = TestHostBoundLandingTransport(
+        bridge=fixture.bridge,
+        connection_epoch_reader=fixture.epoch,
+        **fixture.kwargs,
+    )
+    return fixture, transport
+
+
+def queue_pre_land(fixture, *, completion=None) -> None:
+    fixture.supervisor_reads.extend(
+        [
+            base.state(hl_traj_finished=True),
+            base.state(hl_traj_finished=True),
+        ]
+    )
+    if completion is not None:
+        fixture.supervisor_reads.append(completion)
+
+
+def unpack_land(fixture):
+    require(len(fixture.cf.send_calls) == 1, "controlled landing emits exactly one packet")
+    data = bytes(fixture.cf.send_calls[0][0][0].data)
+    return struct.unpack("<BBf?f?f", data)
+
+
+landing_transport._LANDING_COMPLETION_TIMEOUT_SECONDS = 0.05
+
+
+def test_accepted_landing_requires_fresh_nonflying_completion() -> None:
+    fixture, transport = make_fixture("landing-success")
+    try:
+        queue_pre_land(
+            fixture,
+            completion=base.state(
+                is_flying=False,
+                hl_control_active=False,
+                hl_traj_finished=True,
+            ),
+        )
+        result = transport.send_controlled_landing()
+        require(result.accepted, "zero firmware status accepts exact landing")
+        command, group, height, relative, yaw, current_yaw, velocity = unpack_land(fixture)
+        require(command == 10 and group == 0, "exact command-10 single-Crazyflie header")
+        require(abs(height - 0.8) < 1e-6 and relative is True, "landing descent derives exact AST takeoff height")
+        require(yaw == 0.0 and current_yaw is True, "terminal landing preserves current yaw")
+        require(abs(velocity - 0.5) < 1e-6, "terminal landing uses explicit safe-default velocity")
+        require(
+            fixture.domain.phase == execution.INACTIVE,
+            "accepted landing becomes inactive only after #264 completion evidence",
+        )
+        observed = fixture.supervisor_observed
+        require(
+            any(getattr(item, "is_flying", None) is False for item in observed),
+            "fresh landing completion must observe non-flying state",
+        )
+    finally:
+        fixture.close()
+
+
+def test_positive_ack_without_completion_requires_recovery() -> None:
+    fixture, transport = make_fixture("landing-completion-fault")
+    try:
+        queue_pre_land(
+            fixture,
+            completion=base.state(blocking_fault=True),
+        )
+        expect_error(
+            transport.send_controlled_landing,
+            Exception,
+            "blocking supervisor fault",
+        )
+        require(len(fixture.cf.send_calls) == 1, "accepted but unproven landing is never resent")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "uncertain landing completion poisons ordinary effect eligibility",
+        )
+    finally:
+        fixture.close()
+
+
+def test_definitive_rejection_does_not_complete_or_retry() -> None:
+    fixture, transport = make_fixture("landing-reject", reply_status=17)
+    try:
+        queue_pre_land(fixture)
+        result = transport.send_controlled_landing()
+        require(not result.accepted and result.status == 17, "non-zero firmware reply is definitive rejection")
+        require(len(fixture.cf.send_calls) == 1, "definitive rejection remains one-shot")
+        require(
+            fixture.domain.phase == execution.FLYING,
+            "definitive landing rejection restores exact prior flying phase",
+        )
+    finally:
+        fixture.close()
+
+
+def test_ack_timeout_is_ambiguous_and_never_retried() -> None:
+    fixture, transport = make_fixture("landing-timeout", reply_status=None)
+    try:
+        queue_pre_land(fixture)
+        expect_error(
+            lambda: transport.send_controlled_landing(reply_timeout_seconds=0.02),
+            Exception,
+            "timeout",
+        )
+        require(len(fixture.cf.send_calls) == 1, "ambiguous landing emits exactly once")
+        require(fixture.ack.poisoned, "ambiguous landing acknowledgement poisons epoch")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "ambiguous emitted landing requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_changed_current_program_blocks_before_landing_effect() -> None:
+    fixture, transport = make_fixture("landing-binding")
+    try:
+        fixture.current_binding = teacher.PhysicalRunBinding(
+            profile_id=fixture.binding.profile_id,
+            ast_binding=json.dumps(
+                {
+                    "program": [
+                        {"height_m": 0.7, "kind": "takeoff"},
+                        {"kind": "land"},
+                    ],
+                    "semantics": "webeeblocks-ast-v1",
+                    "version": 1,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            connection_epoch=fixture.binding.connection_epoch,
+        )
+        queue_pre_land(fixture)
+        expect_error(
+            transport.send_controlled_landing,
+            landing_transport.ControlledLandingTransportError,
+            "current-program re-assertion",
+        )
+        require(not fixture.cf.send_calls, "changed current program prevents landing emission")
+        require(fixture.domain.phase == execution.FLYING, "pre-effect provenance failure preserves flying")
+    finally:
+        fixture.close()
+
+
+def test_direct_importable_landing_core_has_no_positive_provenance_path() -> None:
+    fixture, _transport = make_fixture("landing-unbound")
+    try:
+        direct = landing_transport.TrustedControlledLandingTransport(
+            connection_epoch_reader=fixture.epoch,
+            **fixture.kwargs,
+        )
+        queue_pre_land(fixture)
+        expect_error(
+            direct.send_controlled_landing,
+            landing_transport.ControlledLandingTransportError,
+            "trusted #283 physical host",
+        )
+        require(not fixture.cf.send_calls, "unbound controlled landing core cannot emit")
+    finally:
+        fixture.close()
+
+
+def test_source_has_no_stop_retry_or_caller_landing_surface() -> None:
+    source = (PHYSICAL / "controlled_landing_transport.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "COMMAND_STOP",
+        ".stop(",
+        "HighLevelCommander(",
+        "expected_reply=",
+        "resend",
+        "landing_height",
+        "caller_height",
+        "caller_velocity",
+    ):
+        require(forbidden not in source, "controlled landing leaked forbidden surface: " + forbidden)
+    require(
+        "add_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)" in source
+        and "send_packet(packet)" in source,
+        "landing callback registration and one plain send must remain explicit",
+    )
+
+
+def main() -> int:
+    test_accepted_landing_requires_fresh_nonflying_completion()
+    test_positive_ack_without_completion_requires_recovery()
+    test_definitive_rejection_does_not_complete_or_retry()
+    test_ack_timeout_is_ambiguous_and_never_retried()
+    test_changed_current_program_blocks_before_landing_effect()
+    test_direct_importable_landing_core_has_no_positive_provenance_path()
+    test_source_has_no_stop_retry_or_caller_landing_surface()
+    print(
+        "PASS trusted terminal landing transport derives command 10 from exact AST provenance, "
+        "emits once under the shared physical authority domain, and requires fresh #264 completion"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_controlled_landing_transport.py
+++ b/tools/ci/test_physical_controlled_landing_transport.py
@@ -212,25 +212,29 @@ def test_ack_timeout_is_ambiguous_and_never_retried() -> None:
         fixture.close()
 
 
+def changed_binding(fixture) -> teacher.PhysicalRunBinding:
+    return teacher.PhysicalRunBinding(
+        profile_id=fixture.binding.profile_id,
+        ast_binding=json.dumps(
+            {
+                "program": [
+                    {"height_m": 0.7, "kind": "takeoff"},
+                    {"kind": "land"},
+                ],
+                "semantics": "webeeblocks-ast-v1",
+                "version": 1,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        connection_epoch=fixture.binding.connection_epoch,
+    )
+
+
 def test_changed_current_program_blocks_before_landing_effect() -> None:
     fixture, transport = make_fixture("landing-binding")
     try:
-        fixture.current_binding = teacher.PhysicalRunBinding(
-            profile_id=fixture.binding.profile_id,
-            ast_binding=json.dumps(
-                {
-                    "program": [
-                        {"height_m": 0.7, "kind": "takeoff"},
-                        {"kind": "land"},
-                    ],
-                    "semantics": "webeeblocks-ast-v1",
-                    "version": 1,
-                },
-                separators=(",", ":"),
-                sort_keys=True,
-            ),
-            connection_epoch=fixture.binding.connection_epoch,
-        )
+        fixture.current_binding = changed_binding(fixture)
         queue_pre_land(fixture)
         expect_error(
             transport.send_controlled_landing,
@@ -239,6 +243,39 @@ def test_changed_current_program_blocks_before_landing_effect() -> None:
         )
         require(not fixture.cf.send_calls, "changed current program prevents landing emission")
         require(fixture.domain.phase == execution.FLYING, "pre-effect provenance failure preserves flying")
+    finally:
+        fixture.close()
+
+
+def test_program_change_during_blocking_supervisor_reads_is_reconstructed() -> None:
+    fixture, transport = make_fixture("landing-binding-race")
+    try:
+        queue_pre_land(fixture)
+        original_read_finished = transport._read_fresh_finished_flying
+
+        def read_finished_then_change_program():
+            state = original_read_finished()
+            fixture.current_binding = changed_binding(fixture)
+            return state
+
+        transport._read_fresh_finished_flying = read_finished_then_change_program
+        expect_error(
+            transport.send_controlled_landing,
+            landing_transport.ControlledLandingTransportError,
+            "current-program re-assertion",
+        )
+        require(
+            len(fixture.supervisor_observed) >= 2,
+            "landing preparation must cross fresh supervisor reads before the injected program change is rejected",
+        )
+        require(
+            not fixture.cf.send_calls,
+            "program change during fresh supervisor preparation must block before landing emission",
+        )
+        require(
+            fixture.domain.phase == execution.FLYING,
+            "pre-emission current-program race preserves established flying phase",
+        )
     finally:
         fixture.close()
 
@@ -287,11 +324,13 @@ def main() -> int:
     test_definitive_rejection_does_not_complete_or_retry()
     test_ack_timeout_is_ambiguous_and_never_retried()
     test_changed_current_program_blocks_before_landing_effect()
+    test_program_change_during_blocking_supervisor_reads_is_reconstructed()
     test_direct_importable_landing_core_has_no_positive_provenance_path()
     test_source_has_no_stop_retry_or_caller_landing_surface()
     print(
         "PASS trusted terminal landing transport derives command 10 from exact AST provenance, "
-        "emits once under the shared physical authority domain, and requires fresh #264 completion"
+        "reconstructs current-program authority after blocking preflight reads, emits once under "
+        "the shared physical authority domain, and requires fresh #264 completion"
     )
     return 0
 

--- a/tools/ci/test_physical_controlled_landing_transport.py
+++ b/tools/ci/test_physical_controlled_landing_transport.py
@@ -253,7 +253,7 @@ def test_direct_importable_landing_core_has_no_positive_provenance_path() -> Non
         queue_pre_land(fixture)
         expect_error(
             direct.send_controlled_landing,
-            landing_transport.ControlledLandingTransportError,
+            base.transport.SetpointHlTransportError,
             "trusted #283 physical host",
         )
         require(not fixture.cf.send_calls, "unbound controlled landing core cannot emit")

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -19,6 +19,7 @@ HOST = PHYSICAL / "serve_physical_host.py"
 
 import controlled_landing_transport  # noqa: E402
 import setpoint_hl_transport  # noqa: E402
+import test_physical_controlled_landing_transport as landing_effect_test  # noqa: E402
 import test_physical_host_activation as base  # noqa: E402
 import yaw_observer  # noqa: E402
 
@@ -143,9 +144,6 @@ class FakePhysicalTransportBase:
 
 def install_fakes() -> None:
     base.install_fakes()
-    # ``physical_run_activation`` was imported by the reusable #293 fixture
-    # before these substitutions, so patch its exact globals as well as modules
-    # future imports would see.
     base.activation.TrustedControlledLandingTransport = FakePhysicalTransportBase
     base.activation.FreshYawObserver = FakeYawObserver
     controlled_landing_transport.TrustedControlledLandingTransport = FakePhysicalTransportBase
@@ -341,6 +339,10 @@ def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
 
 
 def main() -> int:
+    require(
+        landing_effect_test.main() == 0,
+        "trusted controlled-landing transport regression must pass before host composition",
+    )
     test_started_activation_wait_is_outside_lifecycle_lock()
     test_actual_host_completes_exact_program_with_terminal_landing()
     test_boundary_only_program_lands_without_opening_yaw()

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(CI))
 sys.path.insert(0, str(PHYSICAL))
 HOST = PHYSICAL / "serve_physical_host.py"
 
+import controlled_landing_transport  # noqa: E402
 import setpoint_hl_transport  # noqa: E402
 import test_physical_host_activation as base  # noqa: E402
 import yaw_observer  # noqa: E402
@@ -45,6 +46,21 @@ def canonical_ast(final_statement: dict[str, object] | None = None) -> str:
     )
 
 
+def boundary_only_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.6, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
 class FakeYawObserver:
     def __init__(self, crazyflie: object, epoch_reader) -> None:
         self.bound_crazyflie = crazyflie
@@ -63,7 +79,7 @@ class FakeYawObserver:
         self.is_open = False
 
 
-class FakeInflightTransportBase:
+class FakePhysicalTransportBase:
     def __init__(
         self,
         *,
@@ -75,11 +91,19 @@ class FakeInflightTransportBase:
         powered_session: object,
         watchdog_guard: object,
         supervisor_reader: object,
+        connection_epoch_reader=None,
     ) -> None:
-        require(powered_session.session is crazyflie, "in-flight exact powered session")
+        del acknowledgement_domain, safelink_guard, supervisor_reader
+        require(powered_session.session is crazyflie, "physical effect exact powered session")
         require(execution_domain.phase == base.physical_execution_domain.FLYING, "takeoff must complete first")
+        if connection_epoch_reader is not None:
+            require(
+                connection_epoch_reader() == powered_session.connection_epoch,
+                "landing completion observer must bind exact active epoch",
+            )
         self.teacher_binding = teacher_authorization.binding
         self.bound_connection_epoch = powered_session.connection_epoch
+        self.execution_domain = execution_domain
         self._crazyflie = crazyflie
         self._watchdog = watchdog_guard
 
@@ -87,6 +111,7 @@ class FakeInflightTransportBase:
         raise AssertionError("host-local provenance override is required")
 
     def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
+        del timing_policy
         require(yaw_reader is not None and yaw_reader.is_open, "fresh yaw observer must be opened lazily for moves")
         require(yaw_reader.bound_crazyflie is self._crazyflie, "yaw exact Crazyflie")
         require(self._watchdog.active, "same-session watchdog remains live")
@@ -96,21 +121,35 @@ class FakeInflightTransportBase:
         return SimpleNamespace(accepted=True, status=0)
 
     def send_turn(self, *, angle_deg, timing_policy):
+        del timing_policy
         require(self._watchdog.active, "same-session watchdog remains live")
         binding = self._read_current_binding()
         require(binding == self.teacher_binding, "fresh #249 matches exact teacher run")
         base.EVENTS.append(("inflight-turn", angle_deg, binding.connection_epoch))
         return SimpleNamespace(accepted=True, status=0)
 
+    def send_controlled_landing(self):
+        require(self._watchdog.active, "watchdog must remain live through controlled landing")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact terminal landing")
+        require(
+            self.execution_domain.phase == base.physical_execution_domain.FLYING,
+            "terminal landing starts only from causally established flying",
+        )
+        base.EVENTS.append(("terminal-land", binding.connection_epoch))
+        self.execution_domain.phase = base.physical_execution_domain.INACTIVE
+        return SimpleNamespace(accepted=True, status=0)
+
 
 def install_fakes() -> None:
     base.install_fakes()
     # ``physical_run_activation`` was imported by the reusable #293 fixture
-    # before these substitutions, so patch its exact globals as well as the
-    # modules future imports would see.
-    base.activation.TrustedSetpointHlTransport = FakeInflightTransportBase
+    # before these substitutions, so patch its exact globals as well as modules
+    # future imports would see.
+    base.activation.TrustedControlledLandingTransport = FakePhysicalTransportBase
     base.activation.FreshYawObserver = FakeYawObserver
-    setpoint_hl_transport.TrustedSetpointHlTransport = FakeInflightTransportBase
+    controlled_landing_transport.TrustedControlledLandingTransport = FakePhysicalTransportBase
+    setpoint_hl_transport.TrustedSetpointHlTransport = FakePhysicalTransportBase
     yaw_observer.FreshYawObserver = FakeYawObserver
 
 
@@ -126,7 +165,11 @@ def read_line(stream) -> dict[str, object]:
     return value
 
 
-def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]:
+def run_host_sequence(
+    ast_binding: str | None = None,
+    *,
+    steps: int = 3,
+) -> list[dict[str, object]]:
     caller_host, caller_peer = socket.socketpair()
     caller_stream = caller_peer.makefile("r", encoding="utf-8")
     browser_read, browser_write = os.pipe()
@@ -173,7 +216,6 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
     )
     replies = [read_line(caller_stream)]
 
-    # Caller-selected semantics are rejected before the exact-program operation.
     send_line(
         caller_peer,
         {
@@ -185,12 +227,12 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
     )
     replies.append(read_line(caller_stream))
 
-    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-1"})
-    replies.append(read_line(caller_stream))
-    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-2"})
-    replies.append(read_line(caller_stream))
-    send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-land"})
-    replies.append(read_line(caller_stream))
+    for index in range(steps):
+        send_line(
+            caller_peer,
+            {"op": "execute-next-inflight", "requestId": f"step-{index + 1}"},
+        )
+        replies.append(read_line(caller_stream))
 
     caller_peer.shutdown(socket.SHUT_WR)
     worker.join(timeout=3.0)
@@ -204,10 +246,9 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
 
 
 def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
-    """Keep the validate->execute handoff free of the scheduler race from #276."""
     source = HOST.read_text(encoding="utf-8")
     wait = 'if activation_state["started"]:\n                                    activation_complete.wait()'
-    require(wait in source, "started activation must be awaited before in-flight availability is decided")
+    require(wait in source, "started activation must be awaited before physical availability is decided")
     wait_index = source.index(wait)
     lock_index = source.find("with lifecycle_lock:", wait_index)
     require(lock_index > wait_index, "activation wait must happen before reacquiring lifecycle lock")
@@ -217,7 +258,7 @@ def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
     )
 
 
-def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
+def test_actual_host_completes_exact_program_with_terminal_landing() -> None:
     base.EVENTS.clear()
     install_fakes()
     replies = run_host_sequence()
@@ -227,32 +268,54 @@ def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
     require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
     require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
     require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
-    require(replies[4]["ok"] is False, "landing remains outside this bounded #276 slice")
+    require(replies[4] == {"executionAuthority": False, "ok": True, "requestId": "step-3"}, "exact terminal landing completes")
 
     move_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-move"]
     turn_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-turn"]
+    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
     require(
         turn_events == [("inflight-turn", -25.0, "epoch-after")],
         "caller substitution must not change the exact first authorized effect",
     )
     require(
         move_events == [("inflight-move", "forward", 0.3, "epoch-after")],
-        "second in-flight effect must follow exact canonical AST order",
+        "second physical effect must follow exact canonical AST order",
+    )
+    require(
+        land_events == [("terminal-land", "epoch-after")],
+        "exact terminal landing must execute once on the same authorized epoch",
     )
 
     takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
     turn_index = base.EVENTS.index(turn_events[0])
     yaw_open_index = base.EVENTS.index(("yaw-open", "epoch-after"))
     move_index = base.EVENTS.index(move_events[0])
+    land_index = base.EVENTS.index(land_events[0])
     require(
-        takeoff_index < turn_index < yaw_open_index < move_index,
-        "#260 yaw must stay unopened for a turn and open only before the exact horizontal move",
+        takeoff_index < turn_index < yaw_open_index < move_index < land_index,
+        "takeoff, exact motions and terminal landing must preserve canonical order",
     )
     require(
         any(event == ("current-program", "epoch-after") for event in base.EVENTS[takeoff_index:turn_index]),
-        "fresh host-local #278/#249 must guard the first in-flight effect",
+        "fresh host-local #278/#249 must guard the first post-takeoff effect",
     )
     require(("yaw-close", "epoch-after") in base.EVENTS, "host teardown closes #260 observer")
+
+
+def test_boundary_only_program_lands_without_opening_yaw() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    replies = run_host_sequence(boundary_only_ast(), steps=1)
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "terminal land follows takeoff directly")
+    require(
+        [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
+        == [("terminal-land", "epoch-after")],
+        "boundary-only program consumes exactly one terminal landing",
+    )
+    require(
+        not any(isinstance(event, tuple) and event[0] == "yaw-open" for event in base.EVENTS),
+        "terminal landing must not create a yaw-observer dependency",
+    )
 
 
 def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
@@ -265,22 +328,27 @@ def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
     require(replies[2]["ok"] is False, "malformed terminal must make exact activation unavailable")
     require(
         ("transport-send", "epoch-after") not in base.EVENTS,
-        "malformed terminal must be rejected by #295 before the takeoff effect",
+        "malformed terminal must be rejected before the takeoff effect",
     )
     require(
-        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move"} for event in base.EVENTS),
-        "malformed terminal must never be skipped into an in-flight effect",
+        not any(
+            isinstance(event, tuple)
+            and event[0] in {"inflight-turn", "inflight-move", "terminal-land"}
+            for event in base.EVENTS
+        ),
+        "malformed terminal must never be skipped into a physical effect",
     )
 
 
 def main() -> int:
     test_started_activation_wait_is_outside_lifecycle_lock()
-    test_actual_host_uses_exact_program_sequence_after_takeoff()
+    test_actual_host_completes_exact_program_with_terminal_landing()
+    test_boundary_only_program_lands_without_opening_yaw()
     test_actual_host_rejects_malformed_terminal_before_takeoff()
     print(
-        "PASS actual physical host sequencing: validate/activation handoff is race-free; "
-        "successful takeoff hands the same run/epoch to shared #295 exact-AST turn/move execution; "
-        "#260 yaw opens only for horizontal motion; malformed landing boundaries fail before takeoff"
+        "PASS actual physical host sequencing: validated takeoff hands the same exact run/epoch "
+        "through ordered move/turn effects into one parameter-free terminal controlled landing; "
+        "boundary-only programs land directly and malformed landing boundaries fail before takeoff"
     )
     return 0
 

--- a/tools/physical/controlled_landing_transport.py
+++ b/tools/physical/controlled_landing_transport.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Trusted exactly-once terminal landing effect for the physical Crazyflie.
+
+This module composes the pure exact-AST command-10 semantics from
+``landing_command`` with the already integrated #276 physical-host trust root.
+It adds no caller-selected landing height, velocity, yaw, raw packet, retry or
+alternate authority surface.
+
+A landing request is derived only from the exact teacher-bound canonical AST.
+Fresh host-local current-program provenance, teacher binding, powered-session and
+watchdog state, supervisor flight state, SafeLink and acknowledgement freshness
+are rechecked at the effect boundary. The callback is installed before one plain
+``Crazyflie.send_packet`` call. Positive acknowledgement is not completion: the
+private #279 permit is consumed only after #264 observes a later same-epoch
+finished, non-flying, high-level-inactive state. Any ambiguous post-emission or
+completion outcome remains fail closed and requires recovery.
+"""
+
+from __future__ import annotations
+
+from threading import Event, Lock
+from typing import Callable
+
+import high_level_ack
+import landing_command
+import landing_completion
+import physical_execution_domain
+import setpoint_hl_transport
+
+_DEFAULT_REPLY_TIMEOUT_SECONDS = 0.2
+_LANDING_COMPLETION_TIMEOUT_SECONDS = 8.0
+
+
+class ControlledLandingTransportError(setpoint_hl_transport.SetpointHlTransportError):
+    """Fail-closed trusted terminal-landing transport error."""
+
+
+class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlTransport):
+    """The #276 effect core extended with one exact terminal landing primitive."""
+
+    def __init__(
+        self,
+        *,
+        connection_epoch_reader: Callable[[], str],
+        **kwargs,
+    ) -> None:
+        if not callable(connection_epoch_reader):
+            raise ControlledLandingTransportError(
+                "live connection epoch reader is required for controlled landing"
+            )
+        super().__init__(**kwargs)
+        self._landing_observer = landing_completion.ControlledLandingCompletionObserver(
+            self._supervisor,
+            connection_epoch_reader,
+        )
+        if self._landing_observer.bound_connection_epoch != self.bound_connection_epoch:
+            raise ControlledLandingTransportError(
+                "landing completion observer belongs to a different connection epoch"
+            )
+
+    def _force_completion_uncertainty(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+    ) -> None:
+        if self.execution_domain.phase == physical_execution_domain.AWAITING_COMPLETION:
+            try:
+                self.execution_domain.complete_accepted_effect(
+                    permit,
+                    physical_execution_domain.INACTIVE,
+                    lambda: False,
+                )
+            except physical_execution_domain.PhysicalExecutionDomainError:
+                pass
+
+    def _await_landing_completion(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+        baseline: landing_completion.PreLandingFlightEvidence,
+    ) -> None:
+        if type(permit) is not physical_execution_domain.AcceptedEffectCompletionPermit:
+            raise ControlledLandingTransportError(
+                "exact accepted-effect completion permit is required for landing"
+            )
+        try:
+            self._watchdog.assert_live()
+            evidence = self._landing_observer.await_completion(
+                baseline,
+                total_timeout_seconds=_LANDING_COMPLETION_TIMEOUT_SECONDS,
+            )
+            self._watchdog.assert_live()
+
+            def prove_completion() -> bool:
+                self._watchdog.assert_live()
+                state = evidence.supervisor_state
+                return (
+                    evidence.connection_epoch == self.bound_connection_epoch
+                    and getattr(state, "blocking_fault", None) is False
+                    and getattr(state, "is_flying", None) is False
+                    and getattr(state, "hl_control_active", None) is False
+                    and getattr(state, "hl_traj_finished", None) is True
+                )
+
+            self.execution_domain.complete_accepted_effect(
+                permit,
+                physical_execution_domain.INACTIVE,
+                prove_completion,
+            )
+        except Exception:
+            self._force_completion_uncertainty(permit)
+            raise
+
+    def send_controlled_landing(
+        self,
+        *,
+        reply_timeout_seconds: float = _DEFAULT_REPLY_TIMEOUT_SECONDS,
+    ) -> high_level_ack.HighLevelAckResult:
+        """Emit the exact AST-derived command-10 landing once and prove completion."""
+        timeout = setpoint_hl_transport._positive_timeout(
+            reply_timeout_seconds,
+            "SETPOINT_HL landing reply timeout",
+        )
+        result: high_level_ack.HighLevelAckResult | None = None
+        completion_permit: physical_execution_domain.AcceptedEffectCompletionPermit | None = None
+        baseline: landing_completion.PreLandingFlightEvidence | None = None
+
+        with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            try:
+                bound_command = landing_command.derive_bound_landing_command(
+                    self.teacher_binding.ast_binding
+                )
+            except landing_command.LandingCommandError as exc:
+                raise ControlledLandingTransportError(str(exc)) from exc
+            request = bytes(bound_command.request)
+            packet = setpoint_hl_transport._default_packet_factory(request)
+            self._validate_packet(packet, request)
+
+            final_binding = self._read_current_binding()
+            self._assert_binding_authority(final_binding)
+            if final_binding.ast_binding != bound_command.ast_binding:
+                raise ControlledLandingTransportError(
+                    "fresh current-program binding differs from landing command provenance"
+                )
+            self._read_fresh_finished_flying()
+            baseline = self._landing_observer.capture_pre_land_flight()
+            self._assert_binding_authority(final_binding)
+            self._safelink.assert_ready()
+
+            with self._ack.transaction(request) as acknowledgement:
+                reply_event = Event()
+                reply_lock = Lock()
+                first_reply: list[bytes] = []
+
+                def on_reply(reply_packet: object) -> None:
+                    try:
+                        data = bytes(getattr(reply_packet, "data"))
+                    except Exception:
+                        data = b""
+                    with reply_lock:
+                        if first_reply:
+                            return
+                        first_reply.append(data)
+                        reply_event.set()
+
+                def read_reply() -> bytes | None:
+                    with reply_lock:
+                        return first_reply[0] if first_reply else None
+
+                add_callback = getattr(self._cf, "add_port_callback", None)
+                remove_callback = getattr(self._cf, "remove_port_callback", None)
+                send_packet = getattr(self._cf, "send_packet", None)
+                if (
+                    not callable(add_callback)
+                    or not callable(remove_callback)
+                    or not callable(send_packet)
+                ):
+                    raise ControlledLandingTransportError(
+                        "Crazyflie SETPOINT_HL callback/send surface is unavailable"
+                    )
+
+                callback_installed = False
+                try:
+                    add_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)
+                    callback_installed = True
+                    acknowledgement.mark_emitted()
+                    effect.mark_emitted()
+                    send_packet(packet)
+                    try:
+                        reply = self._wait_for_reply(reply_event, read_reply, timeout)
+                    except Exception as exc:
+                        acknowledgement.fail_ambiguous(str(exc))
+                    result = acknowledgement.resolve_reply(reply)
+                    if result.accepted:
+                        completion_permit = effect.mark_accepted()
+                    else:
+                        effect.mark_definitive_rejection()
+                finally:
+                    if callback_installed:
+                        try:
+                            remove_callback(
+                                setpoint_hl_transport._SETPOINT_HL_PORT,
+                                on_reply,
+                            )
+                        except Exception:
+                            pass
+
+        if result is None:
+            raise ControlledLandingTransportError(
+                "controlled landing acknowledgement result is unavailable"
+            )
+        if result.accepted:
+            if completion_permit is None or baseline is None:
+                raise ControlledLandingTransportError(
+                    "accepted controlled landing lacks private completion state"
+                )
+            self._await_landing_completion(completion_permit, baseline)
+        return result

--- a/tools/physical/controlled_landing_transport.py
+++ b/tools/physical/controlled_landing_transport.py
@@ -124,25 +124,40 @@ class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlT
         baseline: landing_completion.PreLandingFlightEvidence | None = None
 
         with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            # Bind the pure command to a fresh host-owned current-program read,
+            # not merely to the earlier immutable teacher receipt.  The effect
+            # transaction has already performed its own authority reconstruction;
+            # this explicit binding is retained so a later final read can prove
+            # that no program change occurred while fresh supervisor evidence was
+            # being acquired.
+            initial_binding = self._read_current_binding()
+            self._assert_binding_authority(initial_binding)
             try:
                 bound_command = landing_command.derive_bound_landing_command(
-                    self.teacher_binding.ast_binding
+                    initial_binding.ast_binding
                 )
             except landing_command.LandingCommandError as exc:
                 raise ControlledLandingTransportError(str(exc)) from exc
+            if bound_command.ast_binding != initial_binding.ast_binding:
+                raise ControlledLandingTransportError(
+                    "derived landing command differs from current-program provenance"
+                )
             request = bytes(bound_command.request)
             packet = setpoint_hl_transport._default_packet_factory(request)
             self._validate_packet(packet, request)
 
-            final_binding = self._read_current_binding()
-            self._assert_binding_authority(final_binding)
-            if final_binding.ast_binding != bound_command.ast_binding:
-                raise ControlledLandingTransportError(
-                    "fresh current-program binding differs from landing command provenance"
-                )
+            # Fresh supervisor reads may block.  Reconstruct current-program
+            # provenance again afterwards, immediately before the SafeLink/ack
+            # effect boundary, so a workspace/program change during those reads
+            # cannot inherit the earlier authority.
             self._read_fresh_finished_flying()
             baseline = self._landing_observer.capture_pre_land_flight()
+            final_binding = self._read_current_binding()
             self._assert_binding_authority(final_binding)
+            if final_binding != initial_binding:
+                raise ControlledLandingTransportError(
+                    "current physical program changed during landing preparation"
+                )
             self._safelink.assert_ready()
 
             with self._ack.transaction(request) as acknowledgement:

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Trusted #287 host adapter for one production causal physical run activation.
+"""Trusted host adapter for one production causal physical run activation.
 
 The running #283 host supplies the already host-validated profile/canonical-AST
 binding, its one live reset-aware #278 bridge, the distinct launcher-installed
-teacher socket and the shared #273 execution domain.  The generic takeoff
-lifecycle remains in ``production_takeoff_run``.  The exact canonical AST is
-validated against the integrated #295 sequencing boundary before any reset or
-flight effect; after the exact takeoff has causally completed, the same sequence
-owns each bounded #276 move/turn reservation and outcome.
+teacher socket and the shared #273 execution domain. The generic takeoff
+lifecycle remains in ``production_takeoff_run``. The exact canonical AST is
+validated against the integrated sequencing boundary before any reset or flight
+effect; after exact takeoff has causally completed, the same sequence owns each
+bounded move/turn and the one terminal controlled landing.
 
 Importing this module performs no physical effect.
 """
@@ -16,8 +16,12 @@ from __future__ import annotations
 
 import socket
 
+from controlled_landing_transport import (
+    ControlledLandingTransportError,
+    TrustedControlledLandingTransport,
+)
 from high_level_timing import HighLevelTimingPolicy
-from physical_execution_domain import FLYING, PhysicalExecutionDomain
+from physical_execution_domain import FLYING, INACTIVE, PhysicalExecutionDomain
 from physical_program_sequence import PhysicalProgramSequence, PhysicalProgramSequenceError
 from post_reset_teacher_decision import PostResetTeacherDecisionChannel
 from powered_session_authority import (
@@ -26,7 +30,6 @@ from powered_session_authority import (
 )
 from production_takeoff_run import ProductionTakeoffRunController
 from serve_reference_capabilities import CurrentProgramPreflightEvidence
-from setpoint_hl_transport import SetpointHlTransportError, TrustedSetpointHlTransport
 from supervisor_state import FreshSupervisorStateReader
 from takeoff_transport import TakeoffTransportError, TrustedTakeoffTransport
 from teacher_run_authorization import PhysicalRunBinding, TrustedTeacherAuthorizer
@@ -127,13 +130,12 @@ def activate_validated_run(
     execution_domain: PhysicalExecutionDomain,
     assertion_timeout_seconds: float = 1.0,
 ):
-    """Activate one exact host-validated run and return its trusted run controller.
+    """Activate one exact host-validated run and return its trusted controller.
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
-    motion parameters.  It reserves only the next supported top-level move/turn
-    from the exact post-reset #267 binding through the integrated #295 sequence,
-    and keeps the #276 positive provenance path lexical to this adapter's
-    host-owned bridge.
+    semantic parameters. It reserves only the next exact top-level move/turn or
+    terminal land from the post-reset #267 binding and keeps every positive
+    provenance/effect path lexical to this adapter's host-owned bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
         raise PhysicalRunActivationError("physical activation requires explicit radio:// URI")
@@ -146,9 +148,6 @@ def activate_validated_run(
     if assertion_timeout_seconds <= 0:
         raise PhysicalRunActivationError("current-program assertion timeout must be positive")
 
-    # Validate the complete exact-program envelope before any reset or physical
-    # effect. In particular this inherits #295's exact terminal {kind: land}
-    # boundary instead of maintaining a second, weaker parser in #276.
     try:
         sequence = PhysicalProgramSequence(staged_binding.ast_binding)
     except PhysicalProgramSequenceError as exc:
@@ -325,7 +324,7 @@ def activate_validated_run(
                 "post-takeoff teacher run no longer matches the exact sequenced AST"
             )
 
-    class _HostBoundInflightTransport(TrustedSetpointHlTransport):
+    class _HostBoundInflightTransport(TrustedControlledLandingTransport):
         def _read_current_binding(self) -> PhysicalRunBinding:
             binding = self.teacher_binding
             try:
@@ -335,7 +334,7 @@ def activate_validated_run(
                     timeout_seconds=assertion_timeout_seconds,
                 )
             except PhysicalRunActivationError as exc:
-                raise SetpointHlTransportError(str(exc)) from exc
+                raise ControlledLandingTransportError(str(exc)) from exc
             return binding
 
     timing_policy = HighLevelTimingPolicy()
@@ -363,10 +362,11 @@ def activate_validated_run(
                 powered_session=active_run.powered_session,
                 watchdog_guard=active_run.watchdog_guard,
                 supervisor_reader=active_run.supervisor_reader,
+                connection_epoch_reader=session.read_connection_epoch,
             )
             if transport.bound_connection_epoch != session.read_connection_epoch():
                 raise PhysicalRunActivationError(
-                    "#276 transport is not bound to the exact active host epoch"
+                    "physical effect transport is not bound to the exact active host epoch"
                 )
             self._transport = transport
             return transport
@@ -383,72 +383,89 @@ def activate_validated_run(
             return reader
 
         def _release_or_poison_sequence(self, claim: object, reason: str) -> None:
-            # Before-emission/definitive failures restore #273 to flying and are
-            # retryable without advancing. Any other phase means an effect may
-            # have crossed the boundary or completion certainty was lost; #295
-            # must become terminal rather than manufacturing a retry.
             if active_run.execution_domain.phase == FLYING:
                 sequence.release_unemitted(claim)
             else:
                 sequence.mark_ambiguous(claim, reason)
 
         def execute_next_inflight(self):
-            """Advance one exact AST move/turn; accepts no caller semantic data."""
-            claim = sequence.reserve_next_motion()
-            motion = sequence.motion_for_claim(claim)
+            """Advance one exact AST effect; accepts no caller semantic data."""
+            terminal_landing = False
+            try:
+                claim = sequence.reserve_terminal_landing()
+                sequence.landing_for_claim(claim)
+                terminal_landing = True
+                motion = None
+            except PhysicalProgramSequenceError:
+                claim = sequence.reserve_next_motion()
+                motion = sequence.motion_for_claim(claim)
+
             try:
                 transport = self._ensure_transport()
-                if motion.kind == "move":
+                if terminal_landing:
+                    result = transport.send_controlled_landing()
+                elif motion is not None and motion.kind == "move":
                     result = transport.send_horizontal_move(
                         direction=motion.direction,
                         distance_m=motion.distance_m,
                         yaw_reader=self._ensure_yaw_reader(),
                         timing_policy=timing_policy,
                     )
-                elif motion.kind == "turn":
+                elif motion is not None and motion.kind == "turn":
                     result = transport.send_turn(
                         angle_deg=motion.angle_deg,
                         timing_policy=timing_policy,
                     )
                 else:
                     raise PhysicalRunActivationError(
-                        "reserved physical statement is outside the bounded #276 slice"
+                        "reserved physical statement is outside the bounded effect slice"
                     )
             except Exception:
                 self._release_or_poison_sequence(
                     claim,
-                    "in-flight effect outcome is not definitively retryable",
+                    "physical effect outcome is not definitively retryable",
                 )
                 raise
 
             accepted = getattr(result, "accepted", None)
             if accepted is True:
-                if active_run.execution_domain.phase != FLYING:
-                    sequence.mark_ambiguous(
-                        claim,
-                        "accepted in-flight effect did not causally return to flying",
-                    )
-                    raise PhysicalRunActivationError(
-                        "accepted in-flight effect completion is not causally established"
-                    )
-                sequence.complete_motion(claim)
+                if terminal_landing:
+                    if active_run.execution_domain.phase != INACTIVE:
+                        sequence.mark_ambiguous(
+                            claim,
+                            "accepted terminal landing did not causally establish inactive",
+                        )
+                        raise PhysicalRunActivationError(
+                            "accepted terminal landing completion is not causally established"
+                        )
+                    sequence.complete_landing(claim)
+                else:
+                    if active_run.execution_domain.phase != FLYING:
+                        sequence.mark_ambiguous(
+                            claim,
+                            "accepted in-flight effect did not causally return to flying",
+                        )
+                        raise PhysicalRunActivationError(
+                            "accepted in-flight effect completion is not causally established"
+                        )
+                    sequence.complete_motion(claim)
             elif accepted is False:
                 if active_run.execution_domain.phase != FLYING:
                     sequence.mark_ambiguous(
                         claim,
-                        "rejected in-flight effect did not restore the flying phase",
+                        "rejected physical effect did not restore the flying phase",
                     )
                     raise PhysicalRunActivationError(
-                        "definitive in-flight rejection did not restore physical state"
+                        "definitive physical rejection did not restore physical state"
                     )
                 sequence.release_unemitted(claim)
             else:
                 sequence.mark_ambiguous(
                     claim,
-                    "trusted in-flight transport returned an indeterminate result",
+                    "trusted physical transport returned an indeterminate result",
                 )
                 raise PhysicalRunActivationError(
-                    "trusted in-flight transport returned no definitive acknowledgement"
+                    "trusted physical transport returned no definitive acknowledgement"
                 )
             return result
 


### PR DESCRIPTION
Implements the remaining deterministic #304 trusted-host terminal landing slice on top of integrated #305 semantics.

- adds one trusted command-10 terminal landing transport that reuses the #276 current-program/teacher/session/watchdog/supervisor/SafeLink/acknowledgement/exclusion trust root;
- derives the landing request only from the exact teacher-bound canonical AST; no caller height, velocity, yaw, raw packet or retry surface exists;
- installs the SETPOINT_HL acknowledgement callback before exactly one plain send;
- requires the private accepted-effect completion permit plus #264 same-epoch landing-completion evidence before transitioning #273 to inactive;
- extends the production activation controller so the existing parameter-free `execute-next-inflight` operation consumes the exact terminal land only after all prior exact motions causally complete;
- extends the actual host sequencing regression through terminal landing, including the boundary-only takeoff/land program and malformed-terminal preflight rejection.

This is deterministic fake/injected-hardware coverage only. It authorizes no motorized action and requests no `TEST_REQUIRED` checkpoint.

Refs #304 #157 #305 #276 #264.