### PR TITLE
Add trusted controlled terminal landing transport

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -133,6 +133,10 @@ def main():
     if physical_setpoint_transport_test.returncode:
         print('FAIL trusted one-shot SETPOINT_HL effect transport',file=sys.stderr);print(physical_setpoint_transport_test.stdout,file=sys.stderr);print(physical_setpoint_transport_test.stderr,file=sys.stderr);return physical_setpoint_transport_test.returncode
     print(physical_setpoint_transport_test.stdout.strip())
+    controlled_landing_transport_test=subprocess.run([sys.executable,'tools/ci/test_controlled_landing_transport.py'],text=True,capture_output=True)
+    if controlled_landing_transport_test.returncode:
+        print('FAIL trusted one-shot controlled landing transport',file=sys.stderr);print(controlled_landing_transport_test.stdout,file=sys.stderr);print(controlled_landing_transport_test.stderr,file=sys.stderr);return controlled_landing_transport_test.returncode
+    print(controlled_landing_transport_test.stdout.strip())
     physical_host_inflight_test=subprocess.run([sys.executable,'tools/ci/test_physical_host_inflight_sequence.py'],text=True,capture_output=True)
     if physical_host_inflight_test.returncode:
         print('FAIL actual physical-host exact-program in-flight composition',file=sys.stderr);print(physical_host_inflight_test.stdout,file=sys.stderr);print(physical_host_inflight_test.stderr,file=sys.stderr);return physical_host_inflight_test.returncode

--- a/tools/ci/test_controlled_landing_transport.py
+++ b/tools/ci/test_controlled_landing_transport.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Event, Thread
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+import sys
+sys.path.insert(0, str(CI))
+sys.path.insert(0, str(PHYSICAL))
+
+import controlled_landing_transport as landing_transport  # noqa: E402
+import high_level_ack as ack  # noqa: E402
+import landing_command  # noqa: E402
+import physical_execution_domain as execution  # noqa: E402
+import safelink_precondition as safelink  # noqa: E402
+import serve_reference_capabilities as capability_bridge  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
+import test_physical_setpoint_hl_transport as base  # noqa: E402
+import watchdog_liveness as watchdog  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, error_type, pattern: str) -> None:
+    try:
+        callable_()
+    except error_type as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected {error_type.__name__} containing {pattern!r}")
+
+
+def canonical_ast(height: float = 0.8) -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": height, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+class TestHostBoundLandingTransport(landing_transport.TrustedControlledLandingTransport):
+    """Test-only analogue of the lexical physical-host provenance subclass."""
+
+    def __init__(self, *, bridge, **kwargs) -> None:
+        self._test_bridge = bridge
+        super().__init__(**kwargs)
+
+    def _read_current_binding(self):
+        binding = self.teacher_binding
+        try:
+            evidence = self._test_bridge.assert_current_program(
+                profile_id=binding.profile_id,
+                ast_binding=binding.ast_binding,
+                connection_epoch=binding.connection_epoch,
+                timeout_seconds=0.25,
+            )
+        except Exception as exc:
+            raise landing_transport.ControlledLandingTransportError(
+                "integrated #278/#249 current-program re-assertion failed"
+            ) from exc
+        if type(evidence) is not capability_bridge.CurrentProgramPreflightEvidence:
+            raise landing_transport.ControlledLandingTransportError(
+                "invalid current-program evidence"
+            )
+        if evidence.execution_authority is not False:
+            raise landing_transport.ControlledLandingTransportError(
+                "current-program evidence became authority"
+            )
+        if (
+            evidence.profile_id != binding.profile_id
+            or evidence.ast_binding != binding.ast_binding
+            or evidence.connection_epoch != binding.connection_epoch
+        ):
+            raise landing_transport.ControlledLandingTransportError(
+                "current-program binding mismatch"
+            )
+        return binding
+
+
+class LandingFixture:
+    def __init__(self, label: str, cf: base.FakeCrazyflie) -> None:
+        self.cf = cf
+        self.epoch = base.Epoch(base.unique("landing-" + label))
+        self.domain = base.ensure_flying()
+        self.powered = base.mint_powered_session(cf, self.epoch)
+        (
+            self.supervisor_reader,
+            self.supervisor_reads,
+            self.supervisor_observed,
+        ) = base.make_supervisor_reader(cf, self.epoch)
+        self.watchdog = watchdog.EmergencyWatchdogLivenessGuard(
+            cf,
+            self.epoch,
+            self.supervisor_reader,
+            self.powered.watchdog_authority,
+            keepalive_interval_seconds=0.2,
+            max_host_gap_seconds=0.7,
+        )
+        self.watchdog.activate(supervisor_timeout_seconds=0.05)
+        self.supervisor_reads.extend(
+            [
+                base.state(hl_traj_finished=True),
+                base.state(hl_traj_finished=True),
+                base.state(
+                    blocking_fault=False,
+                    is_flying=False,
+                    hl_control_active=False,
+                    hl_traj_finished=True,
+                ),
+            ]
+        )
+        self.binding = teacher.PhysicalRunBinding(
+            profile_id="activity-1",
+            ast_binding=canonical_ast(),
+            connection_epoch=self.epoch(),
+        )
+        self.authorizer = teacher.TrustedTeacherAuthorizer()
+        self.authorization = self.authorizer.authorize_run(
+            self.binding,
+            lambda _binding: True,
+        )
+        self.current_binding = self.binding
+        self.bridge = capability_bridge.ReadOnlyCapabilityHttpBridge(
+            base.FakeCapabilitySession(self.epoch),
+            token=base.unique("landing-capability"),
+            preflight_responder_token=base.unique("landing-responder"),
+        )
+        self.bridge_thread = Thread(target=self.bridge.serve_forever, daemon=True)
+        self.bridge_thread.start()
+        self.stop = Event()
+
+        def answer() -> None:
+            while not self.stop.is_set():
+                try:
+                    challenge = self.bridge._claim_current_program_challenge(
+                        timeout_seconds=0.05
+                    )
+                except capability_bridge.CapabilityBridgeError:
+                    return
+                if challenge is None:
+                    continue
+                current = self.current_binding
+                try:
+                    self.bridge._submit_current_program_assertion(
+                        {
+                            "challengeId": challenge,
+                            "ok": True,
+                            "profileId": current.profile_id,
+                            "astBinding": current.ast_binding,
+                            "connectionEpoch": current.connection_epoch,
+                            "executionAuthority": False,
+                        }
+                    )
+                except capability_bridge.CapabilityBridgeError:
+                    pass
+
+        self.responder_thread = Thread(target=answer, daemon=True)
+        self.responder_thread.start()
+        self.safelink = safelink.LiveSafeLinkPrecondition(cf, self.epoch)
+        self.ack = ack.HighLevelAckDomain(self.epoch)
+        self.transport = TestHostBoundLandingTransport(
+            bridge=self.bridge,
+            connection_epoch_reader=self.epoch,
+            crazyflie=cf,
+            execution_domain=self.domain,
+            acknowledgement_domain=self.ack,
+            safelink_guard=self.safelink,
+            teacher_authorization=self.authorization,
+            powered_session=self.powered,
+            watchdog_guard=self.watchdog,
+            supervisor_reader=self.supervisor_reader,
+        )
+
+    def close(self) -> None:
+        try:
+            self.watchdog.stop_for_terminal_reboot(join_timeout_seconds=0.2)
+        except watchdog.WatchdogLivenessError:
+            pass
+        self.stop.set()
+        self.bridge.shutdown()
+        self.responder_thread.join(timeout=1.0)
+        self.bridge_thread.join(timeout=1.0)
+
+
+def test_accepted_landing_uses_exact_command_10_and_fresh_completion() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = LandingFixture("accept", cf)
+    try:
+        result = fixture.transport.send_controlled_landing()
+        require(result.accepted, "zero firmware result accepts exact landing")
+        require(len(cf.send_calls) == 1, "terminal landing emits exactly one packet")
+        expected = landing_command.derive_bound_landing_command(
+            fixture.binding.ast_binding
+        ).request
+        actual = bytes(cf.send_calls[0][0][0].data)
+        require(actual == expected, "physical packet is exact #305 teacher-bound command 10")
+        require(actual[0] == landing_command.LAND_WITH_VELOCITY_COMMAND, "command id is 10")
+        require(fixture.domain.phase == execution.INACTIVE, "fresh #264 completion establishes inactive")
+        require(
+            any(
+                getattr(item, "is_flying", None) is False
+                and getattr(item, "hl_control_active", None) is False
+                and getattr(item, "hl_traj_finished", None) is True
+                for item in fixture.supervisor_observed
+            ),
+            "accepted landing requires fresh finished non-flying supervisor evidence",
+        )
+    finally:
+        fixture.close()
+
+
+def test_changed_current_program_blocks_before_landing_effect() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = LandingFixture("binding", cf)
+    try:
+        fixture.current_binding = teacher.PhysicalRunBinding(
+            profile_id=fixture.binding.profile_id,
+            ast_binding=canonical_ast(0.7),
+            connection_epoch=fixture.binding.connection_epoch,
+        )
+        expect_error(
+            fixture.transport.send_controlled_landing,
+            landing_transport.ControlledLandingTransportError,
+            "current-program re-assertion",
+        )
+        require(not cf.send_calls, "changed current program must prevent landing emission")
+        require(fixture.domain.phase == execution.FLYING, "pre-effect failure preserves flying phase")
+    finally:
+        fixture.close()
+
+
+def test_definitive_rejection_is_one_shot_and_retryable_by_sequence_layer() -> None:
+    cf = base.FakeCrazyflie(reply_status=23)
+    fixture = LandingFixture("reject", cf)
+    try:
+        result = fixture.transport.send_controlled_landing()
+        require(not result.accepted and result.status == 23, "non-zero landing result is definitive rejection")
+        require(len(cf.send_calls) == 1, "definitive landing rejection is never resent")
+        require(fixture.domain.phase == execution.FLYING, "definitive rejection restores flying phase")
+    finally:
+        fixture.close()
+
+
+def test_acknowledgement_timeout_is_ambiguous_and_never_retried() -> None:
+    cf = base.FakeCrazyflie(reply_status=None)
+    fixture = LandingFixture("timeout", cf)
+    try:
+        expect_error(
+            fixture.transport.send_controlled_landing,
+            ack.HighLevelAckError,
+            "timeout",
+        )
+        require(len(cf.send_calls) == 1, "ambiguous landing is emitted exactly once")
+        require(fixture.ack.poisoned, "ambiguous landing acknowledgement poisons epoch")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "ambiguous landing outcome requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_importable_core_has_no_caller_landing_parameter_surface() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = LandingFixture("surface", cf)
+    try:
+        try:
+            fixture.transport.send_controlled_landing(0.1)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("caller-selected landing parameter entered effect API")
+        require(not cf.send_calls, "parameter substitution cannot emit")
+
+        source = (PHYSICAL / "controlled_landing_transport.py").read_text(encoding="utf-8")
+        for forbidden in (
+            "COMMAND_LAND_2",
+            "COMMAND_STOP",
+            "caller_height",
+            "caller_velocity",
+            "retry=True",
+        ):
+            require(forbidden not in source, "controlled landing leaked alternate effect surface: " + forbidden)
+        require(
+            "landing_command.derive_bound_landing_command" in source,
+            "effect must derive command bytes only from integrated exact-AST landing semantics",
+        )
+    finally:
+        fixture.close()
+
+
+def main() -> int:
+    test_accepted_landing_uses_exact_command_10_and_fresh_completion()
+    test_changed_current_program_blocks_before_landing_effect()
+    test_definitive_rejection_is_one_shot_and_retryable_by_sequence_layer()
+    test_acknowledgement_timeout_is_ambiguous_and_never_retried()
+    test_importable_core_has_no_caller_landing_parameter_surface()
+    print(
+        "PASS trusted controlled landing transport derives exact command 10 from the "
+        "teacher-bound AST, emits once under existing authorities, and accepts completion "
+        "only from fresh same-epoch #264 evidence"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/controlled_landing_transport.py
+++ b/tools/physical/controlled_landing_transport.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Trusted one-shot terminal landing effect for the physical Crazyflie.
+
+This module extends the integrated #276 trusted SETPOINT_HL transport with the
+bounded terminal effect required by #304.  It accepts no caller-selected landing
+height, velocity, yaw, raw bytes, provenance or authority.  The exact command-10
+request is derived solely from the teacher-bound canonical AST through the
+integrated #305 ``landing_command`` semantics.
+
+The effect reuses the exact #276 authority topology: fresh host-local current-
+program provenance, teacher binding, powered session, watchdog, fresh supervisor
+state, SafeLink, acknowledgement freshness and process-wide effect exclusion all
+remain mandatory immediately around one no-retry send.  A zero firmware reply is
+not completion.  The private #279 completion permit is consumed only with the
+integrated #264 same-epoch controlled-landing observation, after which the
+execution domain becomes inactive.  Any ambiguous acknowledgement or completion
+fails closed and cannot manufacture a retry.
+
+Importing this module performs no physical effect.
+"""
+
+from __future__ import annotations
+
+from threading import Event, Lock
+from typing import Callable
+
+import high_level_ack
+import landing_command
+import landing_completion
+import physical_execution_domain
+import setpoint_hl_transport
+
+_DEFAULT_REPLY_TIMEOUT_SECONDS = 0.2
+_LANDING_COMPLETION_TIMEOUT_SECONDS = 8.0
+
+
+class ControlledLandingTransportError(setpoint_hl_transport.SetpointHlTransportError):
+    """Fail-closed trusted controlled-landing transport error."""
+
+
+class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlTransport):
+    """#276 trusted effect core plus one exact terminal command-10 landing."""
+
+    def __init__(
+        self,
+        *,
+        connection_epoch_reader: Callable[[], str],
+        **kwargs,
+    ) -> None:
+        if not callable(connection_epoch_reader):
+            raise ControlledLandingTransportError(
+                "live connection epoch reader is required for controlled landing"
+            )
+        super().__init__(**kwargs)
+        self._landing_observer = landing_completion.ControlledLandingCompletionObserver(
+            self._supervisor,
+            connection_epoch_reader,
+        )
+        if self._landing_observer.bound_connection_epoch != self.bound_connection_epoch:
+            raise ControlledLandingTransportError(
+                "landing completion observer belongs to a different connection epoch"
+            )
+
+    def _force_landing_completion_uncertainty(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+    ) -> None:
+        if self.execution_domain.phase == physical_execution_domain.AWAITING_COMPLETION:
+            try:
+                self.execution_domain.complete_accepted_effect(
+                    permit,
+                    physical_execution_domain.INACTIVE,
+                    lambda: False,
+                )
+            except physical_execution_domain.PhysicalExecutionDomainError:
+                pass
+
+    def _await_landing_completion(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+        baseline: landing_completion.PreLandingFlightEvidence,
+    ) -> None:
+        if type(permit) is not physical_execution_domain.AcceptedEffectCompletionPermit:
+            raise ControlledLandingTransportError(
+                "exact accepted-effect completion permit is required for landing"
+            )
+        try:
+            self._watchdog.assert_live()
+            evidence = self._landing_observer.await_completion(
+                baseline,
+                total_timeout_seconds=_LANDING_COMPLETION_TIMEOUT_SECONDS,
+            )
+            self._watchdog.assert_live()
+
+            def prove_completion() -> bool:
+                self._watchdog.assert_live()
+                state = evidence.supervisor_state
+                return (
+                    evidence.connection_epoch == self.bound_connection_epoch
+                    and getattr(state, "blocking_fault", None) is False
+                    and getattr(state, "is_flying", None) is False
+                    and getattr(state, "hl_control_active", None) is False
+                    and getattr(state, "hl_traj_finished", None) is True
+                )
+
+            self.execution_domain.complete_accepted_effect(
+                permit,
+                physical_execution_domain.INACTIVE,
+                prove_completion,
+            )
+        except Exception:
+            self._force_landing_completion_uncertainty(permit)
+            raise
+
+    def send_controlled_landing(self) -> high_level_ack.HighLevelAckResult:
+        """Emit the exact teacher-bound terminal landing once; accepts no parameters."""
+        result: high_level_ack.HighLevelAckResult | None = None
+        completion_permit: physical_execution_domain.AcceptedEffectCompletionPermit | None = None
+        baseline: landing_completion.PreLandingFlightEvidence | None = None
+
+        with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            # Reconstruct exact current-program provenance again inside the held
+            # physical-effect exclusion before deriving any decision-relevant bytes.
+            final_binding = self._read_current_binding()
+            self._assert_binding_authority(final_binding)
+            try:
+                bound = landing_command.derive_bound_landing_command(
+                    final_binding.ast_binding
+                )
+            except landing_command.LandingCommandError as exc:
+                raise ControlledLandingTransportError(
+                    "exact terminal landing request is unavailable"
+                ) from exc
+            if bound.ast_binding != self.teacher_binding.ast_binding:
+                raise ControlledLandingTransportError(
+                    "landing request no longer matches the exact teacher-bound program"
+                )
+
+            request = bytes(bound.request)
+            packet = setpoint_hl_transport._default_packet_factory(request)
+            self._validate_packet(packet, request)
+
+            # The final safety observation and #264 pre-land baseline are both
+            # fresh same-epoch reads.  Mutable authority is checked after them
+            # before SafeLink and the one-shot acknowledgement transaction.
+            self._read_fresh_finished_flying()
+            baseline = self._landing_observer.capture_pre_land_flight()
+            self._assert_binding_authority(final_binding)
+            self._safelink.assert_ready()
+
+            with self._ack.transaction(request) as acknowledgement:
+                reply_event = Event()
+                reply_lock = Lock()
+                first_reply: list[bytes] = []
+
+                def on_reply(reply_packet: object) -> None:
+                    try:
+                        data = bytes(getattr(reply_packet, "data"))
+                    except Exception:
+                        data = b""
+                    with reply_lock:
+                        if first_reply:
+                            return
+                        first_reply.append(data)
+                        reply_event.set()
+
+                def read_reply() -> bytes | None:
+                    with reply_lock:
+                        return first_reply[0] if first_reply else None
+
+                add_callback = getattr(self._cf, "add_port_callback", None)
+                remove_callback = getattr(self._cf, "remove_port_callback", None)
+                send_packet = getattr(self._cf, "send_packet", None)
+                if (
+                    not callable(add_callback)
+                    or not callable(remove_callback)
+                    or not callable(send_packet)
+                ):
+                    raise ControlledLandingTransportError(
+                        "Crazyflie SETPOINT_HL callback/send surface is unavailable"
+                    )
+                callback_installed = False
+                try:
+                    add_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)
+                    callback_installed = True
+                    acknowledgement.mark_emitted()
+                    effect.mark_emitted()
+                    send_packet(packet)
+                    try:
+                        reply = self._wait_for_reply(
+                            reply_event,
+                            read_reply,
+                            _DEFAULT_REPLY_TIMEOUT_SECONDS,
+                        )
+                    except Exception as exc:
+                        acknowledgement.fail_ambiguous(str(exc))
+                    result = acknowledgement.resolve_reply(reply)
+                    if result.accepted:
+                        completion_permit = effect.mark_accepted()
+                    else:
+                        effect.mark_definitive_rejection()
+                finally:
+                    if callback_installed:
+                        try:
+                            remove_callback(
+                                setpoint_hl_transport._SETPOINT_HL_PORT,
+                                on_reply,
+                            )
+                        except Exception:
+                            pass
+
+        if result is None:
+            raise ControlledLandingTransportError(
+                "controlled landing acknowledgement result is unavailable"
+            )
+        if result.accepted:
+            if completion_permit is None or baseline is None:
+                raise ControlledLandingTransportError(
+                    "accepted controlled landing lacks private completion state"
+                )
+            self._await_landing_completion(completion_permit, baseline)
+        return result


### PR DESCRIPTION
Builds the trusted terminal landing effect core required by #304 on top of integrated #305 semantics.

`TrustedControlledLandingTransport` reuses the existing #276 authority topology and exposes one parameter-free `send_controlled_landing()` operation. Inside the process-wide physical effect exclusion it reasserts the host-local current profile/AST/epoch binding, derives the exact command-10 request only through `landing_command.derive_bound_landing_command`, requires fresh finished-flight and #264 pre-land evidence, rechecks teacher/session/watchdog authority and SafeLink, installs the acknowledgement callback before exactly one plain no-retry SETPOINT_HL send, and treats positive acknowledgement only as the private #279 completion permit. Completion reaches `inactive` only after later fresh same-epoch #264 evidence establishes finished, non-flying and high-level-inactive state while the watchdog remains live. Ambiguous acknowledgement/completion stays fail-closed.

The deterministic regression covers exact command bytes/provenance, fresh landing completion, changed-current-program rejection before effect, definitive rejection without retry, ambiguous acknowledgement recovery, and absence of caller-selected landing parameters. It is wired into the existing Runtime core harness.

This Draft is deliberately a bounded effect-core slice: #304 remains open until the production physical host consumes the exact terminal sequence claim through this transport and completes the parameter-free program lifecycle. No motorized checkpoint or real-flight qualification is requested.

Refs #304 #157 #305 #276 #264 #279.