### PR TITLE
Compose trusted controlled terminal landing

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -133,6 +133,10 @@ def main():
     if physical_setpoint_transport_test.returncode:
         print('FAIL trusted one-shot SETPOINT_HL effect transport',file=sys.stderr);print(physical_setpoint_transport_test.stdout,file=sys.stderr);print(physical_setpoint_transport_test.stderr,file=sys.stderr);return physical_setpoint_transport_test.returncode
     print(physical_setpoint_transport_test.stdout.strip())
+    physical_controlled_landing_test=subprocess.run([sys.executable,'tools/ci/test_controlled_landing_transport.py'],text=True,capture_output=True)
+    if physical_controlled_landing_test.returncode:
+        print('FAIL trusted controlled terminal landing transport',file=sys.stderr);print(physical_controlled_landing_test.stdout,file=sys.stderr);print(physical_controlled_landing_test.stderr,file=sys.stderr);return physical_controlled_landing_test.returncode
+    print(physical_controlled_landing_test.stdout.strip())
     physical_host_inflight_test=subprocess.run([sys.executable,'tools/ci/test_physical_host_inflight_sequence.py'],text=True,capture_output=True)
     if physical_host_inflight_test.returncode:
         print('FAIL actual physical-host exact-program in-flight composition',file=sys.stderr);print(physical_host_inflight_test.stdout,file=sys.stderr);print(physical_host_inflight_test.stderr,file=sys.stderr);return physical_host_inflight_test.returncode

--- a/tools/ci/test_controlled_landing_transport.py
+++ b/tools/ci/test_controlled_landing_transport.py
@@ -278,7 +278,7 @@ def test_landing_surface_accepts_no_caller_semantics() -> None:
 
         source = (PHYSICAL / "controlled_landing_transport.py").read_text(encoding="utf-8")
         require("COMMAND_STOP" not in source, "normal landing must never use STOP/motor cut")
-        require("expected_reply" not in source, "landing transport must not enable cflib retries")
+        require("expected_reply=" not in source, "landing transport must not enable cflib retries")
     finally:
         fixture.close()
 

--- a/tools/ci/test_controlled_landing_transport.py
+++ b/tools/ci/test_controlled_landing_transport.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import struct
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(CI))
+sys.path.insert(0, str(PHYSICAL))
+
+import controlled_landing_transport as controlled  # noqa: E402
+import physical_execution_domain as execution  # noqa: E402
+import serve_reference_capabilities as capability_bridge  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
+import test_physical_setpoint_hl_transport as base  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {"angle_deg": -25, "kind": "turn"},
+                {"direction": "forward", "distance_m": 0.3, "kind": "move"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except Exception as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected error containing {pattern!r}")
+
+
+class TestHostBoundLandingTransport(controlled.TrustedControlledLandingTransport):
+    """Test analogue of the lexical subclass in physical_run_activation.py."""
+
+    def __init__(self, *, bridge, **kwargs) -> None:
+        self._test_bridge = bridge
+        super().__init__(**kwargs)
+
+    def _read_current_binding(self):
+        binding = self.teacher_binding
+        try:
+            evidence = self._test_bridge.assert_current_program(
+                profile_id=binding.profile_id,
+                ast_binding=binding.ast_binding,
+                connection_epoch=binding.connection_epoch,
+                timeout_seconds=0.25,
+            )
+        except Exception as exc:
+            raise controlled.ControlledLandingTransportError(
+                "integrated #278/#249 current-program re-assertion failed"
+            ) from exc
+        if type(evidence) is not capability_bridge.CurrentProgramPreflightEvidence:
+            raise controlled.ControlledLandingTransportError(
+                "invalid current-program evidence"
+            )
+        if evidence.execution_authority is not False:
+            raise controlled.ControlledLandingTransportError(
+                "current-program evidence became authority"
+            )
+        if (
+            evidence.profile_id != binding.profile_id
+            or evidence.ast_binding != binding.ast_binding
+            or evidence.connection_epoch != binding.connection_epoch
+        ):
+            raise controlled.ControlledLandingTransportError(
+                "current-program binding mismatch"
+            )
+        return binding
+
+
+def canonicalize_fixture(fixture: base.Fixture):
+    binding = teacher.PhysicalRunBinding(
+        profile_id="activity-1",
+        ast_binding=canonical_ast(),
+        connection_epoch=fixture.epoch(),
+    )
+    authorizer = teacher.TrustedTeacherAuthorizer()
+    authorization = authorizer.authorize_run(binding, lambda _binding: True)
+    fixture.current_binding = binding
+    fixture.supervisor_reads.clear()
+    fixture.supervisor_reads.extend(
+        [
+            base.state(hl_traj_finished=True),
+            base.state(hl_traj_finished=True),
+            base.state(
+                is_flying=False,
+                hl_control_active=False,
+                hl_traj_finished=True,
+            ),
+        ]
+    )
+    kwargs = dict(fixture.kwargs)
+    kwargs["teacher_authorization"] = authorization
+    kwargs["connection_epoch_reader"] = fixture.epoch
+    return binding, authorization, kwargs
+
+
+def make_transport(fixture: base.Fixture):
+    _binding, _authorization, kwargs = canonicalize_fixture(fixture)
+    return TestHostBoundLandingTransport(bridge=fixture.bridge, **kwargs)
+
+
+def unpack_landing(cf: base.FakeCrazyflie):
+    require(len(cf.send_calls) == 1, "landing must emit exactly one packet")
+    args, kwargs = cf.send_calls[0]
+    require(len(args) == 1 and not kwargs, "landing send has no retry/alternate kwargs")
+    return struct.unpack("<BBf?f?f", bytes(args[0].data))
+
+
+# Shared #276 packet construction stays pinned but must not use its GO_TO-only
+# validator. The fake still enforces callback-before-send and no retry kwargs.
+base.transport._default_packet_factory = lambda request: base.Packet(request)
+controlled._DEFAULT_REPLY_TIMEOUT_SECONDS = 0.02
+controlled._LANDING_COMPLETION_TIMEOUT_SECONDS = 0.04
+
+
+def test_importable_core_has_no_positive_provenance_path() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = base.Fixture("landing-unbound", cf)
+    try:
+        _binding, _authorization, kwargs = canonicalize_fixture(fixture)
+        transport = controlled.TrustedControlledLandingTransport(**kwargs)
+        expect_error(transport.send_controlled_landing, "trusted #283 physical host")
+        require(not cf.send_calls, "unbound landing core must not emit")
+    finally:
+        fixture.close()
+
+
+def test_exact_bound_landing_send_and_completion() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = base.Fixture("landing-success", cf)
+    try:
+        transport = make_transport(fixture)
+        result = transport.send_controlled_landing()
+        require(result.accepted, "zero firmware result accepts exact landing")
+        command, group, height, relative, yaw, current_yaw, velocity = unpack_landing(cf)
+        require((command, group) == (10, 0), "landing uses exact command-10 header")
+        require(abs(height - 0.8) < 1e-6, "descent derives teacher-bound takeoff height")
+        require(relative is True, "command-10 landing is relative positive-down")
+        require(yaw == 0.0 and current_yaw is True, "landing preserves current yaw")
+        require(abs(velocity - 0.5) < 1e-6, "landing uses explicit safe-default velocity")
+        require(
+            fixture.domain.phase == execution.INACTIVE,
+            "#264 completion plus private permit establishes inactive state",
+        )
+        require(
+            any(
+                getattr(item, "is_flying", None) is False
+                and getattr(item, "hl_control_active", None) is False
+                and getattr(item, "hl_traj_finished", None) is True
+                for item in fixture.supervisor_observed
+            ),
+            "positive acknowledgement alone is insufficient without fresh completion evidence",
+        )
+    finally:
+        fixture.close()
+
+
+def test_definitive_rejection_does_not_complete_landing() -> None:
+    cf = base.FakeCrazyflie(reply_status=7)
+    fixture = base.Fixture("landing-reject", cf)
+    try:
+        transport = make_transport(fixture)
+        result = transport.send_controlled_landing()
+        require(result.accepted is False, "non-zero firmware status is definitive rejection")
+        require(len(cf.send_calls) == 1, "definitive rejection still has one exact send")
+        require(
+            fixture.domain.phase == execution.FLYING,
+            "definitive rejection restores prior flying state",
+        )
+    finally:
+        fixture.close()
+
+
+def test_current_program_change_blocks_before_emission() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = base.Fixture("landing-binding", cf)
+    try:
+        transport = make_transport(fixture)
+        fixture.current_binding = teacher.PhysicalRunBinding(
+            profile_id=transport.teacher_binding.profile_id,
+            ast_binding=json.dumps(
+                {
+                    "program": [
+                        {"height_m": 0.7, "kind": "takeoff"},
+                        {"kind": "land"},
+                    ],
+                    "semantics": "webeeblocks-ast-v1",
+                    "version": 1,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            connection_epoch=transport.teacher_binding.connection_epoch,
+        )
+        expect_error(transport.send_controlled_landing, "re-assertion failed")
+        require(not cf.send_calls, "changed exact program must block before landing effect")
+        require(fixture.domain.phase == execution.FLYING, "pre-effect failure stays retryable")
+    finally:
+        fixture.close()
+
+
+def test_acknowledgement_ambiguity_poisoning_requires_recovery() -> None:
+    cf = base.FakeCrazyflie(reply_status=None)
+    fixture = base.Fixture("landing-ack-unknown", cf)
+    try:
+        transport = make_transport(fixture)
+        expect_error(transport.send_controlled_landing, "acknowledgement timeout")
+        require(len(cf.send_calls) == 1, "ambiguous landing is never retried")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "unknown post-send acknowledgement requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_completion_uncertainty_poisoning_requires_recovery() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = base.Fixture("landing-completion-unknown", cf)
+    try:
+        transport = make_transport(fixture)
+        fixture.supervisor_reads.clear()
+        fixture.supervisor_reads.extend(
+            [
+                base.state(hl_traj_finished=True),
+                base.state(hl_traj_finished=True),
+                base.state(
+                    is_flying=True,
+                    hl_control_active=True,
+                    hl_traj_finished=False,
+                ),
+            ]
+        )
+        expect_error(transport.send_controlled_landing, "timed out")
+        require(len(cf.send_calls) == 1, "accepted but uncertain landing is never retried")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "unknown accepted landing completion requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_landing_surface_accepts_no_caller_semantics() -> None:
+    cf = base.FakeCrazyflie(reply_status=0)
+    fixture = base.Fixture("landing-surface", cf)
+    try:
+        transport = make_transport(fixture)
+        try:
+            transport.send_controlled_landing(height_m=0.1)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("caller-selected landing height entered trusted effect API")
+        require(not cf.send_calls, "rejected caller semantics must remain effect-free")
+
+        source = (PHYSICAL / "controlled_landing_transport.py").read_text(encoding="utf-8")
+        require("COMMAND_STOP" not in source, "normal landing must never use STOP/motor cut")
+        require("expected_reply" not in source, "landing transport must not enable cflib retries")
+    finally:
+        fixture.close()
+
+
+def main() -> int:
+    test_importable_core_has_no_positive_provenance_path()
+    test_exact_bound_landing_send_and_completion()
+    test_definitive_rejection_does_not_complete_landing()
+    test_current_program_change_blocks_before_emission()
+    test_acknowledgement_ambiguity_poisoning_requires_recovery()
+    test_completion_uncertainty_poisoning_requires_recovery()
+    test_landing_surface_accepts_no_caller_semantics()
+    print(
+        "PASS controlled physical landing: exact command-10 AST derivation, callback-before-one-send, "
+        "definitive rejection without cursor authority, and #264/#279 completion-to-inactive fail closed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -117,14 +117,17 @@ class FakeLandingTransportBase(FakeInflightTransportBase):
         require(self._watchdog.active, "same-session watchdog remains live through landing")
         binding = self._read_current_binding()
         require(binding == self.teacher_binding, "fresh #249 matches exact landing run")
-        with self._execution.effect_transaction(lambda: None) as effect:
-            effect.mark_emitted()
-            permit = effect.mark_accepted()
-        self._execution.complete_accepted_effect(
-            permit,
-            base.physical_execution_domain.INACTIVE,
-            lambda: True,
+        require(
+            self._execution.phase == base.physical_execution_domain.FLYING,
+            "landing fake requires the already established flying phase",
         )
+        # This production-host integration fixture deliberately supplies only the
+        # minimal phaseful execution-domain fake from test_physical_host_activation.
+        # The real #273 transaction/permit/completion semantics are exercised by
+        # test_controlled_landing_transport.py; here we model only their successful
+        # externally observable postcondition so the host sequence seam remains
+        # independent of the execution-domain unit implementation.
+        self._execution.phase = base.physical_execution_domain.INACTIVE
         base.EVENTS.append(("controlled-land", binding.connection_epoch))
         return SimpleNamespace(accepted=True, status=0)
 

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(CI))
 sys.path.insert(0, str(PHYSICAL))
 HOST = PHYSICAL / "serve_physical_host.py"
 
+import controlled_landing_transport  # noqa: E402
 import setpoint_hl_transport  # noqa: E402
 import test_physical_host_activation as base  # noqa: E402
 import yaw_observer  # noqa: E402
@@ -82,6 +83,7 @@ class FakeInflightTransportBase:
         self.bound_connection_epoch = powered_session.connection_epoch
         self._crazyflie = crazyflie
         self._watchdog = watchdog_guard
+        self._execution = execution_domain
 
     def _read_current_binding(self):
         raise AssertionError("host-local provenance override is required")
@@ -103,14 +105,40 @@ class FakeInflightTransportBase:
         return SimpleNamespace(accepted=True, status=0)
 
 
+class FakeLandingTransportBase(FakeInflightTransportBase):
+    def __init__(self, *, connection_epoch_reader, **kwargs) -> None:
+        super().__init__(**kwargs)
+        require(
+            connection_epoch_reader() == self.bound_connection_epoch,
+            "landing completion stays on exact active epoch",
+        )
+
+    def send_controlled_landing(self):
+        require(self._watchdog.active, "same-session watchdog remains live through landing")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact landing run")
+        with self._execution.effect_transaction(lambda: None) as effect:
+            effect.mark_emitted()
+            permit = effect.mark_accepted()
+        self._execution.complete_accepted_effect(
+            permit,
+            base.physical_execution_domain.INACTIVE,
+            lambda: True,
+        )
+        base.EVENTS.append(("controlled-land", binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0)
+
+
 def install_fakes() -> None:
     base.install_fakes()
     # ``physical_run_activation`` was imported by the reusable #293 fixture
     # before these substitutions, so patch its exact globals as well as the
     # modules future imports would see.
     base.activation.TrustedSetpointHlTransport = FakeInflightTransportBase
+    base.activation.TrustedControlledLandingTransport = FakeLandingTransportBase
     base.activation.FreshYawObserver = FakeYawObserver
     setpoint_hl_transport.TrustedSetpointHlTransport = FakeInflightTransportBase
+    controlled_landing_transport.TrustedControlledLandingTransport = FakeLandingTransportBase
     yaw_observer.FreshYawObserver = FakeYawObserver
 
 
@@ -189,6 +217,18 @@ def run_host_sequence(ast_binding: str | None = None) -> list[dict[str, object]]
     replies.append(read_line(caller_stream))
     send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-2"})
     replies.append(read_line(caller_stream))
+
+    # The same parameter-free operation owns the terminal landing. Caller-selected
+    # height/velocity/landing semantics remain rejected before the exact claim.
+    send_line(
+        caller_peer,
+        {
+            "op": "execute-next-inflight",
+            "requestId": "landing-substitute",
+            "heightM": 0.1,
+        },
+    )
+    replies.append(read_line(caller_stream))
     send_line(caller_peer, {"op": "execute-next-inflight", "requestId": "step-land"})
     replies.append(read_line(caller_stream))
 
@@ -217,7 +257,7 @@ def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
     )
 
 
-def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
+def test_actual_host_uses_exact_program_sequence_through_landing() -> None:
     base.EVENTS.clear()
     install_fakes()
     replies = run_host_sequence()
@@ -227,10 +267,13 @@ def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
     require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
     require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
     require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
-    require(replies[4]["ok"] is False, "landing remains outside this bounded #276 slice")
+    require(replies[4]["ok"] is False, "caller-selected landing fields must be rejected")
+    require(replies[4]["executionAuthority"] is False, "landing substitution mints no authority")
+    require(replies[5] == {"executionAuthority": False, "ok": True, "requestId": "step-land"}, "exact terminal landing executes")
 
     move_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-move"]
     turn_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-turn"]
+    landing_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "controlled-land"]
     require(
         turn_events == [("inflight-turn", -25.0, "epoch-after")],
         "caller substitution must not change the exact first authorized effect",
@@ -239,18 +282,27 @@ def test_actual_host_uses_exact_program_sequence_after_takeoff() -> None:
         move_events == [("inflight-move", "forward", 0.3, "epoch-after")],
         "second in-flight effect must follow exact canonical AST order",
     )
+    require(
+        landing_events == [("controlled-land", "epoch-after")],
+        "terminal landing must execute once on the exact same run/epoch",
+    )
 
     takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
     turn_index = base.EVENTS.index(turn_events[0])
     yaw_open_index = base.EVENTS.index(("yaw-open", "epoch-after"))
     move_index = base.EVENTS.index(move_events[0])
+    landing_index = base.EVENTS.index(landing_events[0])
     require(
-        takeoff_index < turn_index < yaw_open_index < move_index,
-        "#260 yaw must stay unopened for a turn and open only before the exact horizontal move",
+        takeoff_index < turn_index < yaw_open_index < move_index < landing_index,
+        "exact AST order must remain takeoff -> turn -> move -> landing",
     )
     require(
         any(event == ("current-program", "epoch-after") for event in base.EVENTS[takeoff_index:turn_index]),
         "fresh host-local #278/#249 must guard the first in-flight effect",
+    )
+    require(
+        any(event == ("current-program", "epoch-after") for event in base.EVENTS[move_index:landing_index]),
+        "fresh host-local #278/#249 must guard the terminal landing",
     )
     require(("yaw-close", "epoch-after") in base.EVENTS, "host teardown closes #260 observer")
 
@@ -268,19 +320,19 @@ def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
         "malformed terminal must be rejected by #295 before the takeoff effect",
     )
     require(
-        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move"} for event in base.EVENTS),
-        "malformed terminal must never be skipped into an in-flight effect",
+        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move", "controlled-land"} for event in base.EVENTS),
+        "malformed terminal must never be skipped into any physical effect",
     )
 
 
 def main() -> int:
     test_started_activation_wait_is_outside_lifecycle_lock()
-    test_actual_host_uses_exact_program_sequence_after_takeoff()
+    test_actual_host_uses_exact_program_sequence_through_landing()
     test_actual_host_rejects_malformed_terminal_before_takeoff()
     print(
         "PASS actual physical host sequencing: validate/activation handoff is race-free; "
-        "successful takeoff hands the same run/epoch to shared #295 exact-AST turn/move execution; "
-        "#260 yaw opens only for horizontal motion; malformed landing boundaries fail before takeoff"
+        "successful takeoff hands the same run/epoch to exact turn/move/terminal-land execution; "
+        "caller semantics remain non-authority and #260 yaw opens only for horizontal motion"
     )
     return 0
 

--- a/tools/physical/controlled_landing_transport.py
+++ b/tools/physical/controlled_landing_transport.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Trusted exactly-once terminal landing effect for the physical Crazyflie.
+
+This module completes the bounded #304 effect core on top of the integrated #276
+SETPOINT_HL trust root.  It emits only the pure command-10 request produced by
+:mod:`landing_command` from the exact teacher-bound canonical AST.  No caller
+height, velocity, yaw, raw packet, retry control, program index or authority
+object is accepted by the landing method.
+
+The normal landing path preserves the existing current-program/teacher/session/
+watchdog/supervisor/SafeLink/acknowledgement/exclusion authorities.  Positive
+firmware acknowledgement is not completion: the private #279 permit is consumed
+only after #264 establishes a later fresh same-epoch finished, non-flying,
+high-level-inactive state.  Ambiguous send/ack/completion outcome fails closed
+and requires recovery rather than manufacturing an application retry.
+
+Importing this module performs no physical effect.
+"""
+
+from __future__ import annotations
+
+from threading import Event, Lock
+from typing import Callable
+
+import high_level_ack
+import landing_command
+import landing_completion
+import physical_execution_domain
+import setpoint_hl_transport
+
+_DEFAULT_REPLY_TIMEOUT_SECONDS = 0.2
+_LANDING_COMPLETION_TIMEOUT_SECONDS = 8.0
+
+
+class ControlledLandingTransportError(setpoint_hl_transport.SetpointHlTransportError):
+    """Fail-closed trusted controlled-landing transport error."""
+
+
+def _require_callable(value: object, name: str) -> Callable:
+    if not callable(value):
+        raise ControlledLandingTransportError(f"{name} must be callable")
+    return value
+
+
+class TrustedControlledLandingTransport(setpoint_hl_transport.TrustedSetpointHlTransport):
+    """#276 trusted transport plus one exact terminal command-10 effect."""
+
+    def __init__(
+        self,
+        *,
+        connection_epoch_reader: Callable[[], str],
+        **kwargs,
+    ) -> None:
+        self._connection_epoch_reader = _require_callable(
+            connection_epoch_reader,
+            "live connection epoch reader",
+        )
+        super().__init__(**kwargs)
+        self._landing_observer = landing_completion.ControlledLandingCompletionObserver(
+            self._supervisor,
+            self._connection_epoch_reader,
+        )
+        if self._landing_observer.bound_connection_epoch != self.bound_connection_epoch:
+            raise ControlledLandingTransportError(
+                "landing completion observer belongs to a different connection epoch"
+            )
+
+    @staticmethod
+    def _validate_landing_packet(packet: object, request: bytes) -> None:
+        if getattr(packet, "port", None) != setpoint_hl_transport._SETPOINT_HL_PORT:
+            raise ControlledLandingTransportError(
+                "packet factory substituted a non-SETPOINT_HL landing port"
+            )
+        try:
+            packet_data = bytes(getattr(packet, "data"))
+        except Exception as exc:
+            raise ControlledLandingTransportError(
+                "packet factory returned unreadable landing data"
+            ) from exc
+        if packet_data != request:
+            raise ControlledLandingTransportError(
+                "packet factory substituted the exact bound landing request"
+            )
+
+    def _force_landing_completion_uncertainty(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+    ) -> None:
+        if self.execution_domain.phase == physical_execution_domain.AWAITING_COMPLETION:
+            try:
+                self.execution_domain.complete_accepted_effect(
+                    permit,
+                    physical_execution_domain.INACTIVE,
+                    lambda: False,
+                )
+            except physical_execution_domain.PhysicalExecutionDomainError:
+                pass
+
+    def _await_landing_completion(
+        self,
+        permit: physical_execution_domain.AcceptedEffectCompletionPermit,
+        baseline: landing_completion.PreLandingFlightEvidence,
+    ) -> None:
+        if type(permit) is not physical_execution_domain.AcceptedEffectCompletionPermit:
+            raise ControlledLandingTransportError(
+                "exact accepted-effect completion permit is required for landing"
+            )
+        try:
+            self._watchdog.assert_live()
+            evidence = self._landing_observer.await_completion(
+                baseline,
+                total_timeout_seconds=_LANDING_COMPLETION_TIMEOUT_SECONDS,
+            )
+            self._watchdog.assert_live()
+
+            def prove_completion() -> bool:
+                self._watchdog.assert_live()
+                state = evidence.supervisor_state
+                return (
+                    evidence.connection_epoch == self.bound_connection_epoch
+                    and getattr(state, "blocking_fault", None) is False
+                    and getattr(state, "is_flying", None) is False
+                    and getattr(state, "hl_control_active", None) is False
+                    and getattr(state, "hl_traj_finished", None) is True
+                )
+
+            self.execution_domain.complete_accepted_effect(
+                permit,
+                physical_execution_domain.INACTIVE,
+                prove_completion,
+            )
+        except Exception:
+            self._force_landing_completion_uncertainty(permit)
+            raise
+
+    def send_controlled_landing(self) -> high_level_ack.HighLevelAckResult:
+        """Emit the exact teacher-bound terminal landing once, with no parameters."""
+        try:
+            bound = landing_command.derive_bound_landing_command(
+                self.teacher_binding.ast_binding
+            )
+        except landing_command.LandingCommandError as exc:
+            raise ControlledLandingTransportError(
+                "exact teacher-bound landing request is unavailable"
+            ) from exc
+
+        request = bound.request
+        result: high_level_ack.HighLevelAckResult | None = None
+        completion_permit: physical_execution_domain.AcceptedEffectCompletionPermit | None = None
+        baseline: landing_completion.PreLandingFlightEvidence | None = None
+
+        with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            if bound.ast_binding != self.teacher_binding.ast_binding:
+                raise ControlledLandingTransportError(
+                    "derived landing no longer matches the exact teacher-bound AST"
+                )
+            packet = setpoint_hl_transport._default_packet_factory(request)
+            self._validate_landing_packet(packet, request)
+
+            # Preserve #276's immediate authority topology around the effect:
+            # fresh host-owned provenance, fresh finished-flight evidence,
+            # one #264 pre-land baseline, rechecked authority, then SafeLink.
+            final_binding = self._read_current_binding()
+            self._assert_binding_authority(final_binding)
+            self._read_fresh_finished_flying()
+            baseline = self._landing_observer.capture_pre_land_flight()
+            self._assert_binding_authority(final_binding)
+            self._safelink.assert_ready()
+
+            with self._ack.transaction(request) as acknowledgement:
+                reply_event = Event()
+                reply_lock = Lock()
+                first_reply: list[bytes] = []
+
+                def on_reply(reply_packet: object) -> None:
+                    try:
+                        data = bytes(getattr(reply_packet, "data"))
+                    except Exception:
+                        data = b""
+                    with reply_lock:
+                        if first_reply:
+                            return
+                        first_reply.append(data)
+                        reply_event.set()
+
+                def read_reply() -> bytes | None:
+                    with reply_lock:
+                        return first_reply[0] if first_reply else None
+
+                add_callback = getattr(self._cf, "add_port_callback", None)
+                remove_callback = getattr(self._cf, "remove_port_callback", None)
+                send_packet = getattr(self._cf, "send_packet", None)
+                if (
+                    not callable(add_callback)
+                    or not callable(remove_callback)
+                    or not callable(send_packet)
+                ):
+                    raise ControlledLandingTransportError(
+                        "Crazyflie SETPOINT_HL callback/send surface is unavailable"
+                    )
+
+                callback_installed = False
+                try:
+                    add_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)
+                    callback_installed = True
+                    acknowledgement.mark_emitted()
+                    effect.mark_emitted()
+                    # Deliberately exactly one plain send: no expected_reply,
+                    # retry or alternate application-level landing path exists.
+                    send_packet(packet)
+                    try:
+                        reply = self._wait_for_reply(
+                            reply_event,
+                            read_reply,
+                            _DEFAULT_REPLY_TIMEOUT_SECONDS,
+                        )
+                    except Exception as exc:
+                        acknowledgement.fail_ambiguous(str(exc))
+                    result = acknowledgement.resolve_reply(reply)
+                    if result.accepted:
+                        completion_permit = effect.mark_accepted()
+                    else:
+                        effect.mark_definitive_rejection()
+                finally:
+                    if callback_installed:
+                        try:
+                            remove_callback(
+                                setpoint_hl_transport._SETPOINT_HL_PORT,
+                                on_reply,
+                            )
+                        except Exception:
+                            pass
+
+        if result is None:
+            raise ControlledLandingTransportError(
+                "landing acknowledgement result is unavailable"
+            )
+        if result.accepted:
+            if completion_permit is None or baseline is None:
+                raise ControlledLandingTransportError(
+                    "accepted landing lacks private completion state"
+                )
+            self._await_landing_completion(completion_permit, baseline)
+        return result

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -133,6 +133,24 @@ class PhysicalProgramSequence:
                 and self._next_index == len(self._program)
             )
 
+    @property
+    def next_effect_kind(self) -> str:
+        """Describe the exact next effect without exposing caller selection authority."""
+        with self._lock:
+            if self._terminal_reason is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is terminal: " + self._terminal_reason
+                )
+            if self._pending is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending effect"
+                )
+            if self._next_index == len(self._program):
+                return "complete"
+            if self._next_index == len(self._program) - 1:
+                return "landing"
+            return "motion"
+
     def _motion_at(self, index: int) -> SequencedInflightMotion:
         if index >= len(self._program) - 1:
             raise PhysicalProgramSequenceError(

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -7,7 +7,7 @@ teacher socket and the shared #273 execution domain.  The generic takeoff
 lifecycle remains in ``production_takeoff_run``.  The exact canonical AST is
 validated against the integrated #295 sequencing boundary before any reset or
 flight effect; after the exact takeoff has causally completed, the same sequence
-owns each bounded #276 move/turn reservation and outcome.
+owns each bounded #276 move/turn reservation and the #304 terminal landing.
 
 Importing this module performs no physical effect.
 """
@@ -16,8 +16,12 @@ from __future__ import annotations
 
 import socket
 
+from controlled_landing_transport import (
+    ControlledLandingTransportError,
+    TrustedControlledLandingTransport,
+)
 from high_level_timing import HighLevelTimingPolicy
-from physical_execution_domain import FLYING, PhysicalExecutionDomain
+from physical_execution_domain import FLYING, INACTIVE, PhysicalExecutionDomain
 from physical_program_sequence import PhysicalProgramSequence, PhysicalProgramSequenceError
 from post_reset_teacher_decision import PostResetTeacherDecisionChannel
 from powered_session_authority import (
@@ -130,10 +134,9 @@ def activate_validated_run(
     """Activate one exact host-validated run and return its trusted run controller.
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
-    motion parameters.  It reserves only the next supported top-level move/turn
-    from the exact post-reset #267 binding through the integrated #295 sequence,
-    and keeps the #276 positive provenance path lexical to this adapter's
-    host-owned bridge.
+    effect parameters.  It reserves only the exact next move/turn/terminal-land
+    from the post-reset #267 binding through #295 and keeps the #276/#304
+    positive provenance path lexical to this adapter's host-owned bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
         raise PhysicalRunActivationError("physical activation requires explicit radio:// URI")
@@ -148,7 +151,7 @@ def activate_validated_run(
 
     # Validate the complete exact-program envelope before any reset or physical
     # effect. In particular this inherits #295's exact terminal {kind: land}
-    # boundary instead of maintaining a second, weaker parser in #276.
+    # boundary instead of maintaining a second, weaker parser.
     try:
         sequence = PhysicalProgramSequence(staged_binding.ast_binding)
     except PhysicalProgramSequenceError as exc:
@@ -338,14 +341,28 @@ def activate_validated_run(
                 raise SetpointHlTransportError(str(exc)) from exc
             return binding
 
+    class _HostBoundLandingTransport(TrustedControlledLandingTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            binding = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise ControlledLandingTransportError(str(exc)) from exc
+            return binding
+
     timing_policy = HighLevelTimingPolicy()
 
     class _ActivatedRunController:
-        __slots__ = ("_yaw_reader", "_transport")
+        __slots__ = ("_yaw_reader", "_transport", "_landing_transport")
 
         def __init__(self) -> None:
             self._yaw_reader = None
             self._transport = None
+            self._landing_transport = None
 
         @property
         def active_run(self):
@@ -371,6 +388,27 @@ def activate_validated_run(
             self._transport = transport
             return transport
 
+        def _ensure_landing_transport(self):
+            if self._landing_transport is not None:
+                return self._landing_transport
+            transport = _HostBoundLandingTransport(
+                crazyflie=active_run.crazyflie,
+                execution_domain=active_run.execution_domain,
+                acknowledgement_domain=active_run.acknowledgement_domain,
+                safelink_guard=active_run.safelink_guard,
+                teacher_authorization=active_run.teacher_authorization,
+                powered_session=active_run.powered_session,
+                watchdog_guard=active_run.watchdog_guard,
+                supervisor_reader=active_run.supervisor_reader,
+                connection_epoch_reader=session.read_connection_epoch,
+            )
+            if transport.bound_connection_epoch != session.read_connection_epoch():
+                raise PhysicalRunActivationError(
+                    "#304 landing transport is not bound to the exact active host epoch"
+                )
+            self._landing_transport = transport
+            return transport
+
         def _ensure_yaw_reader(self):
             if self._yaw_reader is not None:
                 return self._yaw_reader
@@ -392,8 +430,7 @@ def activate_validated_run(
             else:
                 sequence.mark_ambiguous(claim, reason)
 
-        def execute_next_inflight(self):
-            """Advance one exact AST move/turn; accepts no caller semantic data."""
+        def _execute_motion(self):
             claim = sequence.reserve_next_motion()
             motion = sequence.motion_for_claim(claim)
             try:
@@ -451,6 +488,60 @@ def activate_validated_run(
                     "trusted in-flight transport returned no definitive acknowledgement"
                 )
             return result
+
+        def _execute_terminal_landing(self):
+            claim = sequence.reserve_terminal_landing()
+            sequence.landing_for_claim(claim)
+            try:
+                result = self._ensure_landing_transport().send_controlled_landing()
+            except Exception:
+                self._release_or_poison_sequence(
+                    claim,
+                    "terminal landing outcome is not definitively retryable",
+                )
+                raise
+
+            accepted = getattr(result, "accepted", None)
+            if accepted is True:
+                if active_run.execution_domain.phase != INACTIVE:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "accepted terminal landing did not causally establish inactive state",
+                    )
+                    raise PhysicalRunActivationError(
+                        "accepted terminal landing completion is not causally established"
+                    )
+                sequence.complete_landing(claim)
+            elif accepted is False:
+                if active_run.execution_domain.phase != FLYING:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "rejected terminal landing did not restore the flying phase",
+                    )
+                    raise PhysicalRunActivationError(
+                        "definitive landing rejection did not restore physical state"
+                    )
+                sequence.release_unemitted(claim)
+            else:
+                sequence.mark_ambiguous(
+                    claim,
+                    "trusted landing transport returned an indeterminate result",
+                )
+                raise PhysicalRunActivationError(
+                    "trusted landing transport returned no definitive acknowledgement"
+                )
+            return result
+
+        def execute_next_inflight(self):
+            """Advance the exact next move/turn/land; accepts no caller semantics."""
+            effect_kind = sequence.next_effect_kind
+            if effect_kind == "motion":
+                return self._execute_motion()
+            if effect_kind == "landing":
+                return self._execute_terminal_landing()
+            raise PhysicalRunActivationError(
+                "authorized physical program is already causally complete"
+            )
 
         def shutdown(self) -> None:
             yaw_error = None


### PR DESCRIPTION
Implements the remaining deterministic #304 terminal-landing composition on top of the integrated exact-program physical host.

The new `TrustedControlledLandingTransport` reuses the #276 SETPOINT_HL trust root but emits only the command-10 request already derived by #305 from the exact teacher-bound canonical AST. `send_controlled_landing()` accepts no caller semantics. Inside the shared #273 effect exclusion it reasserts fresh host-owned #278/#249 current-program provenance, the exact #267 teacher binding, #266/#262 powered-session/watchdog identity, fresh #257 finished-flight evidence, one #264 pre-land baseline and #272 SafeLink, then installs the #271 acknowledgement callback before exactly one plain no-retry packet send.

A zero firmware result is not treated as landing completion. The accepted effect's private #279 permit is consumed only after the #264 observer sees a later fresh same-epoch non-flying, high-level-inactive, trajectory-finished state while the watchdog remains live; only then does the shared execution domain transition to `inactive`. A definitive firmware rejection restores `flying` without advancing the exact program. Ambiguous send/ack/completion state requires recovery and makes the #295 sequence terminal rather than creating an application retry.

`PhysicalProgramSequence.next_effect_kind` exposes only whether the immutable exact cursor points to a motion, terminal land or completion. The production host keeps the existing parameter-free `execute-next-inflight` IPC surface and now consumes the exact terminal landing only after every prior move/turn completed. Caller-supplied landing fields are rejected by the same strict IPC shape, and a completed landing advances the terminal sequence exactly once.

Deterministic tests cover command-10 packet bytes, callback-before-one-send, absence of retry/caller landing parameters, current-program mutation before effect, definitive rejection, acknowledgement ambiguity, completion ambiguity, transition to inactive, and the actual production-host sequence `takeoff -> turn -> move -> land` with fake hardware seams. The existing Runtime core CI path runs the new transport regression; no workflow, physical action or new authority surface is introduced.

No motorized checkpoint is required or authorized by this change.

Closes #304. Refs #157 #264 #276 #295 #305.