### PR TITLE
Support exact no-effect physical wait pacing

### DIFF
--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import importlib.util
-import io
 import json
+import os
 from pathlib import Path
+import runpy
 import socket
 import sys
-import threading
+from threading import Thread
 from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
 PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(CI))
 sys.path.insert(0, str(PHYSICAL))
+HOST = PHYSICAL / "serve_physical_host.py"
 
-import physical_program_sequence as sequence  # noqa: E402
-import physical_run_activation as activation  # noqa: E402
+import controlled_landing_transport  # noqa: E402
+import setpoint_hl_transport  # noqa: E402
+import test_physical_controlled_landing_transport as landing_effect_test  # noqa: E402
+import test_physical_host_activation as base  # noqa: E402
+import yaw_observer  # noqa: E402
+
+REAL_EXACT_WAIT = base.activation._execute_exact_wait
 
 
 def require(condition: bool, message: str) -> None:
@@ -23,26 +31,16 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
-def load_host_module():
-    spec = importlib.util.spec_from_file_location(
-        "run_physical_host_test", PHYSICAL / "run_physical_host.py"
-    )
-    if spec is None or spec.loader is None:
-        raise AssertionError("cannot load physical host module")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-host = load_host_module()
-base = host.base
-REAL_EXACT_WAIT = activation._execute_exact_wait
-
-
-def canonical(program: list[dict[str, object]]) -> str:
+def canonical_ast(final_statement: dict[str, object] | None = None) -> str:
+    final = {"kind": "land"} if final_statement is None else final_statement
     return json.dumps(
         {
-            "program": program,
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {"angle_deg": -25, "kind": "turn"},
+                {"direction": "forward", "distance_m": 0.3, "kind": "move"},
+                final,
+            ],
             "semantics": "webeeblocks-ast-v1",
             "version": 1,
         },
@@ -51,203 +49,225 @@ def canonical(program: list[dict[str, object]]) -> str:
     )
 
 
-def wait_ast(seconds: object = 0.12) -> str:
-    return canonical(
-        [
-            {"kind": "takeoff", "height_m": 0.8},
-            {"kind": "wait", "seconds": seconds},
-            {"kind": "land"},
-        ]
+def boundary_only_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.6, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
     )
 
 
-def motion_ast() -> str:
-    return canonical(
-        [
-            {"kind": "takeoff", "height_m": 0.8},
-            {"kind": "move", "direction": "forward", "distance_m": 0.3},
-            {"kind": "turn", "angle_deg": 45},
-            {"kind": "land"},
-        ]
+def wait_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.6, "kind": "takeoff"},
+                {"kind": "wait", "seconds": 0.2},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
     )
 
 
-def send_line(sock: socket.socket, payload: object) -> None:
-    sock.sendall((json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode())
+class FakeYawObserver:
+    def __init__(self, crazyflie: object, epoch_reader) -> None:
+        self.bound_crazyflie = crazyflie
+        self._epoch_reader = epoch_reader
+        self.bound_connection_epoch = epoch_reader()
+        self.is_open = False
+
+    def open(self) -> None:
+        require(self._epoch_reader() == self.bound_connection_epoch, "yaw opens on exact epoch")
+        self.is_open = True
+        base.EVENTS.append(("yaw-open", self.bound_connection_epoch))
+
+    def close(self) -> None:
+        if self.is_open:
+            base.EVENTS.append(("yaw-close", self.bound_connection_epoch))
+        self.is_open = False
+
+
+class FakePhysicalTransportBase:
+    def __init__(
+        self,
+        *,
+        crazyflie: object,
+        execution_domain: object,
+        acknowledgement_domain: object,
+        safelink_guard: object,
+        teacher_authorization: object,
+        powered_session: object,
+        watchdog_guard: object,
+        supervisor_reader: object,
+        connection_epoch_reader=None,
+    ) -> None:
+        del acknowledgement_domain, safelink_guard, supervisor_reader
+        require(powered_session.session is crazyflie, "physical effect exact powered session")
+        require(execution_domain.phase == base.physical_execution_domain.FLYING, "takeoff must complete first")
+        if connection_epoch_reader is not None:
+            require(
+                connection_epoch_reader() == powered_session.connection_epoch,
+                "landing completion observer must bind exact active epoch",
+            )
+        self.teacher_binding = teacher_authorization.binding
+        self.bound_connection_epoch = powered_session.connection_epoch
+        self.execution_domain = execution_domain
+        self._crazyflie = crazyflie
+        self._watchdog = watchdog_guard
+
+    def _read_current_binding(self):
+        raise AssertionError("host-local provenance override is required")
+
+    def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
+        del timing_policy
+        require(yaw_reader is not None and yaw_reader.is_open, "fresh yaw observer must be opened lazily for moves")
+        require(yaw_reader.bound_crazyflie is self._crazyflie, "yaw exact Crazyflie")
+        require(self._watchdog.active, "same-session watchdog remains live")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact teacher run")
+        base.EVENTS.append(("inflight-move", direction, distance_m, binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0)
+
+    def send_turn(self, *, angle_deg, timing_policy):
+        del timing_policy
+        require(self._watchdog.active, "same-session watchdog remains live")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact teacher run")
+        base.EVENTS.append(("inflight-turn", angle_deg, binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0)
+
+    def send_controlled_landing(self):
+        require(self._watchdog.active, "watchdog must remain live through controlled landing")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact terminal landing")
+        require(
+            self.execution_domain.phase == base.physical_execution_domain.FLYING,
+            "terminal landing starts only from causally established flying",
+        )
+        base.EVENTS.append(("terminal-land", binding.connection_epoch))
+        self.execution_domain.phase = base.physical_execution_domain.INACTIVE
+        return SimpleNamespace(accepted=True, status=0)
+
+
+def fake_exact_wait(seconds, watchdog_guard, connection_epoch_reader, bound_epoch):
+    require(seconds == 0.2, "production wait derives exact canonical duration")
+    require(watchdog_guard.active, "watchdog stays live across exact no-effect wait")
+    require(connection_epoch_reader() == bound_epoch, "wait stays on exact active epoch")
+    base.EVENTS.append(("exact-wait", seconds, bound_epoch))
+
+
+def install_fakes() -> None:
+    base.install_fakes()
+    base.activation.TrustedControlledLandingTransport = FakePhysicalTransportBase
+    base.activation.FreshYawObserver = FakeYawObserver
+    base.activation._execute_exact_wait = fake_exact_wait
+    controlled_landing_transport.TrustedControlledLandingTransport = FakePhysicalTransportBase
+    setpoint_hl_transport.TrustedSetpointHlTransport = FakePhysicalTransportBase
+    yaw_observer.FreshYawObserver = FakeYawObserver
+
+
+def send_line(sock: socket.socket, payload: dict[str, object]) -> None:
+    sock.sendall((json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8"))
 
 
 def read_line(stream) -> dict[str, object]:
-    raw = stream.readline()
-    if not raw:
-        raise AssertionError("unexpected EOF from host")
-    return json.loads(raw)
+    line = stream.readline()
+    require(bool(line), "physical host closed caller channel unexpectedly")
+    value = json.loads(line)
+    require(isinstance(value, dict), "caller response must be an object")
+    return value
 
 
-class FakeBridge:
-    def __init__(self, binding: base.PhysicalRunBinding) -> None:
-        self.binding = binding
-        self.events: list[str] = []
-
-    def assert_current_program(self, **kwargs):
-        self.events.append("assert")
-        require(kwargs["profile_id"] == self.binding.profile_id, "profile drift")
-        require(kwargs["ast_binding"] == self.binding.ast_binding, "AST drift")
-        require(kwargs["connection_epoch"] == self.binding.connection_epoch, "epoch drift")
-        return base.CurrentProgramPreflightEvidence(
-            profile_id=self.binding.profile_id,
-            ast_binding=self.binding.ast_binding,
-            connection_epoch=self.binding.connection_epoch,
-            execution_authority=False,
-            challenge_id="challenge",
-        )
-
-    def begin_post_reset_replacement(self, epoch: str) -> None:
-        self.events.append("begin-replacement")
-
-    def install_post_reset_session(self, session: object) -> str:
-        self.events.append("install-replacement")
-        self.binding = base.PhysicalRunBinding(
-            profile_id=self.binding.profile_id,
-            ast_binding=self.binding.ast_binding,
-            connection_epoch=session.read_connection_epoch(),
-        )
-        return self.binding.connection_epoch
-
-
-class FakeSession:
-    def __init__(self, binding: base.PhysicalRunBinding) -> None:
-        self.epoch = binding.connection_epoch
-        self.opened = True
-        self.events: list[str] = []
-        self.cf = SimpleNamespace()
-        self._scf = SimpleNamespace(is_link_open=lambda: self.opened, cf=self.cf)
-
-    def read_connection_epoch(self) -> str:
-        return self.epoch
-
-    def read_capabilities(self):
-        return SimpleNamespace()
-
-    def close(self) -> None:
-        self.events.append("close")
-        self.opened = False
-
-    def open(self) -> None:
-        self.events.append("open")
-        self.opened = True
-        self.epoch = "epoch-post-reset"
-
-
-class FakeExecutionDomain:
-    pass
-
-
-def make_binding(ast_binding: str) -> base.PhysicalRunBinding:
-    return base.PhysicalRunBinding(
-        profile_id="progression-1",
-        ast_binding=ast_binding,
-        connection_epoch="epoch-pre-reset",
-    )
-
-
-def production_host_roundtrip(ast_binding: str, *, steps: int) -> list[dict[str, object]]:
-    binding = make_binding(ast_binding)
-    bridge = FakeBridge(binding)
-    session = FakeSession(binding)
-    teacher_host, teacher_peer = socket.socketpair()
+def run_host_sequence(
+    ast_binding: str | None = None,
+    *,
+    steps: int = 3,
+) -> list[dict[str, object]]:
     caller_host, caller_peer = socket.socketpair()
-    caller_stream = caller_peer.makefile("r", encoding="utf-8", newline="\n")
+    caller_stream = caller_peer.makefile("r", encoding="utf-8")
+    browser_read, browser_write = os.pipe()
+    teacher_host, teacher_peer = socket.socketpair()
+
+    argv = [
+        str(HOST),
+        "--uri",
+        "radio://0/80/2M/E7E7E7E7E7",
+        "--caller-fd",
+        str(caller_host.detach()),
+        "--browser-config-fd",
+        str(browser_write),
+        "--teacher-fd",
+        str(teacher_host.detach()),
+    ]
     outcome: dict[str, object] = {}
+    old_argv = sys.argv[:]
 
-    class FakeActivatedController:
-        def __init__(self) -> None:
-            self.domain = sequence.PhysicalProgramSequence(ast_binding)
-            self.closed = False
+    def target() -> None:
+        sys.argv = argv
+        try:
+            runpy.run_path(str(HOST), run_name="__main__")
+        except Exception as exc:
+            outcome["error"] = exc
+        finally:
+            sys.argv = old_argv
 
-        def execute_next_inflight(self):
-            kind = self.domain.next_step_kind
-            if kind == "wait":
-                claim = self.domain.reserve_next_wait()
-                self.domain.complete_wait(claim)
-                return activation._NoEffectStepResult()
-            if kind in ("move", "turn"):
-                claim = self.domain.reserve_next_motion()
-                self.domain.complete_motion(claim)
-                return SimpleNamespace(accepted=True, emitted=True)
-            if kind == "land":
-                claim = self.domain.reserve_terminal_landing()
-                self.domain.complete_landing(claim)
-                return SimpleNamespace(accepted=True, emitted=True)
-            raise AssertionError("unexpected next kind " + repr(kind))
+    worker = Thread(target=target, daemon=True)
+    worker.start()
+    with os.fdopen(browser_read, "r", encoding="utf-8") as stream:
+        bootstrap = json.loads(stream.readline())
+    require(bootstrap["executionAuthority"] is False, "browser bootstrap remains non-authority")
 
-        def shutdown(self) -> None:
-            self.closed = True
+    send_line(
+        caller_peer,
+        {
+            "op": "validate-run-context",
+            "requestId": "validate-1",
+            "profileId": "activity-1",
+            "astBinding": canonical_ast() if ast_binding is None else ast_binding,
+            "connectionEpoch": "epoch-before",
+        },
+    )
+    replies = [read_line(caller_stream)]
 
-    activated = FakeActivatedController()
+    # Any caller-selected step semantics, including a wait duration, are rejected.
+    send_line(
+        caller_peer,
+        {
+            "op": "execute-next-inflight",
+            "requestId": "substitute-1",
+            "direction": "right",
+            "distanceM": 0.9,
+            "seconds": 5.0,
+        },
+    )
+    replies.append(read_line(caller_stream))
 
-    def fake_activate_validated_run(**kwargs):
-        require(kwargs["staged_binding"] == binding, "host must preserve staged exact binding")
-        return activated
-
-    original_activate = host.base.activate_validated_run
-    host.base.activate_validated_run = fake_activate_validated_run
-    try:
-        worker = threading.Thread(
-            target=lambda: outcome.setdefault(
-                "value",
-                host._serve_validated_run(
-                    uri="radio://0/80/2M/E7E7E7E7E7",
-                    validated_binding=binding,
-                    bridge=bridge,
-                    teacher_socket=teacher_host,
-                    caller_socket=caller_host,
-                    session=session,
-                    execution_domain=SimpleNamespace(),
-                ),
-            ),
-            daemon=True,
-        )
-        worker.start()
-        replies: list[dict[str, object]] = []
+    for index in range(steps):
         send_line(
             caller_peer,
-            {
-                "op": "activate-run",
-                "profileId": "caller-forged-profile",
-                "astBinding": canonical(
-                    [
-                        {"kind": "takeoff", "height_m": 1.5},
-                        {"kind": "wait", "seconds": 5.0},
-                        {"kind": "land"},
-                    ]
-                ),
-                "connectionEpoch": "caller-forged-epoch",
-                "direction": "left",
-                "distanceM": 0.9,
-                "seconds": 5.0,
-            },
+            {"op": "execute-next-inflight", "requestId": f"step-{index + 1}"},
         )
         replies.append(read_line(caller_stream))
 
-        for index in range(steps):
-            send_line(
-                caller_peer,
-                {"op": "execute-next-inflight", "requestId": f"step-{index + 1}"},
-            )
-            replies.append(read_line(caller_stream))
+    caller_peer.shutdown(socket.SHUT_WR)
+    worker.join(timeout=3.0)
+    require(not worker.is_alive(), "actual production host must terminate after caller EOF")
+    require("error" not in outcome, "production host failed: " + repr(outcome.get("error")))
 
-        caller_peer.shutdown(socket.SHUT_WR)
-        worker.join(timeout=3.0)
-        require(not worker.is_alive(), "actual production host must terminate after caller EOF")
-        require("error" not in outcome, "production host failed: " + repr(outcome.get("error")))
-        require(activated.closed, "production host must close activated controller on EOF")
-    finally:
-        host.base.activate_validated_run = original_activate
-        caller_stream.close()
-        caller_peer.close()
-        teacher_peer.close()
-        teacher_host.close()
-        caller_host.close()
+    caller_stream.close()
+    caller_peer.close()
+    teacher_peer.close()
     return replies
 
 
@@ -281,7 +301,7 @@ def test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface() -> None:
         clock=clock,
         sleeper=clock.sleep,
     )
-    require(clock.value >= 10.0 + 0.12, "wait cannot complete before its monotonic deadline")
+    require(sum(clock.sleeps) >= 0.12, "wait cannot complete before full exact duration")
     require(all(0 < value <= 0.05 for value in clock.sleeps), "wait checks liveness in bounded slices")
     require(guard.assertions >= 3, "watchdog liveness is checked throughout exact wait")
 
@@ -308,67 +328,166 @@ def test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface() -> None:
 
     source = (PHYSICAL / "physical_run_activation.py").read_text(encoding="utf-8")
     helper = source[source.index("def _execute_exact_wait("):source.index("def _live_crazyflie(")]
-    for forbidden in (
-        "send_packet(",
-        "HighLevelCommander(",
-        "send_setpoint",
-        "send_extpos",
-        "acknowledgement",
-        "reserve_effect",
-    ):
-        require(forbidden not in helper, "wait helper leaked physical effect surface: " + forbidden)
+    for forbidden in ("send_packet(", "HighLevelCommander(", "effect_transaction(", "acknowledgement"):
+        require(forbidden not in helper, "no-effect wait leaked physical effect surface: " + forbidden)
 
 
-def test_wait_failure_does_not_advance_exact_sequence() -> None:
-    domain = sequence.PhysicalProgramSequence(wait_ast())
-    claim = domain.reserve_next_wait()
-    domain.fail_wait(claim, "trusted wait interrupted")
-    require(domain.terminal, "failed trusted wait must make exact sequence terminal")
-    require(domain.next_index == 1, "failed wait cannot skip into terminal landing")
-    require(not domain.completed, "failed wait cannot manufacture program completion")
+def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
+    source = HOST.read_text(encoding="utf-8")
+    wait = 'if activation_state["started"]:\n                                    activation_complete.wait()'
+    require(wait in source, "started activation must be awaited before physical availability is decided")
+    wait_index = source.index(wait)
+    lock_index = source.find("with lifecycle_lock:", wait_index)
+    require(lock_index > wait_index, "activation wait must happen before reacquiring lifecycle lock")
+    require(
+        'finally:\n                    activation_complete.set()' in source,
+        "every started activation path must release the host wait",
+    )
 
 
-def test_actual_host_accepts_no_caller_wait_semantics() -> None:
-    source = (PHYSICAL / "run_physical_host.py").read_text(encoding="utf-8")
-    require('operation == "execute-next-inflight"' in source, "host must expose one parameter-free next-step operation")
-    require('set(message) != {"op", "requestId"}' in source, "host must reject caller-selected next-step semantics")
-    for forbidden in ("waitSeconds", "wait_seconds", "durationSeconds"):
-        require(forbidden not in source, "caller-selected wait semantic entered production host: " + forbidden)
+def test_actual_host_completes_exact_program_with_terminal_landing() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    replies = run_host_sequence()
+
+    require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation stays diagnostic")
+    require(replies[1]["ok"] is False, "caller-supplied step fields must be rejected")
+    require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
+    require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
+    require(replies[4] == {"executionAuthority": False, "ok": True, "requestId": "step-3"}, "exact terminal landing completes")
+
+    move_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-move"]
+    turn_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-turn"]
+    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
+    require(
+        turn_events == [("inflight-turn", -25.0, "epoch-after")],
+        "caller substitution must not change the exact first authorized effect",
+    )
+    require(
+        move_events == [("inflight-move", "forward", 0.3, "epoch-after")],
+        "second physical effect must follow exact canonical AST order",
+    )
+    require(
+        land_events == [("terminal-land", "epoch-after")],
+        "exact terminal landing must execute once on the same authorized epoch",
+    )
+
+    takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
+    turn_index = base.EVENTS.index(turn_events[0])
+    yaw_open_index = base.EVENTS.index(("yaw-open", "epoch-after"))
+    move_index = base.EVENTS.index(move_events[0])
+    land_index = base.EVENTS.index(land_events[0])
+    require(
+        takeoff_index < turn_index < yaw_open_index < move_index < land_index,
+        "takeoff, exact motions and terminal landing must preserve canonical order",
+    )
+    require(
+        any(event == ("current-program", "epoch-after") for event in base.EVENTS[takeoff_index:turn_index]),
+        "fresh host-local #278/#249 must guard the first post-takeoff effect",
+    )
+    require(("yaw-close", "epoch-after") in base.EVENTS, "host teardown closes #260 observer")
 
 
-def test_actual_production_host_wait_composition() -> None:
-    replies = production_host_roundtrip(wait_ast(0.4), steps=2)
-    require(replies[0]["status"] == "activated", "host must activate exact teacher-bound run")
-    require(replies[1] == {"emitted": False, "ok": True, "requestId": "step-1"}, "wait must report no emitted effect")
-    require(replies[2] == {"emitted": True, "ok": True, "requestId": "step-2"}, "terminal land remains the next exact emitted effect")
+def test_boundary_only_program_lands_without_opening_yaw() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    replies = run_host_sequence(boundary_only_ast(), steps=1)
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "terminal land follows takeoff directly")
+    require(
+        [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
+        == [("terminal-land", "epoch-after")],
+        "boundary-only program consumes exactly one terminal landing",
+    )
+    require(
+        not any(isinstance(event, tuple) and event[0] == "yaw-open" for event in base.EVENTS),
+        "terminal landing must not create a yaw-observer dependency",
+    )
 
 
-def test_existing_motion_and_landing_composition_remain_emitted() -> None:
-    replies = production_host_roundtrip(motion_ast(), steps=3)
-    require(replies[1]["emitted"] is True, "move remains an emitted effect")
-    require(replies[2]["emitted"] is True, "turn remains an emitted effect")
-    require(replies[3]["emitted"] is True, "terminal landing remains an emitted effect")
+def test_actual_host_consumes_exact_wait_without_effect_transport() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    replies = run_host_sequence(wait_ast(), steps=2)
+    require(replies[1]["ok"] is False, "caller-supplied wait duration must be rejected")
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact wait completes")
+    require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "land follows exact wait")
+    wait_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "exact-wait"]
+    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
+    require(wait_events == [("exact-wait", 0.2, "epoch-after")], "host waits exact canonical duration once")
+    require(land_events == [("terminal-land", "epoch-after")], "terminal landing follows wait exactly once")
+    require(
+        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move", "yaw-open"} for event in base.EVENTS),
+        "no-effect wait must not manufacture motion or yaw dependencies",
+    )
+    takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
+    wait_index = base.EVENTS.index(wait_events[0])
+    land_index = base.EVENTS.index(land_events[0])
+    require(takeoff_index < wait_index < land_index, "takeoff/wait/land preserve exact AST order")
+    current_program_events = [event for event in base.EVENTS if event == ("current-program", "epoch-after")]
+    require(len(current_program_events) >= 3, "wait and later landing each re-establish current-program provenance")
 
 
-def test_activated_run_dispatches_wait_without_effect_transport() -> None:
-    source = (PHYSICAL / "physical_run_activation.py").read_text(encoding="utf-8")
-    require('if next_kind == "wait":' in source, "activated run must dispatch exact wait distinctly")
-    require("sequence.reserve_next_wait()" in source, "wait must derive claim from exact sequence")
-    require("sequence.complete_wait(claim)" in source, "full wait completion must advance exact sequence")
-    require("sequence.fail_wait(claim" in source, "interrupted wait must terminalize exact sequence")
-    require("return _NoEffectStepResult()" in source, "wait must return explicit no-effect marker")
+def test_incomplete_host_wait_fails_closed_without_landing() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    prior = base.activation._execute_exact_wait
+
+    def fail_wait(seconds, watchdog_guard, connection_epoch_reader, bound_epoch):
+        del seconds, watchdog_guard, connection_epoch_reader, bound_epoch
+        raise base.activation.PhysicalRunActivationError("injected wait interruption")
+
+    base.activation._execute_exact_wait = fail_wait
+    try:
+        replies = run_host_sequence(wait_ast(), steps=2)
+    finally:
+        base.activation._execute_exact_wait = prior
+    require(replies[2]["ok"] is False, "interrupted wait must fail closed")
+    require(replies[3]["ok"] is False, "terminal sequence cannot advance after failed wait")
+    require(
+        not any(isinstance(event, tuple) and event[0] == "terminal-land" for event in base.EVENTS),
+        "failed wait must not be skipped into terminal landing",
+    )
+
+
+def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    malformed = canonical_ast({"kind": "land", "extra": True})
+    replies = run_host_sequence(malformed)
+
+    require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation remains diagnostic before activation")
+    require(replies[2]["ok"] is False, "malformed terminal must make exact activation unavailable")
+    require(
+        ("transport-send", "epoch-after") not in base.EVENTS,
+        "malformed terminal must be rejected before the takeoff effect",
+    )
+    require(
+        not any(
+            isinstance(event, tuple)
+            and event[0] in {"inflight-turn", "inflight-move", "exact-wait", "terminal-land"}
+            for event in base.EVENTS
+        ),
+        "malformed terminal must never be skipped into a physical step",
+    )
 
 
 def main() -> int:
+    require(
+        landing_effect_test.main() == 0,
+        "trusted controlled-landing transport regression must pass before host composition",
+    )
     test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface()
-    test_wait_failure_does_not_advance_exact_sequence()
-    test_actual_host_accepts_no_caller_wait_semantics()
-    test_actual_production_host_wait_composition()
-    test_existing_motion_and_landing_composition_remain_emitted()
-    test_activated_run_dispatches_wait_without_effect_transport()
+    test_started_activation_wait_is_outside_lifecycle_lock()
+    test_actual_host_completes_exact_program_with_terminal_landing()
+    test_boundary_only_program_lands_without_opening_yaw()
+    test_actual_host_consumes_exact_wait_without_effect_transport()
+    test_incomplete_host_wait_fails_closed_without_landing()
+    test_actual_host_rejects_malformed_terminal_before_takeoff()
     print(
-        "PASS actual physical-host exact-program in-flight composition preserves no-effect wait pacing, "
-        "watchdog/epoch liveness, caller non-authority, and existing emitted move/turn/land semantics"
+        "PASS actual physical host sequencing: validated takeoff preserves exact ordered move/turn, "
+        "no-effect wait pacing and one terminal controlled landing; wait keeps watchdog/epoch/current-program "
+        "guards live without emitting a flight command, and incomplete waits fail closed"
     )
     return 0
 

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -1,29 +1,21 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import importlib.util
+import io
 import json
-import os
 from pathlib import Path
-import runpy
 import socket
 import sys
-from threading import Thread
+import threading
 from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[2]
-CI = ROOT / "tools" / "ci"
 PHYSICAL = ROOT / "tools" / "physical"
-sys.path.insert(0, str(CI))
 sys.path.insert(0, str(PHYSICAL))
-HOST = PHYSICAL / "serve_physical_host.py"
 
-import controlled_landing_transport  # noqa: E402
-import setpoint_hl_transport  # noqa: E402
-import test_physical_controlled_landing_transport as landing_effect_test  # noqa: E402
-import test_physical_host_activation as base  # noqa: E402
-import yaw_observer  # noqa: E402
-
-REAL_EXACT_WAIT = base.activation._execute_exact_wait
+import physical_program_sequence as sequence  # noqa: E402
+import physical_run_activation as activation  # noqa: E402
 
 
 def require(condition: bool, message: str) -> None:
@@ -31,16 +23,26 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
-def canonical_ast(final_statement: dict[str, object] | None = None) -> str:
-    final = {"kind": "land"} if final_statement is None else final_statement
+def load_host_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_physical_host_test", PHYSICAL / "run_physical_host.py"
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("cannot load physical host module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+host = load_host_module()
+base = host.base
+REAL_EXACT_WAIT = activation._execute_exact_wait
+
+
+def canonical(program: list[dict[str, object]]) -> str:
     return json.dumps(
         {
-            "program": [
-                {"height_m": 0.8, "kind": "takeoff"},
-                {"angle_deg": -25, "kind": "turn"},
-                {"direction": "forward", "distance_m": 0.3, "kind": "move"},
-                final,
-            ],
+            "program": program,
             "semantics": "webeeblocks-ast-v1",
             "version": 1,
         },
@@ -49,225 +51,203 @@ def canonical_ast(final_statement: dict[str, object] | None = None) -> str:
     )
 
 
-def boundary_only_ast() -> str:
-    return json.dumps(
-        {
-            "program": [
-                {"height_m": 0.6, "kind": "takeoff"},
-                {"kind": "land"},
-            ],
-            "semantics": "webeeblocks-ast-v1",
-            "version": 1,
-        },
-        separators=(",", ":"),
-        sort_keys=True,
+def wait_ast(seconds: object = 0.12) -> str:
+    return canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "wait", "seconds": seconds},
+            {"kind": "land"},
+        ]
     )
 
 
-def wait_ast() -> str:
-    return json.dumps(
-        {
-            "program": [
-                {"height_m": 0.6, "kind": "takeoff"},
-                {"kind": "wait", "seconds": 0.2},
-                {"kind": "land"},
-            ],
-            "semantics": "webeeblocks-ast-v1",
-            "version": 1,
-        },
-        separators=(",", ":"),
-        sort_keys=True,
+def motion_ast() -> str:
+    return canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "move", "direction": "forward", "distance_m": 0.3},
+            {"kind": "turn", "angle_deg": 45},
+            {"kind": "land"},
+        ]
     )
 
 
-class FakeYawObserver:
-    def __init__(self, crazyflie: object, epoch_reader) -> None:
-        self.bound_crazyflie = crazyflie
-        self._epoch_reader = epoch_reader
-        self.bound_connection_epoch = epoch_reader()
-        self.is_open = False
-
-    def open(self) -> None:
-        require(self._epoch_reader() == self.bound_connection_epoch, "yaw opens on exact epoch")
-        self.is_open = True
-        base.EVENTS.append(("yaw-open", self.bound_connection_epoch))
-
-    def close(self) -> None:
-        if self.is_open:
-            base.EVENTS.append(("yaw-close", self.bound_connection_epoch))
-        self.is_open = False
-
-
-class FakePhysicalTransportBase:
-    def __init__(
-        self,
-        *,
-        crazyflie: object,
-        execution_domain: object,
-        acknowledgement_domain: object,
-        safelink_guard: object,
-        teacher_authorization: object,
-        powered_session: object,
-        watchdog_guard: object,
-        supervisor_reader: object,
-        connection_epoch_reader=None,
-    ) -> None:
-        del acknowledgement_domain, safelink_guard, supervisor_reader
-        require(powered_session.session is crazyflie, "physical effect exact powered session")
-        require(execution_domain.phase == base.physical_execution_domain.FLYING, "takeoff must complete first")
-        if connection_epoch_reader is not None:
-            require(
-                connection_epoch_reader() == powered_session.connection_epoch,
-                "landing completion observer must bind exact active epoch",
-            )
-        self.teacher_binding = teacher_authorization.binding
-        self.bound_connection_epoch = powered_session.connection_epoch
-        self.execution_domain = execution_domain
-        self._crazyflie = crazyflie
-        self._watchdog = watchdog_guard
-
-    def _read_current_binding(self):
-        raise AssertionError("host-local provenance override is required")
-
-    def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
-        del timing_policy
-        require(yaw_reader is not None and yaw_reader.is_open, "fresh yaw observer must be opened lazily for moves")
-        require(yaw_reader.bound_crazyflie is self._crazyflie, "yaw exact Crazyflie")
-        require(self._watchdog.active, "same-session watchdog remains live")
-        binding = self._read_current_binding()
-        require(binding == self.teacher_binding, "fresh #249 matches exact teacher run")
-        base.EVENTS.append(("inflight-move", direction, distance_m, binding.connection_epoch))
-        return SimpleNamespace(accepted=True, status=0)
-
-    def send_turn(self, *, angle_deg, timing_policy):
-        del timing_policy
-        require(self._watchdog.active, "same-session watchdog remains live")
-        binding = self._read_current_binding()
-        require(binding == self.teacher_binding, "fresh #249 matches exact teacher run")
-        base.EVENTS.append(("inflight-turn", angle_deg, binding.connection_epoch))
-        return SimpleNamespace(accepted=True, status=0)
-
-    def send_controlled_landing(self):
-        require(self._watchdog.active, "watchdog must remain live through controlled landing")
-        binding = self._read_current_binding()
-        require(binding == self.teacher_binding, "fresh #249 matches exact terminal landing")
-        require(
-            self.execution_domain.phase == base.physical_execution_domain.FLYING,
-            "terminal landing starts only from causally established flying",
-        )
-        base.EVENTS.append(("terminal-land", binding.connection_epoch))
-        self.execution_domain.phase = base.physical_execution_domain.INACTIVE
-        return SimpleNamespace(accepted=True, status=0)
-
-
-def fake_exact_wait(seconds, watchdog_guard, connection_epoch_reader, bound_epoch):
-    require(seconds == 0.2, "production wait derives exact canonical duration")
-    require(watchdog_guard.active, "watchdog stays live across exact no-effect wait")
-    require(connection_epoch_reader() == bound_epoch, "wait stays on exact active epoch")
-    base.EVENTS.append(("exact-wait", seconds, bound_epoch))
-
-
-def install_fakes() -> None:
-    base.install_fakes()
-    base.activation.TrustedControlledLandingTransport = FakePhysicalTransportBase
-    base.activation.FreshYawObserver = FakeYawObserver
-    base.activation._execute_exact_wait = fake_exact_wait
-    controlled_landing_transport.TrustedControlledLandingTransport = FakePhysicalTransportBase
-    setpoint_hl_transport.TrustedSetpointHlTransport = FakePhysicalTransportBase
-    yaw_observer.FreshYawObserver = FakeYawObserver
-
-
-def send_line(sock: socket.socket, payload: dict[str, object]) -> None:
-    sock.sendall((json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8"))
+def send_line(sock: socket.socket, payload: object) -> None:
+    sock.sendall((json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode())
 
 
 def read_line(stream) -> dict[str, object]:
-    line = stream.readline()
-    require(bool(line), "physical host closed caller channel unexpectedly")
-    value = json.loads(line)
-    require(isinstance(value, dict), "caller response must be an object")
-    return value
+    raw = stream.readline()
+    if not raw:
+        raise AssertionError("unexpected EOF from host")
+    return json.loads(raw)
 
 
-def run_host_sequence(
-    ast_binding: str | None = None,
-    *,
-    steps: int = 3,
-) -> list[dict[str, object]]:
-    caller_host, caller_peer = socket.socketpair()
-    caller_stream = caller_peer.makefile("r", encoding="utf-8")
-    browser_read, browser_write = os.pipe()
+class FakeBridge:
+    def __init__(self, binding: base.PhysicalRunBinding) -> None:
+        self.binding = binding
+        self.events: list[str] = []
+
+    def assert_current_program(self, **kwargs):
+        self.events.append("assert")
+        require(kwargs["profile_id"] == self.binding.profile_id, "profile drift")
+        require(kwargs["ast_binding"] == self.binding.ast_binding, "AST drift")
+        require(kwargs["connection_epoch"] == self.binding.connection_epoch, "epoch drift")
+        return base.CurrentProgramPreflightEvidence(
+            profile_id=self.binding.profile_id,
+            ast_binding=self.binding.ast_binding,
+            connection_epoch=self.binding.connection_epoch,
+            execution_authority=False,
+            challenge_id="challenge",
+        )
+
+    def begin_post_reset_replacement(self, epoch: str) -> None:
+        self.events.append("begin-replacement")
+
+    def install_post_reset_session(self, session: object) -> str:
+        self.events.append("install-replacement")
+        self.binding = base.PhysicalRunBinding(
+            profile_id=self.binding.profile_id,
+            ast_binding=self.binding.ast_binding,
+            connection_epoch=session.read_connection_epoch(),
+        )
+        return self.binding.connection_epoch
+
+
+class FakeSession:
+    def __init__(self, binding: base.PhysicalRunBinding) -> None:
+        self.epoch = binding.connection_epoch
+        self.opened = True
+        self.events: list[str] = []
+        self.cf = SimpleNamespace()
+        self._scf = SimpleNamespace(is_link_open=lambda: self.opened, cf=self.cf)
+
+    def read_connection_epoch(self) -> str:
+        return self.epoch
+
+    def read_capabilities(self):
+        return SimpleNamespace()
+
+    def close(self) -> None:
+        self.events.append("close")
+        self.opened = False
+
+    def open(self) -> None:
+        self.events.append("open")
+        self.opened = True
+        self.epoch = "epoch-post-reset"
+
+
+class FakeExecutionDomain:
+    pass
+
+
+def make_binding(ast_binding: str) -> base.PhysicalRunBinding:
+    return base.PhysicalRunBinding(
+        profile_id="progression-1",
+        ast_binding=ast_binding,
+        connection_epoch="epoch-pre-reset",
+    )
+
+
+def production_host_roundtrip(ast_binding: str, *, steps: int) -> list[dict[str, object]]:
+    binding = make_binding(ast_binding)
+    bridge = FakeBridge(binding)
+    session = FakeSession(binding)
     teacher_host, teacher_peer = socket.socketpair()
-
-    argv = [
-        str(HOST),
-        "--uri",
-        "radio://0/80/2M/E7E7E7E7E7",
-        "--caller-fd",
-        str(caller_host.detach()),
-        "--browser-config-fd",
-        str(browser_write),
-        "--teacher-fd",
-        str(teacher_host.detach()),
-    ]
+    caller_host, caller_peer = socket.socketpair()
+    caller_stream = caller_peer.makefile("r", encoding="utf-8", newline="\n")
     outcome: dict[str, object] = {}
-    old_argv = sys.argv[:]
 
-    def target() -> None:
-        sys.argv = argv
-        try:
-            runpy.run_path(str(HOST), run_name="__main__")
-        except Exception as exc:
-            outcome["error"] = exc
-        finally:
-            sys.argv = old_argv
+    class FakeActivatedController:
+        def __init__(self) -> None:
+            self.domain = sequence.PhysicalProgramSequence(ast_binding)
+            self.closed = False
 
-    worker = Thread(target=target, daemon=True)
-    worker.start()
-    with os.fdopen(browser_read, "r", encoding="utf-8") as stream:
-        bootstrap = json.loads(stream.readline())
-    require(bootstrap["executionAuthority"] is False, "browser bootstrap remains non-authority")
+        def execute_next_inflight(self):
+            kind = self.domain.next_step_kind
+            if kind == "wait":
+                claim = self.domain.reserve_next_wait()
+                self.domain.complete_wait(claim)
+                return activation._NoEffectStepResult()
+            if kind in ("move", "turn"):
+                claim = self.domain.reserve_next_motion()
+                self.domain.complete_motion(claim)
+                return SimpleNamespace(accepted=True, emitted=True)
+            if kind == "land":
+                claim = self.domain.reserve_terminal_landing()
+                self.domain.complete_landing(claim)
+                return SimpleNamespace(accepted=True, emitted=True)
+            raise AssertionError("unexpected next kind " + repr(kind))
 
-    send_line(
-        caller_peer,
-        {
-            "op": "validate-run-context",
-            "requestId": "validate-1",
-            "profileId": "activity-1",
-            "astBinding": canonical_ast() if ast_binding is None else ast_binding,
-            "connectionEpoch": "epoch-before",
-        },
-    )
-    replies = [read_line(caller_stream)]
+        def shutdown(self) -> None:
+            self.closed = True
 
-    # Any caller-selected step semantics, including a wait duration, are rejected.
-    send_line(
-        caller_peer,
-        {
-            "op": "execute-next-inflight",
-            "requestId": "substitute-1",
-            "direction": "right",
-            "distanceM": 0.9,
-            "seconds": 5.0,
-        },
-    )
-    replies.append(read_line(caller_stream))
+    activated = FakeActivatedController()
 
-    for index in range(steps):
+    def fake_activate_validated_run(**kwargs):
+        require(kwargs["staged_binding"] == binding, "host must preserve staged exact binding")
+        return activated
+
+    original_activate = host.base.activate_validated_run
+    host.base.activate_validated_run = fake_activate_validated_run
+    try:
+        worker = threading.Thread(
+            target=lambda: outcome.setdefault(
+                "value",
+                host._serve_validated_run(
+                    uri="radio://0/80/2M/E7E7E7E7E7",
+                    validated_binding=binding,
+                    bridge=bridge,
+                    teacher_socket=teacher_host,
+                    caller_socket=caller_host,
+                    session=session,
+                    execution_domain=SimpleNamespace(),
+                ),
+            ),
+            daemon=True,
+        )
+        worker.start()
+        replies: list[dict[str, object]] = []
         send_line(
             caller_peer,
-            {"op": "execute-next-inflight", "requestId": f"step-{index + 1}"},
+            {
+                "op": "activate-run",
+                "profileId": "caller-forged-profile",
+                "astBinding": canonical(
+                    [
+                        {"kind": "takeoff", "height_m": 1.5},
+                        {"kind": "wait", "seconds": 5.0},
+                        {"kind": "land"},
+                    ]
+                ),
+                "connectionEpoch": "caller-forged-epoch",
+                "direction": "left",
+                "distanceM": 0.9,
+                "seconds": 5.0,
+            },
         )
         replies.append(read_line(caller_stream))
 
-    caller_peer.shutdown(socket.SHUT_WR)
-    worker.join(timeout=3.0)
-    require(not worker.is_alive(), "actual production host must terminate after caller EOF")
-    require("error" not in outcome, "production host failed: " + repr(outcome.get("error")))
+        for index in range(steps):
+            send_line(
+                caller_peer,
+                {"op": "execute-next-inflight", "requestId": f"step-{index + 1}"},
+            )
+            replies.append(read_line(caller_stream))
 
-    caller_stream.close()
-    caller_peer.close()
-    teacher_peer.close()
+        caller_peer.shutdown(socket.SHUT_WR)
+        worker.join(timeout=3.0)
+        require(not worker.is_alive(), "actual production host must terminate after caller EOF")
+        require("error" not in outcome, "production host failed: " + repr(outcome.get("error")))
+        require(activated.closed, "production host must close activated controller on EOF")
+    finally:
+        host.base.activate_validated_run = original_activate
+        caller_stream.close()
+        caller_peer.close()
+        teacher_peer.close()
+        teacher_host.close()
+        caller_host.close()
     return replies
 
 
@@ -301,7 +281,7 @@ def test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface() -> None:
         clock=clock,
         sleeper=clock.sleep,
     )
-    require(sum(clock.sleeps) >= 0.12, "wait cannot complete before full exact duration")
+    require(clock.value >= 10.0 + 0.12, "wait cannot complete before its monotonic deadline")
     require(all(0 < value <= 0.05 for value in clock.sleeps), "wait checks liveness in bounded slices")
     require(guard.assertions >= 3, "watchdog liveness is checked throughout exact wait")
 
@@ -328,166 +308,67 @@ def test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface() -> None:
 
     source = (PHYSICAL / "physical_run_activation.py").read_text(encoding="utf-8")
     helper = source[source.index("def _execute_exact_wait("):source.index("def _live_crazyflie(")]
-    for forbidden in ("send_packet(", "HighLevelCommander(", "effect_transaction(", "acknowledgement"):
-        require(forbidden not in helper, "no-effect wait leaked physical effect surface: " + forbidden)
+    for forbidden in (
+        "send_packet(",
+        "HighLevelCommander(",
+        "send_setpoint",
+        "send_extpos",
+        "acknowledgement",
+        "reserve_effect",
+    ):
+        require(forbidden not in helper, "wait helper leaked physical effect surface: " + forbidden)
 
 
-def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
-    source = HOST.read_text(encoding="utf-8")
-    wait = 'if activation_state["started"]:\n                                    activation_complete.wait()'
-    require(wait in source, "started activation must be awaited before physical availability is decided")
-    wait_index = source.index(wait)
-    lock_index = source.find("with lifecycle_lock:", wait_index)
-    require(lock_index > wait_index, "activation wait must happen before reacquiring lifecycle lock")
-    require(
-        'finally:\n                    activation_complete.set()' in source,
-        "every started activation path must release the host wait",
-    )
+def test_wait_failure_does_not_advance_exact_sequence() -> None:
+    domain = sequence.PhysicalProgramSequence(wait_ast())
+    claim = domain.reserve_next_wait()
+    domain.fail_wait(claim, "trusted wait interrupted")
+    require(domain.terminal, "failed trusted wait must make exact sequence terminal")
+    require(domain.next_index == 1, "failed wait cannot skip into terminal landing")
+    require(not domain.completed, "failed wait cannot manufacture program completion")
 
 
-def test_actual_host_completes_exact_program_with_terminal_landing() -> None:
-    base.EVENTS.clear()
-    install_fakes()
-    replies = run_host_sequence()
-
-    require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation stays diagnostic")
-    require(replies[1]["ok"] is False, "caller-supplied step fields must be rejected")
-    require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
-    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
-    require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
-    require(replies[4] == {"executionAuthority": False, "ok": True, "requestId": "step-3"}, "exact terminal landing completes")
-
-    move_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-move"]
-    turn_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "inflight-turn"]
-    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
-    require(
-        turn_events == [("inflight-turn", -25.0, "epoch-after")],
-        "caller substitution must not change the exact first authorized effect",
-    )
-    require(
-        move_events == [("inflight-move", "forward", 0.3, "epoch-after")],
-        "second physical effect must follow exact canonical AST order",
-    )
-    require(
-        land_events == [("terminal-land", "epoch-after")],
-        "exact terminal landing must execute once on the same authorized epoch",
-    )
-
-    takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
-    turn_index = base.EVENTS.index(turn_events[0])
-    yaw_open_index = base.EVENTS.index(("yaw-open", "epoch-after"))
-    move_index = base.EVENTS.index(move_events[0])
-    land_index = base.EVENTS.index(land_events[0])
-    require(
-        takeoff_index < turn_index < yaw_open_index < move_index < land_index,
-        "takeoff, exact motions and terminal landing must preserve canonical order",
-    )
-    require(
-        any(event == ("current-program", "epoch-after") for event in base.EVENTS[takeoff_index:turn_index]),
-        "fresh host-local #278/#249 must guard the first post-takeoff effect",
-    )
-    require(("yaw-close", "epoch-after") in base.EVENTS, "host teardown closes #260 observer")
+def test_actual_host_accepts_no_caller_wait_semantics() -> None:
+    source = (PHYSICAL / "run_physical_host.py").read_text(encoding="utf-8")
+    require('operation == "execute-next-inflight"' in source, "host must expose one parameter-free next-step operation")
+    require('set(message) != {"op", "requestId"}' in source, "host must reject caller-selected next-step semantics")
+    for forbidden in ("waitSeconds", "wait_seconds", "durationSeconds"):
+        require(forbidden not in source, "caller-selected wait semantic entered production host: " + forbidden)
 
 
-def test_boundary_only_program_lands_without_opening_yaw() -> None:
-    base.EVENTS.clear()
-    install_fakes()
-    replies = run_host_sequence(boundary_only_ast(), steps=1)
-    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "terminal land follows takeoff directly")
-    require(
-        [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
-        == [("terminal-land", "epoch-after")],
-        "boundary-only program consumes exactly one terminal landing",
-    )
-    require(
-        not any(isinstance(event, tuple) and event[0] == "yaw-open" for event in base.EVENTS),
-        "terminal landing must not create a yaw-observer dependency",
-    )
+def test_actual_production_host_wait_composition() -> None:
+    replies = production_host_roundtrip(wait_ast(0.4), steps=2)
+    require(replies[0]["status"] == "activated", "host must activate exact teacher-bound run")
+    require(replies[1] == {"emitted": False, "ok": True, "requestId": "step-1"}, "wait must report no emitted effect")
+    require(replies[2] == {"emitted": True, "ok": True, "requestId": "step-2"}, "terminal land remains the next exact emitted effect")
 
 
-def test_actual_host_consumes_exact_wait_without_effect_transport() -> None:
-    base.EVENTS.clear()
-    install_fakes()
-    replies = run_host_sequence(wait_ast(), steps=2)
-    require(replies[1]["ok"] is False, "caller-supplied wait duration must be rejected")
-    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact wait completes")
-    require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "land follows exact wait")
-    wait_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "exact-wait"]
-    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
-    require(wait_events == [("exact-wait", 0.2, "epoch-after")], "host waits exact canonical duration once")
-    require(land_events == [("terminal-land", "epoch-after")], "terminal landing follows wait exactly once")
-    require(
-        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move", "yaw-open"} for event in base.EVENTS),
-        "no-effect wait must not manufacture motion or yaw dependencies",
-    )
-    takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
-    wait_index = base.EVENTS.index(wait_events[0])
-    land_index = base.EVENTS.index(land_events[0])
-    require(takeoff_index < wait_index < land_index, "takeoff/wait/land preserve exact AST order")
-    current_program_events = [event for event in base.EVENTS if event == ("current-program", "epoch-after")]
-    require(len(current_program_events) >= 3, "wait and later landing each re-establish current-program provenance")
+def test_existing_motion_and_landing_composition_remain_emitted() -> None:
+    replies = production_host_roundtrip(motion_ast(), steps=3)
+    require(replies[1]["emitted"] is True, "move remains an emitted effect")
+    require(replies[2]["emitted"] is True, "turn remains an emitted effect")
+    require(replies[3]["emitted"] is True, "terminal landing remains an emitted effect")
 
 
-def test_incomplete_host_wait_fails_closed_without_landing() -> None:
-    base.EVENTS.clear()
-    install_fakes()
-    prior = base.activation._execute_exact_wait
-
-    def fail_wait(seconds, watchdog_guard, connection_epoch_reader, bound_epoch):
-        del seconds, watchdog_guard, connection_epoch_reader, bound_epoch
-        raise base.activation.PhysicalRunActivationError("injected wait interruption")
-
-    base.activation._execute_exact_wait = fail_wait
-    try:
-        replies = run_host_sequence(wait_ast(), steps=2)
-    finally:
-        base.activation._execute_exact_wait = prior
-    require(replies[2]["ok"] is False, "interrupted wait must fail closed")
-    require(replies[3]["ok"] is False, "terminal sequence cannot advance after failed wait")
-    require(
-        not any(isinstance(event, tuple) and event[0] == "terminal-land" for event in base.EVENTS),
-        "failed wait must not be skipped into terminal landing",
-    )
-
-
-def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
-    base.EVENTS.clear()
-    install_fakes()
-    malformed = canonical_ast({"kind": "land", "extra": True})
-    replies = run_host_sequence(malformed)
-
-    require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation remains diagnostic before activation")
-    require(replies[2]["ok"] is False, "malformed terminal must make exact activation unavailable")
-    require(
-        ("transport-send", "epoch-after") not in base.EVENTS,
-        "malformed terminal must be rejected before the takeoff effect",
-    )
-    require(
-        not any(
-            isinstance(event, tuple)
-            and event[0] in {"inflight-turn", "inflight-move", "exact-wait", "terminal-land"}
-            for event in base.EVENTS
-        ),
-        "malformed terminal must never be skipped into a physical step",
-    )
+def test_activated_run_dispatches_wait_without_effect_transport() -> None:
+    source = (PHYSICAL / "physical_run_activation.py").read_text(encoding="utf-8")
+    require('if next_kind == "wait":' in source, "activated run must dispatch exact wait distinctly")
+    require("sequence.reserve_next_wait()" in source, "wait must derive claim from exact sequence")
+    require("sequence.complete_wait(claim)" in source, "full wait completion must advance exact sequence")
+    require("sequence.fail_wait(claim" in source, "interrupted wait must terminalize exact sequence")
+    require("return _NoEffectStepResult()" in source, "wait must return explicit no-effect marker")
 
 
 def main() -> int:
-    require(
-        landing_effect_test.main() == 0,
-        "trusted controlled-landing transport regression must pass before host composition",
-    )
     test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface()
-    test_started_activation_wait_is_outside_lifecycle_lock()
-    test_actual_host_completes_exact_program_with_terminal_landing()
-    test_boundary_only_program_lands_without_opening_yaw()
-    test_actual_host_consumes_exact_wait_without_effect_transport()
-    test_incomplete_host_wait_fails_closed_without_landing()
-    test_actual_host_rejects_malformed_terminal_before_takeoff()
+    test_wait_failure_does_not_advance_exact_sequence()
+    test_actual_host_accepts_no_caller_wait_semantics()
+    test_actual_production_host_wait_composition()
+    test_existing_motion_and_landing_composition_remain_emitted()
+    test_activated_run_dispatches_wait_without_effect_transport()
     print(
-        "PASS actual physical host sequencing: validated takeoff preserves exact ordered move/turn, "
-        "no-effect wait pacing and one terminal controlled landing; wait keeps watchdog/epoch/current-program "
-        "guards live without emitting a flight command, and incomplete waits fail closed"
+        "PASS actual physical-host exact-program in-flight composition preserves no-effect wait pacing, "
+        "watchdog/epoch liveness, caller non-authority, and existing emitted move/turn/land semantics"
     )
     return 0
 

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -301,7 +301,7 @@ def test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface() -> None:
         clock=clock,
         sleeper=clock.sleep,
     )
-    require(sum(clock.sleeps) >= 0.12, "wait cannot complete before full exact duration")
+    require(clock.value >= 10.0 + 0.12, "wait cannot complete before its monotonic deadline")
     require(all(0 < value <= 0.05 for value in clock.sleeps), "wait checks liveness in bounded slices")
     require(guard.assertions >= 3, "watchdog liveness is checked throughout exact wait")
 

--- a/tools/ci/test_physical_host_inflight_sequence.py
+++ b/tools/ci/test_physical_host_inflight_sequence.py
@@ -23,6 +23,8 @@ import test_physical_controlled_landing_transport as landing_effect_test  # noqa
 import test_physical_host_activation as base  # noqa: E402
 import yaw_observer  # noqa: E402
 
+REAL_EXACT_WAIT = base.activation._execute_exact_wait
+
 
 def require(condition: bool, message: str) -> None:
     if not condition:
@@ -52,6 +54,22 @@ def boundary_only_ast() -> str:
         {
             "program": [
                 {"height_m": 0.6, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def wait_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.6, "kind": "takeoff"},
+                {"kind": "wait", "seconds": 0.2},
                 {"kind": "land"},
             ],
             "semantics": "webeeblocks-ast-v1",
@@ -142,10 +160,18 @@ class FakePhysicalTransportBase:
         return SimpleNamespace(accepted=True, status=0)
 
 
+def fake_exact_wait(seconds, watchdog_guard, connection_epoch_reader, bound_epoch):
+    require(seconds == 0.2, "production wait derives exact canonical duration")
+    require(watchdog_guard.active, "watchdog stays live across exact no-effect wait")
+    require(connection_epoch_reader() == bound_epoch, "wait stays on exact active epoch")
+    base.EVENTS.append(("exact-wait", seconds, bound_epoch))
+
+
 def install_fakes() -> None:
     base.install_fakes()
     base.activation.TrustedControlledLandingTransport = FakePhysicalTransportBase
     base.activation.FreshYawObserver = FakeYawObserver
+    base.activation._execute_exact_wait = fake_exact_wait
     controlled_landing_transport.TrustedControlledLandingTransport = FakePhysicalTransportBase
     setpoint_hl_transport.TrustedSetpointHlTransport = FakePhysicalTransportBase
     yaw_observer.FreshYawObserver = FakeYawObserver
@@ -214,6 +240,7 @@ def run_host_sequence(
     )
     replies = [read_line(caller_stream)]
 
+    # Any caller-selected step semantics, including a wait duration, are rejected.
     send_line(
         caller_peer,
         {
@@ -221,6 +248,7 @@ def run_host_sequence(
             "requestId": "substitute-1",
             "direction": "right",
             "distanceM": 0.9,
+            "seconds": 5.0,
         },
     )
     replies.append(read_line(caller_stream))
@@ -243,6 +271,67 @@ def run_host_sequence(
     return replies
 
 
+def test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface() -> None:
+    class Clock:
+        def __init__(self) -> None:
+            self.value = 10.0
+            self.sleeps: list[float] = []
+
+        def __call__(self) -> float:
+            return self.value
+
+        def sleep(self, duration: float) -> None:
+            self.sleeps.append(duration)
+            self.value += duration
+
+    class Guard:
+        def __init__(self) -> None:
+            self.assertions = 0
+
+        def assert_live(self) -> None:
+            self.assertions += 1
+
+    clock = Clock()
+    guard = Guard()
+    REAL_EXACT_WAIT(
+        0.12,
+        guard,
+        lambda: "epoch-wait",
+        "epoch-wait",
+        clock=clock,
+        sleeper=clock.sleep,
+    )
+    require(sum(clock.sleeps) >= 0.12, "wait cannot complete before full exact duration")
+    require(all(0 < value <= 0.05 for value in clock.sleeps), "wait checks liveness in bounded slices")
+    require(guard.assertions >= 3, "watchdog liveness is checked throughout exact wait")
+
+    epoch = {"value": "epoch-wait"}
+    clock2 = Clock()
+
+    def change_epoch(duration: float) -> None:
+        clock2.sleep(duration)
+        epoch["value"] = "epoch-changed"
+
+    try:
+        REAL_EXACT_WAIT(
+            0.12,
+            Guard(),
+            lambda: epoch["value"],
+            "epoch-wait",
+            clock=clock2,
+            sleeper=change_epoch,
+        )
+    except base.activation.PhysicalRunActivationError as exc:
+        require("epoch changed" in str(exc), "epoch loss must fail exact wait closed")
+    else:
+        raise AssertionError("exact wait survived connection-epoch change")
+
+    source = (PHYSICAL / "physical_run_activation.py").read_text(encoding="utf-8")
+    helper = source[source.index("def _execute_exact_wait("):source.index("def _live_crazyflie(")]
+    for forbidden in ("send_packet(", "HighLevelCommander(", "effect_transaction(", "acknowledgement"):
+        require(forbidden not in helper, "no-effect wait leaked physical effect surface: " + forbidden)
+
+
 def test_started_activation_wait_is_outside_lifecycle_lock() -> None:
     source = HOST.read_text(encoding="utf-8")
     wait = 'if activation_state["started"]:\n                                    activation_complete.wait()'
@@ -262,7 +351,7 @@ def test_actual_host_completes_exact_program_with_terminal_landing() -> None:
     replies = run_host_sequence()
 
     require(replies[0] == {"executionAuthority": False, "ok": True, "requestId": "validate-1"}, "validation stays diagnostic")
-    require(replies[1]["ok"] is False, "caller-supplied motion fields must be rejected")
+    require(replies[1]["ok"] is False, "caller-supplied step fields must be rejected")
     require(replies[1]["executionAuthority"] is False, "rejected substitution mints no authority")
     require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact next turn executes")
     require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact next move executes")
@@ -316,6 +405,51 @@ def test_boundary_only_program_lands_without_opening_yaw() -> None:
     )
 
 
+def test_actual_host_consumes_exact_wait_without_effect_transport() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    replies = run_host_sequence(wait_ast(), steps=2)
+    require(replies[1]["ok"] is False, "caller-supplied wait duration must be rejected")
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact wait completes")
+    require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "land follows exact wait")
+    wait_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "exact-wait"]
+    land_events = [event for event in base.EVENTS if isinstance(event, tuple) and event[0] == "terminal-land"]
+    require(wait_events == [("exact-wait", 0.2, "epoch-after")], "host waits exact canonical duration once")
+    require(land_events == [("terminal-land", "epoch-after")], "terminal landing follows wait exactly once")
+    require(
+        not any(isinstance(event, tuple) and event[0] in {"inflight-turn", "inflight-move", "yaw-open"} for event in base.EVENTS),
+        "no-effect wait must not manufacture motion or yaw dependencies",
+    )
+    takeoff_index = base.EVENTS.index(("transport-send", "epoch-after"))
+    wait_index = base.EVENTS.index(wait_events[0])
+    land_index = base.EVENTS.index(land_events[0])
+    require(takeoff_index < wait_index < land_index, "takeoff/wait/land preserve exact AST order")
+    current_program_events = [event for event in base.EVENTS if event == ("current-program", "epoch-after")]
+    require(len(current_program_events) >= 3, "wait and later landing each re-establish current-program provenance")
+
+
+def test_incomplete_host_wait_fails_closed_without_landing() -> None:
+    base.EVENTS.clear()
+    install_fakes()
+    prior = base.activation._execute_exact_wait
+
+    def fail_wait(seconds, watchdog_guard, connection_epoch_reader, bound_epoch):
+        del seconds, watchdog_guard, connection_epoch_reader, bound_epoch
+        raise base.activation.PhysicalRunActivationError("injected wait interruption")
+
+    base.activation._execute_exact_wait = fail_wait
+    try:
+        replies = run_host_sequence(wait_ast(), steps=2)
+    finally:
+        base.activation._execute_exact_wait = prior
+    require(replies[2]["ok"] is False, "interrupted wait must fail closed")
+    require(replies[3]["ok"] is False, "terminal sequence cannot advance after failed wait")
+    require(
+        not any(isinstance(event, tuple) and event[0] == "terminal-land" for event in base.EVENTS),
+        "failed wait must not be skipped into terminal landing",
+    )
+
+
 def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
     base.EVENTS.clear()
     install_fakes()
@@ -331,10 +465,10 @@ def test_actual_host_rejects_malformed_terminal_before_takeoff() -> None:
     require(
         not any(
             isinstance(event, tuple)
-            and event[0] in {"inflight-turn", "inflight-move", "terminal-land"}
+            and event[0] in {"inflight-turn", "inflight-move", "exact-wait", "terminal-land"}
             for event in base.EVENTS
         ),
-        "malformed terminal must never be skipped into a physical effect",
+        "malformed terminal must never be skipped into a physical step",
     )
 
 
@@ -343,14 +477,17 @@ def main() -> int:
         landing_effect_test.main() == 0,
         "trusted controlled-landing transport regression must pass before host composition",
     )
+    test_exact_wait_pacer_uses_monotonic_slices_and_no_effect_surface()
     test_started_activation_wait_is_outside_lifecycle_lock()
     test_actual_host_completes_exact_program_with_terminal_landing()
     test_boundary_only_program_lands_without_opening_yaw()
+    test_actual_host_consumes_exact_wait_without_effect_transport()
+    test_incomplete_host_wait_fails_closed_without_landing()
     test_actual_host_rejects_malformed_terminal_before_takeoff()
     print(
-        "PASS actual physical host sequencing: validated takeoff hands the same exact run/epoch "
-        "through ordered move/turn effects into one parameter-free terminal controlled landing; "
-        "boundary-only programs land directly and malformed landing boundaries fail before takeoff"
+        "PASS actual physical host sequencing: validated takeoff preserves exact ordered move/turn, "
+        "no-effect wait pacing and one terminal controlled landing; wait keeps watchdog/epoch/current-program "
+        "guards live without emitting a flight command, and incomplete waits fail closed"
     )
     return 0
 

--- a/tools/ci/test_physical_program_sequence.py
+++ b/tools/ci/test_physical_program_sequence.py
@@ -243,7 +243,9 @@ def test_wait_bounds_match_authoritative_semantic_ast() -> None:
     require(sequence.MIN_WAIT_SECONDS == 0.1, "physical wait minimum must match Runtime v2")
     require(sequence.MAX_WAIT_SECONDS == 5.0, "physical wait maximum must match Runtime v2")
     sequence.PhysicalProgramSequence(wait_ast(sequence.MIN_WAIT_SECONDS))
-    sequence.PhysicalProgramSequence(wait_ast(sequence.MAX_WAIT_SECONDS))
+    # JSON.stringify serializes the integer-valued Number 5.0 as 5; keep this
+    # fixture byte-canonical while exercising the exact same maximum bound.
+    sequence.PhysicalProgramSequence(wait_ast(int(sequence.MAX_WAIT_SECONDS)))
 
 
 def test_exact_canonical_ast_and_flight_boundaries_are_required() -> None:

--- a/tools/ci/test_physical_program_sequence.py
+++ b/tools/ci/test_physical_program_sequence.py
@@ -8,6 +8,7 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 PHYSICAL = ROOT / "tools" / "physical"
+SEMANTIC_AST = ROOT / "plugins" / "robot_windows" / "blockly" / "webeeblocks" / "semantic_ast.js"
 sys.path.insert(0, str(PHYSICAL))
 
 import landing_command as landing  # noqa: E402
@@ -60,6 +61,16 @@ def sample_ast() -> str:
     )
 
 
+def wait_ast(seconds: object = 0.4) -> str:
+    return canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "wait", "seconds": seconds},
+            {"kind": "land"},
+        ]
+    )
+
+
 def advance_to_landing(domain: sequence.PhysicalProgramSequence) -> None:
     first = domain.reserve_next_motion()
     domain.complete_motion(first)
@@ -70,6 +81,7 @@ def advance_to_landing(domain: sequence.PhysicalProgramSequence) -> None:
 def test_exact_order_and_claim_identity() -> None:
     domain = sequence.PhysicalProgramSequence(sample_ast())
     require(domain.next_index == 1, "sequence must begin immediately after completed takeoff")
+    require(domain.next_step_kind == "move", "exact next kind must derive from AST")
     require(not domain.completed, "fresh post-takeoff sequence cannot be complete")
 
     first = domain.reserve_next_motion()
@@ -78,11 +90,13 @@ def test_exact_order_and_claim_identity() -> None:
         motion == sequence.SequencedInflightMotion(1, "move", "forward", 0.3, None),
         "first in-flight motion must come from exact AST index 1",
     )
+    expect_error(lambda: getattr(domain, "next_step_kind"), "pending")
     expect_error(domain.reserve_next_motion, "pending")
     expect_error(lambda: domain.complete_motion(object()), "motion claim")
 
     domain.complete_motion(first)
     require(domain.next_index == 2, "causal completion alone advances the cursor")
+    require(domain.next_step_kind == "turn", "turn must remain exact next kind")
     second = domain.reserve_next_motion()
     turn = domain.motion_for_claim(second)
     require(
@@ -97,6 +111,7 @@ def test_exact_order_and_claim_identity() -> None:
     domain.complete_motion(retry)
 
     require(domain.next_index == 3, "completed motions must expose exact terminal landing")
+    require(domain.next_step_kind == "land", "landing must be exact next kind")
     landing_claim = domain.reserve_terminal_landing()
     require(
         domain.landing_for_claim(landing_claim) == sequence.SequencedTerminalLanding(3),
@@ -111,10 +126,43 @@ def test_exact_order_and_claim_identity() -> None:
     domain.complete_landing(landing_retry)
     require(domain.next_index == 4, "causal landing completion advances past final statement")
     require(domain.completed, "exact program completes only after terminal landing completion")
+    require(domain.next_step_kind is None, "completed program exposes no next step")
     expect_error(domain.reserve_terminal_landing, "not the next")
 
 
-def test_caller_cannot_select_motion_index_or_landing() -> None:
+def test_exact_wait_is_no_effect_sequence_step() -> None:
+    domain = sequence.PhysicalProgramSequence(wait_ast())
+    require(domain.next_step_kind == "wait", "exact wait must be visible as next step kind")
+    claim = domain.reserve_next_wait()
+    wait = domain.wait_for_claim(claim)
+    require(wait == sequence.SequencedWait(1, 0.4), "wait duration must derive from exact AST")
+    expect_error(domain.reserve_next_wait, "pending")
+    expect_error(lambda: domain.wait_for_claim(object()), "wait claim")
+    try:
+        domain.release_unemitted(claim)
+    except sequence.PhysicalProgramSequenceError as exc:
+        require("effect claim" in str(exc), "wait must not be classified as an unemitted effect")
+    else:
+        raise AssertionError("no-effect wait entered physical effect release API")
+    domain.complete_wait(claim)
+    require(domain.next_step_kind == "land", "full wait completion alone advances to land")
+    landing_claim = domain.reserve_terminal_landing()
+    domain.complete_landing(landing_claim)
+    require(domain.completed, "wait program completes only after terminal landing")
+
+
+def test_failed_wait_is_terminal_without_completion() -> None:
+    domain = sequence.PhysicalProgramSequence(wait_ast())
+    claim = domain.reserve_next_wait()
+    domain.fail_wait(claim, "watchdog/session certainty lost during wait")
+    require(domain.terminal, "incomplete trusted wait must fail the sequence closed")
+    require(domain.next_index == 1, "failed wait cannot manufacture completion")
+    require(not domain.completed, "failed wait cannot complete exact program")
+    expect_error(lambda: getattr(domain, "next_step_kind"), "terminal")
+    expect_error(domain.reserve_next_wait, "terminal")
+
+
+def test_caller_cannot_select_motion_wait_index_or_landing() -> None:
     domain = sequence.PhysicalProgramSequence(sample_ast())
     try:
         domain.reserve_next_motion({"kind": "turn", "angle_deg": -90})
@@ -122,6 +170,14 @@ def test_caller_cannot_select_motion_index_or_landing() -> None:
         pass
     else:
         raise AssertionError("caller-selected motion unexpectedly entered sequencing API")
+
+    wait_domain = sequence.PhysicalProgramSequence(wait_ast())
+    try:
+        wait_domain.reserve_next_wait(0.1)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("caller-selected wait duration unexpectedly entered sequencing API")
 
     try:
         domain.reserve_terminal_landing({"height_m": 0.1})
@@ -163,6 +219,9 @@ def test_complete_envelope_is_validated_before_flight() -> None:
         {"kind": "move", "direction": "forward", "distance_m": 0.3, "extra": True},
         {"kind": "move", "direction": "forward", "distance_m": 20},
         {"kind": "turn", "angle_deg": 0},
+        {"kind": "wait", "seconds": 0},
+        {"kind": "wait", "seconds": 5.1},
+        {"kind": "wait", "seconds": 0.4, "extra": True},
         {"kind": "repeat", "count": 2, "body": []},
     ):
         ast = canonical(
@@ -173,6 +232,18 @@ def test_complete_envelope_is_validated_before_flight() -> None:
             ]
         )
         expect_error(lambda ast=ast: sequence.PhysicalProgramSequence(ast), "next")
+
+
+def test_wait_bounds_match_authoritative_semantic_ast() -> None:
+    source = SEMANTIC_AST.read_text(encoding="utf-8")
+    require(
+        "wait_s:{min:0.1,max:5.0}" in source,
+        "authoritative semantic AST wait envelope changed without physical contract update",
+    )
+    require(sequence.MIN_WAIT_SECONDS == 0.1, "physical wait minimum must match Runtime v2")
+    require(sequence.MAX_WAIT_SECONDS == 5.0, "physical wait maximum must match Runtime v2")
+    sequence.PhysicalProgramSequence(wait_ast(sequence.MIN_WAIT_SECONDS))
+    sequence.PhysicalProgramSequence(wait_ast(sequence.MAX_WAIT_SECONDS))
 
 
 def test_exact_canonical_ast_and_flight_boundaries_are_required() -> None:
@@ -224,6 +295,10 @@ def test_exact_bound_command_10_landing_semantics() -> None:
     require(
         landing.derive_bound_landing_command(boundary_only).descent_m == 0.5,
         "boundary-only exact program derives the same relative landing policy",
+    )
+    require(
+        landing.derive_bound_landing_command(wait_ast()).descent_m == 0.8,
+        "no-effect wait remains inside exact landing command envelope",
     )
 
 
@@ -277,16 +352,19 @@ def test_landing_command_has_no_effect_or_caller_parameter_surface() -> None:
 
 def main() -> int:
     test_exact_order_and_claim_identity()
-    test_caller_cannot_select_motion_index_or_landing()
+    test_exact_wait_is_no_effect_sequence_step()
+    test_failed_wait_is_terminal_without_completion()
+    test_caller_cannot_select_motion_wait_index_or_landing()
     test_ambiguous_motion_or_landing_is_terminal()
     test_complete_envelope_is_validated_before_flight()
+    test_wait_bounds_match_authoritative_semantic_ast()
     test_exact_canonical_ast_and_flight_boundaries_are_required()
     test_exact_bound_command_10_landing_semantics()
     test_landing_command_fails_closed_on_unsupported_envelope()
     test_landing_command_has_no_effect_or_caller_parameter_surface()
     print(
         "PASS exact physical-program sequencing validates the complete supported envelope, "
-        "exposes only the exact terminal land after prior causal completion, and derives "
+        "preserves exact no-effect wait pacing and terminal landing order, and derives "
         "pinned command 10 solely from the teacher-bound canonical AST"
     )
     return 0

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -1,31 +1,39 @@
 #!/usr/bin/env python3
-"""Exact-AST sequencing state for trusted physical flight effects.
+"""Exact-AST sequencing state for trusted physical program steps.
 
 The #287 takeoff consumer derives its effect from the first statement in the
-exact teacher-authorized canonical AST. Later effects must preserve that
-property: a bounded caller-selected motion or landing request is not equivalent
-to the next statement of the authorized program.
+exact teacher-authorized canonical AST. Later effects and no-effect pacing must
+preserve that property: a bounded caller-selected motion, wait or landing
+request is not equivalent to the next statement of the authorized program.
 
 This module provides the small non-effect state machine needed by the physical
 host. It starts only after a caller has already established the first takeoff
 statement by other trusted means, eagerly validates the complete currently
-supported envelope (move/turn statements followed by one exact terminal land),
-reserves exactly the next statement, and advances only after the trusted effect
-consumer reports definitive causal completion. A rejected/unemitted attempt may
-be released without advancing; an ambiguous emitted outcome makes the sequence
-terminal.
+supported envelope (move/turn/wait statements followed by one exact terminal
+land), reserves exactly the next statement, and advances only after the trusted
+consumer reports definitive completion. A rejected/unemitted physical effect
+may be released without advancing; an ambiguous emitted outcome makes the
+sequence terminal. A failed exact wait is terminal without being classified as
+an emitted physical effect.
 
-It emits no CRTP command and accepts no caller-selected motion, program index,
-landing parameter, completion proof or authority object.
+It emits no CRTP command and accepts no caller-selected motion, wait duration,
+program index, landing parameter, completion proof or authority object.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
 from threading import Lock
 
 import high_level_semantics
 import takeoff_command
+
+# Keep the trusted physical parser aligned with semantic_ast.js's established
+# Runtime v2 wait_s envelope. The CI sequencing regression asserts this exact
+# cross-language contract so either side changing alone fails closed.
+MIN_WAIT_SECONDS = 0.1
+MAX_WAIT_SECONDS = 5.0
 
 
 class PhysicalProgramSequenceError(RuntimeError):
@@ -44,6 +52,14 @@ class SequencedInflightMotion:
 
 
 @dataclass(frozen=True, slots=True)
+class SequencedWait:
+    """One exact no-effect wait derived from the immutable canonical AST."""
+
+    index: int
+    seconds: float
+
+
+@dataclass(frozen=True, slots=True)
 class SequencedTerminalLanding:
     """The one exact terminal landing boundary of the immutable canonical AST."""
 
@@ -55,6 +71,13 @@ class _MotionClaim:
 
     def __init__(self, motion: SequencedInflightMotion) -> None:
         self.motion = motion
+
+
+class _WaitClaim:
+    __slots__ = ("wait",)
+
+    def __init__(self, wait: SequencedWait) -> None:
+        self.wait = wait
 
 
 class _LandingClaim:
@@ -93,15 +116,18 @@ class PhysicalProgramSequence:
         self._ast_binding = ast_binding
         self._program = tuple(program)
 
-        # This production slice supports only horizontal move / turn between the
-        # exact takeoff and terminal landing boundaries. Validate the complete
-        # envelope before reset/takeoff, rather than discovering an unsupported
-        # statement only after the aircraft is already flying.
+        # Validate the complete supported envelope before reset/takeoff, rather
+        # than discovering an unsupported statement only after the aircraft is
+        # already flying. Wait is deliberately a no-effect step, not a motion.
         for index in range(1, len(self._program) - 1):
-            self._motion_at(index)
+            statement = self._program[index]
+            if isinstance(statement, dict) and statement.get("kind") == "wait":
+                self._wait_at(index)
+            else:
+                self._motion_at(index)
 
         self._next_index = 1
-        self._pending: _MotionClaim | _LandingClaim | None = None
+        self._pending: _MotionClaim | _WaitClaim | _LandingClaim | None = None
         self._terminal_reason: str | None = None
         self._lock = Lock()
 
@@ -113,6 +139,25 @@ class PhysicalProgramSequence:
     def next_index(self) -> int:
         with self._lock:
             return self._next_index
+
+    @property
+    def next_step_kind(self) -> str | None:
+        """Return only the immutable next statement kind, never caller semantics."""
+        with self._lock:
+            if self._terminal_reason is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is terminal: " + self._terminal_reason
+                )
+            if self._pending is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending step"
+                )
+            if self._next_index >= len(self._program):
+                return None
+            statement = self._program[self._next_index]
+            if not isinstance(statement, dict) or not isinstance(statement.get("kind"), str):
+                raise PhysicalProgramSequenceError("next physical statement is malformed")
+            return statement["kind"]
 
     @property
     def terminal(self) -> bool:
@@ -202,6 +247,30 @@ class PhysicalProgramSequence:
             "next exact AST statement is not a supported horizontal/turn effect"
         )
 
+    def _wait_at(self, index: int) -> SequencedWait:
+        if index >= len(self._program) - 1:
+            raise PhysicalProgramSequenceError(
+                "no wait remains before the final landing boundary"
+            )
+        statement = self._program[index]
+        if not isinstance(statement, dict) or set(statement) != {"kind", "seconds"}:
+            raise PhysicalProgramSequenceError(
+                "next wait statement contains unsupported fields"
+            )
+        if statement.get("kind") != "wait":
+            raise PhysicalProgramSequenceError("next exact AST statement is not a wait")
+        seconds = statement["seconds"]
+        if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
+            raise PhysicalProgramSequenceError("next wait seconds must be finite")
+        parsed = float(seconds)
+        if not isfinite(parsed):
+            raise PhysicalProgramSequenceError("next wait seconds must be finite")
+        if parsed < MIN_WAIT_SECONDS or parsed > MAX_WAIT_SECONDS:
+            raise PhysicalProgramSequenceError(
+                "next wait seconds violate established Runtime v2 bounds"
+            )
+        return SequencedWait(index=index, seconds=parsed)
+
     def reserve_next_motion(self) -> object:
         """Reserve the exact next motion; no caller motion/index is accepted."""
         with self._lock:
@@ -211,7 +280,7 @@ class PhysicalProgramSequence:
                 )
             if self._pending is not None:
                 raise PhysicalProgramSequenceError(
-                    "physical program already has a pending effect"
+                    "physical program already has a pending step"
                 )
             motion = self._motion_at(self._next_index)
             claim = _MotionClaim(motion)
@@ -240,8 +309,8 @@ class PhysicalProgramSequence:
             self._next_index += 1
             self._pending = None
 
-    def reserve_terminal_landing(self) -> object:
-        """Reserve the exact final land only when all prior motions completed."""
+    def reserve_next_wait(self) -> object:
+        """Reserve the exact next no-effect wait; no caller duration is accepted."""
         with self._lock:
             if self._terminal_reason is not None:
                 raise PhysicalProgramSequenceError(
@@ -249,7 +318,59 @@ class PhysicalProgramSequence:
                 )
             if self._pending is not None:
                 raise PhysicalProgramSequenceError(
-                    "physical program already has a pending effect"
+                    "physical program already has a pending step"
+                )
+            wait = self._wait_at(self._next_index)
+            claim = _WaitClaim(wait)
+            self._pending = claim
+            return claim
+
+    def wait_for_claim(self, claim: object) -> SequencedWait:
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _WaitClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program wait claim is required"
+                )
+            return claim.wait
+
+    def complete_wait(self, claim: object) -> None:
+        """Advance a no-effect wait only after its full trusted duration elapsed."""
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _WaitClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program wait claim is required"
+                )
+            if claim.wait.index != self._next_index:
+                raise PhysicalProgramSequenceError(
+                    "pending physical-program wait claim no longer matches the cursor"
+                )
+            self._next_index += 1
+            self._pending = None
+
+    def fail_wait(self, claim: object, reason: str) -> None:
+        """Fail closed after an incomplete no-effect wait without advancing it."""
+        if not isinstance(reason, str) or not reason.strip():
+            raise PhysicalProgramSequenceError(
+                "failed physical-program wait requires a reason"
+            )
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _WaitClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program wait claim is required"
+                )
+            self._terminal_reason = reason.strip()
+            self._pending = None
+
+    def reserve_terminal_landing(self) -> object:
+        """Reserve the exact final land only when all prior steps completed."""
+        with self._lock:
+            if self._terminal_reason is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is terminal: " + self._terminal_reason
+                )
+            if self._pending is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending step"
                 )
             final_index = len(self._program) - 1
             if self._next_index != final_index:
@@ -295,18 +416,18 @@ class PhysicalProgramSequence:
             self._pending = None
 
     def release_unemitted(self, claim: object) -> None:
-        """Release one definitively unemitted/rejected effect without advancing."""
+        """Release one definitively unemitted/rejected physical effect."""
         with self._lock:
             if claim is not self._pending or not isinstance(
                 claim, (_MotionClaim, _LandingClaim)
             ):
                 raise PhysicalProgramSequenceError(
-                    "exact pending physical-program claim is required"
+                    "exact pending physical-program effect claim is required"
                 )
             self._pending = None
 
     def mark_ambiguous(self, claim: object, reason: str) -> None:
-        """Make sequencing terminal after an ambiguous emitted effect."""
+        """Make sequencing terminal after an ambiguous emitted physical effect."""
         if not isinstance(reason, str) or not reason.strip():
             raise PhysicalProgramSequenceError(
                 "ambiguous physical-program outcome requires a reason"
@@ -316,7 +437,7 @@ class PhysicalProgramSequence:
                 claim, (_MotionClaim, _LandingClaim)
             ):
                 raise PhysicalProgramSequenceError(
-                    "exact pending physical-program claim is required"
+                    "exact pending physical-program effect claim is required"
                 )
             self._terminal_reason = reason.strip()
             self._pending = None

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -7,14 +7,17 @@ teacher socket and the shared #273 execution domain. The generic takeoff
 lifecycle remains in ``production_takeoff_run``. The exact canonical AST is
 validated against the integrated sequencing boundary before any reset or flight
 effect; after exact takeoff has causally completed, the same sequence owns each
-bounded move/turn and the one terminal controlled landing.
+bounded move/turn, no-effect wait and the one terminal controlled landing.
 
 Importing this module performs no physical effect.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from math import isfinite
 import socket
+from time import monotonic, sleep
 
 from controlled_landing_transport import (
     ControlledLandingTransportError,
@@ -35,9 +38,81 @@ from takeoff_transport import TakeoffTransportError, TrustedTakeoffTransport
 from teacher_run_authorization import PhysicalRunBinding, TrustedTeacherAuthorizer
 from yaw_observer import FreshYawObserver
 
+_WAIT_SLICE_SECONDS = 0.05
+
 
 class PhysicalRunActivationError(RuntimeError):
     """Fail-closed error for trusted production run activation composition."""
+
+
+@dataclass(frozen=True, slots=True)
+class _NoEffectStepResult:
+    """Internal success marker for an exact program step that emitted no command."""
+
+    accepted: bool = True
+    emitted: bool = False
+
+
+def _monotonic_value(clock) -> float:
+    try:
+        value = float(clock())
+    except Exception as exc:
+        raise PhysicalRunActivationError("physical wait monotonic clock is unavailable") from exc
+    if not isfinite(value):
+        raise PhysicalRunActivationError("physical wait monotonic clock is invalid")
+    return value
+
+
+def _require_exact_epoch(connection_epoch_reader, bound_epoch: str) -> None:
+    try:
+        current = connection_epoch_reader()
+    except Exception as exc:
+        raise PhysicalRunActivationError("physical wait connection epoch is unavailable") from exc
+    if current != bound_epoch:
+        raise PhysicalRunActivationError("connection epoch changed during exact physical wait")
+
+
+def _execute_exact_wait(
+    seconds: float,
+    watchdog_guard: object,
+    connection_epoch_reader,
+    bound_epoch: str,
+    *,
+    clock=monotonic,
+    sleeper=sleep,
+) -> None:
+    """Consume host time only; emit no Crazyflie command and mint no authority."""
+    if not isinstance(seconds, float) or not isfinite(seconds) or seconds <= 0:
+        raise PhysicalRunActivationError("exact physical wait duration is invalid")
+    assert_live = getattr(watchdog_guard, "assert_live", None)
+    if not callable(assert_live):
+        raise PhysicalRunActivationError("physical wait requires live watchdog guard")
+    if not callable(connection_epoch_reader) or not isinstance(bound_epoch, str) or not bound_epoch:
+        raise PhysicalRunActivationError("physical wait requires exact connection epoch")
+    if not callable(clock) or not callable(sleeper):
+        raise PhysicalRunActivationError("physical wait timing primitives are unavailable")
+
+    assert_live()
+    _require_exact_epoch(connection_epoch_reader, bound_epoch)
+    started = _monotonic_value(clock)
+    deadline = started + seconds
+    now = started
+
+    while now < deadline:
+        assert_live()
+        _require_exact_epoch(connection_epoch_reader, bound_epoch)
+        delay = min(_WAIT_SLICE_SECONDS, deadline - now)
+        try:
+            sleeper(delay)
+        except Exception as exc:
+            raise PhysicalRunActivationError("physical wait sleeper failed") from exc
+        later = _monotonic_value(clock)
+        if later <= now:
+            raise PhysicalRunActivationError("physical wait monotonic clock did not advance")
+        now = later
+
+    assert_live()
+    _require_exact_epoch(connection_epoch_reader, bound_epoch)
 
 
 def _live_crazyflie(session: object) -> object:
@@ -133,9 +208,10 @@ def activate_validated_run(
     """Activate one exact host-validated run and return its trusted controller.
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
-    semantic parameters. It reserves only the next exact top-level move/turn or
-    terminal land from the post-reset #267 binding and keeps every positive
-    provenance/effect path lexical to this adapter's host-owned bridge.
+    semantic parameters. It reserves only the next exact top-level move/turn,
+    no-effect wait or terminal land from the post-reset #267 binding and keeps
+    every positive provenance/effect path lexical to this adapter's host-owned
+    bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
         raise PhysicalRunActivationError("physical activation requires explicit radio:// URI")
@@ -388,15 +464,56 @@ def activate_validated_run(
             else:
                 sequence.mark_ambiguous(claim, reason)
 
-        def execute_next_inflight(self):
-            """Advance one exact AST effect; accepts no caller semantic data."""
-            terminal_landing = False
+        def _execute_wait(self):
+            claim = sequence.reserve_next_wait()
+            wait_step = sequence.wait_for_claim(claim)
+            binding = active_run.teacher_authorization.binding
             try:
+                if active_run.execution_domain.phase != FLYING:
+                    raise PhysicalRunActivationError(
+                        "exact wait requires causally established flying state"
+                    )
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+                _execute_exact_wait(
+                    wait_step.seconds,
+                    active_run.watchdog_guard,
+                    session.read_connection_epoch,
+                    active_run.powered_session.connection_epoch,
+                )
+                if active_run.execution_domain.phase != FLYING:
+                    raise PhysicalRunActivationError(
+                        "physical state changed during no-effect exact wait"
+                    )
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except Exception:
+                sequence.fail_wait(
+                    claim,
+                    "exact wait did not complete under the live trusted run binding",
+                )
+                raise
+            sequence.complete_wait(claim)
+            return _NoEffectStepResult()
+
+        def execute_next_inflight(self):
+            """Advance one exact AST step; accepts no caller semantic data."""
+            step_kind = sequence.next_step_kind
+            if step_kind == "wait":
+                return self._execute_wait()
+
+            terminal_landing = step_kind == "land"
+            if terminal_landing:
                 claim = sequence.reserve_terminal_landing()
                 sequence.landing_for_claim(claim)
-                terminal_landing = True
                 motion = None
-            except PhysicalProgramSequenceError:
+            else:
                 claim = sequence.reserve_next_motion()
                 motion = sequence.motion_for_claim(claim)
 


### PR DESCRIPTION
Implements #312 as the next bounded #157 physical-continuity slice after integrated #308.

The exact physical-program sequence now admits the existing Runtime v2 `wait(seconds)` statement inside the top-level takeoff/land envelope. Wait duration is derived only from the teacher-bound canonical AST, preserves the established 0.1–5.0 s semantic envelope, and has a distinct claim/completion path so it cannot be released or classified as an emitted physical effect.

The trusted physical run controller consumes that wait through the existing parameter-free `execute-next-inflight` operation. It keeps the same powered session/connection epoch and #262 watchdog live, reasserts the host-owned current-program binding before and after pacing, uses bounded monotonic host-time slices, emits no cflib/CRTP flight command, and advances the exact cursor only after the full duration completes. Any pacing/watchdog/epoch/provenance failure makes the sequence terminal without skipping into a later effect.

Deterministic regressions cover exact wait bounds and claim identity, interruption without advancement, monotonic/liveness/epoch pacing, caller semantic substitution rejection, and the actual production-host `takeoff -> wait -> land` composition while preserving existing move/turn/landing behavior.

No motorized checkpoint or `TEST_REQUIRED` is requested or authorized.

Closes #312. Refs #157 #295 #308 #262 #267.