### PR TITLE
Implement Firefox direct project files through local WWI broker

### DIFF
--- a/controllers/crazyflie_runtime_v2/Makefile
+++ b/controllers/crazyflie_runtime_v2/Makefile
@@ -1,5 +1,19 @@
 C_SOURCES = crazyflie_runtime_v2.c ../crazyflie_square/pid_controller.c
 CFLAGS = -I../crazyflie_square
+
+# Firefox direct project files use a local Qt broker only on Linux desktop
+# Webots. The Windows classroom release remains on the established C-only
+# controller until its separate Firefox qualification is complete.
+ifneq ($(OS),Windows_NT)
+ CXX_SOURCES = file_broker.cpp qt_file_dialog_provider.cpp file_broker_runtime.cpp
+ USE_C_API = true
+ CFLAGS += -std=c++17 -fPIC -include file_broker_interpose.h
+ LDFLAGS += -pie
+ QT_INCLUDE_DIR = $(WEBOTS_HOME)/include/qt
+ DYNAMIC_LIBRARIES += -L"$(WEBOTS_HOME)/lib/webots" -lQt6Core -lQt6Gui -lQt6Widgets
+ INCLUDE += -isystem "$(QT_INCLUDE_DIR)" -isystem "$(QT_INCLUDE_DIR)/QtCore" -isystem "$(QT_INCLUDE_DIR)/QtGui" -isystem "$(QT_INCLUDE_DIR)/QtWidgets"
+endif
+
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))

--- a/controllers/crazyflie_runtime_v2/file_broker.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.cpp
@@ -1,0 +1,211 @@
+#include "file_broker.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <regex>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace {
+constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1";
+constexpr char kBase64Alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+bool hasBrokerPrefix(const char *message) {
+  if (!message)
+    return false;
+  const std::string prefix = std::string(kPrefix) + " ";
+  return std::string(message).compare(0, prefix.size(), prefix) == 0;
+}
+
+bool safeToken(const std::string &value) {
+  static const std::regex safe("^[A-Za-z0-9_-]{1,128}$");
+  return std::regex_match(value, safe);
+}
+
+std::string safeCode(const std::string &value) {
+  static const std::regex safe("^[A-Z][A-Z0-9_]{0,63}$");
+  return std::regex_match(value, safe) ? value : "IO_ERROR";
+}
+
+std::string safeProviderName(const std::string &value) {
+  static const std::regex safe("^[a-z0-9-]{1,48}$");
+  return std::regex_match(value, safe) ? value : "invalid-provider";
+}
+
+bool safeSuggestedName(const std::string &value) {
+  if (value.empty() || value.size() > 255 || value == "." || value == "..")
+    return false;
+  return value.find('/') == std::string::npos && value.find('\\') == std::string::npos &&
+         value.find('\0') == std::string::npos;
+}
+
+std::string base64Encode(const std::string &input) {
+  std::string output;
+  output.reserve(((input.size() + 2) / 3) * 4);
+  for (std::size_t i = 0; i < input.size(); i += 3) {
+    const unsigned a = static_cast<unsigned char>(input[i]);
+    const unsigned b = i + 1 < input.size() ? static_cast<unsigned char>(input[i + 1]) : 0;
+    const unsigned c = i + 2 < input.size() ? static_cast<unsigned char>(input[i + 2]) : 0;
+    const unsigned value = (a << 16) | (b << 8) | c;
+    output.push_back(kBase64Alphabet[(value >> 18) & 0x3f]);
+    output.push_back(kBase64Alphabet[(value >> 12) & 0x3f]);
+    output.push_back(i + 1 < input.size() ? kBase64Alphabet[(value >> 6) & 0x3f] : '=');
+    output.push_back(i + 2 < input.size() ? kBase64Alphabet[value & 0x3f] : '=');
+  }
+  return output;
+}
+
+int base64Value(char c) {
+  if (c >= 'A' && c <= 'Z') return c - 'A';
+  if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+  if (c >= '0' && c <= '9') return c - '0' + 52;
+  if (c == '+') return 62;
+  if (c == '/') return 63;
+  return -1;
+}
+
+bool base64Decode(const std::string &input, std::string *output) {
+  if (!output || input.size() % 4 != 0)
+    return false;
+  output->clear();
+  output->reserve((input.size() / 4) * 3);
+  for (std::size_t i = 0; i < input.size(); i += 4) {
+    const bool last = i + 4 == input.size();
+    const char c2 = input[i + 2];
+    const char c3 = input[i + 3];
+    if ((!last && (c2 == '=' || c3 == '=')) || (c2 == '=' && c3 != '='))
+      return false;
+    const int a = base64Value(input[i]);
+    const int b = base64Value(input[i + 1]);
+    const int c = c2 == '=' ? 0 : base64Value(c2);
+    const int d = c3 == '=' ? 0 : base64Value(c3);
+    if (a < 0 || b < 0 || c < 0 || d < 0)
+      return false;
+    const unsigned value = (static_cast<unsigned>(a) << 18) | (static_cast<unsigned>(b) << 12) |
+                           (static_cast<unsigned>(c) << 6) | static_cast<unsigned>(d);
+    output->push_back(static_cast<char>((value >> 16) & 0xff));
+    if (c2 != '=') output->push_back(static_cast<char>((value >> 8) & 0xff));
+    if (c3 != '=') output->push_back(static_cast<char>(value & 0xff));
+  }
+  return true;
+}
+
+std::vector<std::string> split(const std::string &value) {
+  std::vector<std::string> parts;
+  std::istringstream stream(value);
+  std::string part;
+  while (stream >> part)
+    parts.push_back(part);
+  return parts;
+}
+
+std::string responsePrefix(int id) {
+  return std::string(kPrefix) + " RESPONSE " + std::to_string(id) + " ";
+}
+
+std::string operationError(int id, const std::string &code) {
+  return responsePrefix(id) + "ERR " + safeCode(code);
+}
+
+std::string openResponse(int id, const webeeblocks::OpenFileResult &result) {
+  if (result.status == webeeblocks::FileOperationStatus::Cancelled)
+    return responsePrefix(id) + "OPEN CANCELLED";
+  if (result.status != webeeblocks::FileOperationStatus::Ok)
+    return operationError(id, result.errorCode);
+  if (!safeToken(result.reference) || result.name.empty() || result.bytes.size() > webeeblocks::FileBroker::kMaxProjectBytes)
+    return operationError(id, "INVALID_PROVIDER_RESULT");
+  return responsePrefix(id) + "OPEN OK " + result.reference + " " + base64Encode(result.name) + " " + base64Encode(result.bytes);
+}
+
+std::string saveResponse(int id, const char *operation, const webeeblocks::SaveFileResult &result) {
+  if (result.status == webeeblocks::FileOperationStatus::Cancelled)
+    return responsePrefix(id) + operation + " CANCELLED";
+  if (result.status != webeeblocks::FileOperationStatus::Ok)
+    return operationError(id, result.errorCode);
+  if (!safeToken(result.reference) || result.name.empty())
+    return operationError(id, "INVALID_PROVIDER_RESULT");
+  return responsePrefix(id) + operation + " OK " + result.reference + " " + base64Encode(result.name);
+}
+}  // namespace
+
+namespace webeeblocks {
+
+FileBroker::FileBroker(std::unique_ptr<FileDialogProvider> provider) : mProvider(std::move(provider)) {}
+FileBroker::~FileBroker() = default;
+
+bool FileBroker::handleMessage(const char *message, std::string *response) {
+  if (!hasBrokerPrefix(message))
+    return false;
+  if (!response)
+    return true;
+  response->clear();
+  if (!mProvider)
+    return true;
+
+  const std::string text(message);
+  const std::string requestPrefix = std::string(kPrefix) + " REQUEST ";
+  if (text.compare(0, requestPrefix.size(), requestPrefix) != 0)
+    return true;
+  const std::string tail = text.substr(requestPrefix.size());
+  const std::vector<std::string> parts = split(tail);
+  if (parts.size() < 2)
+    return true;
+
+  int id = -1;
+  try {
+    std::size_t consumed = 0;
+    id = std::stoi(parts[0], &consumed);
+    if (consumed != parts[0].size() || id < 1)
+      return true;
+  } catch (...) {
+    return true;
+  }
+
+  const std::string &operation = parts[1];
+  if (operation == "CAPABILITIES" && parts.size() == 2) {
+    const std::string provider = safeProviderName(mProvider->name());
+    *response = responsePrefix(id) +
+      "CAPABILITIES {\"protocol\":1,\"provider\":\"" + provider +
+      "\",\"providerInjectable\":true,\"operationsReady\":true,\"sameFileSave\":true,\"canonicalExtension\":\".wbb\"}";
+    return true;
+  }
+  if (operation == "OPEN" && parts.size() == 2) {
+    *response = openResponse(id, mProvider->open());
+    return true;
+  }
+  if (operation == "SAVE_AS" && parts.size() == 4) {
+    std::string name;
+    std::string bytes;
+    if (!base64Decode(parts[2], &name) || !base64Decode(parts[3], &bytes) || !safeSuggestedName(name)) {
+      *response = operationError(id, "INVALID_REQUEST");
+      return true;
+    }
+    if (bytes.size() > kMaxProjectBytes) {
+      *response = operationError(id, "PROJECT_TOO_LARGE");
+      return true;
+    }
+    *response = saveResponse(id, "SAVE_AS", mProvider->saveAs(name, bytes));
+    return true;
+  }
+  if (operation == "SAVE" && parts.size() == 4) {
+    std::string bytes;
+    if (!safeToken(parts[2]) || !base64Decode(parts[3], &bytes)) {
+      *response = operationError(id, "INVALID_REQUEST");
+      return true;
+    }
+    if (bytes.size() > kMaxProjectBytes) {
+      *response = operationError(id, "PROJECT_TOO_LARGE");
+      return true;
+    }
+    *response = saveResponse(id, "SAVE", mProvider->save(parts[2], bytes));
+    return true;
+  }
+
+  *response = operationError(id, "INVALID_REQUEST");
+  return true;
+}
+
+}  // namespace webeeblocks

--- a/controllers/crazyflie_runtime_v2/file_broker.hpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.hpp
@@ -1,0 +1,58 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_HPP
+#define WEBEEBLOCKS_FILE_BROKER_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace webeeblocks {
+
+enum class FileOperationStatus { Ok, Cancelled, Error };
+
+struct OpenFileResult {
+  FileOperationStatus status = FileOperationStatus::Error;
+  std::string reference;
+  std::string name;
+  std::string bytes;
+  std::string errorCode = "IO_ERROR";
+};
+
+struct SaveFileResult {
+  FileOperationStatus status = FileOperationStatus::Error;
+  std::string reference;
+  std::string name;
+  std::string errorCode = "IO_ERROR";
+};
+
+class FileDialogProvider {
+public:
+  virtual ~FileDialogProvider() = default;
+  virtual std::string name() const = 0;
+  virtual OpenFileResult open() = 0;
+  virtual SaveFileResult saveAs(const std::string &suggestedName, const std::string &bytes) = 0;
+  virtual SaveFileResult save(const std::string &reference, const std::string &bytes) = 0;
+};
+
+std::unique_ptr<FileDialogProvider> createQtFileDialogProvider();
+
+class FileBroker {
+public:
+  static constexpr std::size_t kMaxProjectBytes = 4u * 1024u * 1024u;
+
+  explicit FileBroker(std::unique_ptr<FileDialogProvider> provider);
+  ~FileBroker();
+
+  FileBroker(const FileBroker &) = delete;
+  FileBroker &operator=(const FileBroker &) = delete;
+
+  // Returns false only when message is not a file-broker message. A broker
+  // message is always consumed; malformed requests receive a fail-closed error
+  // whenever a valid request id can be recovered.
+  bool handleMessage(const char *message, std::string *response);
+
+private:
+  std::unique_ptr<FileDialogProvider> mProvider;
+};
+
+}  // namespace webeeblocks
+#endif

--- a/controllers/crazyflie_runtime_v2/file_broker_c.h
+++ b/controllers/crazyflie_runtime_v2/file_broker_c.h
@@ -1,0 +1,19 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_C_H
+#define WEBEEBLOCKS_FILE_BROKER_C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct WbFileBroker WbFileBroker;
+
+WbFileBroker *wb_file_broker_create_qt(void);
+void wb_file_broker_destroy(WbFileBroker *broker);
+// Returns NULL when the message is not for the broker. The returned string is
+// owned by broker and remains valid until the next broker call or destruction.
+const char *wb_file_broker_handle_message(WbFileBroker *broker, const char *message);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/controllers/crazyflie_runtime_v2/file_broker_interpose.h
+++ b/controllers/crazyflie_runtime_v2/file_broker_interpose.h
@@ -1,0 +1,12 @@
+#ifndef WEBEEBLOCKS_FILE_BROKER_INTERPOSE_H
+#define WEBEEBLOCKS_FILE_BROKER_INTERPOSE_H
+
+// The product controller remains C-only. On Linux desktop Webots builds with
+// bundled Qt headers, interpose only its two Webots C calls so broker traffic can
+// be consumed locally without changing Runtime v2 semantics or the C source.
+#ifndef __cplusplus
+#define wb_robot_wwi_receive_text webeeblocks_file_broker_receive_text
+#define wb_robot_cleanup webeeblocks_file_broker_robot_cleanup
+#endif
+
+#endif

--- a/controllers/crazyflie_runtime_v2/file_broker_runtime.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker_runtime.cpp
@@ -1,0 +1,57 @@
+#include "file_broker_c.h"
+
+#include <webots/robot.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace {
+constexpr const char *kPrefix = "WEBEEBLOCKS_FILE_BROKER_V1 ";
+WbFileBroker *gBroker = nullptr;
+
+bool isBrokerMessage(const char *message) {
+  return message && std::strncmp(message, kPrefix, std::strlen(kPrefix)) == 0;
+}
+
+int requestId(const char *message) {
+  int id = -1;
+  if (message)
+    std::sscanf(message, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST %d", &id);
+  return id;
+}
+
+void sendUnavailable(const char *message) {
+  const int id = requestId(message);
+  if (id < 1)
+    return;
+  const std::string response = "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE " + std::to_string(id) + " ERR UNAVAILABLE";
+  wb_robot_wwi_send_text(response.c_str());
+}
+}  // namespace
+
+extern "C" const char *webeeblocks_file_broker_receive_text(void) {
+  const char *message = nullptr;
+  while ((message = wb_robot_wwi_receive_text()) != nullptr) {
+    if (!isBrokerMessage(message))
+      return message;
+    if (!gBroker)
+      gBroker = wb_file_broker_create_qt();
+    if (!gBroker) {
+      sendUnavailable(message);
+      continue;
+    }
+    const char *response = wb_file_broker_handle_message(gBroker, message);
+    if (response)
+      wb_robot_wwi_send_text(response);
+  }
+  return nullptr;
+}
+
+extern "C" void webeeblocks_file_broker_robot_cleanup(void) {
+  if (gBroker) {
+    wb_file_broker_destroy(gBroker);
+    gBroker = nullptr;
+  }
+  wb_robot_cleanup();
+}

--- a/controllers/crazyflie_runtime_v2/file_broker_runtime.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker_runtime.cpp
@@ -1,5 +1,6 @@
 #include "file_broker_c.h"
 
+#include <webots/plugins/robot_window/default.h>
 #include <webots/robot.h>
 
 #include <cstdio>

--- a/controllers/crazyflie_runtime_v2/qt_file_dialog_provider.cpp
+++ b/controllers/crazyflie_runtime_v2/qt_file_dialog_provider.cpp
@@ -1,0 +1,194 @@
+#include "file_broker.hpp"
+#include "file_broker_c.h"
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QHash>
+#include <QtCore/QSaveFile>
+#include <QtCore/QString>
+#include <QtCore/QUuid>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileDialog>
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace {
+class QtFileDialogProvider final : public webeeblocks::FileDialogProvider {
+public:
+  QtFileDialogProvider() {
+    std::strcpy(mProgramName.data(), "webeeblocks-file-broker");
+    mArgv[0] = mProgramName.data();
+    mArgv[1] = nullptr;
+    if (!QCoreApplication::instance())
+      mApplication = std::make_unique<QApplication>(mArgc, mArgv.data());
+    if (!qobject_cast<QApplication *>(QCoreApplication::instance()))
+      throw std::runtime_error("Qt application is not a QApplication");
+  }
+
+  std::string name() const override { return "qt6-native-dialog"; }
+
+  webeeblocks::OpenFileResult open() override {
+    if (!canAllocateReference())
+      return openError("REFERENCE_LIMIT");
+    QFileDialog dialog;
+    dialog.setWindowTitle(QStringLiteral("Ouvrir un projet WebeeBlocks"));
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setNameFilter(QStringLiteral("Projet WebeeBlocks (*.wbb *.json)"));
+    if (dialog.exec() != QDialog::Accepted)
+      return {webeeblocks::FileOperationStatus::Cancelled, "", "", "", ""};
+    const QStringList selected = dialog.selectedFiles();
+    if (selected.size() != 1)
+      return openError("INVALID_SELECTION");
+    const QFileInfo info(selected.front());
+    const QString lowerName = info.fileName().toLower();
+    if (!info.exists() || !info.isFile() || (!lowerName.endsWith(QStringLiteral(".wbb")) && !lowerName.endsWith(QStringLiteral(".json"))))
+      return openError("INVALID_SELECTION");
+    if (info.size() < 0 || static_cast<qulonglong>(info.size()) > webeeblocks::FileBroker::kMaxProjectBytes)
+      return openError("PROJECT_TOO_LARGE");
+    QFile file(info.absoluteFilePath());
+    if (!file.open(QIODevice::ReadOnly))
+      return openError("READ_FAILED");
+    const QByteArray bytes = file.readAll();
+    if (static_cast<std::size_t>(bytes.size()) > webeeblocks::FileBroker::kMaxProjectBytes)
+      return openError("PROJECT_TOO_LARGE");
+    const QString canonical = info.canonicalFilePath();
+    if (canonical.isEmpty())
+      return openError("TARGET_UNAVAILABLE");
+    const std::string reference = allocateReference(canonical);
+    return {webeeblocks::FileOperationStatus::Ok, reference, info.fileName().toUtf8().toStdString(),
+            std::string(bytes.constData(), static_cast<std::size_t>(bytes.size())), ""};
+  }
+
+  webeeblocks::SaveFileResult saveAs(const std::string &suggestedName, const std::string &bytes) override {
+    if (!canAllocateReference())
+      return saveError("REFERENCE_LIMIT");
+    QFileDialog dialog;
+    dialog.setWindowTitle(QStringLiteral("Enregistrer le projet WebeeBlocks"));
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setDefaultSuffix(QStringLiteral("wbb"));
+    dialog.setNameFilter(QStringLiteral("Projet WebeeBlocks (*.wbb)"));
+    dialog.selectFile(QString::fromUtf8(suggestedName.data(), static_cast<int>(suggestedName.size())));
+    if (dialog.exec() != QDialog::Accepted)
+      return {webeeblocks::FileOperationStatus::Cancelled, "", "", ""};
+    const QStringList selected = dialog.selectedFiles();
+    if (selected.size() != 1)
+      return saveError("INVALID_SELECTION");
+    const QString path = QFileInfo(selected.front()).absoluteFilePath();
+    if (!path.toLower().endsWith(QStringLiteral(".wbb")))
+      return saveError("INVALID_EXTENSION");
+    const std::string writeError = writeAtomically(path, bytes, false);
+    if (!writeError.empty())
+      return saveError(writeError);
+    const QFileInfo written(path);
+    const QString canonical = written.canonicalFilePath();
+    if (canonical.isEmpty())
+      return saveError("TARGET_UNAVAILABLE");
+    const std::string reference = allocateReference(canonical);
+    return {webeeblocks::FileOperationStatus::Ok, reference, written.fileName().toUtf8().toStdString(), ""};
+  }
+
+  webeeblocks::SaveFileResult save(const std::string &reference, const std::string &bytes) override {
+    const QString key = QString::fromLatin1(reference.data(), static_cast<int>(reference.size()));
+    const auto it = mReferences.constFind(key);
+    if (it == mReferences.cend())
+      return saveError("TARGET_UNAVAILABLE");
+    const QString path = it.value();
+    const QFileInfo before(path);
+    if (!before.exists() || !before.isFile())
+      return saveError("TARGET_UNAVAILABLE");
+    const std::string writeError = writeAtomically(path, bytes, true);
+    if (!writeError.empty())
+      return saveError(writeError);
+    const QFileInfo after(path);
+    if (!after.exists() || !after.isFile())
+      return saveError("TARGET_UNAVAILABLE");
+    return {webeeblocks::FileOperationStatus::Ok, reference, after.fileName().toUtf8().toStdString(), ""};
+  }
+
+private:
+  static webeeblocks::OpenFileResult openError(const std::string &code) {
+    return {webeeblocks::FileOperationStatus::Error, "", "", "", code};
+  }
+  static webeeblocks::SaveFileResult saveError(const std::string &code) {
+    return {webeeblocks::FileOperationStatus::Error, "", "", code};
+  }
+  bool canAllocateReference() const { return mReferences.size() < 128; }
+  std::string allocateReference(const QString &path) {
+    QString token;
+    do {
+      token = QUuid::createUuid().toString(QUuid::WithoutBraces);
+      token.remove(QLatin1Char('-'));
+    } while (mReferences.contains(token));
+    mReferences.insert(token, path);
+    return token.toLatin1().toStdString();
+  }
+  static std::string writeAtomically(const QString &path, const std::string &bytes, bool requireExisting) {
+    if (bytes.size() > webeeblocks::FileBroker::kMaxProjectBytes)
+      return "PROJECT_TOO_LARGE";
+    if (requireExisting) {
+      const QFileInfo info(path);
+      if (!info.exists() || !info.isFile())
+        return "TARGET_UNAVAILABLE";
+    }
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly))
+      return "WRITE_FAILED";
+    const qint64 expected = static_cast<qint64>(bytes.size());
+    const qint64 written = file.write(bytes.data(), expected);
+    if (written != expected) {
+      file.cancelWriting();
+      return "WRITE_FAILED";
+    }
+    if (!file.commit())
+      return "WRITE_FAILED";
+    return "";
+  }
+
+  int mArgc = 1;
+  std::array<char, 64> mProgramName{};
+  std::array<char *, 2> mArgv{};
+  std::unique_ptr<QApplication> mApplication;
+  QHash<QString, QString> mReferences;
+};
+}  // namespace
+
+namespace webeeblocks {
+std::unique_ptr<FileDialogProvider> createQtFileDialogProvider() {
+  return std::make_unique<QtFileDialogProvider>();
+}
+}  // namespace webeeblocks
+
+struct WbFileBroker {
+  explicit WbFileBroker(std::unique_ptr<webeeblocks::FileDialogProvider> provider) : broker(std::move(provider)) {}
+  webeeblocks::FileBroker broker;
+  std::string response;
+};
+
+extern "C" WbFileBroker *wb_file_broker_create_qt(void) {
+  try {
+    return new WbFileBroker(webeeblocks::createQtFileDialogProvider());
+  } catch (const std::exception &error) {
+    std::fprintf(stderr, "WEBEEBLOCKS_FILE_BROKER_V1 FATAL %s\n", error.what());
+    return nullptr;
+  }
+}
+
+extern "C" void wb_file_broker_destroy(WbFileBroker *broker) { delete broker; }
+
+extern "C" const char *wb_file_broker_handle_message(WbFileBroker *broker, const char *message) {
+  if (!broker)
+    return nullptr;
+  broker->response.clear();
+  if (!broker->broker.handleMessage(message, &broker->response))
+    return nullptr;
+  return broker->response.empty() ? nullptr : broker->response.c_str();
+}

--- a/controllers/crazyflie_runtime_v2/runtime.ini
+++ b/controllers/crazyflie_runtime_v2/runtime.ini
@@ -1,0 +1,6 @@
+; Runtime v2 native broker uses the Qt libraries shipped with Webots.
+; Official Webots controller runtime.ini mechanism: prepend
+; WEBOTS_LIBRARY_PATH to the platform library search path.
+
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/lib/webots

--- a/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
@@ -79,7 +79,12 @@
     var id = this.nextId++;
     var suffix = args && args.length ? ' ' + args.join(' ') : '';
     return new Promise(function(resolve, reject) {
-      var timer = setTimeout(function() {
+      // Native Open/Save As dialogs are explicitly user-paced. Do not let the
+      // short broker/readiness timeout detach the browser from a dialog which
+      // may legitimately remain open for minutes. Non-interactive operations
+      // (capabilities and same-file Save) stay bounded and fail closed.
+      var interactive = operation === 'OPEN' || operation === 'SAVE_AS';
+      var timer = interactive ? null : setTimeout(function() {
         if (!self.pending[id]) return;
         delete self.pending[id];
         reject(new BrokerError('TIMEOUT'));

--- a/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
@@ -79,16 +79,17 @@
     var id = this.nextId++;
     var suffix = args && args.length ? ' ' + args.join(' ') : '';
     return new Promise(function(resolve, reject) {
-      // Native Open/Save As dialogs are explicitly user-paced. Do not let the
-      // short broker/readiness timeout detach the browser from a dialog which
-      // may legitimately remain open for minutes. Non-interactive operations
-      // (capabilities and same-file Save) stay bounded and fail closed.
-      var interactive = operation === 'OPEN' || operation === 'SAVE_AS';
-      var timer = interactive ? null : setTimeout(function() {
+      // Bound only the non-side-effecting readiness handshake. Open and Save As
+      // are user-paced, while Save may legitimately block on slow local/network
+      // storage. The protocol has no cancellation acknowledgement: timing out a
+      // file operation could detach the browser from an operation that later
+      // commits, leaving the manager's target state inconsistent with disk.
+      var bounded = operation === 'CAPABILITIES';
+      var timer = bounded ? setTimeout(function() {
         if (!self.pending[id]) return;
         delete self.pending[id];
         reject(new BrokerError('TIMEOUT'));
-      }, self.timeoutMs);
+      }, self.timeoutMs) : null;
       self.pending[id] = {operation: operation, resolve: resolve, reject: reject, timer: timer};
       try {
         self.robotWindow.send(PREFIX + ' REQUEST ' + id + ' ' + operation + suffix);

--- a/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
@@ -1,0 +1,178 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports)
+    module.exports = factory();
+  else
+    root.WebeeBlocksProjectFileWwiTransport = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  var PREFIX = 'WEBEEBLOCKS_FILE_BROKER_V1';
+  var TOKEN = /^[A-Za-z0-9_-]{1,128}$/;
+
+  function BrokerError(code) {
+    this.name = 'ProjectFileBrokerError';
+    this.code = String(code || 'IO_ERROR');
+    this.message = 'Project file broker error: ' + this.code;
+    if (Error.captureStackTrace) Error.captureStackTrace(this, BrokerError);
+  }
+  BrokerError.prototype = Object.create(Error.prototype);
+  BrokerError.prototype.constructor = BrokerError;
+
+  function cancellation() {
+    var error = new Error('Project file dialog cancelled');
+    error.name = 'AbortError';
+    error.code = 20;
+    return error;
+  }
+
+  function bytesToBase64(bytes) {
+    if (typeof btoa === 'function') {
+      var binary = '';
+      for (var offset = 0; offset < bytes.length; offset += 0x8000) {
+        var chunk = bytes.subarray(offset, Math.min(offset + 0x8000, bytes.length));
+        binary += String.fromCharCode.apply(null, chunk);
+      }
+      return btoa(binary);
+    }
+    if (typeof Buffer !== 'undefined') return Buffer.from(bytes).toString('base64');
+    throw new Error('Base64 encoder unavailable');
+  }
+
+  function base64ToBytes(value) {
+    if (typeof atob === 'function') {
+      var binary = atob(value);
+      var bytes = new Uint8Array(binary.length);
+      for (var i = 0; i < binary.length; ++i) bytes[i] = binary.charCodeAt(i);
+      return bytes;
+    }
+    if (typeof Buffer !== 'undefined') return new Uint8Array(Buffer.from(value, 'base64'));
+    throw new Error('Base64 decoder unavailable');
+  }
+
+  function encodeText(value) {
+    if (typeof TextEncoder !== 'function') throw new Error('UTF-8 encoder unavailable');
+    return bytesToBase64(new TextEncoder().encode(String(value)));
+  }
+
+  function decodeText(value) {
+    if (typeof TextDecoder !== 'function') throw new Error('UTF-8 decoder unavailable');
+    return new TextDecoder('utf-8', {fatal: true}).decode(base64ToBytes(value));
+  }
+
+  function WwiProjectFileTransport(robotWindow, options) {
+    if (!robotWindow || typeof robotWindow.send !== 'function')
+      throw new Error('Project file WWI transport unavailable');
+    this.robotWindow = robotWindow;
+    this.timeoutMs = options && Number.isFinite(options.timeoutMs) ? options.timeoutMs : 5000;
+    this.nextId = 1;
+    this.pending = Object.create(null);
+    this.readyPromise = null;
+    this.capabilities = null;
+    // Compatibility with the existing project manager/UI contract: both the
+    // Chromium picker and the local WWI broker provide direct same-file access.
+    this.nativeFileSystemAccess = true;
+    this.mode = 'wwi-native';
+  }
+
+  WwiProjectFileTransport.prototype._request = function(operation, args) {
+    var self = this;
+    var id = this.nextId++;
+    var suffix = args && args.length ? ' ' + args.join(' ') : '';
+    return new Promise(function(resolve, reject) {
+      var timer = setTimeout(function() {
+        if (!self.pending[id]) return;
+        delete self.pending[id];
+        reject(new BrokerError('TIMEOUT'));
+      }, self.timeoutMs);
+      self.pending[id] = {operation: operation, resolve: resolve, reject: reject, timer: timer};
+      try {
+        self.robotWindow.send(PREFIX + ' REQUEST ' + id + ' ' + operation + suffix);
+      } catch (error) {
+        clearTimeout(timer);
+        delete self.pending[id];
+        reject(error);
+      }
+    });
+  };
+
+  WwiProjectFileTransport.prototype.waitUntilReady = function() {
+    if (this.readyPromise) return this.readyPromise;
+    var self = this;
+    this.readyPromise = this._request('CAPABILITIES', []).then(function(capabilities) {
+      if (!capabilities || capabilities.protocol !== 1 || capabilities.operationsReady !== true ||
+          capabilities.sameFileSave !== true || capabilities.canonicalExtension !== '.wbb')
+        throw new BrokerError('CAPABILITY_UNAVAILABLE');
+      self.capabilities = Object.freeze(capabilities);
+      return self.capabilities;
+    });
+    return this.readyPromise;
+  };
+
+  WwiProjectFileTransport.prototype.handleMessage = function(message) {
+    if (typeof message !== 'string' || message.indexOf(PREFIX + ' RESPONSE ') !== 0)
+      return false;
+    var match = message.match(/^WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE (\d+) (.+)$/);
+    if (!match) return true;
+    var id = Number(match[1]);
+    var pending = this.pending[id];
+    if (!pending) return true;
+    clearTimeout(pending.timer);
+    delete this.pending[id];
+    var payload = match[2];
+    var error = payload.match(/^ERR ([A-Z][A-Z0-9_]{0,63})$/);
+    if (error) {
+      pending.reject(new BrokerError(error[1]));
+      return true;
+    }
+    if (payload === pending.operation + ' CANCELLED') {
+      pending.reject(cancellation());
+      return true;
+    }
+    try {
+      if (pending.operation === 'CAPABILITIES') {
+        var capabilities = payload.match(/^CAPABILITIES (\{.*\})$/);
+        if (!capabilities) throw new BrokerError('INVALID_RESPONSE');
+        pending.resolve(JSON.parse(capabilities[1]));
+        return true;
+      }
+      if (pending.operation === 'OPEN') {
+        var opened = payload.match(/^OPEN OK ([A-Za-z0-9_-]{1,128}) ([A-Za-z0-9+/=]+) ([A-Za-z0-9+/=]+)$/);
+        if (!opened) throw new BrokerError('INVALID_RESPONSE');
+        pending.resolve({handle:{kind:'wwi',reference:opened[1]}, name:decodeText(opened[2]), text:decodeText(opened[3]), mode:this.mode});
+        return true;
+      }
+      var saved = payload.match(new RegExp('^' + pending.operation + ' OK ([A-Za-z0-9_-]{1,128}) ([A-Za-z0-9+/=]+)$'));
+      if (!saved) throw new BrokerError('INVALID_RESPONSE');
+      pending.resolve({handle:{kind:'wwi',reference:saved[1]}, name:decodeText(saved[2]), mode:this.mode});
+    } catch (responseError) {
+      pending.reject(responseError instanceof BrokerError ? responseError : new BrokerError('INVALID_RESPONSE'));
+    }
+    return true;
+  };
+
+  WwiProjectFileTransport.prototype.open = function() {
+    var self = this;
+    return this.waitUntilReady().then(function() { return self._request('OPEN', []); });
+  };
+
+  WwiProjectFileTransport.prototype.saveAs = function(name, text) {
+    var self = this;
+    return this.waitUntilReady().then(function() {
+      return self._request('SAVE_AS', [encodeText(name), encodeText(text)]);
+    });
+  };
+
+  WwiProjectFileTransport.prototype.save = function(target, name, text) {
+    var self = this;
+    if (!target || target.kind !== 'wwi' || !TOKEN.test(target.reference || ''))
+      return Promise.reject(new BrokerError('TARGET_UNAVAILABLE'));
+    return this.waitUntilReady().then(function() {
+      return self._request('SAVE', [target.reference, encodeText(text)]);
+    });
+  };
+
+  WwiProjectFileTransport.BrokerError = BrokerError;
+  WwiProjectFileTransport.encodeText = encodeText;
+  WwiProjectFileTransport.decodeText = decodeText;
+  return WwiProjectFileTransport;
+});

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -100,7 +100,7 @@
   async function createDirectTransport() {
     var browserTransport = WebeeBlocksProjectFiles.createBrowserTransport(window, document);
     if (browserTransport.nativeFileSystemAccess) {
-      browserTransport.mode = 'native';
+      browserTransport.mode = 'browser-native';
       return browserTransport;
     }
 

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -100,7 +100,7 @@
   async function createDirectTransport() {
     var browserTransport = WebeeBlocksProjectFiles.createBrowserTransport(window, document);
     if (browserTransport.nativeFileSystemAccess) {
-      browserTransport.mode = 'browser-native';
+      browserTransport.mode = 'native';
       return browserTransport;
     }
 

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -5,6 +5,7 @@
   var busy = false;
   var supported = false;
   var runtimeLocked = false;
+  var brokerTransport = null;
 
   function fileState(text, error) {
     var target = document.getElementById('projectFileState');
@@ -78,47 +79,54 @@
     return WebeeBlocksProjectFiles.normalizeName(base);
   }
 
-  window.addEventListener('webeeblocks-runtime-v2', function(event) {
-    var state = event && event.detail ? event.detail.state : null;
-    setRuntimeLocked(state === 'EN VOL' || state === 'RÉINITIALISATION');
-  });
-
-  window.addEventListener('load', function() {
-    if (!workspace || !runtimeProfile) {
-      fileState('Fichiers projet indisponibles', true);
-      renderButtons();
-      return;
-    }
-
-    var transport = WebeeBlocksProjectFiles.createBrowserTransport(window, document);
-    manager = WebeeBlocksProjectFiles.createManager({
-      Blockly: Blockly,
-      profiles: WebeeBlocksActivityProfiles,
-      activitiesDocument: WebeeBlocksActivities.DOCUMENT,
-      blockCatalog: WebeeBlocksActivities.BLOCK_CATALOG,
-      semanticAst: WebeeBlocksSemanticAst,
-      activityContract: WebeeBlocksActivityContract,
-      workspace: workspace,
-      getProfile: function() { return runtimeProfile; },
-      setProfile: applyProfile,
-      transport: transport
+  function waitForRobotWindow(timeoutMs) {
+    return new Promise(function(resolve, reject) {
+      var deadline = Date.now() + timeoutMs;
+      function poll() {
+        if (typeof robotWindow !== 'undefined' && robotWindow && typeof robotWindow.send === 'function' && typeof robotWindow.receive === 'function') {
+          resolve(robotWindow);
+          return;
+        }
+        if (Date.now() >= deadline) {
+          reject(new Error('Robot Window transport unavailable for project files'));
+          return;
+        }
+        setTimeout(poll, 25);
+      }
+      poll();
     });
-    window.WebeeBlocksProjectManager = manager;
-    supported = manager.nativeFileSystemAccess;
-    document.body.dataset.projectFileMode = supported ? 'native' : 'unavailable';
-    window.dispatchEvent(new CustomEvent('webeeblocks-project-files-ready', {
-      detail: {nativeFileSystemAccess: supported, mode: supported ? 'native' : 'unavailable'}
-    }));
+  }
 
-    if (!supported) {
-      fileState('Gestion des fichiers projet : utilisez Google Chrome', true);
-      renderButtons();
-      return;
+  async function createDirectTransport() {
+    var browserTransport = WebeeBlocksProjectFiles.createBrowserTransport(window, document);
+    if (browserTransport.nativeFileSystemAccess) {
+      browserTransport.mode = 'browser-native';
+      return browserTransport;
     }
 
-    fileState('Aucun fichier projet sélectionné', false);
-    renderButtons();
+    await import('../blockly/webeeblocks/project_file_wwi_transport.js');
+    if (typeof window.WebeeBlocksProjectFileWwiTransport !== 'function')
+      throw new Error('Project file WWI transport module unavailable');
+    var directRobotWindow = await waitForRobotWindow(5000);
+    brokerTransport = new window.WebeeBlocksProjectFileWwiTransport(directRobotWindow, {timeoutMs: 5000});
 
+    // RobotWindow has one receive callback. Runtime v2 keeps ownership of the
+    // existing handler; the broker consumes only its own prefixed responses and
+    // forwards every other message unchanged.
+    var runtimeReceive = directRobotWindow.receive;
+    directRobotWindow.receive = function(value) {
+      if (brokerTransport && brokerTransport.handleMessage(value)) {
+        window.dispatchEvent(new CustomEvent('webeeblocks-wwi', {detail: value}));
+        return;
+      }
+      return runtimeReceive.call(directRobotWindow, value);
+    };
+    await brokerTransport.waitUntilReady();
+    window.WebeeBlocksProjectTransport = brokerTransport;
+    return brokerTransport;
+  }
+
+  function bindProjectButtons() {
     document.getElementById('projectOpen').addEventListener('click', function() {
       operation('open', async function() {
         var result = await manager.open();
@@ -146,6 +154,65 @@
         var result = await manager.save();
         fileState('Projet : ' + result.name, false);
       });
+    });
+  }
+
+  window.addEventListener('webeeblocks-runtime-v2', function(event) {
+    var state = event && event.detail ? event.detail.state : null;
+    setRuntimeLocked(state === 'EN VOL' || state === 'RÉINITIALISATION');
+  });
+
+  window.addEventListener('load', function() {
+    (async function() {
+      if (!workspace || !runtimeProfile) {
+        fileState('Fichiers projet indisponibles', true);
+        renderButtons();
+        return;
+      }
+
+      var transport;
+      try {
+        transport = await createDirectTransport();
+      } catch (error) {
+        diagnostic('initialisation', error);
+        fileState('Gestion des fichiers projet indisponible dans ce navigateur', true);
+        document.body.dataset.projectFileMode = 'unavailable';
+        renderButtons();
+        return;
+      }
+
+      manager = WebeeBlocksProjectFiles.createManager({
+        Blockly: Blockly,
+        profiles: WebeeBlocksActivityProfiles,
+        activitiesDocument: WebeeBlocksActivities.DOCUMENT,
+        blockCatalog: WebeeBlocksActivities.BLOCK_CATALOG,
+        semanticAst: WebeeBlocksSemanticAst,
+        activityContract: WebeeBlocksActivityContract,
+        workspace: workspace,
+        getProfile: function() { return runtimeProfile; },
+        setProfile: applyProfile,
+        transport: transport
+      });
+      window.WebeeBlocksProjectManager = manager;
+      supported = manager.nativeFileSystemAccess;
+      document.body.dataset.projectFileMode = transport.mode || 'native';
+      window.dispatchEvent(new CustomEvent('webeeblocks-project-files-ready', {
+        detail: {nativeFileSystemAccess: supported, mode: document.body.dataset.projectFileMode}
+      }));
+
+      if (!supported) {
+        fileState('Gestion des fichiers projet indisponible dans ce navigateur', true);
+        renderButtons();
+        return;
+      }
+
+      fileState('Aucun fichier projet sélectionné', false);
+      bindProjectButtons();
+      renderButtons();
+    })().catch(function(error) {
+      diagnostic('initialisation', error);
+      fileState('Gestion des fichiers projet indisponible dans ce navigateur', true);
+      renderButtons();
     });
   });
 })();

--- a/tools/ci/prepare_runtime_v2_project_files.py
+++ b/tools/ci/prepare_runtime_v2_project_files.py
@@ -128,7 +128,7 @@ harness = r'''
         if (String(Blockly.VERSION) !== '13.2.1') throw new Error('unexpected Blockly version ' + Blockly.VERSION);
         if (!document.getElementById('projectOpen') || !document.getElementById('projectSave') || !document.getElementById('projectSaveAs'))
           throw new Error('manual project buttons missing');
-        if (document.body.dataset.projectFileMode !== 'native') throw new Error('R2025a project file mode is not native');
+        if (document.body.dataset.projectFileMode !== 'browser-native') throw new Error('R2025a Chrome project file mode is not browser-native');
 
         loadXml(__FIXTURE__);
         const initialAst = currentAst();

--- a/tools/ci/test_firefox_file_broker.cpp
+++ b/tools/ci/test_firefox_file_broker.cpp
@@ -1,0 +1,94 @@
+#include "file_broker.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+struct FakeState {
+  std::string lastName;
+  std::string lastBytes;
+  std::string lastReference;
+  bool cancelOpen = false;
+  bool missingTarget = false;
+};
+
+class FakeProvider final : public webeeblocks::FileDialogProvider {
+public:
+  explicit FakeProvider(FakeState *state) : state_(state) {}
+  std::string name() const override { return "fake-native"; }
+  webeeblocks::OpenFileResult open() override {
+    if (state_->cancelOpen)
+      return {webeeblocks::FileOperationStatus::Cancelled, "", "", "", ""};
+    return {webeeblocks::FileOperationStatus::Ok, "opaque_open_1", "élève.wbb", "{\"format\":\"webeeblocks-project\"}\n", ""};
+  }
+  webeeblocks::SaveFileResult saveAs(const std::string &name, const std::string &bytes) override {
+    state_->lastName = name;
+    state_->lastBytes = bytes;
+    return {webeeblocks::FileOperationStatus::Ok, "opaque_saveas_2", name, ""};
+  }
+  webeeblocks::SaveFileResult save(const std::string &reference, const std::string &bytes) override {
+    state_->lastReference = reference;
+    state_->lastBytes = bytes;
+    if (state_->missingTarget)
+      return {webeeblocks::FileOperationStatus::Error, "", "", "TARGET_UNAVAILABLE"};
+    return {webeeblocks::FileOperationStatus::Ok, reference, "élève.wbb", ""};
+  }
+private:
+  FakeState *state_;
+};
+
+std::string send(webeeblocks::FileBroker &broker, const std::string &message) {
+  std::string response;
+  assert(broker.handleMessage(message.c_str(), &response));
+  assert(!response.empty());
+  return response;
+}
+}  // namespace
+
+int main() {
+  FakeState state;
+  webeeblocks::FileBroker broker(std::make_unique<FakeProvider>(&state));
+  std::string ignored;
+  assert(!broker.handleMessage("WEBEEBLOCKS_RUNTIME_V2 READY", &ignored));
+
+  const auto capabilities = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 1 CAPABILITIES");
+  assert(capabilities.find("\"operationsReady\":true") != std::string::npos);
+  assert(capabilities.find("\"sameFileSave\":true") != std::string::npos);
+
+  const auto opened = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 2 OPEN");
+  assert(opened.find("RESPONSE 2 OPEN OK opaque_open_1 ") != std::string::npos);
+  assert(opened.find("/tmp/") == std::string::npos);
+
+  const std::string bytes64 = "eyJvayI6MX0K";  // {"ok":1}\n
+  const auto saveAs = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 3 SAVE_AS ZW5jb3Vycy53YmI= " + bytes64);
+  assert(saveAs.find("RESPONSE 3 SAVE_AS OK opaque_saveas_2 ") != std::string::npos);
+  assert(state.lastName == "encours.wbb");
+  assert(state.lastBytes == "{\"ok\":1}\n");
+
+  const auto save = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 4 SAVE opaque_saveas_2 " + bytes64);
+  assert(save.find("RESPONSE 4 SAVE OK opaque_saveas_2 ") != std::string::npos);
+  assert(state.lastReference == "opaque_saveas_2");
+  assert(state.lastBytes == "{\"ok\":1}\n");
+
+  // A browser-supplied path is rejected at the protocol boundary; the provider
+  // can receive only a basename proposal and an opaque reference.
+  const auto pathInjection = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 5 SAVE_AS L3RtcC9ldmlsLndiYg== " + bytes64);
+  assert(pathInjection == "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 5 ERR INVALID_REQUEST");
+
+  state.cancelOpen = true;
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 6 OPEN") ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 6 OPEN CANCELLED");
+  state.cancelOpen = false;
+
+  state.missingTarget = true;
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 SAVE opaque_saveas_2 " + bytes64) ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 7 ERR TARGET_UNAVAILABLE");
+
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 8 SAVE ../escape " + bytes64) ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 8 ERR INVALID_REQUEST");
+
+  std::cout << "PASS firefox-file-broker: capabilities/open/save-as/same-reference-save/cancel/errors/no-browser-path\n";
+  return 0;
+}

--- a/tools/ci/test_runtime_v2_project_files.js
+++ b/tools/ci/test_runtime_v2_project_files.js
@@ -9,6 +9,7 @@ const Activities = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeb
 const SemanticAst = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/semantic_ast.js'));
 const ActivityContract = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/activity_contract.js'));
 const ProjectFiles = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/project_files.js'));
+const WwiProjectFileTransport = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js'));
 
 Blockly.defineBlocksWithJsonArray([
   {type:'webeeblocks_v2_takeoff', message0:'takeoff %1', args0:[{type:'field_number',name:'HEIGHT',value:1,min:0.2,max:1.5,precision:0.1}], previousStatement:null,nextStatement:null},
@@ -163,8 +164,64 @@ async function exerciseBrowserBoundary() {
   assert(!ProjectFiles.createBrowserTransport.toString().includes("createElement('input')"), 'input upload fallback must not exist');
 }
 
+async function exerciseWwiBoundary() {
+  const sent = [];
+  const robotWindow = {send(message) { sent.push(String(message)); }};
+  const transport = new WwiProjectFileTransport(robotWindow, {timeoutMs:1000});
+  assert.strictEqual(transport.nativeFileSystemAccess, true);
+  assert.strictEqual(transport.mode, 'wwi-native');
+
+  function requestId() {
+    const match = sent.at(-1).match(/^WEBEEBLOCKS_FILE_BROKER_V1 REQUEST (\d+) /);
+    assert(match, sent.at(-1));
+    return match[1];
+  }
+
+  let pending = transport.waitUntilReady();
+  let id = requestId();
+  assert(transport.handleMessage(`WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} CAPABILITIES {"protocol":1,"provider":"qt6-native-dialog","operationsReady":true,"sameFileSave":true,"canonicalExtension":".wbb"}`));
+  await pending;
+
+  const openedText = '{"format":"webeeblocks-project"}\n';
+  pending = transport.open();
+  await Promise.resolve();
+  id = requestId();
+  transport.handleMessage(`WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} OPEN OK opaque_open_1 ${WwiProjectFileTransport.encodeText('élève.wbb')} ${WwiProjectFileTransport.encodeText(openedText)}`);
+  const opened = await pending;
+  assert.deepStrictEqual(opened.handle, {kind:'wwi',reference:'opaque_open_1'});
+  assert.strictEqual(opened.name, 'élève.wbb');
+  assert.strictEqual(opened.text, openedText);
+
+  pending = transport.saveAs('élève.wbb', '{"ok":2}\n');
+  await Promise.resolve();
+  id = requestId();
+  assert(sent.at(-1).includes(' SAVE_AS '));
+  assert(!sent.at(-1).includes('{"ok":2}'), 'WWI request leaked raw project bytes');
+  transport.handleMessage(`WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} SAVE_AS OK opaque_saveas_2 ${WwiProjectFileTransport.encodeText('élève.wbb')}`);
+  const saved = await pending;
+  assert.deepStrictEqual(saved.handle, {kind:'wwi',reference:'opaque_saveas_2'});
+
+  pending = transport.save(saved.handle, saved.name, '{"ok":3}\n');
+  await Promise.resolve();
+  id = requestId();
+  assert(sent.at(-1).includes(' SAVE opaque_saveas_2 '), 'Save did not reuse opaque same-file reference');
+  transport.handleMessage(`WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} SAVE OK opaque_saveas_2 ${WwiProjectFileTransport.encodeText('élève.wbb')}`);
+  const resaved = await pending;
+  assert.deepStrictEqual(resaved.handle, saved.handle);
+
+  pending = transport.open();
+  await Promise.resolve();
+  id = requestId();
+  transport.handleMessage(`WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} OPEN CANCELLED`);
+  await assert.rejects(pending, error => error && error.name === 'AbortError');
+
+  await assert.rejects(transport.save({kind:'wwi',reference:'../path'}, 'x.wbb', '{}'), error => error && error.code === 'TARGET_UNAVAILABLE');
+  assert.strictEqual(transport.handleMessage('WEBEEBLOCKS_RUNTIME_V2 READY'), false, 'broker consumed runtime traffic');
+}
+
 (async function() {
   await exerciseBrowserBoundary();
+  await exerciseWwiBoundary();
   assert.strictEqual(ProjectFiles.EXTENSION, '.wbb');
   assert.strictEqual(ProjectFiles.normalizeName('eleve'), 'eleve.wbb');
   assert.strictEqual(ProjectFiles.normalizeName('eleve.webeeblocks.json'), 'eleve.wbb');
@@ -258,7 +315,9 @@ async function exerciseBrowserBoundary() {
   const uiSource = fs.readFileSync(path.join(ROOT, 'plugins/robot_windows/blockly_v2/project_ui.js'), 'utf8');
   assert(uiSource.includes("error.name === 'AbortError'"), 'UI must treat native cancellation neutrally');
   assert(uiSource.includes('!manager.hasCurrentTarget()'), 'UI must disable Save without a current handle');
-  assert(uiSource.includes('utilisez Google Chrome'), 'unsupported-browser message must be explicit');
+  assert(uiSource.includes('createDirectTransport'), 'UI must select a direct browser-or-WWI transport');
+  assert(uiSource.includes('project_file_wwi_transport.js'), 'UI must load local WWI transport for Firefox');
+  assert(!uiSource.includes('utilisez Google Chrome'), 'UI must not hard-code Chrome as the only direct-file browser');
   assert(!uiSource.includes('Nouvelle copie'), 'UI must not advertise download copies');
-  console.log('PASS project-files: Chrome .wbb/options/same-handle/state/fail-closed/profile-field-injection/no-fallback/no-autosave');
+  console.log('PASS project-files: Chrome+WWI direct .wbb/options/same-handle/state/fail-closed/profile-field-injection/no-fallback/no-autosave');
 })().catch(error => { console.error(error); process.exit(1); });

--- a/tools/ci/test_runtime_v2_reset.js
+++ b/tools/ci/test_runtime_v2_reset.js
@@ -66,7 +66,7 @@ async function testBackendResetContract() {
   await assert.rejects(() => physical.resetSimulation(), /simulation reset unavailable/);
 }
 
-async function testInteractiveProjectDialogsOutliveBrokerTimeout() {
+async function testProjectFileOperationsOutliveReadinessTimeout() {
   const sent = [];
   const transport = new WwiProjectFileTransport(
     {send: message => sent.push(String(message))},
@@ -90,7 +90,7 @@ async function testInteractiveProjectDialogsOutliveBrokerTimeout() {
   await Promise.resolve();
   id = requestId();
   await new Promise(resolve => setTimeout(resolve, 20));
-  assert(transport.pending[id], 'interactive Open expired on the ordinary broker timeout');
+  assert(transport.pending[id], 'Open expired on the readiness timeout');
   transport.handleMessage(
     `WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} OPEN OK delayed_open ${WwiProjectFileTransport.encodeText('delayed.wbb')} ${WwiProjectFileTransport.encodeText('{"ok":1}')}`
   );
@@ -101,18 +101,30 @@ async function testInteractiveProjectDialogsOutliveBrokerTimeout() {
   await Promise.resolve();
   id = requestId();
   await new Promise(resolve => setTimeout(resolve, 20));
-  assert(transport.pending[id], 'interactive Save As expired on the ordinary broker timeout');
+  assert(transport.pending[id], 'Save As expired on the readiness timeout');
   transport.handleMessage(
     `WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} SAVE_AS OK delayed_save ${WwiProjectFileTransport.encodeText('delayed.wbb')}`
   );
   const saved = await pending;
   assert.strictEqual(saved.handle.reference, 'delayed_save');
 
+  pending = transport.save(saved.handle, saved.name, '{"ok":3}');
+  await Promise.resolve();
+  id = requestId();
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert(transport.pending[id], 'same-file Save expired after its disk effect could have committed');
+  transport.handleMessage(
+    `WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} SAVE OK delayed_save ${WwiProjectFileTransport.encodeText('delayed.wbb')}`
+  );
+  const resaved = await pending;
+  assert.strictEqual(resaved.handle.reference, 'delayed_save');
+
+  const unavailable = new WwiProjectFileTransport({send: () => {}}, {timeoutMs: 5});
   await assert.rejects(
-    transport.save(saved.handle, saved.name, '{"ok":3}'),
+    unavailable.waitUntilReady(),
     error => error && error.code === 'TIMEOUT'
   );
-  assert.strictEqual(Object.keys(transport.pending).length, 0, 'timed-out same-file Save stayed pending');
+  assert.strictEqual(Object.keys(unavailable.pending).length, 0, 'readiness timeout stayed pending');
 }
 
 async function testProjectOpenKeepsResetRequirementAndLocksDuringReset() {
@@ -228,10 +240,10 @@ function testNativeResetTimeoutSourceContract() {
 
 (async () => {
   await testBackendResetContract();
-  await testInteractiveProjectDialogsOutliveBrokerTimeout();
+  await testProjectFileOperationsOutliveReadinessTimeout();
   await testProjectOpenKeepsResetRequirementAndLocksDuringReset();
   testNativeResetTimeoutSourceContract();
-  console.log('PASS: reset cancels stale requests, project dialogs remain user-paced, same-file Save stays bounded, reset stays retryable, Blockly/Open lock while pending, and project reset gating remains simulation-only.');
+  console.log('PASS: reset cancels stale requests, project-file effects stay attached while readiness stays bounded, reset stays retryable, Blockly/Open lock while pending, and project reset gating remains simulation-only.');
 })().catch(error => {
   console.error(error.stack || error);
   process.exit(1);

--- a/tools/ci/test_runtime_v2_reset.js
+++ b/tools/ci/test_runtime_v2_reset.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 const WwiBackend = require('../../plugins/robot_windows/blockly/webeeblocks/wwi_backend.js');
+const WwiProjectFileTransport = require('../../plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js');
 
 async function testBackendResetContract() {
   const sent = [];
@@ -63,6 +64,55 @@ async function testBackendResetContract() {
   const physical = new WwiBackend({send: () => {}}, {timeoutMs: 1000});
   assert.notStrictEqual(physical.capabilities.simulationReset, true);
   await assert.rejects(() => physical.resetSimulation(), /simulation reset unavailable/);
+}
+
+async function testInteractiveProjectDialogsOutliveBrokerTimeout() {
+  const sent = [];
+  const transport = new WwiProjectFileTransport(
+    {send: message => sent.push(String(message))},
+    {timeoutMs: 5}
+  );
+
+  function requestId() {
+    const match = sent.at(-1).match(/^WEBEEBLOCKS_FILE_BROKER_V1 REQUEST (\d+) /);
+    assert(match, sent.at(-1));
+    return Number(match[1]);
+  }
+
+  let pending = transport.waitUntilReady();
+  let id = requestId();
+  transport.handleMessage(
+    `WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} CAPABILITIES {"protocol":1,"provider":"qt6-native-dialog","operationsReady":true,"sameFileSave":true,"canonicalExtension":".wbb"}`
+  );
+  await pending;
+
+  pending = transport.open();
+  await Promise.resolve();
+  id = requestId();
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert(transport.pending[id], 'interactive Open expired on the ordinary broker timeout');
+  transport.handleMessage(
+    `WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} OPEN OK delayed_open ${WwiProjectFileTransport.encodeText('delayed.wbb')} ${WwiProjectFileTransport.encodeText('{"ok":1}')}`
+  );
+  const opened = await pending;
+  assert.strictEqual(opened.handle.reference, 'delayed_open');
+
+  pending = transport.saveAs('delayed.wbb', '{"ok":2}');
+  await Promise.resolve();
+  id = requestId();
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert(transport.pending[id], 'interactive Save As expired on the ordinary broker timeout');
+  transport.handleMessage(
+    `WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE ${id} SAVE_AS OK delayed_save ${WwiProjectFileTransport.encodeText('delayed.wbb')}`
+  );
+  const saved = await pending;
+  assert.strictEqual(saved.handle.reference, 'delayed_save');
+
+  await assert.rejects(
+    transport.save(saved.handle, saved.name, '{"ok":3}'),
+    error => error && error.code === 'TIMEOUT'
+  );
+  assert.strictEqual(Object.keys(transport.pending).length, 0, 'timed-out same-file Save stayed pending');
 }
 
 async function testProjectOpenKeepsResetRequirementAndLocksDuringReset() {
@@ -178,9 +228,10 @@ function testNativeResetTimeoutSourceContract() {
 
 (async () => {
   await testBackendResetContract();
+  await testInteractiveProjectDialogsOutliveBrokerTimeout();
   await testProjectOpenKeepsResetRequirementAndLocksDuringReset();
   testNativeResetTimeoutSourceContract();
-  console.log('PASS: reset cancels stale requests, stays retryable, locks Blockly/Open while pending, preserves project reset gating, and remains simulation-only.');
+  console.log('PASS: reset cancels stale requests, project dialogs remain user-paced, same-file Save stays bounded, reset stays retryable, Blockly/Open lock while pending, and project reset gating remains simulation-only.');
 })().catch(error => {
   console.error(error.stack || error);
   process.exit(1);

--- a/tools/ci/test_runtime_v2_reset.js
+++ b/tools/ci/test_runtime_v2_reset.js
@@ -128,7 +128,7 @@ async function testProjectOpenKeepsResetRequirementAndLocksDuringReset() {
     WebeeBlocksSemanticAst: {},
     WebeeBlocksActivityContract: {applyFieldBounds() {}},
     WebeeBlocksProjectFiles: {
-      createBrowserTransport: () => ({}),
+      createBrowserTransport: () => ({nativeFileSystemAccess: true, mode: 'browser-native'}),
       createManager: () => manager,
       normalizeName: name => name
     },
@@ -142,6 +142,10 @@ async function testProjectOpenKeepsResetRequirementAndLocksDuringReset() {
   assert.strictEqual(typeof loadHandler, 'function');
   assert.strictEqual(typeof runtimeStatusHandler, 'function');
   loadHandler();
+  // Project-file transport selection is asynchronous now that Firefox may
+  // negotiate the local WWI broker. Let the established browser-native path
+  // finish initialization before exercising the reset interlock.
+  await new Promise(resolve => setTimeout(resolve, 0));
   assert.strictEqual(typeof openHandler, 'function');
 
   runtimeStatusHandler({detail: {state: 'RÉINITIALISATION'}});


### PR DESCRIPTION
Advances #87 from the established #317 Qt/controller continuity prerequisite to the product file path.

This slice keeps the existing project manager semantics and adds a local WWI transport for browsers without File System Access. Chrome keeps its existing direct native-picker transport. On the Linux desktop Webots path, Firefox uses a Qt6 native file broker co-located with the Runtime v2 controller.

The broker exposes only session-scoped opaque references to the browser: JavaScript never supplies an arbitrary filesystem path. Open returns bytes plus an opaque reference, but the existing manager adopts that target only after full `.wbb` validation. Save As adopts a new opaque reference only after the native atomic write commits. Save reuses the exact existing reference with no dialog or generated copy; a missing or unavailable target fails explicitly. Cancellation remains neutral and errors preserve the current project/target.

The runtime integration consumes only `WEBEEBLOCKS_FILE_BROKER_V1` WWI traffic and forwards Runtime v2 traffic unchanged. The Qt provider is lazy, so the established Chrome Runtime path does not create a file dialog provider unless broker traffic is requested. The implementation uses the QFileDialog/QApplication continuity established by #317 rather than restarting the historical research harness.

Windows Firefox qualification remains a separate later boundary; the current Windows classroom release path is unchanged.

Local evidence before publication:
- native broker fake-provider C++ contract: PASS for capabilities, Open, Save As, same-reference Save, cancellation, explicit errors and no browser-supplied path;
- WWI JavaScript transport request/response contract: PASS;
- syntax checks for the transport, project UI and extended project-file test: PASS.

Canonical CI must still compile/link the Qt integration against official Webots R2025a and exercise the unchanged Runtime/Chrome path before this candidate is stable.

Refs #87 #317.