### PR TITLE
Apply exact physical set_speed as trusted run state

### DIFF
--- a/tools/ci/test_physical_high_level_timing.py
+++ b/tools/ci/test_physical_high_level_timing.py
@@ -64,6 +64,11 @@ assert "send_packet" not in source
 assert "takeoff_duration" not in source
 assert "landing_duration" not in source
 
+# Keep the new exact-AST set_speed production-shaped regression on the same
+# already-selected physical timing CI path without broadening workflow authority.
+import test_physical_set_speed_state as speed_state  # noqa: E402
+assert speed_state.main() == 0
+
 print(
     "PASS pure physical timing preserves horizontal speed/yaw-rate ceilings "
     "for serialized rest-to-rest HighLevelCommander trajectories"

--- a/tools/ci/test_physical_set_speed_state.py
+++ b/tools/ci/test_physical_set_speed_state.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+SEMANTIC_AST = ROOT / "plugins" / "robot_windows" / "blockly" / "webeeblocks" / "semantic_ast.js"
+sys.path.insert(0, str(CI))
+sys.path.insert(0, str(PHYSICAL))
+
+import controlled_landing_transport  # noqa: E402
+import high_level_timing as timing  # noqa: E402
+import landing_command  # noqa: E402
+import physical_program_sequence as sequence  # noqa: E402
+import physical_run_activation as activation  # noqa: E402
+import setpoint_hl_transport  # noqa: E402
+import test_physical_host_inflight_sequence as host  # noqa: E402
+
+REAL_TIMING_POLICY = activation.HighLevelTimingPolicy
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical(program: list[dict[str, object]]) -> str:
+    return json.dumps(
+        {
+            "program": program,
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def speed_ast(speed: object = 0.10, *, include_turn: bool = True) -> str:
+    program: list[dict[str, object]] = [
+        {"height_m": 0.6, "kind": "takeoff"},
+        {"kind": "set_speed", "speed_m_s": speed},
+        {"direction": "forward", "distance_m": 0.3, "kind": "move"},
+    ]
+    if include_turn:
+        program.append({"angle_deg": -25, "kind": "turn"})
+    program.append({"kind": "land"})
+    return canonical(program)
+
+
+def expect_sequence_error(ast_binding: str, pattern: str) -> None:
+    try:
+        sequence.PhysicalProgramSequence(ast_binding)
+    except sequence.PhysicalProgramSequenceError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError("expected fail-closed physical set_speed sequence error")
+
+
+def test_exact_speed_sequence_state() -> None:
+    domain = sequence.PhysicalProgramSequence(speed_ast(include_turn=False))
+    require(domain.next_step_kind == "set_speed", "exact set_speed must be next AST kind")
+    claim = domain.reserve_next_speed()
+    speed = domain.speed_for_claim(claim)
+    require(speed == sequence.SequencedSpeed(1, 0.10), "speed derives exact AST value/index")
+    try:
+        domain.release_unemitted(claim)
+    except sequence.PhysicalProgramSequenceError as exc:
+        require("effect claim" in str(exc), "set_speed must stay outside effect retry API")
+    else:
+        raise AssertionError("no-effect set_speed entered physical effect release API")
+    try:
+        domain.reserve_next_speed(0.2)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("caller-selected speed entered exact sequence API")
+    domain.complete_speed(claim)
+    require(domain.next_step_kind == "move", "completed speed state advances exactly once")
+    move = domain.reserve_next_motion()
+    require(domain.motion_for_claim(move).distance_m == 0.3, "next exact move remains intact")
+    domain.complete_motion(move)
+    land = domain.reserve_terminal_landing()
+    domain.complete_landing(land)
+    require(domain.completed, "speed program completes only through exact terminal land")
+
+    failed = sequence.PhysicalProgramSequence(speed_ast(include_turn=False))
+    failed_claim = failed.reserve_next_speed()
+    failed.fail_speed(failed_claim, "live run binding lost")
+    require(failed.terminal and failed.next_index == 1, "failed speed state is terminal without advance")
+
+
+def test_physical_speed_bounds_are_stricter_than_generic_ast() -> None:
+    require(
+        "speed_m_s:{min:0.1,max:0.6}" in SEMANTIC_AST.read_text(encoding="utf-8"),
+        "backend-neutral AST speed envelope was silently narrowed",
+    )
+    require(sequence.high_level_timing.MIN_HORIZONTAL_SPEED_M_S == 0.10, "physical minimum drifted")
+    require(sequence.high_level_timing.MAX_HORIZONTAL_SPEED_M_S == 0.35, "physical maximum drifted")
+
+    for value in (0.09, 0.36, 0.60, True, "0.2", float("nan"), float("inf")):
+        expect_sequence_error(speed_ast(value, include_turn=False), "set_speed")
+
+    malformed = canonical(
+        [
+            {"height_m": 0.6, "kind": "takeoff"},
+            {"kind": "set_speed", "speed_m_s": 0.2, "extra": True},
+            {"kind": "land"},
+        ]
+    )
+    expect_sequence_error(malformed, "unsupported fields")
+
+    # No-effect speed state must remain compatible with the existing exact
+    # terminal landing derivation because it changes no altitude.
+    landing = landing_command.derive_bound_landing_command(speed_ast(0.2, include_turn=False))
+    require(landing.descent_m == 0.6, "set_speed must not change terminal landing height")
+
+
+def _install_recording_fakes(*, failing_watchdog: bool = False) -> None:
+    host.install_fakes()
+
+    class RecordingTimingPolicy(REAL_TIMING_POLICY):
+        def set_horizontal_speed(self, speed_m_s: object) -> None:
+            super().set_horizontal_speed(speed_m_s)
+            host.base.EVENTS.append(("speed-state", self.horizontal_speed_m_s))
+
+    class RecordingTransport(host.FakePhysicalTransportBase):
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            host.base.EVENTS.append(("inflight-transport-init", self.bound_connection_epoch))
+
+        def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
+            host.base.EVENTS.append(
+                (
+                    "move-timing",
+                    timing_policy.horizontal_speed_m_s,
+                    timing_policy.horizontal_move_duration(distance_m),
+                )
+            )
+            return super().send_horizontal_move(
+                direction=direction,
+                distance_m=distance_m,
+                yaw_reader=yaw_reader,
+                timing_policy=timing_policy,
+            )
+
+        def send_turn(self, *, angle_deg, timing_policy):
+            host.base.EVENTS.append(
+                (
+                    "turn-timing",
+                    timing_policy.horizontal_speed_m_s,
+                    timing_policy.turn_duration(angle_deg),
+                )
+            )
+            return super().send_turn(angle_deg=angle_deg, timing_policy=timing_policy)
+
+    activation.HighLevelTimingPolicy = RecordingTimingPolicy
+    activation.TrustedControlledLandingTransport = RecordingTransport
+    controlled_landing_transport.TrustedControlledLandingTransport = RecordingTransport
+    setpoint_hl_transport.TrustedSetpointHlTransport = RecordingTransport
+
+    if failing_watchdog:
+        class FailingWatchdog(host.base.FakeWatchdog):
+            def assert_live(self) -> None:
+                super().assert_live()
+                raise RuntimeError("injected set_speed watchdog liveness loss")
+
+        host.base.watchdog_liveness.EmergencyWatchdogLivenessGuard = FailingWatchdog
+
+
+def test_production_host_consumes_speed_without_effect_and_reuses_policy() -> None:
+    host.base.EVENTS.clear()
+    _install_recording_fakes()
+    replies = host.run_host_sequence(speed_ast(0.10), steps=4)
+
+    require(replies[1]["ok"] is False, "caller-selected substitute fields remain rejected")
+    for offset in range(2, 6):
+        require(replies[offset]["ok"] is True, f"exact speed program step {offset - 1} failed")
+        require(replies[offset]["executionAuthority"] is False, "caller response remains non-authority")
+
+    events = host.base.EVENTS
+    takeoff_index = events.index(("transport-send", "epoch-after"))
+    speed_index = events.index(("speed-state", 0.10))
+    transport_index = events.index(("inflight-transport-init", "epoch-after"))
+    require(
+        takeoff_index < speed_index < transport_index,
+        "set_speed must complete before any post-takeoff physical effect transport is created",
+    )
+
+    move_timing = next(event for event in events if isinstance(event, tuple) and event[0] == "move-timing")
+    require(math.isclose(move_timing[1], 0.10), "move did not receive exact run-local selected speed")
+    expected_selected = timing.REST_TO_REST_PEAK_FACTOR * 0.3 / 0.10
+    expected_default = timing.REST_TO_REST_PEAK_FACTOR * 0.3 / timing.DEFAULT_HORIZONTAL_SPEED_M_S
+    require(math.isclose(move_timing[2], expected_selected), "move duration does not use selected speed")
+    require(move_timing[2] > expected_default, "selected lower speed must causally lengthen move duration")
+
+    turn_timing = next(event for event in events if isinstance(event, tuple) and event[0] == "turn-timing")
+    expected_turn = timing.HighLevelTimingPolicy().turn_duration(-25)
+    require(math.isclose(turn_timing[2], expected_turn), "turn duration was coupled to horizontal set_speed")
+
+    speed_event_count = sum(1 for event in events if event == ("speed-state", 0.10))
+    require(speed_event_count == 1, "consumed exact speed statement replayed")
+    current_program_events = [event for event in events if event == ("current-program", "epoch-after")]
+    require(len(current_program_events) >= 5, "speed and later effects must re-establish current-program provenance")
+
+
+def test_invalid_speed_is_rejected_before_takeoff() -> None:
+    host.base.EVENTS.clear()
+    _install_recording_fakes()
+    replies = host.run_host_sequence(speed_ast(0.60, include_turn=False), steps=1)
+    require(replies[2]["ok"] is False, "out-of-envelope physical set_speed must reject activation")
+    require(
+        ("transport-send", "epoch-after") not in host.base.EVENTS,
+        "physical speed envelope violation reached takeoff",
+    )
+
+
+def test_watchdog_failure_while_applying_speed_is_terminal() -> None:
+    host.base.EVENTS.clear()
+    _install_recording_fakes(failing_watchdog=True)
+    replies = host.run_host_sequence(speed_ast(0.10, include_turn=False), steps=2)
+    require(replies[2]["ok"] is False, "watchdog loss must fail exact speed application")
+    require(replies[3]["ok"] is False, "terminal speed failure must reject the later move")
+    require(
+        not any(
+            isinstance(event, tuple)
+            and event[0] in {"inflight-move", "terminal-land", "move-timing"}
+            for event in host.base.EVENTS
+        ),
+        "failed no-effect speed state was skipped into a later physical effect",
+    )
+
+
+def main() -> int:
+    try:
+        test_exact_speed_sequence_state()
+        test_physical_speed_bounds_are_stricter_than_generic_ast()
+        test_production_host_consumes_speed_without_effect_and_reuses_policy()
+        test_invalid_speed_is_rejected_before_takeoff()
+        test_watchdog_failure_while_applying_speed_is_terminal()
+    finally:
+        activation.HighLevelTimingPolicy = REAL_TIMING_POLICY
+    print(
+        "PASS exact physical set_speed is bounded pre-takeoff, consumed once as trusted no-effect run state, "
+        "changes only subsequent horizontal move timing, and fails terminal on lost live-run certainty"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_set_speed_state.py
+++ b/tools/ci/test_physical_set_speed_state.py
@@ -103,8 +103,10 @@ def test_physical_speed_bounds_are_stricter_than_generic_ast() -> None:
     require(sequence.high_level_timing.MIN_HORIZONTAL_SPEED_M_S == 0.10, "physical minimum drifted")
     require(sequence.high_level_timing.MAX_HORIZONTAL_SPEED_M_S == 0.35, "physical maximum drifted")
 
-    for value in (0.09, 0.36, 0.60, True, "0.2", float("nan"), float("inf")):
+    for value in (0.09, 0.36, 0.60, True, "0.2"):
         expect_sequence_error(speed_ast(value, include_turn=False), "set_speed")
+    for value in (float("nan"), float("inf")):
+        expect_sequence_error(speed_ast(value, include_turn=False), "non-finite")
 
     malformed = canonical(
         [

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -2,22 +2,23 @@
 """Exact-AST sequencing state for trusted physical program steps.
 
 The #287 takeoff consumer derives its effect from the first statement in the
-exact teacher-authorized canonical AST. Later effects and no-effect pacing must
-preserve that property: a bounded caller-selected motion, wait or landing
-request is not equivalent to the next statement of the authorized program.
+exact teacher-authorized canonical AST. Later effects and no-effect semantic
+steps must preserve that property: a bounded caller-selected motion, wait,
+speed state or landing request is not equivalent to the next statement of the
+authorized program.
 
 This module provides the small non-effect state machine needed by the physical
 host. It starts only after a caller has already established the first takeoff
 statement by other trusted means, eagerly validates the complete currently
-supported envelope (move/turn/wait statements followed by one exact terminal
-land), reserves exactly the next statement, and advances only after the trusted
-consumer reports definitive completion. A rejected/unemitted physical effect
-may be released without advancing; an ambiguous emitted outcome makes the
-sequence terminal. A failed exact wait is terminal without being classified as
-an emitted physical effect.
+supported envelope (move/turn/wait/set_speed statements followed by one exact
+terminal land), reserves exactly the next statement, and advances only after
+the trusted consumer reports definitive completion. A rejected/unemitted
+physical effect may be released without advancing; an ambiguous emitted outcome
+makes the sequence terminal. Failed exact wait/speed no-effect steps are terminal
+without being classified as emitted physical effects.
 
 It emits no CRTP command and accepts no caller-selected motion, wait duration,
-program index, landing parameter, completion proof or authority object.
+speed, program index, landing parameter, completion proof or authority object.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from math import isfinite
 from threading import Lock
 
 import high_level_semantics
+import high_level_timing
 import takeoff_command
 
 # Keep the trusted physical parser aligned with semantic_ast.js's established
@@ -60,6 +62,14 @@ class SequencedWait:
 
 
 @dataclass(frozen=True, slots=True)
+class SequencedSpeed:
+    """One exact no-effect horizontal speed-state change from the canonical AST."""
+
+    index: int
+    speed_m_s: float
+
+
+@dataclass(frozen=True, slots=True)
 class SequencedTerminalLanding:
     """The one exact terminal landing boundary of the immutable canonical AST."""
 
@@ -78,6 +88,13 @@ class _WaitClaim:
 
     def __init__(self, wait: SequencedWait) -> None:
         self.wait = wait
+
+
+class _SpeedClaim:
+    __slots__ = ("speed",)
+
+    def __init__(self, speed: SequencedSpeed) -> None:
+        self.speed = speed
 
 
 class _LandingClaim:
@@ -118,16 +135,19 @@ class PhysicalProgramSequence:
 
         # Validate the complete supported envelope before reset/takeoff, rather
         # than discovering an unsupported statement only after the aircraft is
-        # already flying. Wait is deliberately a no-effect step, not a motion.
+        # already flying. Wait and set_speed are deliberately no-effect steps.
         for index in range(1, len(self._program) - 1):
             statement = self._program[index]
-            if isinstance(statement, dict) and statement.get("kind") == "wait":
+            kind = statement.get("kind") if isinstance(statement, dict) else None
+            if kind == "wait":
                 self._wait_at(index)
+            elif kind == "set_speed":
+                self._speed_at(index)
             else:
                 self._motion_at(index)
 
         self._next_index = 1
-        self._pending: _MotionClaim | _WaitClaim | _LandingClaim | None = None
+        self._pending: _MotionClaim | _WaitClaim | _SpeedClaim | _LandingClaim | None = None
         self._terminal_reason: str | None = None
         self._lock = Lock()
 
@@ -201,20 +221,7 @@ class PhysicalProgramSequence:
                         "next move direction is malformed"
                     )
                 # #256 remains the source of horizontal direction/distance bounds.
-                target = high_level_semantics.body_relative_move(
-                    direction,
-                    distance,
-                    0.0,
-                )
-                validated_distance = (
-                    target.x_m
-                    if direction in {"forward", "right"}
-                    else -target.x_m
-                )
-                # body_relative_move at yaw=0 maps left/right onto Y, so preserve
-                # the exact canonical scalar instead of reverse-engineering the
-                # target. The call above is solely the authoritative validation.
-                del validated_distance
+                high_level_semantics.body_relative_move(direction, distance, 0.0)
                 return SequencedInflightMotion(
                     index=index,
                     kind="move",
@@ -270,6 +277,35 @@ class PhysicalProgramSequence:
                 "next wait seconds violate established Runtime v2 bounds"
             )
         return SequencedWait(index=index, seconds=parsed)
+
+    def _speed_at(self, index: int) -> SequencedSpeed:
+        if index >= len(self._program) - 1:
+            raise PhysicalProgramSequenceError(
+                "no set_speed remains before the final landing boundary"
+            )
+        statement = self._program[index]
+        if not isinstance(statement, dict) or set(statement) != {"kind", "speed_m_s"}:
+            raise PhysicalProgramSequenceError(
+                "next set_speed statement contains unsupported fields"
+            )
+        if statement.get("kind") != "set_speed":
+            raise PhysicalProgramSequenceError(
+                "next exact AST statement is not a set_speed state change"
+            )
+        speed = statement["speed_m_s"]
+        if isinstance(speed, bool) or not isinstance(speed, (int, float)):
+            raise PhysicalProgramSequenceError("next set_speed speed_m_s must be finite")
+        parsed = float(speed)
+        if not isfinite(parsed):
+            raise PhysicalProgramSequenceError("next set_speed speed_m_s must be finite")
+        if (
+            parsed < high_level_timing.MIN_HORIZONTAL_SPEED_M_S
+            or parsed > high_level_timing.MAX_HORIZONTAL_SPEED_M_S
+        ):
+            raise PhysicalProgramSequenceError(
+                "next set_speed violates established physical horizontal-speed bounds"
+            )
+        return SequencedSpeed(index=index, speed_m_s=parsed)
 
     def reserve_next_motion(self) -> object:
         """Reserve the exact next motion; no caller motion/index is accepted."""
@@ -357,6 +393,58 @@ class PhysicalProgramSequence:
             if claim is not self._pending or not isinstance(claim, _WaitClaim):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program wait claim is required"
+                )
+            self._terminal_reason = reason.strip()
+            self._pending = None
+
+    def reserve_next_speed(self) -> object:
+        """Reserve the exact next no-effect speed state; no caller speed is accepted."""
+        with self._lock:
+            if self._terminal_reason is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program sequence is terminal: " + self._terminal_reason
+                )
+            if self._pending is not None:
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending step"
+                )
+            speed = self._speed_at(self._next_index)
+            claim = _SpeedClaim(speed)
+            self._pending = claim
+            return claim
+
+    def speed_for_claim(self, claim: object) -> SequencedSpeed:
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _SpeedClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program set_speed claim is required"
+                )
+            return claim.speed
+
+    def complete_speed(self, claim: object) -> None:
+        """Advance only after the exact run-local speed state was accepted."""
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _SpeedClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program set_speed claim is required"
+                )
+            if claim.speed.index != self._next_index:
+                raise PhysicalProgramSequenceError(
+                    "pending physical-program set_speed claim no longer matches the cursor"
+                )
+            self._next_index += 1
+            self._pending = None
+
+    def fail_speed(self, claim: object, reason: str) -> None:
+        """Fail closed if exact no-effect speed state cannot be safely applied."""
+        if not isinstance(reason, str) or not reason.strip():
+            raise PhysicalProgramSequenceError(
+                "failed physical-program set_speed requires a reason"
+            )
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _SpeedClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program set_speed claim is required"
                 )
             self._terminal_reason = reason.strip()
             self._pending = None

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -7,7 +7,8 @@ teacher socket and the shared #273 execution domain. The generic takeoff
 lifecycle remains in ``production_takeoff_run``. The exact canonical AST is
 validated against the integrated sequencing boundary before any reset or flight
 effect; after exact takeoff has causally completed, the same sequence owns each
-bounded move/turn, no-effect wait and the one terminal controlled landing.
+bounded move/turn, no-effect wait/set_speed state and the one terminal controlled
+landing.
 
 Importing this module performs no physical effect.
 """
@@ -63,13 +64,18 @@ def _monotonic_value(clock) -> float:
     return value
 
 
-def _require_exact_epoch(connection_epoch_reader, bound_epoch: str) -> None:
+def _require_exact_epoch(
+    connection_epoch_reader,
+    bound_epoch: str,
+    *,
+    context: str,
+) -> None:
     try:
         current = connection_epoch_reader()
     except Exception as exc:
-        raise PhysicalRunActivationError("physical wait connection epoch is unavailable") from exc
+        raise PhysicalRunActivationError(context + " connection epoch is unavailable") from exc
     if current != bound_epoch:
-        raise PhysicalRunActivationError("connection epoch changed during exact physical wait")
+        raise PhysicalRunActivationError("connection epoch changed during " + context)
 
 
 def _execute_exact_wait(
@@ -93,14 +99,22 @@ def _execute_exact_wait(
         raise PhysicalRunActivationError("physical wait timing primitives are unavailable")
 
     assert_live()
-    _require_exact_epoch(connection_epoch_reader, bound_epoch)
+    _require_exact_epoch(
+        connection_epoch_reader,
+        bound_epoch,
+        context="exact physical wait",
+    )
     started = _monotonic_value(clock)
     deadline = started + seconds
     now = started
 
     while now < deadline:
         assert_live()
-        _require_exact_epoch(connection_epoch_reader, bound_epoch)
+        _require_exact_epoch(
+            connection_epoch_reader,
+            bound_epoch,
+            context="exact physical wait",
+        )
         delay = min(_WAIT_SLICE_SECONDS, deadline - now)
         try:
             sleeper(delay)
@@ -112,7 +126,11 @@ def _execute_exact_wait(
         now = later
 
     assert_live()
-    _require_exact_epoch(connection_epoch_reader, bound_epoch)
+    _require_exact_epoch(
+        connection_epoch_reader,
+        bound_epoch,
+        context="exact physical wait",
+    )
 
 
 def _live_crazyflie(session: object) -> object:
@@ -209,9 +227,9 @@ def activate_validated_run(
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
     semantic parameters. It reserves only the next exact top-level move/turn,
-    no-effect wait or terminal land from the post-reset #267 binding and keeps
-    every positive provenance/effect path lexical to this adapter's host-owned
-    bridge.
+    no-effect wait/set_speed state or terminal land from the post-reset #267
+    binding and keeps every positive provenance/effect path lexical to this
+    adapter's host-owned bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
         raise PhysicalRunActivationError("physical activation requires explicit radio:// URI")
@@ -502,11 +520,67 @@ def activate_validated_run(
             sequence.complete_wait(claim)
             return _NoEffectStepResult()
 
+        def _execute_speed(self):
+            claim = sequence.reserve_next_speed()
+            speed_step = sequence.speed_for_claim(claim)
+            binding = active_run.teacher_authorization.binding
+            assert_live = getattr(active_run.watchdog_guard, "assert_live", None)
+            try:
+                if active_run.execution_domain.phase != FLYING:
+                    raise PhysicalRunActivationError(
+                        "exact set_speed requires causally established flying state"
+                    )
+                if not callable(assert_live):
+                    raise PhysicalRunActivationError(
+                        "exact set_speed requires live watchdog guard"
+                    )
+                assert_live()
+                _require_exact_epoch(
+                    session.read_connection_epoch,
+                    active_run.powered_session.connection_epoch,
+                    context="exact physical set_speed",
+                )
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+
+                # This is host-local run state only. It emits no command and the
+                # same policy object is later consumed by exact horizontal moves.
+                timing_policy.set_horizontal_speed(speed_step.speed_m_s)
+
+                if active_run.execution_domain.phase != FLYING:
+                    raise PhysicalRunActivationError(
+                        "physical state changed during no-effect exact set_speed"
+                    )
+                assert_live()
+                _require_exact_epoch(
+                    session.read_connection_epoch,
+                    active_run.powered_session.connection_epoch,
+                    context="exact physical set_speed",
+                )
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except Exception:
+                sequence.fail_speed(
+                    claim,
+                    "exact set_speed did not complete under the live trusted run binding",
+                )
+                raise
+            sequence.complete_speed(claim)
+            return _NoEffectStepResult()
+
         def execute_next_inflight(self):
             """Advance one exact AST step; accepts no caller semantic data."""
             step_kind = sequence.next_step_kind
             if step_kind == "wait":
                 return self._execute_wait()
+            if step_kind == "set_speed":
+                return self._execute_speed()
 
             terminal_landing = step_kind == "land"
             if terminal_landing:


### PR DESCRIPTION
Advances #157 by extending the exact teacher-bound physical sequence with backend-neutral `set_speed(speed_m_s)` as host-local no-effect run state.

The physical sequencer now validates `set_speed` before reset/takeoff against the already-proven #268 physical envelope (0.10–0.35 m/s) while leaving the generic semantic AST ceiling at 0.6 m/s unchanged. Exact speed statements have their own no-effect claim lifecycle and remain outside the physical-effect release/ambiguity APIs.

The production activation path consumes the exact next speed statement with no caller semantic input, requires the established flying/watchdog/epoch/current-program binding, mutates only the per-run `HighLevelTimingPolicy`, revalidates the live binding, then advances the exact cursor. Failure is terminal. Later horizontal moves keep their existing provenance/effect/completion path and receive the same run-local timing policy; turn timing remains independent.

Production-shaped deterministic coverage exercises exact ordering, strict physical bounds, no-effect behavior, selected-speed move duration, turn independence, pre-takeoff rejection, and terminal watchdog-loss behavior.

Refs #320 #157 #268 #295 #316 #276.