### PR TITLE
Preserve staged teacher activation across caller EOF

### DIFF
--- a/tools/physical/serve_physical_host.py
+++ b/tools/physical/serve_physical_host.py
@@ -126,10 +126,16 @@ if __name__ == "__main__":
                     while not staged_ready.wait(0.05):
                         if host_stopping.is_set():
                             return
-                    if host_stopping.is_set():
-                        return
 
                     with lifecycle_lock:
+                        # Caller EOF may stop ordinary IPC immediately after a
+                        # successful validation reply. Once that validation has
+                        # staged the exact trusted candidate, the non-authority
+                        # caller must not be able to cancel the distinct teacher
+                        # transaction merely by closing its channel. Conversely,
+                        # shutdown with no staged candidate remains effect-free.
+                        if not activation_state["started"]:
+                            return
                         binding = staged_state["binding"]
                         if type(binding) is not PhysicalRunBinding:
                             raise RuntimeError(


### PR DESCRIPTION
Superseded by #325.

Issue #323 explicitly scopes the repair to deterministic synchronization in `tools/ci/test_physical_host_authority_path.py` and requires **no product/authority semantics change**. #325 implements that smaller test-only repair. This production-host lifecycle change is therefore dominated and is closed without integration.

---

Repairs the latent trusted-host scheduling race exposed by Firefox PR #319 Ready CI run 34676465040.

The existing production-shaped `test_physical_host_authority_path.py` validates a run, reads the non-authority validation reply, then closes the ordinary caller write side. On current `main`, `serve_physical_host.py` may observe that EOF and set `host_stopping` before the already-staged activation worker is scheduled. The worker then returns at its second `host_stopping` check without ever publishing the exact post-reset proposal on the distinct trusted teacher channel. This produced `trusted teacher peer received no post-reset proposal` while all Firefox-specific project-file paths were green.

Once `validate-run-context` has atomically installed `PhysicalRunBinding`, set `activation_state.started`, and signalled `staged_ready`, ordinary caller EOF must not acquire cancellation authority over the separate teacher transaction. This change therefore distinguishes shutdown-with-no-staged-candidate from shutdown-after-staging: the former remains effect-free; the latter completes the already-started trusted activation transaction before teardown, as the host already joins that worker.

No caller gains teacher/execution authority, no safety oracle is weakened, and no physical effect retry/reset behavior changes. The existing authority-path regression is the product-shaped reproducer for the caller-EOF boundary.

Refs #157 #319 #291 #283.