### PR TITLE
Make physical host authority regression causal

### DIFF
--- a/tools/ci/test_physical_host_authority_path.py
+++ b/tools/ci/test_physical_host_authority_path.py
@@ -230,6 +230,19 @@ def run_host(*, teacher_mode: str | None) -> dict[str, object]:
         },
         "caller reply must remain diagnostic/non-authority",
     )
+
+    # Teacher-enabled cases must let the host's activation worker consume the
+    # staged binding and complete the one-shot proposal/decision exchange before
+    # caller EOF can trigger host teardown. This is a causal test synchronization
+    # point, not a delay: a missing proposal still fails the existing bounded join.
+    if teacher_worker is not None:
+        teacher_worker.join(timeout=1.0)
+        require(not teacher_worker.is_alive(), "teacher peer did not finish one-shot exchange")
+        require(
+            "error" not in teacher_result,
+            "teacher peer failed: " + repr(teacher_result.get("error")),
+        )
+
     caller_peer.shutdown(socket.SHUT_WR)
 
     worker.join(timeout=3.0)
@@ -238,14 +251,6 @@ def run_host(*, teacher_mode: str | None) -> dict[str, object]:
         "error" not in outcome,
         "actual production host runner failed: " + repr(outcome.get("error")),
     )
-
-    if teacher_worker is not None:
-        teacher_worker.join(timeout=1.0)
-        require(not teacher_worker.is_alive(), "teacher peer did not finish one-shot exchange")
-        require(
-            "error" not in teacher_result,
-            "teacher peer failed: " + repr(teacher_result.get("error")),
-        )
 
     caller_peer.close()
     if teacher_peer is not None:


### PR DESCRIPTION
Repairs #323 without changing production physical-host semantics.

The shared authority-path regression previously closed ordinary caller IPC immediately after `validate-run-context`. That caller EOF could set `host_stopping` before the already-staged activation worker published its host-first teacher proposal, so identical core harness executions could either pass or fail by scheduling order.

Teacher-enabled cases now wait on the existing one-shot teacher peer's bounded completion before caller teardown. This is causal synchronization, not a delay: no sleep is added, the existing 1 s peer bound is unchanged, and a missing proposal still fails. Caller-only/no-teacher validation retains immediate teardown and remains effect-free.

CI must re-run the shared Runtime v2 core path and preserve mismatch/positive/no-teacher authority assertions.

Fixes #323.