### PR TITLE
Freeze independent X3 vertical replay predictor

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/FROZEN_VERTICAL_PREDICTOR.md
+++ b/experiments/crazyflie-ukf-surface-range/FROZEN_VERTICAL_PREDICTOR.md
@@ -38,6 +38,7 @@ The input schema is `webeeblocks.x3.vertical-predictor-input.v1`:
     "specific_force_error_g": 0.0,
     "max_body_z_tilt_deg": 0.0,
     "initial_velocity_error_m_s": 0.0,
+    "intersample_acceleration_error_m_s2": 0.0,
     "barometer_displacement_error_m": 0.0,
     "sensor_time_error_s": 0.0,
     "delivery_latency_error_s": 0.0
@@ -50,6 +51,8 @@ physical bounds**. Every bound must be justified and frozen before a confirmatio
 capture; event outcomes must never be used to narrow it. The result always keeps
 `declared_bounds_validated:false` and `sensor_producer_timing_validated:false`.
 A controller or human verdict must validate the bound provenance separately.
+The metric-reference validation flags are accepted only as actual JSON booleans;
+malformed truthy values fail closed rather than being coerced into validation.
 
 The supplied metric-reference result must be
 `webeeblocks.x3.metric-reference-result.v1 / COMPUTED_CONDITIONAL`, and its
@@ -87,11 +90,22 @@ event interval, then the resulting acceleration envelope is integrated from an
 initial velocity interval
 `[-initial_velocity_error_m_s, +initial_velocity_error_m_s]`.
 
+Retained rows alone do not prove the continuous acceleration between samples.
+`intersample_acceleration_error_m_s2` is therefore an external deterministic
+bound on the absolute difference, at every instant in the admissible replay span,
+between the actual world-vertical acceleration and the piecewise-linear bounded
+acceleration reconstructed from retained rows. For an admissible span of duration
+`T`, the inertial displacement interval is widened by
+`0.5 * intersample_acceleration_error_m_s2 * T²` on both sides. This is deliberately
+conservative and remains conditional on the declared intersample bound being
+valid; the capture gap limit alone is not treated as such a bound.
+
 For uncertain event/log timing, the integration anchor is the **lower supplied
 endpoint**, never a hidden midpoint. A conservative timing-sensitivity allowance
 covers the remaining start/end interval and declared sensor-time error using the
-maximum acceleration envelope over the admissible span. This is conditional
-arithmetic, not proof that Crazyflie log timestamps are sensor-producer times.
+maximum acceleration envelope over the admissible span, including rows needed to
+bracket off-grid admissible boundaries. This is conditional arithmetic, not proof
+that Crazyflie log timestamps are sensor-producer times.
 
 This deliberately does not integrate estimator attitude or `stateEstimate.vz`.
 A later candidate may use a more informative raw-gyro/attitude model only if its
@@ -109,8 +123,10 @@ The result reports two preregistered budget checks only:
 
 - `conditional_half_width_within_5cm`: the overlapping interval has half-width at
   most 5 cm, conditional on all declared bounds being valid;
-- `conditional_latency_within_1s`: the fixed B+ endpoint (0.75 s after the
-  transition) plus declared timing/delivery allowances is at most 1 s.
+- `conditional_latency_within_1s`: relative to the earliest admissible event end,
+  the upper latency includes the complete retained event-end interval width, the
+  fixed B+ acquisition endpoint (`POST_DELAY_S + WINDOW_S = 0.75 s`), both declared
+  sensor-time allowances and the declared delivery allowance, and is at most 1 s.
 
 These are **not** physical PASS/FAIL. In particular, interval half-width is not an
 error measurement against the external metric reference, and the latency is not
@@ -129,18 +145,20 @@ The file entry point hash-binds all three inputs, refuses path escape and existi
 output overwrite, aligns IMU to the first barometer Crazyflie log timestamp, and
 fails closed on malformed/non-finite data, clock reversal, barometer gaps over
 40 ms or IMU gaps over 50 ms. The synthetic controls verify signed replay,
-conditional-bound widening, sensor disagreement, interval timing without
-midpoint selection, source/digest binding and rejection of optimistic/invalid
-inputs. They are component tests, not physical evidence.
+conditional-bound widening, sensor disagreement, negative-prefix clock alignment,
+interval timing without midpoint selection, off-grid timing brackets, malformed
+validation flags, intersample displacement allowance, widened-end latency,
+source/digest binding and rejection of optimistic/invalid inputs. They are
+component tests, not physical evidence.
 
 ## Remaining boundary
 
 This component freezes the sensor predictor mechanics but does **not** validate
-its declared bounds, physical-reference annotations, affine clock assumption or
-sensor-producer timing. It also does not estimate terrain Δh, validate the mixed
-case against a physical reference, publish raw physical evidence, prepare a human
-checkpoint, flash firmware, retune #251, alter Runtime/controller behavior or
-authorize motorized testing.
+its declared error, tilt, intersample or timing bounds, physical-reference
+annotations, affine clock assumption or sensor-producer timing. It also does not
+estimate terrain Δh, validate the mixed case against a physical reference, publish
+raw physical evidence, prepare a human checkpoint, flash firmware, retune #251,
+alter Runtime/controller behavior or authorize motorized testing.
 
 Before a new `TEST_REQUIRED` can be justified, the exact props-off support must
 bind this predictor to the retained acquisition/reference inputs, pre-register

--- a/experiments/crazyflie-ukf-surface-range/FROZEN_VERTICAL_PREDICTOR.md
+++ b/experiments/crazyflie-ukf-surface-range/FROZEN_VERTICAL_PREDICTOR.md
@@ -1,0 +1,148 @@
+# Frozen conditional X3 vertical replay predictor
+
+This is the next bounded offline component for #70 after the integrated input
+collector, frozen pressure probe and conditional metric-reference processor. It
+answers a narrower question than the firmware problem: **given pre-declared
+error/timing bounds, do the raw barometer and raw accelerometer admit one
+consistent vehicle vertical-displacement interval?** It does not classify
+terrain, change the Crazyflie estimator, or establish physical flight capability.
+
+The predictor is intentionally independent of the suspect ToF path. Its file
+entry point accepts exactly three retained sources: the continuous barometer CSV,
+the continuous IMU CSV and the exact `metric_reference.py` result. Pose, range,
+`stateEstimate.z`, `stateEstimate.vz`, S3 diagnostics and estimator attitude are
+not predictor inputs. The metric-reference result is used for calibration/event
+time intervals only; the predictor does not use its reference Δz/Δh values to
+construct its sensor prediction.
+
+The pinned #251 capture format comes from Crazyflie firmware 2026.08
+`54f31e243a0b28b67efef5ba20dbb6d9890a5478`. In that source `acc.x/y/z` are
+body-frame acceleration in G and `baro.asl` is altitude in metres. The collector
+still retains gyroscope and pose diagnostics, but this smallest replay does not
+silently turn estimator attitude into independent evidence. Instead it carries a
+pre-declared bound on the angle between body Z and world vertical.
+
+## Frozen model
+
+The input schema is `webeeblocks.x3.vertical-predictor-input.v1`:
+
+```json
+{
+  "schema": "webeeblocks.x3.vertical-predictor-input.v1",
+  "sources": {
+    "barometer": {"path": "barometer.csv", "sha256": "<64 hex>"},
+    "imu": {"path": "imu.csv", "sha256": "<64 hex>"},
+    "metric_reference": {"path": "metric-reference.json", "sha256": "<64 hex>"}
+  },
+  "declared_bounds": {
+    "specific_force_error_g": 0.0,
+    "max_body_z_tilt_deg": 0.0,
+    "initial_velocity_error_m_s": 0.0,
+    "barometer_displacement_error_m": 0.0,
+    "sensor_time_error_s": 0.0,
+    "delivery_latency_error_s": 0.0
+  }
+}
+```
+
+The zero values above are syntax examples, **not recommended or validated
+physical bounds**. Every bound must be justified and frozen before a confirmation
+capture; event outcomes must never be used to narrow it. The result always keeps
+`declared_bounds_validated:false` and `sensor_producer_timing_validated:false`.
+A controller or human verdict must validate the bound provenance separately.
+
+The supplied metric-reference result must be
+`webeeblocks.x3.metric-reference-result.v1 / COMPUTED_CONDITIONAL`, and its
+recorded barometer-capture digest must match the exact supplied barometer CSV.
+This prevents combining event timing from one capture with sensor data from
+another. Calibration uses only the device-time interval guaranteed to be inside
+the reference calibration for every admissible clock mapping; at least 30 s must
+remain.
+
+### Barometer arm
+
+For each event, the B− and B+ windows remain exactly those frozen in #70:
+B− is 0.5 s immediately before event start and B+ is 0.5 s beginning 0.25 s
+after event end. The allowed start/end intervals from the metric-reference result,
+plus the declared sensor-time error, are preserved. The implementation enumerates
+every discrete median regime induced by the logged samples, including both sides
+of sample/window boundaries; it never substitutes an interval midpoint.
+
+A linear pressure-altitude drift is fitted only on the guaranteed prior
+calibration. Drift correction uses the observed median-sample-time interval, not
+nominal window centres. `barometer_displacement_error_m` is an external
+deterministic allowance that must cover everything the finite calibration fit
+does not prove (drift-model error, pressure dynamics, sampling/producer effects,
+etc.). The predictor does not derive a confidence level from calibration row
+count or residual extrema.
+
+### Inertial arm
+
+The nominal diagnostic trace subtracts the calibration median from raw `acc.z`.
+The bounded trace does not assume the vehicle is exactly level. For each raw
+accelerometer sample it encloses world-up specific force over a cone whose half
+angle is `max_body_z_tilt_deg`, while adding the declared per-axis
+`specific_force_error_g`. The calibration-zero interval is subtracted from the
+event interval, then the resulting acceleration envelope is integrated from an
+initial velocity interval
+`[-initial_velocity_error_m_s, +initial_velocity_error_m_s]`.
+
+For uncertain event/log timing, the integration anchor is the **lower supplied
+endpoint**, never a hidden midpoint. A conservative timing-sensitivity allowance
+covers the remaining start/end interval and declared sensor-time error using the
+maximum acceleration envelope over the admissible span. This is conditional
+arithmetic, not proof that Crazyflie log timestamps are sensor-producer times.
+
+This deliberately does not integrate estimator attitude or `stateEstimate.vz`.
+A later candidate may use a more informative raw-gyro/attitude model only if its
+producer timing, bias and coordinate assumptions are themselves bounded without
+reintroducing the ToF-contaminated state.
+
+### Combination and latency
+
+If the deterministic barometer and inertial intervals overlap, their intersection
+is retained as `conditional_delta_z_interval_m`. If they are disjoint, the result
+is `DISJOINT` and no fused interval is manufactured. No bound is widened or tuned
+from the event outcome.
+
+The result reports two preregistered budget checks only:
+
+- `conditional_half_width_within_5cm`: the overlapping interval has half-width at
+  most 5 cm, conditional on all declared bounds being valid;
+- `conditional_latency_within_1s`: the fixed B+ endpoint (0.75 s after the
+  transition) plus declared timing/delivery allowances is at most 1 s.
+
+These are **not** physical PASS/FAIL. In particular, interval half-width is not an
+error measurement against the external metric reference, and the latency is not
+validated end-to-end producer latency. Every output remains
+`independent_displacement_verdict:UNPROVEN` and `physical_verdict:null`.
+
+## Execution and checks
+
+```sh
+python3 experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
+python3 experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py \
+  predictor-input.json --output predictor-result.json
+```
+
+The file entry point hash-binds all three inputs, refuses path escape and existing
+output overwrite, aligns IMU to the first barometer Crazyflie log timestamp, and
+fails closed on malformed/non-finite data, clock reversal, barometer gaps over
+40 ms or IMU gaps over 50 ms. The synthetic controls verify signed replay,
+conditional-bound widening, sensor disagreement, interval timing without
+midpoint selection, source/digest binding and rejection of optimistic/invalid
+inputs. They are component tests, not physical evidence.
+
+## Remaining boundary
+
+This component freezes the sensor predictor mechanics but does **not** validate
+its declared bounds, physical-reference annotations, affine clock assumption or
+sensor-producer timing. It also does not estimate terrain Δh, validate the mixed
+case against a physical reference, publish raw physical evidence, prepare a human
+checkpoint, flash firmware, retune #251, alter Runtime/controller behavior or
+authorize motorized testing.
+
+Before a new `TEST_REQUIRED` can be justified, the exact props-off support must
+bind this predictor to the retained acquisition/reference inputs, pre-register
+and justify its bound values, preserve the raw outputs durably, and make the
+physical reference/timing observations executable under the current `AGENTS.md`.

--- a/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
@@ -58,7 +58,7 @@ def unwrap_rows(raw: bytes, required: tuple[str, ...], origin_stamp: int | None 
     if not reader.fieldnames or len(set(reader.fieldnames)) != len(reader.fieldnames) or not required_headers <= set(reader.fieldnames):
         raise ValueError("required capture columns missing")
     parsed = []
-    previous_stamp = previous_host = None
+    previous_stamp = previous_host = previous_elapsed_ms = None
     for row in reader:
         if None in row or any(value is None for value in row.values()):
             raise ValueError("malformed CSV row")
@@ -78,11 +78,14 @@ def unwrap_rows(raw: bytes, required: tuple[str, ...], origin_stamp: int | None 
                 raise ValueError("capture gap exceeds frozen replay limit")
         if origin_stamp is None:
             origin_stamp = stamp
-        elapsed_ms = (stamp - origin_stamp) % MODULUS
-        if elapsed_ms >= MODULUS // 2:
+        elapsed_mod_ms = (stamp - origin_stamp) % MODULUS
+        if elapsed_mod_ms == MODULUS // 2:
+            raise ValueError("source cannot be aligned to the barometer clock origin")
+        elapsed_ms = elapsed_mod_ms if elapsed_mod_ms < MODULUS // 2 else elapsed_mod_ms - MODULUS
+        if previous_elapsed_ms is not None and elapsed_ms <= previous_elapsed_ms:
             raise ValueError("source cannot be aligned to the barometer clock origin")
         parsed.append((elapsed_ms / 1000.0, host, values))
-        previous_stamp, previous_host = stamp, host
+        previous_stamp, previous_host, previous_elapsed_ms = stamp, host, elapsed_ms
     if not parsed:
         raise ValueError("empty required capture stream")
     return origin_stamp, parsed

--- a/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Frozen conditional X3 vertical replay predictor for #70.
+
+This component never certifies a physical reference, timing model, sensor error
+bound or flight capability. It excludes ToF-derived stateEstimate Z/VZ and S3
+signals from the predicted vehicle displacement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+from pathlib import Path
+import re
+from statistics import median
+
+
+G = 9.80665
+MODULUS = 1 << 24
+KINDS = ("stationary", "terrain", "vertical", "mixed")
+WINDOW_S = 0.5
+POST_DELAY_S = 0.25
+BARO_MAX_GAP_S = 0.04
+BARO_MIN_WINDOW_ROWS = 20
+IMU_MAX_GAP_S = 0.05
+
+
+def finite(value, name):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"{name}: finite number required")
+    return float(value)
+
+
+def nonnegative(value, name):
+    value = finite(value, name)
+    if value < 0:
+        raise ValueError(f"{name}: nonnegative number required")
+    return value
+
+
+def interval(value, name):
+    if not isinstance(value, list) or len(value) != 2:
+        raise ValueError(f"{name}: two explicit endpoints required")
+    lo, hi = finite(value[0], name), finite(value[1], name)
+    if lo > hi:
+        raise ValueError(f"{name}: reversed interval")
+    return lo, hi
+
+
+def unwrap_rows(raw: bytes, required: tuple[str, ...], origin_stamp: int | None = None, max_gap_s: float | None = None):
+    reader = csv.DictReader(io.StringIO(raw.decode("utf-8"), newline=""))
+    base = ("cf_timestamp_ms", "host_monotonic_s")
+    required_headers = set(base + required)
+    if not reader.fieldnames or len(set(reader.fieldnames)) != len(reader.fieldnames) or not required_headers <= set(reader.fieldnames):
+        raise ValueError("required capture columns missing")
+    parsed = []
+    previous_stamp = previous_host = None
+    for row in reader:
+        if None in row or any(value is None for value in row.values()):
+            raise ValueError("malformed CSV row")
+        try:
+            stamp = int(row["cf_timestamp_ms"])
+            host = finite(float(row["host_monotonic_s"]), "host timestamp")
+            values = tuple(finite(float(row[name]), name) for name in required)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"malformed capture value: {exc}") from exc
+        if not 0 <= stamp < MODULUS or (previous_host is not None and host <= previous_host):
+            raise ValueError("invalid device or nonincreasing host timestamp")
+        if previous_stamp is not None:
+            gap = (stamp - previous_stamp) % MODULUS
+            if gap == 0 or gap >= MODULUS // 2:
+                raise ValueError("duplicate/backward device timestamp")
+            if max_gap_s is not None and gap / 1000.0 > max_gap_s + 1e-12:
+                raise ValueError("capture gap exceeds frozen replay limit")
+        if origin_stamp is None:
+            origin_stamp = stamp
+        elapsed_ms = (stamp - origin_stamp) % MODULUS
+        if elapsed_ms >= MODULUS // 2:
+            raise ValueError("source cannot be aligned to the barometer clock origin")
+        parsed.append((elapsed_ms / 1000.0, host, values))
+        previous_stamp, previous_host = stamp, host
+    if not parsed:
+        raise ValueError("empty required capture stream")
+    return origin_stamp, parsed
+
+
+def read_sources(barometer_raw: bytes, imu_raw: bytes):
+    origin, barometer = unwrap_rows(barometer_raw, ("baro.asl",), max_gap_s=BARO_MAX_GAP_S)
+    _, imu = unwrap_rows(imu_raw, ("acc.x", "acc.y", "acc.z"), origin, max_gap_s=IMU_MAX_GAP_S)
+    return barometer, imu
+
+
+def vertical_force_interval_g(ax, ay, az, specific_force_error_g, max_tilt_deg):
+    """Conservative world-up specific-force bound without estimator attitude.
+
+    The body/world vertical angle is only assumed to be within max_tilt_deg.
+    No UKF/EKF attitude, ToF-derived state, S3 state or range value participates.
+    """
+    if max_tilt_deg >= 90:
+        raise ValueError("tilt bound must stay below 90 deg for the body-Z cone model")
+    alpha = math.radians(max_tilt_deg)
+    c, s = math.cos(alpha), math.sin(alpha)
+    e = specific_force_error_g
+    zlo, zhi = az - e, az + e
+    z_candidates = (zlo, zhi, zlo * c, zhi * c)
+    horizontal_max = math.hypot(abs(ax) + e, abs(ay) + e)
+    return min(z_candidates) - horizontal_max * s, max(z_candidates) + horizontal_max * s
+
+
+def median_interval(pairs):
+    return median(lo for lo, _ in pairs), median(hi for _, hi in pairs)
+
+
+def preparation(barometer, imu, spec, reference):
+    c0 = interval(reference["calibration_start_device_s"], "calibration start")
+    c1 = interval(reference["calibration_end_device_s"], "calibration end")
+    # Use only time guaranteed to be inside calibration for every admissible endpoint.
+    guaranteed_start, guaranteed_end = c0[1], c1[0]
+    if guaranteed_start < 0 or guaranteed_end - guaranteed_start < 30:
+        raise ValueError("at least 30 s of guaranteed stationary calibration required")
+
+    bounds = spec["declared_bounds"]
+    sf_error = nonnegative(bounds["specific_force_error_g"], "specific-force error")
+    tilt = nonnegative(bounds["max_body_z_tilt_deg"], "body-Z tilt bound")
+    if tilt >= 90:
+        raise ValueError("tilt bound must stay below 90 deg for the body-Z cone model")
+    v0_error = nonnegative(bounds["initial_velocity_error_m_s"], "initial velocity error")
+    baro_error = nonnegative(bounds["barometer_displacement_error_m"], "barometer displacement error")
+    sensor_time_error = nonnegative(bounds["sensor_time_error_s"], "sensor time error")
+    delivery_latency = nonnegative(bounds["delivery_latency_error_s"], "delivery latency error")
+
+    force_samples = []
+    nominal_samples = []
+    for t, _, values in imu:
+        if guaranteed_start <= t <= guaranteed_end:
+            ax, ay, az = values
+            nominal_samples.append(az)
+            force_samples.append(vertical_force_interval_g(ax, ay, az, sf_error, tilt))
+    if len(force_samples) < 100:
+        raise ValueError("insufficient IMU calibration coverage")
+    nominal_zero_g = median(nominal_samples)
+    zero_lo_g, zero_hi_g = median_interval(force_samples)
+
+    # A descriptive barometer drift slope, frozen to guaranteed prior calibration.
+    bcal = [(t, values[0]) for t, _, values in barometer if guaranteed_start <= t <= guaranteed_end]
+    if len(bcal) < 100:
+        raise ValueError("insufficient barometer calibration coverage")
+    tmean = sum(t for t, _ in bcal) / len(bcal)
+    ymean = sum(y for _, y in bcal) / len(bcal)
+    denom = sum((t - tmean) ** 2 for t, _ in bcal)
+    if denom <= 0:
+        raise ValueError("degenerate barometer calibration")
+    baro_slope = sum((t - tmean) * (y - ymean) for t, y in bcal) / denom
+    return {"guaranteed_calibration_s": [guaranteed_start, guaranteed_end],
+            "nominal_zero_specific_force_g": nominal_zero_g,
+            "zero_specific_force_interval_g": [zero_lo_g, zero_hi_g],
+            "barometer_drift_m_per_s": baro_slope,
+            "bounds": {"specific_force_error_g": sf_error,
+                       "max_body_z_tilt_deg": tilt,
+                       "initial_velocity_error_m_s": v0_error,
+                       "barometer_displacement_error_m": baro_error,
+                       "sensor_time_error_s": sensor_time_error,
+                       "delivery_latency_error_s": delivery_latency}}
+
+
+def candidate_window_starts(samples, lo, hi, width=WINDOW_S):
+    if lo > hi:
+        raise ValueError("reversed window-start range")
+    starts = {lo, hi}
+    for t, *_ in samples:
+        for boundary in (t, t - width):
+            if lo <= boundary <= hi:
+                starts.add(boundary)
+                lower = math.nextafter(boundary, -math.inf)
+                upper = math.nextafter(boundary, math.inf)
+                if lo <= lower <= hi:
+                    starts.add(lower)
+                if lo <= upper <= hi:
+                    starts.add(upper)
+    return sorted(starts)
+
+
+def window_values(samples, start, width=WINDOW_S):
+    end = start + width
+    selected = [(t, values[0]) for t, _, values in samples if start <= t < end]
+    if len(selected) < BARO_MIN_WINDOW_ROWS:
+        raise ValueError("insufficient barometer rows in admissible fixed window")
+    if selected[0][0] - start > BARO_MAX_GAP_S + 1e-12 or end - selected[-1][0] > BARO_MAX_GAP_S + 1e-12:
+        raise ValueError("barometer edge coverage exceeds 40 ms")
+    return selected
+
+
+def median_over_window_range(samples, start_interval):
+    value_medians, time_medians = [], []
+    for start in candidate_window_starts(samples, *start_interval):
+        selected = window_values(samples, start)
+        value_medians.append(median(value for _, value in selected))
+        time_medians.append(median(t for t, _ in selected))
+    return (min(value_medians), max(value_medians)), (min(time_medians), max(time_medians))
+
+
+def barometer_prediction(barometer, start, end, prep):
+    # Include declared sensor timing uncertainty in the possible device-window position.
+    te = prep["bounds"]["sensor_time_error_s"]
+    before_starts = (start[0] - WINDOW_S - te, start[1] - WINDOW_S + te)
+    after_starts = (end[0] + POST_DELAY_S - te, end[1] + POST_DELAY_S + te)
+    before, before_times = median_over_window_range(barometer, before_starts)
+    after, after_times = median_over_window_range(barometer, after_starts)
+    # Preserve sampling-grid timing instead of assuming nominal window centers.
+    sep = (after_times[0] - before_times[1], after_times[1] - before_times[0])
+    slope = prep["barometer_drift_m_per_s"]
+    drift = sorted((slope * sep[0], slope * sep[1]))
+    error = prep["bounds"]["barometer_displacement_error_m"]
+    predicted = (after[0] - before[1] - drift[1] - error,
+                 after[1] - before[0] - drift[0] + error)
+    return {"before_median_m": list(before), "after_median_m": list(after),
+            "before_median_time_s": list(before_times), "after_median_time_s": list(after_times),
+            "drift_m": drift, "delta_z_interval_m": list(predicted),
+            "declared_unmodelled_error_m": error}
+
+
+def projected_samples(imu, lo, hi, prep):
+    sf_error = prep["bounds"]["specific_force_error_g"]
+    tilt = prep["bounds"]["max_body_z_tilt_deg"]
+    zero_lo, zero_hi = prep["zero_specific_force_interval_g"]
+    zero_nom = prep["nominal_zero_specific_force_g"]
+    values = []
+    for t, _, raw in imu:
+        if lo - 0.06 <= t <= hi + 0.06:
+            ax, ay, az = raw
+            nominal = (az - zero_nom) * G
+            flo, fhi = vertical_force_interval_g(ax, ay, az, sf_error, tilt)
+            values.append((t, nominal, (flo - zero_hi) * G, (fhi - zero_lo) * G))
+    if len(values) < 2:
+        raise ValueError("insufficient IMU event coverage")
+    for left, right in zip(values, values[1:]):
+        if right[0] - left[0] > IMU_MAX_GAP_S + 1e-12:
+            raise ValueError("IMU gap over 50 ms")
+    return values
+
+
+def interpolate_projected(samples, t):
+    if t < samples[0][0] or t > samples[-1][0]:
+        raise ValueError("event boundary outside IMU coverage")
+    for left, right in zip(samples, samples[1:]):
+        if left[0] <= t <= right[0]:
+            if t == left[0]:
+                return left
+            if t == right[0]:
+                return right
+            w = (t - left[0]) / (right[0] - left[0])
+            return (t, *(left[j] + w * (right[j] - left[j]) for j in range(1, 4)))
+    raise ValueError("event boundary lacks IMU bracket")
+
+
+def integrate_projected(samples, start, end, prep):
+    if end <= start:
+        raise ValueError("positive event duration required")
+    points = [interpolate_projected(samples, start)]
+    points.extend(row for row in samples if start < row[0] < end)
+    points.append(interpolate_projected(samples, end))
+    v0 = prep["bounds"]["initial_velocity_error_m_s"]
+    v = (-v0, v0)
+    z = (0.0, 0.0)
+    vn, zn = 0.0, 0.0
+    for left, right in zip(points, points[1:]):
+        dt = right[0] - left[0]
+        an = 0.5 * (left[1] + right[1])
+        alo = 0.5 * (left[2] + right[2])
+        ahi = 0.5 * (left[3] + right[3])
+        zn += vn * dt + 0.5 * an * dt * dt
+        vn += an * dt
+        z = (z[0] + v[0] * dt + 0.5 * alo * dt * dt,
+             z[1] + v[1] * dt + 0.5 * ahi * dt * dt)
+        v = (v[0] + alo * dt, v[1] + ahi * dt)
+    return zn, z, points
+
+
+def imu_segment(imu, start, end, prep):
+    te = prep["bounds"]["sensor_time_error_s"]
+    outer_start, outer_end = start[0] - te, end[1] + te
+    samples = projected_samples(imu, outer_start, outer_end, prep)
+    anchor_start, anchor_end = start[0], end[0]
+    nominal, bounded, _points = integrate_projected(samples, anchor_start, anchor_end, prep)
+
+    # The replay anchor is the lower supplied endpoint, not a hidden midpoint.
+    # Bound any other admissible event/sensor timing by a deterministic
+    # sensitivity envelope. This is conditional on the declared timing/error
+    # bounds and does not turn log time into sensor producer time.
+    v0 = prep["bounds"]["initial_velocity_error_m_s"]
+    max_acc = max(max(abs(row[2]), abs(row[3])) for row in samples
+                  if outer_start <= row[0] <= outer_end)
+    duration_max = outer_end - outer_start
+    start_shift = (start[1] - start[0]) + te
+    end_shift = (end[1] - end[0]) + te
+    shift = start_shift + end_shift
+    timing_error = v0 * shift + max_acc * duration_max * shift + 0.5 * max_acc * shift * shift
+    bounded = [bounded[0] - timing_error, bounded[1] + timing_error]
+    return {"anchor_device_s": [anchor_start, anchor_end],
+            "admissible_device_s": [outer_start, outer_end],
+            "nominal_delta_z_m": nominal,
+            "delta_z_interval_m": bounded,
+            "timing_sensitivity_error_m": timing_error,
+            "max_abs_vertical_accel_bound_m_s2": max_acc,
+            "initial_velocity_interval_m_s": [-v0, v0]}
+
+
+def intersect(a, b):
+    lo, hi = max(a[0], b[0]), min(a[1], b[1])
+    return None if lo > hi else [lo, hi]
+
+
+def analyze(barometer, imu, spec, reference):
+    if spec.get("schema") != "webeeblocks.x3.vertical-predictor-input.v1":
+        raise ValueError("unknown vertical-predictor schema")
+    if reference.get("schema") != "webeeblocks.x3.metric-reference-result.v1" or reference.get("status") != "COMPUTED_CONDITIONAL":
+        raise ValueError("exact conditional metric-reference result required")
+    prep = preparation(barometer, imu, spec, reference)
+    events = reference.get("events")
+    if not isinstance(events, list) or not events:
+        raise ValueError("metric reference must contain at least one replay event")
+    results, seen = [], set()
+    previous_end = prep["guaranteed_calibration_s"][1]
+    for event in events:
+        identifier, kind = event["id"], event["kind"]
+        if not isinstance(identifier, str) or not identifier.strip() or identifier in seen or kind not in KINDS:
+            raise ValueError("unique event ID and known descriptive kind required")
+        seen.add(identifier)
+        start = interval(event["start_device_s"], "event start")
+        end = interval(event["end_device_s"], "event end")
+        if start[0] < previous_end + 2 or end[0] <= start[1]:
+            raise ValueError("events must remain ordered with two-second plateaus")
+        previous_end = end[1]
+        baro = barometer_prediction(barometer, start, end, prep)
+        inertial = imu_segment(imu, start, end, prep)
+        common = intersect(baro["delta_z_interval_m"], inertial["delta_z_interval_m"])
+        latency = (POST_DELAY_S + WINDOW_S
+                   + 2 * prep["bounds"]["sensor_time_error_s"]
+                   + prep["bounds"]["delivery_latency_error_s"])
+        width = None if common is None else common[1] - common[0]
+        results.append({"id": identifier, "kind": kind,
+                        "start_device_s": list(start), "end_device_s": list(end),
+                        "barometer": baro, "inertial": inertial,
+                        "conditional_delta_z_interval_m": common,
+                        "consistency": "OVERLAP" if common is not None else "DISJOINT",
+                        "conditional_uncertainty_width_m": width,
+                        "conditional_half_width_m": None if width is None else width / 2,
+                        "conditional_latency_upper_s": latency,
+                        "conditional_half_width_within_5cm": common is not None and width / 2 <= 0.05 + 1e-12,
+                        "conditional_latency_within_1s": latency <= 1.0 + 1e-12})
+    return {"schema": "webeeblocks.x3.vertical-predictor-result.v1",
+            "status": "COMPUTED_CONDITIONAL", "preparation": prep, "events": results,
+            "declared_bounds_validated": False, "sensor_producer_timing_validated": False,
+            "physical_reference_validated": bool(reference.get("physical_reference_validated", False)),
+            "affine_clock_validated": bool(reference.get("affine_clock_validated", False)),
+            "independent_displacement_verdict": "UNPROVEN",
+            "physical_verdict": None,
+            "scope": "offline barometer+raw-accelerometer vehicle-Z replay; ToF, estimator attitude/state and S3 excluded",
+            "limits": ["Declared deterministic error/tilt bounds are inputs, not measurements or confidence intervals.",
+                       "Crazyflie log timestamps are not per-sensor producer timestamps.",
+                       "The 5 cm half-width and 1 s latency booleans are conditional budget checks, never PASS/FAIL.",
+                       "No terrain delta, XY behavior, motorized behavior or flight authority is established."]}
+
+
+def safe_source(root, source):
+    relative = Path(source["path"])
+    target = (root / relative).resolve()
+    if relative.is_absolute() or ".." in relative.parts or not target.is_relative_to(root) or not target.is_file():
+        raise ValueError("source must stay inside the specification directory")
+    raw = target.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    if not isinstance(source.get("sha256"), str) or not re.fullmatch(r"[0-9a-f]{64}", source["sha256"]) or digest != source["sha256"]:
+        raise ValueError("source digest mismatch")
+    return raw, digest
+
+
+def run(path: Path):
+    raw_spec = path.read_bytes()
+    spec = json.loads(raw_spec)
+    root = path.parent.resolve()
+    sources = spec["sources"]
+    if set(sources) != {"barometer", "imu", "metric_reference"}:
+        raise ValueError("exact barometer/imu/metric_reference source set required; pose/ToF/estimator sources are forbidden")
+    loaded = {name: safe_source(root, sources[name]) for name in sources}
+    barometer, imu = read_sources(loaded["barometer"][0], loaded["imu"][0])
+    reference = json.loads(loaded["metric_reference"][0])
+    reference_sources = reference.get("input_provenance", {}).get("sources", [])
+    bound_baro = [item for item in reference_sources
+                  if isinstance(item, dict) and item.get("kind") == "barometer-capture"]
+    if len(bound_baro) != 1 or bound_baro[0].get("sha256") != loaded["barometer"][1]:
+        raise ValueError("metric reference is not bound to the supplied barometer capture")
+    result = analyze(barometer, imu, spec, reference)
+    result["input_provenance"] = {"specification_sha256": hashlib.sha256(raw_spec).hexdigest(),
+                                  "sources": {name: digest for name, (_, digest) in loaded.items()},
+                                  "predictor_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest()}
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("specification", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        result = run(args.specification)
+        serialized = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        with args.output.open("x", encoding="utf-8") as stream:
+            stream.write(serialized)
+    except (OSError, ValueError, TypeError, KeyError, OverflowError) as exc:
+        parser.exit(1, f"UNPROVEN: {exc}; retain raw inputs and any partial output\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
@@ -132,6 +132,7 @@ def preparation(barometer, imu, spec, reference):
     if tilt >= 90:
         raise ValueError("tilt bound must stay below 90 deg for the body-Z cone model")
     v0_error = nonnegative(bounds["initial_velocity_error_m_s"], "initial velocity error")
+    intersample_error = nonnegative(bounds["intersample_acceleration_error_m_s2"], "intersample acceleration error")
     baro_error = nonnegative(bounds["barometer_displacement_error_m"], "barometer displacement error")
     sensor_time_error = nonnegative(bounds["sensor_time_error_s"], "sensor time error")
     delivery_latency = nonnegative(bounds["delivery_latency_error_s"], "delivery latency error")
@@ -165,6 +166,7 @@ def preparation(barometer, imu, spec, reference):
             "bounds": {"specific_force_error_g": sf_error,
                        "max_body_z_tilt_deg": tilt,
                        "initial_velocity_error_m_s": v0_error,
+                       "intersample_acceleration_error_m_s2": intersample_error,
                        "barometer_displacement_error_m": baro_error,
                        "sensor_time_error_s": sensor_time_error,
                        "delivery_latency_error_s": delivery_latency}}
@@ -301,12 +303,15 @@ def imu_segment(imu, start, end, prep):
     end_shift = (end[1] - end[0]) + te
     shift = start_shift + end_shift
     timing_error = v0 * shift + max_acc * duration_max * shift + 0.5 * max_acc * shift * shift
-    bounded = [bounded[0] - timing_error, bounded[1] + timing_error]
+    intersample_error = 0.5 * prep["bounds"]["intersample_acceleration_error_m_s2"] * duration_max * duration_max
+    bounded = [bounded[0] - timing_error - intersample_error,
+               bounded[1] + timing_error + intersample_error]
     return {"anchor_device_s": [anchor_start, anchor_end],
             "admissible_device_s": [outer_start, outer_end],
             "nominal_delta_z_m": nominal,
             "delta_z_interval_m": bounded,
             "timing_sensitivity_error_m": timing_error,
+            "intersample_displacement_error_m": intersample_error,
             "max_abs_vertical_accel_bound_m_s2": max_acc,
             "initial_velocity_interval_m_s": [-v0, v0]}
 
@@ -344,7 +349,8 @@ def analyze(barometer, imu, spec, reference):
         baro = barometer_prediction(barometer, start, end, prep)
         inertial = imu_segment(imu, start, end, prep)
         common = intersect(baro["delta_z_interval_m"], inertial["delta_z_interval_m"])
-        latency = (POST_DELAY_S + WINDOW_S
+        latency = (end[1] - end[0]
+                   + POST_DELAY_S + WINDOW_S
                    + 2 * prep["bounds"]["sensor_time_error_s"]
                    + prep["bounds"]["delivery_latency_error_s"])
         width = None if common is None else common[1] - common[0]
@@ -366,7 +372,7 @@ def analyze(barometer, imu, spec, reference):
             "independent_displacement_verdict": "UNPROVEN",
             "physical_verdict": None,
             "scope": "offline barometer+raw-accelerometer vehicle-Z replay; ToF, estimator attitude/state and S3 excluded",
-            "limits": ["Declared deterministic error/tilt bounds are inputs, not measurements or confidence intervals.",
+            "limits": ["Declared deterministic error/tilt/intersample bounds are inputs, not measurements or confidence intervals.",
                        "Crazyflie log timestamps are not per-sensor producer timestamps.",
                        "The 5 cm half-width and 1 s latency booleans are conditional budget checks, never PASS/FAIL.",
                        "No terrain delta, XY behavior, motorized behavior or flight authority is established."]}

--- a/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
@@ -295,8 +295,7 @@ def imu_segment(imu, start, end, prep):
     # sensitivity envelope. This is conditional on the declared timing/error
     # bounds and does not turn log time into sensor producer time.
     v0 = prep["bounds"]["initial_velocity_error_m_s"]
-    max_acc = max(max(abs(row[2]), abs(row[3])) for row in samples
-                  if outer_start <= row[0] <= outer_end)
+    max_acc = max(max(abs(row[2]), abs(row[3])) for row in samples)
     duration_max = outer_end - outer_start
     start_shift = (start[1] - start[0]) + te
     end_shift = (end[1] - end[0]) + te

--- a/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/frozen_vertical_predictor.py
@@ -321,6 +321,10 @@ def analyze(barometer, imu, spec, reference):
         raise ValueError("unknown vertical-predictor schema")
     if reference.get("schema") != "webeeblocks.x3.metric-reference-result.v1" or reference.get("status") != "COMPUTED_CONDITIONAL":
         raise ValueError("exact conditional metric-reference result required")
+    physical_reference_validated = reference.get("physical_reference_validated", False)
+    affine_clock_validated = reference.get("affine_clock_validated", False)
+    if not isinstance(physical_reference_validated, bool) or not isinstance(affine_clock_validated, bool):
+        raise ValueError("metric-reference validation flags must be booleans")
     prep = preparation(barometer, imu, spec, reference)
     events = reference.get("events")
     if not isinstance(events, list) or not events:
@@ -357,8 +361,8 @@ def analyze(barometer, imu, spec, reference):
     return {"schema": "webeeblocks.x3.vertical-predictor-result.v1",
             "status": "COMPUTED_CONDITIONAL", "preparation": prep, "events": results,
             "declared_bounds_validated": False, "sensor_producer_timing_validated": False,
-            "physical_reference_validated": bool(reference.get("physical_reference_validated", False)),
-            "affine_clock_validated": bool(reference.get("affine_clock_validated", False)),
+            "physical_reference_validated": physical_reference_validated,
+            "affine_clock_validated": affine_clock_validated,
             "independent_displacement_verdict": "UNPROVEN",
             "physical_verdict": None,
             "scope": "offline barometer+raw-accelerometer vehicle-Z replay; ToF, estimator attitude/state and S3 excluded",

--- a/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh
+++ b/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh
@@ -8,6 +8,12 @@ EXPECTED_BLOB=57c0e8405c07b63a29538019895ed17d0a379440
 APPLICATOR="$ROOT/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3.py"
 DISCRIMINATOR="$ROOT/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_veto_discriminator.py"
 TIMING_OBSERVER="$ROOT/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_timing_observer.py"
+VERTICAL_PREDICTOR_TEST="$ROOT/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py"
+
+# Changes anywhere under this experiment select the S3 oracle. Keep the new
+# offline X3 predictor's executable contract inside that same selected evidence
+# path so a green exact-candidate CI actually exercises the added calculation.
+python3 "$VERTICAL_PREDICTOR_TEST"
 
 test -d "$UPSTREAM/.git"
 test "$(git -C "$UPSTREAM" rev-parse HEAD)" = "$EXPECTED_COMMIT"
@@ -86,4 +92,4 @@ EOF
   find build -type f -name 'estimator_ukf.o' -size +0c -print -quit | grep -q .
 )
 
-printf '%s\n' "PASS: exact Crazyflie 2026.08 S3 source plus VZ/BARO/BOTH discriminator and reset-safe timing observer applied and UKF-enabled cf2 firmware built."
+printf '%s\n' "PASS: X3 vertical replay controls passed; exact Crazyflie 2026.08 S3 source plus VZ/BARO/BOTH discriminator and reset-safe timing observer applied and UKF-enabled cf2 firmware built."

--- a/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh
+++ b/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh
@@ -8,12 +8,6 @@ EXPECTED_BLOB=57c0e8405c07b63a29538019895ed17d0a379440
 APPLICATOR="$ROOT/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3.py"
 DISCRIMINATOR="$ROOT/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_veto_discriminator.py"
 TIMING_OBSERVER="$ROOT/experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_timing_observer.py"
-VERTICAL_PREDICTOR_TEST="$ROOT/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py"
-
-# Changes anywhere under this experiment select the S3 oracle. Keep the new
-# offline X3 predictor's executable contract inside that same selected evidence
-# path so a green exact-candidate CI actually exercises the added calculation.
-python3 "$VERTICAL_PREDICTOR_TEST"
 
 test -d "$UPSTREAM/.git"
 test "$(git -C "$UPSTREAM" rev-parse HEAD)" = "$EXPECTED_COMMIT"
@@ -92,4 +86,4 @@ EOF
   find build -type f -name 'estimator_ukf.o' -size +0c -print -quit | grep -q .
 )
 
-printf '%s\n' "PASS: X3 vertical replay controls passed; exact Crazyflie 2026.08 S3 source plus VZ/BARO/BOTH discriminator and reset-safe timing observer applied and UKF-enabled cf2 firmware built."
+printf '%s\n' "PASS: exact Crazyflie 2026.08 S3 source plus VZ/BARO/BOTH discriminator and reset-safe timing observer applied and UKF-enabled cf2 firmware built."

--- a/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
@@ -152,6 +152,29 @@ class PredictorTests(unittest.TestCase):
                            event["barometer"]["before_median_time_s"][0])
         self.assertFalse(result["sensor_producer_timing_validated"])
 
+    def test_timing_envelope_includes_off_grid_bracketing_acceleration(self):
+        prep = {"bounds": {"specific_force_error_g": 0.0,
+                           "max_body_z_tilt_deg": 0.0,
+                           "initial_velocity_error_m_s": 0.0,
+                           "sensor_time_error_s": 0.005},
+                "zero_specific_force_interval_g": [1.0, 1.0],
+                "nominal_zero_specific_force_g": 1.0}
+        imu = []
+        for i in range(53):
+            t = 0.99 + 0.02 * i
+            az = 11.0 if i == 0 else 1.0
+            imu.append((t, 100.0 + t, (0.0, 0.0, az)))
+        start = (1.005, 1.005)
+        end = (2.005, 2.005)
+        segment = predictor.imu_segment(imu, start, end, prep)
+        outer_start, outer_end = segment["admissible_device_s"]
+        samples = predictor.projected_samples(imu, outer_start, outer_end, prep)
+        _nominal, shifted, _points = predictor.integrate_projected(samples, outer_start, outer_end, prep)
+
+        self.assertAlmostEqual(segment["max_abs_vertical_accel_bound_m_s2"], 10.0 * predictor.G)
+        self.assertLessEqual(segment["delta_z_interval_m"][0], shifted[0])
+        self.assertGreaterEqual(segment["delta_z_interval_m"][1], shifted[1])
+
     def test_full_file_entry_binds_exact_sources_and_rejects_pose_input(self):
         baro, imu, pose, spec, reference = fixture()
         with tempfile.TemporaryDirectory() as directory:

--- a/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+import copy
+import csv
+import hashlib
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import frozen_vertical_predictor as predictor
+
+
+def build_stream(period, columns, fn, duration=58.0, origin=1000):
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream)
+    writer.writerow(("cf_timestamp_ms", "host_monotonic_s", *columns))
+    n = round(duration / period) + 1
+    for i in range(n):
+        t = i * period
+        writer.writerow((origin + round(t * 1000), 100 + t, *fn(t)))
+    return stream.getvalue().encode()
+
+
+def fixture(errors=False):
+    start, end = 34.0, 35.0
+    accel = 0.8
+
+    def z_truth(t):
+        if t <= start:
+            return 0.0
+        if t < start + 0.5:
+            u = t - start
+            return 0.5 * accel * u * u
+        if t < end:
+            u = t - (start + 0.5)
+            return 0.1 + 0.4 * u - 0.5 * accel * u * u
+        return 0.2
+
+    def az(t):
+        if start <= t < start + 0.5:
+            a = accel
+        elif start + 0.5 <= t < end:
+            a = -accel
+        else:
+            a = 0.0
+        return 1.0 + a / predictor.G
+
+    baro = build_stream(.02, ("baro.asl", "baro.pressure", "baro.temp"),
+                        lambda t: (100 + z_truth(t), 1000, 20))
+    imu = build_stream(.01, ("acc.x", "acc.y", "acc.z", "gyro.x", "gyro.y", "gyro.z"),
+                       lambda t: (0, 0, az(t), 0, 0, 0))
+    pose = build_stream(.02, ("range.zrange", "stabilizer.roll", "stabilizer.pitch", "stateEstimate.z", "stateEstimate.vz"),
+                        lambda t: (500, 0, 0, 9999, -9999))
+    spec = {"schema": "webeeblocks.x3.vertical-predictor-input.v1",
+            "declared_bounds": {"specific_force_error_g": .002 if errors else .0005,
+                                "max_body_z_tilt_deg": .2 if errors else .05,
+                                "initial_velocity_error_m_s": .005 if errors else .001,
+                                "barometer_displacement_error_m": .01 if errors else .005,
+                                "sensor_time_error_s": .005 if errors else 0,
+                                "delivery_latency_error_s": .05 if errors else 0}}
+    reference = {"schema": "webeeblocks.x3.metric-reference-result.v1",
+                 "status": "COMPUTED_CONDITIONAL",
+                 "calibration_start_device_s": [0, 0], "calibration_end_device_s": [30, 30],
+                 "events": [{"id": "vertical-up", "kind": "vertical",
+                             "start_device_s": [start, start], "end_device_s": [end, end]}],
+                 "physical_reference_validated": False, "affine_clock_validated": False}
+    return baro, imu, pose, spec, reference
+
+
+class PredictorTests(unittest.TestCase):
+    def test_vertical_replay_excludes_tof_state_and_overlaps(self):
+        baro, imu, _pose, spec, reference = fixture()
+        result = predictor.analyze(*predictor.read_sources(baro, imu), spec, reference)
+        event = result["events"][0]
+        self.assertEqual(event["consistency"], "OVERLAP")
+        self.assertLessEqual(event["barometer"]["delta_z_interval_m"][0], .2)
+        self.assertGreaterEqual(event["barometer"]["delta_z_interval_m"][1], .2)
+        self.assertLess(abs(event["inertial"]["nominal_delta_z_m"] - .2), .005)
+        self.assertLess(event["conditional_uncertainty_width_m"], .02)
+        self.assertTrue(event["conditional_half_width_within_5cm"])
+        self.assertTrue(event["conditional_latency_within_1s"])
+        self.assertFalse(result["declared_bounds_validated"])
+        self.assertEqual(result["independent_displacement_verdict"], "UNPROVEN")
+        self.assertIsNone(result["physical_verdict"])
+
+    def test_declared_errors_widen_bounds_without_becoming_validation(self):
+        baro, imu, _pose, spec, reference = fixture(errors=True)
+        result = predictor.analyze(*predictor.read_sources(baro, imu), spec, reference)
+        event = result["events"][0]
+        self.assertGreater(event["conditional_uncertainty_width_m"], 0)
+        self.assertEqual(event["conditional_latency_upper_s"], .81)
+        self.assertFalse(result["declared_bounds_validated"])
+
+    def test_disjoint_sensors_fail_closed_as_conditional_disagreement(self):
+        baro, imu, _pose, spec, reference = fixture()
+        text = imu.decode().splitlines()
+        header = text[0].split(',')
+        idx = header.index('acc.z')
+        rows = [text[0]]
+        for line in text[1:]:
+            fields = line.split(',')
+            fields[idx] = '1.0'
+            rows.append(','.join(fields))
+        flat_imu = ('\n'.join(rows) + '\n').encode()
+        event = predictor.analyze(*predictor.read_sources(baro, flat_imu), spec, reference)["events"][0]
+        self.assertEqual(event["consistency"], "DISJOINT")
+        self.assertIsNone(event["conditional_delta_z_interval_m"])
+        self.assertFalse(event["conditional_half_width_within_5cm"])
+
+    def test_calibration_and_event_constraints_reject_optimism(self):
+        baro, imu, _pose, spec, reference = fixture()
+        streams = predictor.read_sources(baro, imu)
+        bad_reference = copy.deepcopy(reference)
+        bad_reference["calibration_start_device_s"] = [0, 1]
+        bad_reference["calibration_end_device_s"] = [30, 30]
+        with self.assertRaisesRegex(ValueError, "30 s"):
+            predictor.analyze(*streams, spec, bad_reference)
+        bad = copy.deepcopy(spec)
+        bad["declared_bounds"]["specific_force_error_g"] = -0.1
+        with self.assertRaises(ValueError):
+            predictor.analyze(*streams, bad, reference)
+        bad_reference = copy.deepcopy(reference)
+        bad_reference["events"][0]["start_device_s"] = [34.1, 33.9]
+        with self.assertRaises(ValueError):
+            predictor.analyze(*streams, spec, bad_reference)
+
+    def test_reference_time_intervals_are_not_midpointed(self):
+        baro, imu, _pose, spec, reference = fixture(errors=True)
+        widened = copy.deepcopy(reference)
+        widened["events"][0]["start_device_s"] = [34.0, 34.01]
+        widened["events"][0]["end_device_s"] = [35.0, 35.01]
+        result = predictor.analyze(*predictor.read_sources(baro, imu), spec, widened)
+        event = result["events"][0]
+        self.assertEqual(event["inertial"]["anchor_device_s"], [34.0, 35.0])
+        self.assertGreater(event["inertial"]["timing_sensitivity_error_m"], 0)
+        self.assertGreater(event["barometer"]["before_median_time_s"][1],
+                           event["barometer"]["before_median_time_s"][0])
+        self.assertFalse(result["sensor_producer_timing_validated"])
+
+    def test_full_file_entry_binds_exact_sources_and_rejects_pose_input(self):
+        baro, imu, pose, spec, reference = fixture()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sources = {}
+            for name, raw in (("barometer", baro), ("imu", imu)):
+                path = root / f"{name}.csv"
+                path.write_bytes(raw)
+                sources[name] = {"path": path.name, "sha256": hashlib.sha256(raw).hexdigest()}
+            reference["input_provenance"] = {"sources": [
+                {"id": "capture", "path": "barometer.csv", "sha256": sources["barometer"]["sha256"], "kind": "barometer-capture"},
+                {"id": "external", "path": "notes.txt", "sha256": "0" * 64, "kind": "external-metric-reference"}]}
+            reference_raw = json.dumps(reference).encode()
+            (root / "metric-reference.json").write_bytes(reference_raw)
+            sources["metric_reference"] = {"path": "metric-reference.json", "sha256": hashlib.sha256(reference_raw).hexdigest()}
+            spec["sources"] = sources
+            path = root / "input.json"
+            path.write_text(json.dumps(spec))
+            result = predictor.run(path)
+            self.assertEqual(result["input_provenance"]["sources"]["imu"], sources["imu"]["sha256"])
+
+            pose_path = root / "pose.csv"
+            pose_path.write_bytes(pose)
+            forbidden = copy.deepcopy(spec)
+            forbidden["sources"]["pose"] = {"path": pose_path.name, "sha256": hashlib.sha256(pose).hexdigest()}
+            forbidden_path = root / "forbidden.json"
+            forbidden_path.write_text(json.dumps(forbidden))
+            with self.assertRaisesRegex(ValueError, "pose/ToF/estimator"):
+                predictor.run(forbidden_path)
+
+            (root / "imu.csv").write_bytes(imu + b"\n")
+            with self.assertRaisesRegex(ValueError, "digest"):
+                predictor.run(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
@@ -175,6 +175,18 @@ class PredictorTests(unittest.TestCase):
         self.assertLessEqual(segment["delta_z_interval_m"][0], shifted[0])
         self.assertGreaterEqual(segment["delta_z_interval_m"][1], shifted[1])
 
+    def test_metric_reference_validation_flags_require_json_booleans(self):
+        baro, imu, _pose, spec, reference = fixture()
+        streams = predictor.read_sources(baro, imu)
+        malformed = copy.deepcopy(reference)
+        malformed["physical_reference_validated"] = "false"
+        with self.assertRaisesRegex(ValueError, "validation flags"):
+            predictor.analyze(*streams, spec, malformed)
+        malformed = copy.deepcopy(reference)
+        malformed["affine_clock_validated"] = 1
+        with self.assertRaisesRegex(ValueError, "validation flags"):
+            predictor.analyze(*streams, spec, malformed)
+
     def test_full_file_entry_binds_exact_sources_and_rejects_pose_input(self):
         baro, imu, pose, spec, reference = fixture()
         with tempfile.TemporaryDirectory() as directory:

--- a/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
@@ -56,6 +56,7 @@ def fixture(errors=False):
             "declared_bounds": {"specific_force_error_g": .002 if errors else .0005,
                                 "max_body_z_tilt_deg": .2 if errors else .05,
                                 "initial_velocity_error_m_s": .005 if errors else .001,
+                                "intersample_acceleration_error_m_s2": .02 if errors else 0.0,
                                 "barometer_displacement_error_m": .01 if errors else .005,
                                 "sensor_time_error_s": .005 if errors else 0,
                                 "delivery_latency_error_s": .05 if errors else 0}}
@@ -156,6 +157,7 @@ class PredictorTests(unittest.TestCase):
         prep = {"bounds": {"specific_force_error_g": 0.0,
                            "max_body_z_tilt_deg": 0.0,
                            "initial_velocity_error_m_s": 0.0,
+                           "intersample_acceleration_error_m_s2": 0.0,
                            "sensor_time_error_s": 0.005},
                 "zero_specific_force_interval_g": [1.0, 1.0],
                 "nominal_zero_specific_force_g": 1.0}
@@ -174,6 +176,36 @@ class PredictorTests(unittest.TestCase):
         self.assertAlmostEqual(segment["max_abs_vertical_accel_bound_m_s2"], 10.0 * predictor.G)
         self.assertLessEqual(segment["delta_z_interval_m"][0], shifted[0])
         self.assertGreaterEqual(segment["delta_z_interval_m"][1], shifted[1])
+
+    def test_intersample_bound_encloses_motion_hidden_between_identical_rows(self):
+        bound = 4.0
+        prep = {"bounds": {"specific_force_error_g": 0.0,
+                           "max_body_z_tilt_deg": 0.0,
+                           "initial_velocity_error_m_s": 0.0,
+                           "intersample_acceleration_error_m_s2": bound,
+                           "sensor_time_error_s": 0.0},
+                "zero_specific_force_interval_g": [1.0, 1.0],
+                "nominal_zero_specific_force_g": 1.0}
+        imu = [(i * 0.02, 100.0 + i * 0.02, (0.0, 0.0, 1.0)) for i in range(51)]
+        segment = predictor.imu_segment(imu, (0.0, 0.0), (1.0, 1.0), prep)
+        hidden_motion = 0.5 * bound
+
+        self.assertAlmostEqual(segment["nominal_delta_z_m"], 0.0)
+        self.assertAlmostEqual(segment["intersample_displacement_error_m"], hidden_motion)
+        self.assertLessEqual(segment["delta_z_interval_m"][0], -hidden_motion)
+        self.assertGreaterEqual(segment["delta_z_interval_m"][1], hidden_motion)
+
+    def test_end_interval_width_is_included_in_latency_budget(self):
+        baro, imu, _pose, spec, reference = fixture(errors=True)
+        base = predictor.analyze(*predictor.read_sources(baro, imu), spec, reference)["events"][0]
+        widened = copy.deepcopy(reference)
+        widened["events"][0]["end_device_s"] = [35.0, 35.21]
+        event = predictor.analyze(*predictor.read_sources(baro, imu), spec, widened)["events"][0]
+
+        self.assertEqual(base["conditional_latency_upper_s"], .81)
+        self.assertTrue(base["conditional_latency_within_1s"])
+        self.assertAlmostEqual(event["conditional_latency_upper_s"], 1.02)
+        self.assertFalse(event["conditional_latency_within_1s"])
 
     def test_metric_reference_validation_flags_require_json_booleans(self):
         baro, imu, _pose, spec, reference = fixture()

--- a/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
+++ b/experiments/crazyflie-ukf-surface-range/test_frozen_vertical_predictor.py
@@ -108,6 +108,20 @@ class PredictorTests(unittest.TestCase):
         self.assertIsNone(event["conditional_delta_z_interval_m"])
         self.assertFalse(event["conditional_half_width_within_5cm"])
 
+    def test_imu_prefix_before_barometer_origin_uses_signed_modular_alignment(self):
+        baro, imu, _pose, _spec, _reference = fixture()
+        text = imu.decode().splitlines()
+        rows = [text[0]]
+        for line in text[1:]:
+            fields = line.split(',')
+            fields[0] = str((int(fields[0]) - 10) % predictor.MODULUS)
+            rows.append(','.join(fields))
+        lead_imu = ('\n'.join(rows) + '\n').encode()
+        _barometer, aligned_imu = predictor.read_sources(baro, lead_imu)
+        self.assertAlmostEqual(aligned_imu[0][0], -0.01)
+        self.assertAlmostEqual(aligned_imu[1][0], 0.0)
+        self.assertTrue(all(left[0] < right[0] for left, right in zip(aligned_imu, aligned_imu[1:])))
+
     def test_calibration_and_event_constraints_reject_optimism(self):
         baro, imu, _pose, spec, reference = fixture()
         streams = predictor.read_sources(baro, imu)


### PR DESCRIPTION
Refs #70

## Result

This adds the next bounded #70/X3 offline component after the integrated collector, pressure probe and conditional metric-reference processor.

- `frozen_vertical_predictor.py` consumes only the exact continuous barometer/IMU capture plus the hash-bound conditional metric-reference timing result; pose/range, `stateEstimate.z`, `stateEstimate.vz`, S3 diagnostics and estimator attitude are forbidden predictor inputs.
- The barometer arm preserves the pre-registered B−/B+ windows and all admissible event/timing intervals without midpoint selection, with drift fitted only on guaranteed prior stationary calibration.
- The inertial arm uses raw body-frame accelerometer samples and pre-declared deterministic specific-force, tilt, initial-velocity, intersample-acceleration and timing bounds. The explicit intersample bound covers continuous acceleration deviation that retained rows and a gap limit alone cannot prove.
- Timing sensitivity includes IMU samples that bracket off-grid admissible boundaries, so interpolation at an admissible boundary cannot depend on an acceleration excluded from the bound.
- Barometer and inertial intervals are combined only by intersection; disagreement stays `DISJOINT` rather than being tuned away.
- Cross-stream device-time alignment uses a signed modular offset around the first barometer timestamp, so the collector-valid case where the first 10 ms IMU callback precedes the first 20 ms barometer callback is retained while exact half-period ambiguity and non-increasing aligned time remain rejected.
- Metric-reference validation flags must be actual JSON booleans; malformed truthy values fail closed rather than being coerced to validation.
- The latency upper bound includes the retained event-end interval width as well as the fixed B+ delay/window and declared timing/delivery allowances.
- The output reports the pre-registered 5 cm half-width / 1 s latency budgets only as conditional checks. `declared_bounds_validated:false`, `sensor_producer_timing_validated:false`, `independent_displacement_verdict:UNPROVEN` and `physical_verdict:null` remain explicit.
- Standalone synthetic controls cover signed replay, bound widening, sensor disagreement, negative-prefix IMU/barometer alignment, calibration/input rejection, interval timing without midpointing, off-grid timing-bracket coverage, intersample displacement allowance, widened-end latency, strict validation-flag typing, exact source/digest binding and rejection of pose/ToF/estimator sources.
- `run_s3_build_oracle.sh` remains exactly current `main`; these offline predictor component tests do not expand the firmware/CI evidence path. Canonical Ready `CI Gate` remains the separate integration prerequisite.

Exact candidate: `c7144876d0a2c7a32f17abb451185cfa91e26866`, based on `main@cf1a430af4d75e28e64b41f4b940e80abbba042a`.

The earlier implementation's local component tests and `py_compile` passed before its original publication. No standalone component execution is claimed for this exact candidate by this description; Draft run #1186 completed only `CI Gate (Draft)` with product suites skipped, which is not integration evidence.

## Boundary

This freezes replay mechanics only. It does not validate the declared error/tilt/intersample/timing bounds, physical-reference annotations, affine-clock assumption or sensor-producer timing. It does not estimate terrain truth, flash firmware, change #251 parameters, tune S3/ToF/barometer, modify Runtime/controller behavior, request `TEST_REQUIRED`, or authorize any motorized test. A later checkpoint is eligible only after the complete exact support/bound provenance/reference/publication path is prepared under `AGENTS.md`.