### PR TITLE
Refresh Firefox project UI cache key

### DIFF
--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -66,6 +66,6 @@
   <script src="main.js"></script>
   <script src="physical_preflight_runtime.js"></script>
   <script src="classroom_fixes.js"></script>
-  <script src="project_ui.js?rev=20260830-1"></script>
+  <script src="project_ui.js?rev=20260912-1"></script>
 </body>
 </html>


### PR DESCRIPTION
Fix a deployment boundary left by #319: `project_ui.js` gained the Firefox WWI/native-broker path, but `blockly_v2.html` retained the pre-existing `rev=20260830-1` cache key. A browser profile that had already cached the old project UI could therefore keep executing the pre-#319 unsupported-Firefox code even with the new broker present.

This slice changes only the project UI cache key so the integrated #319 logic is fetched as a distinct resource. It does not change project semantics, the broker protocol, Chromium behavior, Windows qualification, or the human-checkpoint mechanism.

Refs #87 #319.