### PR TITLE
Bound Firefox broker reference lifetime

### DIFF
--- a/controllers/crazyflie_runtime_v2/file_broker.cpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.cpp
@@ -169,7 +169,7 @@ bool FileBroker::handleMessage(const char *message, std::string *response) {
     const std::string provider = safeProviderName(mProvider->name());
     *response = responsePrefix(id) +
       "CAPABILITIES {\"protocol\":1,\"provider\":\"" + provider +
-      "\",\"providerInjectable\":true,\"operationsReady\":true,\"sameFileSave\":true,\"canonicalExtension\":\".wbb\"}";
+      "\",\"providerInjectable\":true,\"operationsReady\":true,\"sameFileSave\":true,\"referenceRelease\":true,\"canonicalExtension\":\".wbb\"}";
     return true;
   }
   if (operation == "OPEN" && parts.size() == 2) {
@@ -201,6 +201,15 @@ bool FileBroker::handleMessage(const char *message, std::string *response) {
       return true;
     }
     *response = saveResponse(id, "SAVE", mProvider->save(parts[2], bytes));
+    return true;
+  }
+  if (operation == "RELEASE" && parts.size() == 3) {
+    if (!safeToken(parts[2])) {
+      *response = operationError(id, "INVALID_REQUEST");
+      return true;
+    }
+    mProvider->release(parts[2]);
+    *response = responsePrefix(id) + "RELEASE OK";
     return true;
   }
 

--- a/controllers/crazyflie_runtime_v2/file_broker.hpp
+++ b/controllers/crazyflie_runtime_v2/file_broker.hpp
@@ -31,6 +31,7 @@ public:
   virtual OpenFileResult open() = 0;
   virtual SaveFileResult saveAs(const std::string &suggestedName, const std::string &bytes) = 0;
   virtual SaveFileResult save(const std::string &reference, const std::string &bytes) = 0;
+  virtual void release(const std::string &reference) = 0;
 };
 
 std::unique_ptr<FileDialogProvider> createQtFileDialogProvider();

--- a/controllers/crazyflie_runtime_v2/qt_file_dialog_provider.cpp
+++ b/controllers/crazyflie_runtime_v2/qt_file_dialog_provider.cpp
@@ -114,6 +114,11 @@ public:
     return {webeeblocks::FileOperationStatus::Ok, reference, after.fileName().toUtf8().toStdString(), ""};
   }
 
+  void release(const std::string &reference) override {
+    const QString key = QString::fromLatin1(reference.data(), static_cast<int>(reference.size()));
+    mReferences.remove(key);
+  }
+
 private:
   static webeeblocks::OpenFileResult openError(const std::string &code) {
     return {webeeblocks::FileOperationStatus::Error, "", "", "", code};

--- a/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_file_wwi_transport.js
@@ -79,12 +79,11 @@
     var id = this.nextId++;
     var suffix = args && args.length ? ' ' + args.join(' ') : '';
     return new Promise(function(resolve, reject) {
-      // Bound only the non-side-effecting readiness handshake. Open and Save As
-      // are user-paced, while Save may legitimately block on slow local/network
-      // storage. The protocol has no cancellation acknowledgement: timing out a
-      // file operation could detach the browser from an operation that later
-      // commits, leaving the manager's target state inconsistent with disk.
-      var bounded = operation === 'CAPABILITIES';
+      // Bound non-file effects only. Open and Save As are user-paced, while Save
+      // may legitimately block on slow local/network storage. RELEASE abandons
+      // an opaque session capability only, so a lost acknowledgement may be
+      // treated as best-effort cleanup without ambiguity about file contents.
+      var bounded = operation === 'CAPABILITIES' || operation === 'RELEASE';
       var timer = bounded ? setTimeout(function() {
         if (!self.pending[id]) return;
         delete self.pending[id];
@@ -141,6 +140,11 @@
         pending.resolve(JSON.parse(capabilities[1]));
         return true;
       }
+      if (pending.operation === 'RELEASE') {
+        if (payload !== 'RELEASE OK') throw new BrokerError('INVALID_RESPONSE');
+        pending.resolve(null);
+        return true;
+      }
       if (pending.operation === 'OPEN') {
         var opened = payload.match(/^OPEN OK ([A-Za-z0-9_-]{1,128}) ([A-Za-z0-9+/=]+) ([A-Za-z0-9+/=]+)$/);
         if (!opened) throw new BrokerError('INVALID_RESPONSE');
@@ -174,6 +178,19 @@
       return Promise.reject(new BrokerError('TARGET_UNAVAILABLE'));
     return this.waitUntilReady().then(function() {
       return self._request('SAVE', [target.reference, encodeText(text)]);
+    });
+  };
+
+  WwiProjectFileTransport.prototype.release = function(target) {
+    var self = this;
+    if (!target || target.kind !== 'wwi' || !TOKEN.test(target.reference || ''))
+      return Promise.reject(new BrokerError('TARGET_UNAVAILABLE'));
+    return this.waitUntilReady().then(function(capabilities) {
+      // Older brokers did not expose explicit reference release. Treat their
+      // absence as a compatibility no-op; current brokers advertise and honor
+      // this session-lifetime cleanup capability.
+      if (!capabilities.referenceRelease) return;
+      return self._request('RELEASE', [target.reference]);
     });
   };
 

--- a/plugins/robot_windows/blockly/webeeblocks/project_files.js
+++ b/plugins/robot_windows/blockly/webeeblocks/project_files.js
@@ -25,7 +25,7 @@
     if (!sameJson(actual, wanted)) fail(path + ' has unsupported fields: ' + actual.join(', '));
   }
   function requireString(value, path) {
-    if (typeof value !== 'string' || value.trim() === '') fail(path + ' must be a non-empty string');
+    if (typeof value !== 'string' || !value.trim()) fail(path + ' must be a non-empty string');
   }
   function requireDependencies(options) {
     ['Blockly', 'profiles', 'activitiesDocument', 'blockCatalog', 'semanticAst', 'activityContract'].forEach(function(key) {
@@ -206,7 +206,8 @@
         requireNative();
         await writeHandle(target, text);
         return {handle: target, name: preserveSelectedName(target.name || name), mode: 'native'};
-      }
+      },
+      async release() {}
     };
   }
 
@@ -238,6 +239,11 @@
       options.Blockly.serialization.workspaces.load(saved.workspace, options.workspace);
       options.activityContract.applyFieldBounds(saved.profile, options.workspace);
     }
+    async function releaseTarget(handle) {
+      if (!handle || typeof options.transport.release !== 'function') return;
+      try { await options.transport.release(handle); }
+      catch (error) { console.warn('WebeeBlocks project target release failed', error); }
+    }
     function applyValidated(validated) {
       var before = snapshot();
       applying = true;
@@ -261,17 +267,37 @@
     return {
       async open() {
         var opened = await options.transport.open();
-        var validated = validateProjectText(opened.text, options.getProfile(), dependencies());
-        applyValidated(validated);
-        targetHandle = opened.handle || null;
-        targetName = preserveSelectedName(opened.name || validated.profile.id + EXTENSION);
+        var nextHandle = opened.handle || null;
+        var validated;
+        var nextName;
+        try {
+          validated = validateProjectText(opened.text, options.getProfile(), dependencies());
+          applyValidated(validated);
+          nextName = preserveSelectedName(opened.name || validated.profile.id + EXTENSION);
+        } catch (error) {
+          if (nextHandle && nextHandle !== targetHandle) await releaseTarget(nextHandle);
+          throw error;
+        }
+        var previousHandle = targetHandle;
+        targetHandle = nextHandle;
+        targetName = nextName;
+        if (previousHandle && previousHandle !== targetHandle) await releaseTarget(previousHandle);
         return {name: targetName, ast: validated.ast, mode: opened.mode || null};
       },
       async saveAs(name) {
         var proposal = normalizeName(name || targetName || options.getProfile().id);
         var result = await options.transport.saveAs(proposal, currentBytes());
-        targetHandle = result.handle || null;
-        targetName = preserveSelectedName(result.name || proposal);
+        var nextHandle = result.handle || null;
+        var nextName;
+        try { nextName = preserveSelectedName(result.name || proposal); }
+        catch (error) {
+          if (nextHandle && nextHandle !== targetHandle) await releaseTarget(nextHandle);
+          throw error;
+        }
+        var previousHandle = targetHandle;
+        targetHandle = nextHandle;
+        targetName = nextName;
+        if (previousHandle && previousHandle !== targetHandle) await releaseTarget(previousHandle);
         return {name: targetName, mode: result.mode || null};
       },
       async save() {

--- a/plugins/robot_windows/blockly_v2/blockly_v2.html
+++ b/plugins/robot_windows/blockly_v2/blockly_v2.html
@@ -22,7 +22,7 @@
   <script src="../blockly/webeeblocks/execution_observer.js"></script>
   <script src="../blockly/webeeblocks/runtime_outcome.js"></script>
   <script src="../blockly/webeeblocks/activity_contract.js"></script>
-  <script src="../blockly/webeeblocks/project_files.js"></script>
+  <script src="../blockly/webeeblocks/project_files.js?rev=20260912-2"></script>
   <script src="../blockly/webeeblocks/wwi_backend.js"></script>
   <script src="led_observability.js"></script>
 </head>
@@ -66,6 +66,6 @@
   <script src="main.js"></script>
   <script src="physical_preflight_runtime.js"></script>
   <script src="classroom_fixes.js"></script>
-  <script src="project_ui.js?rev=20260912-1"></script>
+  <script src="project_ui.js?rev=20260912-2"></script>
 </body>
 </html>

--- a/plugins/robot_windows/blockly_v2/project_ui.js
+++ b/plugins/robot_windows/blockly_v2/project_ui.js
@@ -104,7 +104,7 @@
       return browserTransport;
     }
 
-    await import('../blockly/webeeblocks/project_file_wwi_transport.js');
+    await import('../blockly/webeeblocks/project_file_wwi_transport.js?rev=20260912-2');
     if (typeof window.WebeeBlocksProjectFileWwiTransport !== 'function')
       throw new Error('Project file WWI transport module unavailable');
     var directRobotWindow = await waitForRobotWindow(5000);

--- a/tools/ci/test_firefox_file_broker.cpp
+++ b/tools/ci/test_firefox_file_broker.cpp
@@ -4,12 +4,14 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace {
 struct FakeState {
   std::string lastName;
   std::string lastBytes;
   std::string lastReference;
+  std::vector<std::string> releasedReferences;
   bool cancelOpen = false;
   bool missingTarget = false;
 };
@@ -35,6 +37,9 @@ public:
       return {webeeblocks::FileOperationStatus::Error, "", "", "TARGET_UNAVAILABLE"};
     return {webeeblocks::FileOperationStatus::Ok, reference, "élève.wbb", ""};
   }
+  void release(const std::string &reference) override {
+    state_->releasedReferences.push_back(reference);
+  }
 private:
   FakeState *state_;
 };
@@ -56,6 +61,7 @@ int main() {
   const auto capabilities = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 1 CAPABILITIES");
   assert(capabilities.find("\"operationsReady\":true") != std::string::npos);
   assert(capabilities.find("\"sameFileSave\":true") != std::string::npos);
+  assert(capabilities.find("\"referenceRelease\":true") != std::string::npos);
 
   const auto opened = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 2 OPEN");
   assert(opened.find("RESPONSE 2 OPEN OK opaque_open_1 ") != std::string::npos);
@@ -72,23 +78,32 @@ int main() {
   assert(state.lastReference == "opaque_saveas_2");
   assert(state.lastBytes == "{\"ok\":1}\n");
 
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 5 RELEASE opaque_open_1") ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 5 RELEASE OK");
+  assert(state.releasedReferences.size() == 1);
+  assert(state.releasedReferences.back() == "opaque_open_1");
+
   // A browser-supplied path is rejected at the protocol boundary; the provider
   // can receive only a basename proposal and an opaque reference.
-  const auto pathInjection = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 5 SAVE_AS L3RtcC9ldmlsLndiYg== " + bytes64);
-  assert(pathInjection == "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 5 ERR INVALID_REQUEST");
+  const auto pathInjection = send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 6 SAVE_AS L3RtcC9ldmlsLndiYg== " + bytes64);
+  assert(pathInjection == "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 6 ERR INVALID_REQUEST");
 
   state.cancelOpen = true;
-  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 6 OPEN") ==
-         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 6 OPEN CANCELLED");
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 OPEN") ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 7 OPEN CANCELLED");
   state.cancelOpen = false;
 
   state.missingTarget = true;
-  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 7 SAVE opaque_saveas_2 " + bytes64) ==
-         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 7 ERR TARGET_UNAVAILABLE");
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 8 SAVE opaque_saveas_2 " + bytes64) ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 8 ERR TARGET_UNAVAILABLE");
 
-  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 8 SAVE ../escape " + bytes64) ==
-         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 8 ERR INVALID_REQUEST");
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 9 SAVE ../escape " + bytes64) ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 9 ERR INVALID_REQUEST");
+  const auto releaseCount = state.releasedReferences.size();
+  assert(send(broker, "WEBEEBLOCKS_FILE_BROKER_V1 REQUEST 10 RELEASE ../escape") ==
+         "WEBEEBLOCKS_FILE_BROKER_V1 RESPONSE 10 ERR INVALID_REQUEST");
+  assert(state.releasedReferences.size() == releaseCount);
 
-  std::cout << "PASS firefox-file-broker: capabilities/open/save-as/same-reference-save/cancel/errors/no-browser-path\n";
+  std::cout << "PASS firefox-file-broker: capabilities/open/save-as/same-reference-save/release/cancel/errors/no-browser-path\n";
   return 0;
 }


### PR DESCRIPTION
## Why

The Linux Firefox Qt/WWI broker keeps every opaque Open/Save As reference in a session map capped at 128. The project manager previously never released references when an opened project was rejected by validation or when a later Open/Save As replaced the current target, so a long-lived session could eventually fail with `REFERENCE_LIMIT` despite retaining only one logical project target.

## Change

- add a protocol-v1 `RELEASE <opaque-ref>` session operation and advertise `referenceRelease:true`;
- remove released tokens from the Qt provider map without touching file contents;
- make the WWI transport use release only when the broker advertises the capability, preserving compatibility with older brokers;
- release rejected candidate references and superseded project targets in the manager while keeping browser-native handles a no-op cleanup path;
- preserve same-file `Save` semantics and neutral cancellation/errors;
- refresh the cache keys for the changed project-file modules;
- extend the broker protocol regression for release and malformed tokens.

Local bounded checks were run on product patch commit `a3e73c33c9f92f829621c59aec6a06442b9ba6a8`:

- `g++ -std=c++17 -Wall -Wextra -pedantic ... file_broker.cpp test_firefox_file_broker.cpp` + executable PASS;
- `node --check` on `project_file_wwi_transport.js`, `project_files.js`, and `project_ui.js`.

Current candidate `c795fdcbce7b492a3e8d08df929ae95f4a7740e3` adds only the merge of current `main@f33cebc17ad4ab0e382caede2a51b1bdb167752f`; the PR diff remains the same eight Firefox/reference-lifecycle files.

This does not claim real Linux Firefox end-to-end acceptance or Windows Firefox qualification.

Refs #87 #319 #327.