### PR TITLE
Retain X3 sensor-to-output latency diagnostic

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/INDEPENDENT_INPUT_CAPTURE.md
+++ b/experiments/crazyflie-ukf-surface-range/INDEPENDENT_INPUT_CAPTURE.md
@@ -23,20 +23,27 @@ This is explicitly not remote firmware attestation. No flash is performed.
 | --- | ---: | --- | ---: |
 | `barometer` | 20 ms | `baro.asl`, `pressure`, `temp` | 12 bytes |
 | `imu` | 10 ms | `acc.x/y/z`, `gyro.x/y/z` | 24 bytes |
-| `pose` | 20 ms | downward range, roll/pitch, UKF Z/VZ | 20 bytes |
+| `pose` | 20 ms | downward range, roll/pitch, UKF Z/VZ, `stabilizer.intToOut` | 24 bytes |
 | `detector` | 20 ms | S3 state/reason/offset/barometer delta, local Flow flag, late eligibility | 24 bytes |
 
 Every field is fetched as a float; each block fits cflib's 26-byte log payload.
 Units remain the pinned firmware units: barometer altitude in m, pressure in
 mbar, temperature in Celsius; accelerometer in g; filtered gyro in degrees/s;
-downward range in mm; roll/pitch in degrees; UKF Z in m and VZ in m/s. Diagnostic
-UKF outputs must not become independent displacement inputs.
+downward range in mm; roll/pitch in degrees; UKF Z in m and VZ in m/s.
+`stabilizer.intToOut` is the pinned firmware's microsecond latency from the IMU
+interrupt timestamp carried by the stabilizer's current `sensorData` to the end
+of that stabilizer iteration. Diagnostic UKF outputs and this latency diagnostic
+must not become independent displacement inputs.
 
 Both the 24-bit device log timestamp and host monotonic receipt time are retained
 for every row. Log time does not identify a sensor's producer time, and fetching
 acceleration/gyro in one block does not prove simultaneous sensor acquisition.
-The chosen cadence is an acquisition configuration, not proof that inertial
-integration or a 5 cm / 1 s bound is achievable. No missing row is interpolated.
+The `intToOut` value is read later by the log worker from shared state and is not
+atomically paired with the pose or IMU row; it characterizes the firmware's
+internal sensor-to-output path but does not validate `sensor_time_error_s` or
+supply a producer timestamp. The chosen cadence is an acquisition configuration,
+not proof that inertial integration or a 5 cm / 1 s bound is achievable. No
+missing row is interpolated.
 
 ## Machine checks and output
 
@@ -100,7 +107,9 @@ component alone. The remaining checkpoint preparation is narrower:
 - Pre-register and justify the deterministic error, tilt, initial-velocity,
   intersample-acceleration, sensor-time, barometer and delivery-latency bounds
   consumed by [the frozen vertical predictor](FROZEN_VERTICAL_PREDICTOR.md).
-  Outcome data must never be used to narrow these bounds.
+  Outcome data must never be used to narrow these bounds. The retained
+  `stabilizer.intToOut` diagnostic can falsify assumptions about the internal
+  sensor-to-output path but cannot by itself validate sensor producer timing.
 - Package and validate the exact cflib runtime, exact #251 firmware file, capture
   script, reference/predictor support and executable physical procedure in the
   trusted checkpoint preparation. The collector's module hashes identify two
@@ -115,6 +124,6 @@ boundary. No estimator or controller change follows from successful acquisition.
 
 ## Inspected API sources
 
-- [Firmware log names/units](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/modules/src/stabilizer.c).
+- [Firmware log names/units](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/modules/src/stabilizer.c), including the existing `stabilizer.intToOut` sensor-to-output diagnostic.
 - [Pinned cflib LogConfig/TOC/log lifecycle](https://github.com/bitcraze/crazyflie-lib-python/blob/45fdb784c9d13074c42835f3b5ac1d12133bf873/cflib/crazyflie/log.py).
 - [Pinned cflib asynchronous connection/parameter-ready and close lifecycle](https://github.com/bitcraze/crazyflie-lib-python/blob/45fdb784c9d13074c42835f3b5ac1d12133bf873/cflib/crazyflie/__init__.py).

--- a/experiments/crazyflie-ukf-surface-range/capture_independent_inputs.py
+++ b/experiments/crazyflie-ukf-surface-range/capture_independent_inputs.py
@@ -29,13 +29,15 @@ PARAMETERS = {
     "ukf.baroNoise": 6.25, "ukf.surfaceOffsetS3": 1,
 }
 # Every variable is fetched as a 32-bit float: at most 24 of 26 payload bytes.
-# A log timestamp is NOT a per-sensor producer timestamp. No synchronized IMU
-# integration claim follows from this choice of log periods.
+# A log timestamp is NOT a per-sensor producer timestamp. The existing
+# stabilizer.intToOut diagnostic is retained only as a non-atomic sensor-to-output
+# latency observation; it does not timestamp the acc/gyro row. No synchronized
+# IMU integration claim follows from this choice of log periods.
 BLOCKS = {
     "barometer": (20, ("baro.asl", "baro.pressure", "baro.temp")),
     "imu": (10, ("acc.x", "acc.y", "acc.z", "gyro.x", "gyro.y", "gyro.z")),
     "pose": (20, ("range.zrange", "stabilizer.roll", "stabilizer.pitch",
-                  "stateEstimate.z", "stateEstimate.vz")),
+                  "stateEstimate.z", "stateEstimate.vz", "stabilizer.intToOut")),
     "detector": (20, ("sensorFilter.surfState", "sensorFilter.surfReason",
                       "sensorFilter.surfOffset", "sensorFilter.surfBaroD",
                       "sensorFilter.flowLocal", "sensorFilter.lateElig")),


### PR DESCRIPTION
Refs #70 #332.

## Scope

This bounded follow-up keeps the existing #251 firmware and X3 capture profile unchanged while retaining one already-exposed firmware diagnostic in the future raw capture:

- adds `stabilizer.intToOut` to the existing 20 ms `pose` log block; the six-float block remains 24/26 payload bytes;
- documents the pinned firmware semantics: microseconds from the IMU interrupt timestamp carried by the stabilizer's current `sensorData` to the end of that stabilizer iteration;
- explicitly keeps the value diagnostic-only. The low-priority log worker reads shared state later, so this observation is not atomically paired with an IMU row, is not a sensor producer timestamp and cannot validate `sensor_time_error_s` by itself;
- preserves all four existing CSV blocks, unchanged #251 firmware/parameters, X3 provenance identity, props-off boundary and the existing fail-closed acquisition lifecycle.

This directly records one existing internal timing witness without changing firmware or manufacturing a deterministic timing bound. It is intended to falsify overly optimistic sensor-to-output assumptions, not to turn observed latency into physical proof.

No estimator/controller/firmware source, Runtime, CI workflow, checkpoint registry, notification mechanism or governance change is included. No physical verdict, `CHECKPOINT_REQUEST`, `TEST_REQUIRED`, parameter write, estimator reset, commander motion or motorized action follows.

Exact candidate: `a97f906ceb9a1b55ab3a819e6c68fabb7ed599e9`, containing current `main@0a87debefe9a8dafc82ea77f37301e30867c5813`. The head-only transition from the previously reviewed `f0441cad8ca9ab831e8bca9d22d726e6455bc713` is a clean merge of current main after #333; the PR diff against current main remains limited to the collector and its acquisition documentation.

Any Draft `CI Gate (Draft)` result is non-decision evidence. A fresh canonical Ready `CI Gate` and independent exact-head review are required before integration.