### PR TITLE
Expose X3 BMP3 chip-id symbol provenance

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh
+++ b/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh
@@ -79,6 +79,19 @@ EOF
     grep -q "^CONFIG_ESTIMATOR_UKF_ENABLE=y$" build/.config
     grep -q "^CONFIG_ESTIMATOR_UKF=y$" build/.config
     ./tools/build/build UNIT_TEST_STYLE=min
+
+    symbol_count="$(arm-none-eabi-nm -S --defined-only build/cf2.elf | grep -Ec "[[:space:]]bmp3_chip_id$")"
+    test "$symbol_count" -eq 1
+    symbol="$(arm-none-eabi-nm -S --defined-only build/cf2.elf | grep -E "[[:space:]]bmp3_chip_id$")"
+    read -r address size type name <<<"$symbol"
+    test "$name" = "bmp3_chip_id"
+    test "$size" = "00000001"
+    case "$type" in
+      B|b|D|d) ;;
+      *) echo "unexpected bmp3_chip_id symbol type: $type" >&2; exit 1 ;;
+    esac
+    printf "X3_BMP3_CHIP_ID_SYMBOL address=0x%s size=0x%s type=%s name=%s\n" \
+      "$address" "$size" "$type" "$name"
   '
 
   test -s build/cf2.elf


### PR DESCRIPTION
Refs #70.

## Scope

This support-only candidate makes the already-linked Bosch `bmp3_chip_id` symbol observable in the deterministic S3 build oracle without changing firmware source or the produced binary:

- after the exact pinned Crazyflie 2026.08 S3 build, run the bundled ARM `nm` against `build/cf2.elf`;
- require exactly one defined `bmp3_chip_id` data/BSS symbol with size exactly one byte;
- print its exact linked address/type in the existing retained build-oracle log.

The purpose is narrower than physical barometer identification. The pinned firmware accepts either BMP388 or BMP390 and currently exposes only `imu_sensors.BMP3XX` presence, not the concrete chip id. A later X3 acquisition change can use an address only after it is bound to the exact #251 `cf2.bin`; this PR itself neither reads device RAM nor claims which barometer is installed.

No estimator/controller logic, firmware source, firmware parameters, Runtime, checkpoint profile, notification/governance behavior, physical verdict or motorized action is changed. No `CHECKPOINT_REQUEST` or `TEST_REQUIRED` follows from this candidate.

Exact Draft candidate: `a81459d5e3e796c537065c7a19c658d8281117d2`, containing current `main@0593ed990f495b5c6bd5f08945010748c0d34b7e`. The current-main merge carries integrated #334 Windows Firefox preparation outside this one-file S3 build-oracle slice; the PR diff against current main remains only `experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh`. Draft CI is non-decision evidence; a fresh canonical Ready `CI Gate` and independent exact-head review are required before integration.