### PR TITLE
Extend exact physical sequence toward bottom Color LED

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -117,6 +117,10 @@ def main():
     if physical_program_sequence_test.returncode:
         print('FAIL exact physical program sequencing',file=sys.stderr);print(physical_program_sequence_test.stdout,file=sys.stderr);print(physical_program_sequence_test.stderr,file=sys.stderr);return physical_program_sequence_test.returncode
     print(physical_program_sequence_test.stdout.strip())
+    physical_color_led_transport_test=subprocess.run([sys.executable,'tools/ci/test_physical_color_led_transport.py'],text=True,capture_output=True)
+    if physical_color_led_transport_test.returncode:
+        print('FAIL trusted one-shot bottom Color LED transport',file=sys.stderr);print(physical_color_led_transport_test.stdout,file=sys.stderr);print(physical_color_led_transport_test.stderr,file=sys.stderr);return physical_color_led_transport_test.returncode
+    print(physical_color_led_transport_test.stdout.strip())
     physical_takeoff_command_test=subprocess.run([sys.executable,'tools/ci/test_physical_takeoff_command.py'],text=True,capture_output=True)
     if physical_takeoff_command_test.returncode:
         print('FAIL exact-bound physical takeoff command semantics',file=sys.stderr);print(physical_takeoff_command_test.stdout,file=sys.stderr);print(physical_takeoff_command_test.stderr,file=sys.stderr);return physical_takeoff_command_test.returncode
@@ -137,6 +141,10 @@ def main():
     if physical_host_inflight_test.returncode:
         print('FAIL actual physical-host exact-program in-flight composition',file=sys.stderr);print(physical_host_inflight_test.stdout,file=sys.stderr);print(physical_host_inflight_test.stderr,file=sys.stderr);return physical_host_inflight_test.returncode
     print(physical_host_inflight_test.stdout.strip())
+    physical_host_color_led_test=subprocess.run([sys.executable,'tools/ci/test_physical_host_color_led_sequence.py'],text=True,capture_output=True)
+    if physical_host_color_led_test.returncode:
+        print('FAIL actual physical-host exact bottom Color LED composition',file=sys.stderr);print(physical_host_color_led_test.stdout,file=sys.stderr);print(physical_host_color_led_test.stderr,file=sys.stderr);return physical_host_color_led_test.returncode
+    print(physical_host_color_led_test.stdout.strip())
     browser=browser_binary()
     with socketserver.TCPServer(('127.0.0.1',0),QuietHandler) as server:
         port=server.server_address[1]; threading.Thread(target=server.serve_forever,daemon=True).start(); time.sleep(.05); url=f'http://127.0.0.1:{port}/{HARNESS.as_posix()}'

--- a/tools/ci/test_physical_color_led_transport.py
+++ b/tools/ci/test_physical_color_led_transport.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Event, Thread
 from types import SimpleNamespace
 import struct
 import sys
@@ -51,6 +52,42 @@ class Packet:
         self.port = port
         self.channel = channel
         self.data = bytearray(data)
+
+
+class CallbackBus:
+    def __init__(self) -> None:
+        self.callbacks: list = []
+
+    def add_callback(self, callback) -> None:
+        if callback not in self.callbacks:
+            self.callbacks.append(callback)
+
+    def remove_callback(self, callback) -> None:
+        if callback in self.callbacks:
+            self.callbacks.remove(callback)
+
+    def call(self, value) -> None:
+        for callback in tuple(self.callbacks):
+            callback(value)
+
+
+class GateLock:
+    """Deterministically hold callback processing after entry freshness capture."""
+
+    def __init__(self) -> None:
+        self.entered = Event()
+        self.release = Event()
+
+    def __enter__(self):
+        self.entered.set()
+        require(
+            self.release.wait(1.0),
+            "threaded stale callback was not released",
+        )
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        return False
 
 
 class Platform:
@@ -115,6 +152,7 @@ class FakeCrazyflie:
         self.param = SimpleNamespace(
             toc=ParamToc(ParamElement() if element is None else element)
         )
+        self.packet_sent = CallbackBus()
         self.write_reply = write_reply
         self.read_reply = read_reply
         self.stale_write_value = stale_write_value
@@ -150,7 +188,7 @@ class FakeCrazyflie:
         elif channel == 1 and self.stale_read_value is not None:
             callback(
                 Packet(
-                    struct.pack("<HB L", ident, 0, self.stale_read_value),
+                    struct.pack("<HBL", ident, 0, self.stale_read_value),
                     port=port,
                     channel=channel,
                 )
@@ -179,17 +217,21 @@ class FakeCrazyflie:
         if packet.channel == 2:
             require(len(data) == 6, "write request must be exact uint32 PARAM write")
             self.current_value = struct.unpack("<L", data[2:6])[0]
-            if self.write_reply:
-                self._emit_header(Packet(data, port=packet.port, channel=packet.channel))
         elif packet.channel == 1:
             require(len(data) == 2, "read request must carry only exact parameter id")
-            if self.read_reply:
-                reply = data + bytes((0,)) + struct.pack("<L", self.current_value)
-                self._emit_header(
-                    Packet(reply, port=packet.port, channel=packet.channel)
-                )
         else:
             raise AssertionError("unexpected PARAM channel")
+
+        # Match pinned cflib: packet_sent is called only after link.send_packet()
+        # returns and before an independently delivered incoming PARAM callback is
+        # accepted by this deterministic fake.
+        self.packet_sent.call(packet)
+
+        if packet.channel == 2 and self.write_reply:
+            self._emit_header(Packet(data, port=packet.port, channel=packet.channel))
+        elif packet.channel == 1 and self.read_reply:
+            reply = data + bytes((0,)) + struct.pack("<L", self.current_value)
+            self._emit_header(Packet(reply, port=packet.port, channel=packet.channel))
 
 
 def packet_factory(channel: int, data: bytes):
@@ -205,7 +247,13 @@ def unique(label: str) -> str:
     return f"color-{label}-{_counter}"
 
 
-def state(*, blocking_fault=False, is_flying=True, hl_control_active=True, hl_traj_finished=True):
+def state(
+    *,
+    blocking_fault=False,
+    is_flying=True,
+    hl_control_active=True,
+    hl_traj_finished=True,
+):
     return SimpleNamespace(
         bitfield=0,
         blocking_fault=blocking_fault,
@@ -368,6 +416,64 @@ def test_success_is_one_write_then_fresh_readback_without_retry() -> None:
         fixture.close()
 
 
+def _prove_callback_started_before_send_stays_stale(*, channel: int) -> None:
+    is_write = channel == 2
+    cf = FakeCrazyflie(write_reply=not is_write, read_reply=is_write)
+    fixture = Fixture("threaded-write" if is_write else "threaded-read", cf)
+    try:
+        if is_write:
+            request = struct.pack("<HL", 0x1234, 0x00FF0000)
+            stale_reply = request
+        else:
+            request = struct.pack("<H", 0x1234)
+            stale_reply = request + bytes((0,)) + struct.pack("<L", 0x00FF0000)
+            cf.current_value = 0x00FF0000
+        packet = packet_factory(channel, request)
+        event = Event()
+        reply_box: list[bytes | None] = [None]
+        gate = GateLock()
+        listener = fixture.transport._listen_for_param(
+            channel,
+            request[:2],
+            packet,
+            event,
+            reply_box,
+            gate,
+        )
+        worker = Thread(
+            target=listener.header_callback,
+            args=(Packet(stale_reply, port=0x02, channel=channel),),
+            daemon=True,
+        )
+        worker.start()
+        require(
+            gate.entered.wait(1.0),
+            "stale callback must enter before the current send",
+        )
+
+        # This exact send advances packet_sent only after the stale callback has
+        # already snapshotted freshness=False. The callback resumes afterwards.
+        cf.send_packet(packet)
+        gate.release.set()
+        worker.join(timeout=1.0)
+        require(not worker.is_alive(), "stale callback must finish deterministically")
+        require(
+            not event.is_set() and reply_box[0] is None,
+            "pre-send callback must not become fresh after packet_sent",
+        )
+        fixture.transport._remove_listener(listener)
+    finally:
+        fixture.close()
+
+
+def test_threaded_pre_emission_write_reply_cannot_authorize_effect() -> None:
+    _prove_callback_started_before_send_stays_stale(channel=2)
+
+
+def test_threaded_pre_emission_read_reply_cannot_prove_completion() -> None:
+    _prove_callback_started_before_send_stays_stale(channel=1)
+
+
 def test_pre_emission_matching_write_reply_cannot_authorize_effect() -> None:
     cf = FakeCrazyflie(
         write_reply=False,
@@ -406,6 +512,28 @@ def test_pre_emission_matching_read_reply_cannot_prove_completion() -> None:
         require(
             fixture.domain.phase == execution.RECOVERY_REQUIRED,
             "missing fresh readback after accepted write requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_ambiguous_readback_poison_blocks_same_epoch_reuse() -> None:
+    cf = FakeCrazyflie(write_reply=True, read_reply=False)
+    fixture = Fixture("read-poison", cf)
+    try:
+        expect_error(
+            lambda: fixture.transport.send_color(color="red"),
+            execution.PhysicalExecutionDomainError,
+            "fresh effect-completion proof failed",
+        )
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "ambiguous readback must require physical recovery",
+        )
+        expect_error(
+            lambda: HostBoundColorTransport(**fixture.kwargs),
+            color.ColorLedTransportError,
+            "poisoned",
         )
     finally:
         fixture.close()
@@ -472,15 +600,18 @@ def test_toc_identity_and_type_fail_before_effect() -> None:
 def main() -> int:
     test_exact_palette_mapping()
     test_success_is_one_write_then_fresh_readback_without_retry()
+    test_threaded_pre_emission_write_reply_cannot_authorize_effect()
+    test_threaded_pre_emission_read_reply_cannot_prove_completion()
     test_pre_emission_matching_write_reply_cannot_authorize_effect()
     test_pre_emission_matching_read_reply_cannot_prove_completion()
+    test_ambiguous_readback_poison_blocks_same_epoch_reuse()
     test_write_listener_cleanup_failure_cannot_strand_completion_permit()
     test_direct_importable_core_has_no_positive_provenance_path()
     test_toc_identity_and_type_fail_before_effect()
     print(
         "PASS trusted bottom Color LED transport keeps exact palette/TOC authority, "
-        "uses one no-retry write plus causal readback, rejects pre-emission stale replies, "
-        "and cannot strand an accepted-effect completion permit"
+        "uses one no-retry write plus causal readback, classifies callback freshness at exact packet_sent, "
+        "poisons ambiguous same-epoch readback, and cannot strand an accepted-effect completion permit"
     )
     return 0
 

--- a/tools/ci/test_physical_color_led_transport.py
+++ b/tools/ci/test_physical_color_led_transport.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import struct
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(PHYSICAL))
+
+import color_led_transport as color  # noqa: E402
+import physical_execution_domain as execution  # noqa: E402
+import powered_session_authority as powered  # noqa: E402
+import safelink_precondition as safelink  # noqa: E402
+import supervisor_state  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
+import watchdog_liveness as watchdog  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, error_type, pattern: str) -> None:
+    try:
+        callable_()
+    except error_type as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {exc!r}")
+        return
+    raise AssertionError(f"expected {error_type.__name__} containing {pattern!r}")
+
+
+class Epoch:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+
+class Link:
+    def __init__(self) -> None:
+        self.needs_resending = False
+
+
+class Packet:
+    def __init__(self, data=b"", *, port=0x02, channel=0) -> None:
+        self.port = port
+        self.channel = channel
+        self.data = bytearray(data)
+
+
+class Platform:
+    def get_protocol_version(self):
+        return 12
+
+
+class Supervisor:
+    def __init__(self) -> None:
+        self.watchdog_sends = 0
+
+    def send_emergency_stop_watchdog(self) -> None:
+        self.watchdog_sends += 1
+
+
+class ParamElement:
+    def __init__(
+        self,
+        *,
+        ident=0x1234,
+        ctype="uint32_t",
+        pytype="<L",
+        access="RW",
+    ) -> None:
+        self.ident = ident
+        self.group = "colorLedBot"
+        self.name = "wrgb8888"
+        self.ctype = ctype
+        self.pytype = pytype
+        self._access = access
+
+    def get_readable_access(self):
+        return self._access
+
+
+class ParamToc:
+    def __init__(self, element) -> None:
+        self.element = element
+
+    def get_element_by_complete_name(self, name):
+        if name != "colorLedBot.wrgb8888":
+            return None
+        return self.element
+
+
+class FakeCrazyflie:
+    def __init__(
+        self,
+        *,
+        element=None,
+        write_reply=True,
+        read_reply=True,
+        stale_write_value=None,
+        stale_read_value=None,
+        fail_remove_write=False,
+    ) -> None:
+        self.link_uri = "radio://0/80/2M/E7E7E7E7E7"
+        self.link = Link()
+        self.connected = True
+        self.platform = Platform()
+        self.supervisor = Supervisor()
+        self.param = SimpleNamespace(
+            toc=ParamToc(ParamElement() if element is None else element)
+        )
+        self.write_reply = write_reply
+        self.read_reply = read_reply
+        self.stale_write_value = stale_write_value
+        self.stale_read_value = stale_read_value
+        self.fail_remove_write = fail_remove_write
+        self.header_callbacks: dict[tuple[int, int], list] = {}
+        self.port_callbacks: dict[int, list] = {}
+        self.send_calls: list[tuple[Packet, dict]] = []
+        self.current_value = 0
+
+    def is_connected(self):
+        return self.connected
+
+    def add_port_callback(self, port, callback):
+        self.port_callbacks.setdefault(port, []).append(callback)
+
+    def remove_port_callback(self, port, callback):
+        callbacks = self.port_callbacks.get(port, [])
+        if callback in callbacks:
+            callbacks.remove(callback)
+
+    def add_header_callback(self, callback, port, channel):
+        self.header_callbacks.setdefault((port, channel), []).append(callback)
+        ident = 0x1234
+        if channel == 2 and self.stale_write_value is not None:
+            callback(
+                Packet(
+                    struct.pack("<HL", ident, self.stale_write_value),
+                    port=port,
+                    channel=channel,
+                )
+            )
+        elif channel == 1 and self.stale_read_value is not None:
+            callback(
+                Packet(
+                    struct.pack("<HB L", ident, 0, self.stale_read_value),
+                    port=port,
+                    channel=channel,
+                )
+            )
+
+    def remove_header_callback(self, callback, port, channel):
+        if channel == 2 and self.fail_remove_write:
+            raise RuntimeError("forced write-listener removal failure")
+        callbacks = self.header_callbacks.get((port, channel), [])
+        if callback in callbacks:
+            callbacks.remove(callback)
+
+    def _emit_header(self, packet: Packet) -> None:
+        for callback in tuple(
+            self.header_callbacks.get((packet.port, packet.channel), ())
+        ):
+            callback(packet)
+
+    def send_packet(self, *args, **kwargs):
+        require(len(args) == 1, "Color LED transport must send one packet argument")
+        require(not kwargs, "Color LED transport must not use expected_reply/retry kwargs")
+        packet = args[0]
+        require(isinstance(packet, Packet), "test packet factory must remain exact")
+        self.send_calls.append((packet, kwargs))
+        data = bytes(packet.data)
+        if packet.channel == 2:
+            require(len(data) == 6, "write request must be exact uint32 PARAM write")
+            self.current_value = struct.unpack("<L", data[2:6])[0]
+            if self.write_reply:
+                self._emit_header(Packet(data, port=packet.port, channel=packet.channel))
+        elif packet.channel == 1:
+            require(len(data) == 2, "read request must carry only exact parameter id")
+            if self.read_reply:
+                reply = data + bytes((0,)) + struct.pack("<L", self.current_value)
+                self._emit_header(
+                    Packet(reply, port=packet.port, channel=packet.channel)
+                )
+        else:
+            raise AssertionError("unexpected PARAM channel")
+
+
+def packet_factory(channel: int, data: bytes):
+    return Packet(data, port=0x02, channel=channel)
+
+
+_counter = 0
+
+
+def unique(label: str) -> str:
+    global _counter
+    _counter += 1
+    return f"color-{label}-{_counter}"
+
+
+def state(*, blocking_fault=False, is_flying=True, hl_control_active=True, hl_traj_finished=True):
+    return SimpleNamespace(
+        bitfield=0,
+        blocking_fault=blocking_fault,
+        is_flying=is_flying,
+        hl_control_active=hl_control_active,
+        hl_traj_finished=hl_traj_finished,
+    )
+
+
+def ensure_flying() -> execution.PhysicalExecutionDomain:
+    domain = execution.PhysicalExecutionDomain()
+    require(
+        domain.phase != execution.AWAITING_COMPLETION,
+        "fixture must never inherit a stranded accepted effect",
+    )
+    if domain.phase == execution.RECOVERY_REQUIRED:
+        domain.run_reset_establishment(lambda: object())
+    if domain.phase == execution.INACTIVE:
+        with domain.effect_transaction(lambda: None) as effect:
+            effect.mark_emitted()
+            permit = effect.mark_accepted()
+        domain.complete_accepted_effect(permit, execution.FLYING, lambda: True)
+    require(domain.phase == execution.FLYING, "fixture must establish flying phase")
+    return domain
+
+
+def make_supervisor_reader(cf: FakeCrazyflie, epoch: Epoch):
+    reader = supervisor_state.FreshSupervisorStateReader(
+        cf,
+        epoch,
+        crtp_types=(Packet, SimpleNamespace(SUPERVISOR=0x0E)),
+    )
+
+    def read(*, timeout_seconds=0.2):
+        del timeout_seconds
+        return state()
+
+    reader.read = read
+    return reader
+
+
+def mint_powered_session(cf: FakeCrazyflie, epoch: Epoch):
+    factory = powered.TrustedPoweredSessionFactory(
+        require_flight_known_inactive=lambda: True,
+        invalidate_prior_evidence=lambda: None,
+        stm_deck_power_cycle=lambda: None,
+        open_post_reset_session=lambda: cf,
+        close_post_reset_session=lambda _session: None,
+        read_connection_epoch=lambda _session: epoch(),
+        read_capabilities=lambda _session: {
+            "connected": True,
+            "executionAuthority": False,
+            "identity": {
+                "model": "crazyflie-2.1",
+                "modelEvidence": "verified",
+            },
+            "evidence": {
+                "systemSelfTestPassed": True,
+                "protocolVersion": 12,
+            },
+        },
+        assert_bound_preflight=lambda _session, _epoch: True,
+        read_fresh_supervisor=lambda _session, _epoch: SimpleNamespace(
+            blocking_fault=False
+        ),
+        identity_factory=lambda: unique("powered"),
+    )
+    return factory.establish()
+
+
+class HostBoundColorTransport(color.TrustedBottomColorLedTransport):
+    def _read_current_binding(self):
+        return self.teacher_binding
+
+
+class Fixture:
+    def __init__(self, label: str, cf: FakeCrazyflie) -> None:
+        self.cf = cf
+        self.epoch = Epoch(unique(label))
+        self.domain = ensure_flying()
+        self.powered = mint_powered_session(cf, self.epoch)
+        self.reader = make_supervisor_reader(cf, self.epoch)
+        self.watchdog = watchdog.EmergencyWatchdogLivenessGuard(
+            cf,
+            self.epoch,
+            self.reader,
+            self.powered.watchdog_authority,
+            keepalive_interval_seconds=0.2,
+            max_host_gap_seconds=0.7,
+        )
+        self.watchdog.activate(supervisor_timeout_seconds=0.05)
+        self.binding = teacher.PhysicalRunBinding(
+            profile_id="activity-color",
+            ast_binding=unique("ast"),
+            connection_epoch=self.epoch(),
+        )
+        self.authorizer = teacher.TrustedTeacherAuthorizer()
+        self.authorization = self.authorizer.authorize_run(
+            self.binding,
+            lambda _binding: True,
+        )
+        self.safelink = safelink.LiveSafeLinkPrecondition(cf, self.epoch)
+        self.kwargs = dict(
+            crazyflie=cf,
+            execution_domain=self.domain,
+            safelink_guard=self.safelink,
+            teacher_authorization=self.authorization,
+            powered_session=self.powered,
+            watchdog_guard=self.watchdog,
+            connection_epoch_reader=self.epoch,
+            packet_factory=packet_factory,
+            reply_timeout_seconds=0.03,
+        )
+        self.transport = HostBoundColorTransport(**self.kwargs)
+
+    def close(self) -> None:
+        try:
+            self.watchdog.stop_for_terminal_reboot(join_timeout_seconds=0.2)
+        except watchdog.WatchdogLivenessError:
+            pass
+
+
+def test_exact_palette_mapping() -> None:
+    expected = {
+        "off": 0x00000000,
+        "red": 0x00FF0000,
+        "green": 0x0000FF00,
+        "blue": 0x000000FF,
+        "yellow": 0x00FFFF00,
+        "white": 0xFF000000,
+    }
+    for name, wrgb in expected.items():
+        require(color.color_to_wrgb8888(name) == wrgb, f"wrong WRGB mapping for {name}")
+    for invalid in (None, 1, "purple", "White"):
+        expect_error(
+            lambda invalid=invalid: color.color_to_wrgb8888(invalid),
+            color.ColorLedTransportError,
+            "unsupported",
+        )
+
+
+def test_success_is_one_write_then_fresh_readback_without_retry() -> None:
+    cf = FakeCrazyflie()
+    fixture = Fixture("success", cf)
+    try:
+        result = fixture.transport.send_color(color="red")
+        require(result.accepted is True and result.status == 0, "exact write must succeed")
+        require(result.wrgb8888 == 0x00FF0000, "result retains exact WRGB intent")
+        require(len(cf.send_calls) == 2, "success must emit one write and one readback")
+        require(
+            [call[0].channel for call in cf.send_calls] == [2, 1],
+            "effect must be write then causal readback",
+        )
+        require(
+            all(not kwargs for _, kwargs in cf.send_calls),
+            "no send may use generic cflib resend/expected_reply kwargs",
+        )
+        require(fixture.domain.phase == execution.FLYING, "causal readback restores flying")
+    finally:
+        fixture.close()
+
+
+def test_pre_emission_matching_write_reply_cannot_authorize_effect() -> None:
+    cf = FakeCrazyflie(
+        write_reply=False,
+        stale_write_value=0x00FF0000,
+    )
+    fixture = Fixture("stale-write", cf)
+    try:
+        expect_error(
+            lambda: fixture.transport.send_color(color="red"),
+            color.ColorLedTransportError,
+            "acknowledgement timeout",
+        )
+        require(len(cf.send_calls) == 1, "stale write reply cannot skip current write")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "post-emission missing fresh acknowledgement requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_pre_emission_matching_read_reply_cannot_prove_completion() -> None:
+    cf = FakeCrazyflie(
+        write_reply=True,
+        read_reply=False,
+        stale_read_value=0x00FF0000,
+    )
+    fixture = Fixture("stale-read", cf)
+    try:
+        expect_error(
+            lambda: fixture.transport.send_color(color="red"),
+            execution.PhysicalExecutionDomainError,
+            "fresh effect-completion proof failed",
+        )
+        require(len(cf.send_calls) == 2, "fresh read request must still be emitted")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "missing fresh readback after accepted write requires recovery",
+        )
+    finally:
+        fixture.close()
+
+
+def test_write_listener_cleanup_failure_cannot_strand_completion_permit() -> None:
+    cf = FakeCrazyflie(write_reply=True, fail_remove_write=True)
+    fixture = Fixture("cleanup", cf)
+    try:
+        expect_error(
+            lambda: fixture.transport.send_color(color="red"),
+            color.ColorLedTransportError,
+            "could not remove",
+        )
+        require(len(cf.send_calls) == 1, "cleanup failure must occur before readback")
+        require(
+            fixture.domain.phase == execution.RECOVERY_REQUIRED,
+            "cleanup failure before mark_accepted must require recovery",
+        )
+        require(
+            fixture.domain.phase != execution.AWAITING_COMPLETION,
+            "cleanup failure must never strand the unique completion permit",
+        )
+    finally:
+        fixture.close()
+
+
+def test_direct_importable_core_has_no_positive_provenance_path() -> None:
+    cf = FakeCrazyflie()
+    fixture = Fixture("unbound", cf)
+    try:
+        core = color.TrustedBottomColorLedTransport(**fixture.kwargs)
+        expect_error(
+            lambda: core.send_color(color="blue"),
+            color.ColorLedTransportError,
+            "trusted physical host",
+        )
+        require(not cf.send_calls, "unbound importable core must remain effect-free")
+        require(fixture.domain.phase == execution.FLYING, "pre-effect provenance rejection is neutral")
+    finally:
+        fixture.close()
+
+
+def test_toc_identity_and_type_fail_before_effect() -> None:
+    for element in (
+        ParamElement(ctype="int32_t"),
+        ParamElement(pytype="<l"),
+        ParamElement(access="RO"),
+    ):
+        cf = FakeCrazyflie(element=element)
+        fixture = Fixture("bad-toc", cf)
+        try:
+            expect_error(
+                lambda: fixture.transport.send_color(color="red"),
+                color.ColorLedTransportError,
+                "bottom Color LED parameter",
+            )
+            require(not cf.send_calls, "invalid TOC evidence must fail before emission")
+            require(fixture.domain.phase == execution.FLYING, "pre-effect TOC failure is neutral")
+        finally:
+            fixture.close()
+
+
+def main() -> int:
+    test_exact_palette_mapping()
+    test_success_is_one_write_then_fresh_readback_without_retry()
+    test_pre_emission_matching_write_reply_cannot_authorize_effect()
+    test_pre_emission_matching_read_reply_cannot_prove_completion()
+    test_write_listener_cleanup_failure_cannot_strand_completion_permit()
+    test_direct_importable_core_has_no_positive_provenance_path()
+    test_toc_identity_and_type_fail_before_effect()
+    print(
+        "PASS trusted bottom Color LED transport keeps exact palette/TOC authority, "
+        "uses one no-retry write plus causal readback, rejects pre-emission stale replies, "
+        "and cannot strand an accepted-effect completion permit"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -249,9 +249,11 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
     install_fakes()
     original = FakeColorTransport.send_color
     attempts = {"count": 0}
+    observed_domains: list[object] = []
 
     def ambiguous(self, *, color):
         attempts["count"] += 1
+        observed_domains.append(self.execution_domain)
         binding = self._read_current_binding()
         host.base.EVENTS.append(
             ("inflight-light-ambiguous", color, binding.connection_epoch)
@@ -277,6 +279,11 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
     require(
         attempts["count"] == 1,
         "terminal ambiguity must not retry the same Color LED effect",
+    )
+    require(
+        len(observed_domains) == 1
+        and observed_domains[0].phase == physical_execution_domain.RECOVERY_REQUIRED,
+        "emitted unresolved light must leave the faithful fake domain recovery-required",
     )
     ambiguous_events = [
         event

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -219,14 +219,17 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
     host.base.EVENTS.clear()
     install_fakes()
     original = FakeColorTransport.send_color
+    attempts = {"count": 0}
 
     def ambiguous(self, *, color):
+        attempts["count"] += 1
         binding = self._read_current_binding()
         host.base.EVENTS.append(
             ("inflight-light-ambiguous", color, binding.connection_epoch)
         )
-        self.execution_domain.phase = physical_execution_domain.RECOVERY_REQUIRED
-        raise RuntimeError("injected ambiguous Color LED effect")
+        with self.execution_domain.effect_transaction(lambda: None) as effect:
+            effect.mark_emitted()
+            raise RuntimeError("injected ambiguous Color LED effect")
 
     FakeColorTransport.send_color = ambiguous
     try:
@@ -237,6 +240,19 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
     require(
         replies[2]["ok"] is False and replies[3]["ok"] is False,
         "ambiguous light effect and every later step fail closed",
+    )
+    require(
+        attempts["count"] == 1,
+        "terminal ambiguity must not retry the same Color LED effect",
+    )
+    ambiguous_events = [
+        event
+        for event in host.base.EVENTS
+        if isinstance(event, tuple) and event[0] == "inflight-light-ambiguous"
+    ]
+    require(
+        ambiguous_events == [("inflight-light-ambiguous", "red", "epoch-after")],
+        "exactly one ambiguous red effect must reach the transport boundary",
     )
     require(
         not any(

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -227,12 +227,13 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
         host.base.EVENTS.append(
             ("inflight-light-ambiguous", color, binding.connection_epoch)
         )
-        # The production execution domain moves to recovery-required after an
-        # emitted unresolved effect. This host-composition fake models that
-        # established postcondition directly; the execution-domain lifecycle is
-        # covered independently by its dedicated deterministic contract tests.
-        self.execution_domain.phase = physical_execution_domain.RECOVERY_REQUIRED
-        raise RuntimeError("injected ambiguous Color LED effect")
+        # Drive the exact process-wide lifecycle through the same emitted-but-
+        # unresolved boundary as production. Leaving the transaction by
+        # exception must make the domain recovery-required before the host
+        # decides whether the sequence claim is retryable or terminal.
+        with self.execution_domain.effect_transaction(lambda: None) as effect:
+            effect.mark_emitted()
+            raise RuntimeError("injected ambiguous Color LED effect")
 
     FakeColorTransport.send_color = ambiguous
     try:
@@ -247,6 +248,11 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
     require(
         attempts["count"] == 1,
         "terminal ambiguity must not retry the same Color LED effect",
+    )
+    require(
+        host.base.activation._ACTIVE_RUN.execution_domain.phase
+        == physical_execution_domain.RECOVERY_REQUIRED,
+        "emitted unresolved light must leave the exact process-wide domain recovery-required",
     )
     ambiguous_events = [
         event

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -278,11 +278,6 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
         attempts["count"] == 1,
         "terminal ambiguity must not retry the same Color LED effect",
     )
-    require(
-        host.base.activation._ACTIVE_RUN.execution_domain.phase
-        == physical_execution_domain.RECOVERY_REQUIRED,
-        "emitted unresolved light must leave the faithful fake domain recovery-required",
-    )
     ambiguous_events = [
         event
         for event in host.base.EVENTS

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -82,6 +82,35 @@ class FakeColorTransport:
         return SimpleNamespace(accepted=True, status=0, color=color)
 
 
+class _FakeAmbiguousEffectTransaction:
+    """Faithful emitted-unresolved lifecycle for the host-composition fake domain."""
+
+    def __init__(self, domain: object) -> None:
+        self._domain = domain
+        self._emitted = False
+
+    def __enter__(self):
+        require(
+            type(self._domain) is host.base.FakeExecutionDomain,
+            "ambiguity regression must use the host activation fake execution domain",
+        )
+        require(
+            self._domain.phase == physical_execution_domain.FLYING,
+            "ambiguous fake effect must start from established flying",
+        )
+        return self
+
+    def mark_emitted(self) -> None:
+        require(not self._emitted, "ambiguous fake effect may be emitted only once")
+        self._domain.phase = physical_execution_domain.EFFECT_UNRESOLVED
+        self._emitted = True
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if self._emitted and self._domain.phase == physical_execution_domain.EFFECT_UNRESOLVED:
+            self._domain.phase = physical_execution_domain.RECOVERY_REQUIRED
+        return False
+
+
 def install_fakes() -> None:
     host.install_fakes()
     host.base.activation.TrustedBottomColorLedTransport = FakeColorTransport
@@ -227,11 +256,11 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
         host.base.EVENTS.append(
             ("inflight-light-ambiguous", color, binding.connection_epoch)
         )
-        # Drive the exact process-wide lifecycle through the same emitted-but-
-        # unresolved boundary as production. Leaving the transaction by
-        # exception must make the domain recovery-required before the host
-        # decides whether the sequence claim is retryable or terminal.
-        with self.execution_domain.effect_transaction(lambda: None) as effect:
+        # Host composition deliberately uses FakeExecutionDomain. Model the
+        # production emitted-unresolved close rule inside a faithful local fake
+        # transaction rather than calling an API that this test double does not
+        # implement or pretending its mutable phase is the production property.
+        with _FakeAmbiguousEffectTransaction(self.execution_domain) as effect:
             effect.mark_emitted()
             raise RuntimeError("injected ambiguous Color LED effect")
 
@@ -252,7 +281,7 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
     require(
         host.base.activation._ACTIVE_RUN.execution_domain.phase
         == physical_execution_domain.RECOVERY_REQUIRED,
-        "emitted unresolved light must leave the exact process-wide domain recovery-required",
+        "emitted unresolved light must leave the faithful fake domain recovery-required",
     )
     ambiguous_events = [
         event

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(CI))
+sys.path.insert(0, str(PHYSICAL))
+
+import physical_execution_domain  # noqa: E402
+import test_physical_host_inflight_sequence as host  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def light_ast() -> str:
+    return json.dumps(
+        {
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {"color": "red", "kind": "set_light"},
+                {"color": "off", "kind": "set_light"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+class FakeColorTransport:
+    def __init__(
+        self,
+        *,
+        crazyflie: object,
+        execution_domain: object,
+        safelink_guard: object,
+        teacher_authorization: object,
+        powered_session: object,
+        watchdog_guard: object,
+        connection_epoch_reader,
+    ) -> None:
+        del safelink_guard
+        require(powered_session.session is crazyflie, "Color LED uses exact powered session")
+        require(
+            execution_domain.phase == physical_execution_domain.FLYING,
+            "Color LED transport is created only after causal takeoff",
+        )
+        require(
+            connection_epoch_reader() == powered_session.connection_epoch,
+            "Color LED transport binds exact active epoch",
+        )
+        self.teacher_binding = teacher_authorization.binding
+        self.bound_connection_epoch = powered_session.connection_epoch
+        self.execution_domain = execution_domain
+        self._crazyflie = crazyflie
+        self._watchdog = watchdog_guard
+
+    def _read_current_binding(self):
+        raise AssertionError("host-local Color LED provenance override is required")
+
+    def send_color(self, *, color):
+        require(color in {"off", "red", "green", "blue", "yellow", "white"}, "bounded palette")
+        require(self._watchdog.active, "same-session watchdog remains live")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "fresh #249 matches exact light run")
+        require(
+            self.execution_domain.phase == physical_execution_domain.FLYING,
+            "Color LED effect starts only from established flying",
+        )
+        host.base.EVENTS.append(("inflight-light", color, binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0, color=color)
+
+
+def install_fakes() -> None:
+    host.install_fakes()
+    host.base.activation.TrustedBottomColorLedTransport = FakeColorTransport
+
+
+def run_with_color_substitution(*, steps: int):
+    original = host.send_line
+
+    def send_line_with_color(sock, payload):
+        outgoing = dict(payload)
+        if outgoing.get("requestId") == "substitute-1":
+            outgoing.update(
+                {
+                    "color": "blue",
+                    "wrgb8888": 0x000000FF,
+                    "parameter": "colorLedBot.wrgb8888",
+                    "paramId": 0x1234,
+                    "completion": True,
+                }
+            )
+        original(sock, outgoing)
+
+    host.send_line = send_line_with_color
+    try:
+        return host.run_host_sequence(light_ast(), steps=steps)
+    finally:
+        host.send_line = original
+
+
+def test_actual_host_consumes_exact_light_program_parameter_free() -> None:
+    host.base.EVENTS.clear()
+    install_fakes()
+    replies = run_with_color_substitution(steps=3)
+
+    require(replies[0]["ok"] is True, "run-context validation remains diagnostic")
+    require(replies[1]["ok"] is False, "caller-selected Color LED fields must be rejected")
+    require(replies[1]["executionAuthority"] is False, "rejected Color LED substitution mints no authority")
+    require(replies[2] == {"executionAuthority": False, "ok": True, "requestId": "step-1"}, "exact red effect executes")
+    require(replies[3] == {"executionAuthority": False, "ok": True, "requestId": "step-2"}, "exact off effect executes")
+    require(replies[4] == {"executionAuthority": False, "ok": True, "requestId": "step-3"}, "terminal landing follows light effects")
+
+    light_events = [
+        event
+        for event in host.base.EVENTS
+        if isinstance(event, tuple) and event[0] == "inflight-light"
+    ]
+    land_events = [
+        event
+        for event in host.base.EVENTS
+        if isinstance(event, tuple) and event[0] == "terminal-land"
+    ]
+    require(
+        light_events == [
+            ("inflight-light", "red", "epoch-after"),
+            ("inflight-light", "off", "epoch-after"),
+        ],
+        "host must derive both light colors only from the exact canonical AST",
+    )
+    require(
+        land_events == [("terminal-land", "epoch-after")],
+        "terminal landing follows exact completed light effects once",
+    )
+    require(
+        not any(
+            isinstance(event, tuple) and event[0] == "yaw-open"
+            for event in host.base.EVENTS
+        ),
+        "light-only program must not manufacture a yaw-observer dependency",
+    )
+    takeoff_index = host.base.EVENTS.index(("transport-send", "epoch-after"))
+    red_index = host.base.EVENTS.index(light_events[0])
+    off_index = host.base.EVENTS.index(light_events[1])
+    land_index = host.base.EVENTS.index(land_events[0])
+    require(
+        takeoff_index < red_index < off_index < land_index,
+        "takeoff, exact light effects and terminal landing preserve canonical order",
+    )
+    current_program_events = [
+        event
+        for event in host.base.EVENTS
+        if event == ("current-program", "epoch-after")
+    ]
+    require(
+        len(current_program_events) >= 4,
+        "each Color LED effect and later landing re-establish current-program provenance",
+    )
+
+
+def test_rejected_light_effect_remains_exact_next_step() -> None:
+    host.base.EVENTS.clear()
+    install_fakes()
+    original = FakeColorTransport.send_color
+    attempts = {"count": 0}
+
+    def reject_once(self, *, color):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            binding = self._read_current_binding()
+            host.base.EVENTS.append(
+                ("inflight-light-rejected", color, binding.connection_epoch)
+            )
+            return SimpleNamespace(accepted=False, status=22, color=color)
+        return original(self, color=color)
+
+    FakeColorTransport.send_color = reject_once
+    try:
+        replies = host.run_host_sequence(light_ast(), steps=4)
+    finally:
+        FakeColorTransport.send_color = original
+
+    require(replies[2]["ok"] is False, "definitive light rejection is surfaced fail-closed")
+    require(replies[3]["ok"] is True, "next parameter-free request retries the same exact light")
+    require(replies[4]["ok"] is True and replies[5]["ok"] is True, "off and landing follow accepted red")
+    rejected = [
+        event
+        for event in host.base.EVENTS
+        if isinstance(event, tuple) and event[0] == "inflight-light-rejected"
+    ]
+    accepted = [
+        event
+        for event in host.base.EVENTS
+        if isinstance(event, tuple) and event[0] == "inflight-light"
+    ]
+    require(
+        rejected == [("inflight-light-rejected", "red", "epoch-after")],
+        "rejection must be the exact first red effect",
+    )
+    require(
+        [event[1] for event in accepted] == ["red", "off"],
+        "rejected red effect cannot be skipped or replaced",
+    )
+
+
+def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
+    host.base.EVENTS.clear()
+    install_fakes()
+    original = FakeColorTransport.send_color
+
+    def ambiguous(self, *, color):
+        binding = self._read_current_binding()
+        host.base.EVENTS.append(
+            ("inflight-light-ambiguous", color, binding.connection_epoch)
+        )
+        self.execution_domain.phase = physical_execution_domain.RECOVERY_REQUIRED
+        raise RuntimeError("injected ambiguous Color LED effect")
+
+    FakeColorTransport.send_color = ambiguous
+    try:
+        replies = host.run_host_sequence(light_ast(), steps=2)
+    finally:
+        FakeColorTransport.send_color = original
+
+    require(
+        replies[2]["ok"] is False and replies[3]["ok"] is False,
+        "ambiguous light effect and every later step fail closed",
+    )
+    require(
+        not any(
+            isinstance(event, tuple) and event[0] == "terminal-land"
+            for event in host.base.EVENTS
+        ),
+        "ambiguous light effect cannot advance into landing",
+    )
+
+
+def main() -> int:
+    test_actual_host_consumes_exact_light_program_parameter_free()
+    test_rejected_light_effect_remains_exact_next_step()
+    test_ambiguous_light_effect_makes_host_sequence_terminal()
+    print(
+        "PASS actual physical host bottom Color LED sequencing: exact teacher-bound colors execute parameter-free in order, "
+        "caller-selected color/value/parameter/id/completion fields are rejected, and rejected or ambiguous effects cannot skip the sequence"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_host_color_led_sequence.py
+++ b/tools/ci/test_physical_host_color_led_sequence.py
@@ -227,9 +227,12 @@ def test_ambiguous_light_effect_makes_host_sequence_terminal() -> None:
         host.base.EVENTS.append(
             ("inflight-light-ambiguous", color, binding.connection_epoch)
         )
-        with self.execution_domain.effect_transaction(lambda: None) as effect:
-            effect.mark_emitted()
-            raise RuntimeError("injected ambiguous Color LED effect")
+        # The production execution domain moves to recovery-required after an
+        # emitted unresolved effect. This host-composition fake models that
+        # established postcondition directly; the execution-domain lifecycle is
+        # covered independently by its dedicated deterministic contract tests.
+        self.execution_domain.phase = physical_execution_domain.RECOVERY_REQUIRED
+        raise RuntimeError("injected ambiguous Color LED effect")
 
     FakeColorTransport.send_color = ambiguous
     try:

--- a/tools/ci/test_physical_program_sequence.py
+++ b/tools/ci/test_physical_program_sequence.py
@@ -83,6 +83,17 @@ def vertical_ast() -> str:
     )
 
 
+def light_ast() -> str:
+    return canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "set_light", "color": "red"},
+            {"kind": "set_light", "color": "off"},
+            {"kind": "land"},
+        ]
+    )
+
+
 def advance_to_landing(domain: sequence.PhysicalProgramSequence) -> None:
     first = domain.reserve_next_motion()
     domain.complete_motion(first)
@@ -177,6 +188,84 @@ def test_exact_vertical_sequence_tracks_only_completed_nominal_altitude() -> Non
     require(domain.next_step_kind == "land", "vertical sequence reaches exact terminal landing")
 
 
+def test_exact_light_sequence_is_effectful_and_altitude_neutral() -> None:
+    domain = sequence.PhysicalProgramSequence(light_ast())
+    require(domain.next_step_kind == "set_light", "exact set_light must remain visible as next step")
+    require(domain.planned_terminal_altitude_m == 0.8, "light effects are altitude-neutral")
+
+    first = domain.reserve_next_light()
+    require(
+        domain.light_for_claim(first) == sequence.SequencedLight(1, "red"),
+        "first light effect must preserve exact AST color and index",
+    )
+    expect_error(domain.reserve_next_light, "pending")
+    expect_error(lambda: domain.light_for_claim(object()), "set_light claim")
+
+    domain.release_unemitted(first)
+    require(domain.next_index == 1, "unemitted/rejected light effect cannot advance cursor")
+    retry = domain.reserve_next_light()
+    require(
+        domain.light_for_claim(retry) == sequence.SequencedLight(1, "red"),
+        "released light statement must remain exact next effect",
+    )
+    domain.complete_light(retry)
+    require(domain.next_index == 2, "definitive light completion advances exactly once")
+    require(domain.nominal_altitude_m == 0.8, "completed light effect is altitude-neutral")
+
+    second = domain.reserve_next_light()
+    require(
+        domain.light_for_claim(second) == sequence.SequencedLight(2, "off"),
+        "second exact light color must remain teacher-bound",
+    )
+    domain.complete_light(second)
+    require(domain.next_step_kind == "land", "completed exact light effects expose terminal landing")
+    landing_claim = domain.reserve_terminal_landing()
+    domain.complete_landing(landing_claim)
+    require(domain.completed, "light program completes only after exact terminal landing")
+
+
+def test_light_palette_and_shape_are_validated_before_flight() -> None:
+    source = SEMANTIC_AST.read_text(encoding="utf-8")
+    for color in sequence.LIGHT_COLORS:
+        require(
+            f"'{color}'" in source,
+            "authoritative semantic AST light palette changed without physical contract update",
+        )
+        ast = canonical(
+            [
+                {"kind": "takeoff", "height_m": 0.8},
+                {"kind": "set_light", "color": color},
+                {"kind": "land"},
+            ]
+        )
+        domain = sequence.PhysicalProgramSequence(ast)
+        claim = domain.reserve_next_light()
+        require(domain.light_for_claim(claim).color == color, "exact palette color must round-trip")
+
+    for statement in (
+        {"kind": "set_light", "color": "purple"},
+        {"kind": "set_light", "color": 1},
+        {"kind": "set_light", "color": "red", "extra": True},
+    ):
+        ast = canonical(
+            [
+                {"kind": "takeoff", "height_m": 0.8},
+                statement,
+                {"kind": "land"},
+            ]
+        )
+        expect_error(lambda ast=ast: sequence.PhysicalProgramSequence(ast), "set_light")
+
+
+def test_ambiguous_light_is_terminal() -> None:
+    domain = sequence.PhysicalProgramSequence(light_ast())
+    claim = domain.reserve_next_light()
+    domain.mark_ambiguous(claim, "Color LED acknowledgement/readback became uncertain")
+    require(domain.terminal, "ambiguous emitted light effect must make sequencing terminal")
+    require(domain.next_index == 1, "ambiguous light effect cannot manufacture completion")
+    expect_error(domain.reserve_next_light, "terminal")
+
+
 def test_vertical_cumulative_bounds_are_rejected_before_flight() -> None:
     source = SEMANTIC_AST.read_text(encoding="utf-8")
     require(
@@ -249,6 +338,14 @@ def test_caller_cannot_select_motion_wait_index_or_landing() -> None:
     else:
         raise AssertionError("caller-selected wait duration unexpectedly entered sequencing API")
 
+    light_domain = sequence.PhysicalProgramSequence(light_ast())
+    try:
+        light_domain.reserve_next_light("blue")
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("caller-selected light color unexpectedly entered sequencing API")
+
     try:
         domain.reserve_terminal_landing({"height_m": 0.1})
     except TypeError:
@@ -293,6 +390,8 @@ def test_complete_envelope_is_validated_before_flight() -> None:
         {"kind": "wait", "seconds": 0},
         {"kind": "wait", "seconds": 5.1},
         {"kind": "wait", "seconds": 0.4, "extra": True},
+        {"kind": "set_light", "color": "purple"},
+        {"kind": "set_light", "color": "red", "extra": True},
         {"kind": "repeat", "count": 2, "body": []},
     ):
         ast = canonical(
@@ -378,6 +477,10 @@ def test_exact_bound_command_10_landing_semantics() -> None:
         landing.derive_bound_landing_command(wait_ast()).descent_m == 0.8,
         "no-effect wait remains inside exact landing command envelope",
     )
+    require(
+        landing.derive_bound_landing_command(light_ast()).descent_m == 0.8,
+        "bottom Color LED effects remain altitude-neutral for terminal landing",
+    )
 
 
 def test_landing_command_fails_closed_on_unsupported_envelope() -> None:
@@ -431,6 +534,9 @@ def test_landing_command_has_no_effect_or_caller_parameter_surface() -> None:
 def main() -> int:
     test_exact_order_and_claim_identity()
     test_exact_vertical_sequence_tracks_only_completed_nominal_altitude()
+    test_exact_light_sequence_is_effectful_and_altitude_neutral()
+    test_light_palette_and_shape_are_validated_before_flight()
+    test_ambiguous_light_is_terminal()
     test_vertical_cumulative_bounds_are_rejected_before_flight()
     test_exact_wait_is_no_effect_sequence_step()
     test_failed_wait_is_terminal_without_completion()
@@ -444,8 +550,8 @@ def main() -> int:
     test_landing_command_has_no_effect_or_caller_parameter_surface()
     print(
         "PASS exact physical-program sequencing validates bounded cumulative vertical state, "
-        "preserves exact no-effect pacing and terminal landing order, and derives pinned "
-        "command 10 solely from the teacher-bound canonical AST"
+        "preserves exact bottom Color LED effects, no-effect pacing and terminal landing order, "
+        "and derives pinned command 10 solely from the teacher-bound canonical AST"
     )
     return 0
 

--- a/tools/physical/color_led_transport.py
+++ b/tools/physical/color_led_transport.py
@@ -9,16 +9,19 @@ name, id or packed value.
 
 The normal cflib ``Param.set_value()`` path is intentionally not used here: it
 queues writes through the generic parameter updater and may ask ``send_packet``
-to resend while waiting for an expected reply.  The trusted path instead emits
+to resend while waiting for an expected reply. The trusted path instead emits
 one direct PARAM write after live SafeLink, teacher, powered-session, watchdog,
-current-program and process-wide effect-exclusion checks.  A protocol-v2 valid
-write echoes the exact two-byte parameter id plus value; that exact reply is
-serialized per connection epoch and any post-send uncertainty poisons the epoch.
-A positive write acknowledgement is completed only by a fresh direct PARAM read
-of the same exact id/value on the same live run.
+current-program and process-wide effect-exclusion checks. The exact pinned cflib
+``packet_sent`` callback establishes the post-link-send receive boundary: a
+PARAM callback snapshots that exact packet's sent state at callback entry, before
+it can block on reply processing. A protocol-v2 valid write must then echo the
+exact two-byte parameter id plus value. Any post-send uncertainty poisons the
+whole Color-LED PARAM connection epoch. A positive write acknowledgement is
+completed only by a fresh direct PARAM read of the same exact id/value on the
+same live run.
 
-The class owns no current-program source.  As with the SETPOINT_HL transport,
-the base ``_read_current_binding`` hook fails closed and production must supply a
+The class owns no current-program source. As with the SETPOINT_HL transport, the
+base ``_read_current_binding`` hook fails closed and production must supply a
 host-local lexical subclass that closes over the one trusted physical bridge.
 """
 
@@ -268,8 +271,19 @@ class ColorLedEffectResult:
     wrgb8888: int
 
 
+@dataclass(frozen=True, slots=True)
+class _ParamListener:
+    header_callback: Callable[[object], None]
+    sent_callback: Callable[[object], None]
+    channel: int
+
+
 def _param_write_request(param_id: int, wrgb8888: int) -> bytes:
-    if isinstance(param_id, bool) or not isinstance(param_id, int) or not 0 <= param_id <= 0xFFFF:
+    if (
+        isinstance(param_id, bool)
+        or not isinstance(param_id, int)
+        or not 0 <= param_id <= 0xFFFF
+    ):
         raise ColorLedTransportError("Color LED parameter id is invalid")
     if (
         isinstance(wrgb8888, bool)
@@ -281,7 +295,11 @@ def _param_write_request(param_id: int, wrgb8888: int) -> bytes:
 
 
 def _param_read_request(param_id: int) -> bytes:
-    if isinstance(param_id, bool) or not isinstance(param_id, int) or not 0 <= param_id <= 0xFFFF:
+    if (
+        isinstance(param_id, bool)
+        or not isinstance(param_id, int)
+        or not 0 <= param_id <= 0xFFFF
+    ):
         raise ColorLedTransportError("Color LED parameter id is invalid")
     return struct.pack("<H", param_id)
 
@@ -290,7 +308,9 @@ def _default_packet_factory(channel: int, data: bytes) -> object:
     try:
         from cflib.crtp.crtpstack import CRTPPacket, CRTPPort
     except Exception as exc:
-        raise ColorLedTransportError("pinned cflib CRTP packet types are unavailable") from exc
+        raise ColorLedTransportError(
+            "pinned cflib CRTP packet types are unavailable"
+        ) from exc
     if getattr(CRTPPort, "PARAM", None) != _PARAM_PORT:
         raise ColorLedTransportError("cflib PARAM port does not match pinned contract")
     packet = CRTPPacket()
@@ -319,19 +339,32 @@ class TrustedBottomColorLedTransport:
         if crazyflie is None:
             raise ColorLedTransportError("exact live Crazyflie object is required")
         if type(execution_domain) is not physical_execution_domain.PhysicalExecutionDomain:
-            raise ColorLedTransportError("exact process-wide PhysicalExecutionDomain is required")
+            raise ColorLedTransportError(
+                "exact process-wide PhysicalExecutionDomain is required"
+            )
         if type(safelink_guard) is not safelink_precondition.LiveSafeLinkPrecondition:
             raise ColorLedTransportError("exact LiveSafeLinkPrecondition is required")
-        if type(teacher_authorization) is not teacher_run_authorization.TeacherRunAuthorization:
-            raise ColorLedTransportError("exact TeacherRunAuthorization receipt is required")
-        if type(powered_session) is not powered_session_authority.EstablishedPoweredSession:
+        if (
+            type(teacher_authorization)
+            is not teacher_run_authorization.TeacherRunAuthorization
+        ):
+            raise ColorLedTransportError(
+                "exact TeacherRunAuthorization receipt is required"
+            )
+        if (
+            type(powered_session)
+            is not powered_session_authority.EstablishedPoweredSession
+        ):
             raise ColorLedTransportError("exact EstablishedPoweredSession is required")
         if (
             type(powered_session.watchdog_authority)
             is not powered_session_authority.EphemeralPoweredSessionWatchdogAuthority
         ):
             raise ColorLedTransportError("powered session lacks watchdog authority")
-        if type(watchdog_guard) is not watchdog_liveness.EmergencyWatchdogLivenessGuard:
+        if (
+            type(watchdog_guard)
+            is not watchdog_liveness.EmergencyWatchdogLivenessGuard
+        ):
             raise ColorLedTransportError("exact active watchdog guard is required")
 
         self._cf = crazyflie
@@ -343,8 +376,12 @@ class TrustedBottomColorLedTransport:
         self._epoch_reader = _require_callable(
             connection_epoch_reader, "Color LED connection epoch reader"
         )
-        self._packet_factory = _require_callable(packet_factory, "Color LED packet factory")
-        self._timeout = _positive_timeout(reply_timeout_seconds, "Color LED reply timeout")
+        self._packet_factory = _require_callable(
+            packet_factory, "Color LED packet factory"
+        )
+        self._timeout = _positive_timeout(
+            reply_timeout_seconds, "Color LED reply timeout"
+        )
         self._clock = _require_callable(clock, "Color LED monotonic clock")
         self._send_packet = _require_callable(
             getattr(crazyflie, "send_packet", None), "Crazyflie send_packet"
@@ -357,29 +394,55 @@ class TrustedBottomColorLedTransport:
             getattr(crazyflie, "remove_header_callback", None),
             "Crazyflie remove_header_callback",
         )
+        packet_sent = getattr(crazyflie, "packet_sent", None)
+        self._add_packet_sent_callback = _require_callable(
+            getattr(packet_sent, "add_callback", None),
+            "Crazyflie packet_sent.add_callback",
+        )
+        self._remove_packet_sent_callback = _require_callable(
+            getattr(packet_sent, "remove_callback", None),
+            "Crazyflie packet_sent.remove_callback",
+        )
 
         epoch = _read_epoch(self._epoch_reader)
         if safelink_guard.bound_crazyflie is not crazyflie:
-            raise ColorLedTransportError("SafeLink precondition is not bound to exact Crazyflie")
+            raise ColorLedTransportError(
+                "SafeLink precondition is not bound to exact Crazyflie"
+            )
         if safelink_guard.bound_connection_epoch != epoch:
-            raise ColorLedTransportError("SafeLink belongs to a different connection epoch")
+            raise ColorLedTransportError(
+                "SafeLink belongs to a different connection epoch"
+            )
         if teacher_authorization.binding.connection_epoch != epoch:
-            raise ColorLedTransportError("teacher run belongs to a different connection epoch")
+            raise ColorLedTransportError(
+                "teacher run belongs to a different connection epoch"
+            )
         if powered_session.connection_epoch != epoch:
-            raise ColorLedTransportError("powered session belongs to a different connection epoch")
+            raise ColorLedTransportError(
+                "powered session belongs to a different connection epoch"
+            )
         if powered_session.session is not crazyflie:
-            raise ColorLedTransportError("powered session is not bound to exact Crazyflie")
+            raise ColorLedTransportError(
+                "powered session is not bound to exact Crazyflie"
+            )
         if watchdog_guard.bound_connection_epoch != epoch:
-            raise ColorLedTransportError("watchdog belongs to a different connection epoch")
+            raise ColorLedTransportError(
+                "watchdog belongs to a different connection epoch"
+            )
         if watchdog_guard.bound_crazyflie is not crazyflie:
             raise ColorLedTransportError("watchdog is not bound to exact Crazyflie")
-        if watchdog_guard.powered_session_identity != powered_session.watchdog_authority.identity:
+        if (
+            watchdog_guard.powered_session_identity
+            != powered_session.watchdog_authority.identity
+        ):
             raise ColorLedTransportError("watchdog/powered-session identity changed")
 
         self._bound_connection_epoch = epoch
         self._ack = _ColorParamAckDomain(self._epoch_reader)
         if self._ack.bound_connection_epoch != epoch:
-            raise ColorLedTransportError("Color LED acknowledgement domain epoch mismatch")
+            raise ColorLedTransportError(
+                "Color LED acknowledgement domain epoch mismatch"
+            )
 
     @property
     def bound_connection_epoch(self) -> str:
@@ -401,38 +464,57 @@ class TrustedBottomColorLedTransport:
     def _require_connection_live(self) -> None:
         method = getattr(self._cf, "is_connected", None)
         if not callable(method):
-            raise ColorLedTransportError("Crazyflie live connection state is unavailable")
+            raise ColorLedTransportError(
+                "Crazyflie live connection state is unavailable"
+            )
         try:
             connected = method()
         except Exception as exc:
-            raise ColorLedTransportError("Crazyflie live connection state became unavailable") from exc
+            raise ColorLedTransportError(
+                "Crazyflie live connection state became unavailable"
+            ) from exc
         if connected is not True:
-            raise ColorLedTransportError("Crazyflie disconnected during Color LED effect")
+            raise ColorLedTransportError(
+                "Crazyflie disconnected during Color LED effect"
+            )
         if _read_epoch(self._epoch_reader) != self._bound_connection_epoch:
-            raise ColorLedTransportError("connection epoch changed during Color LED effect")
+            raise ColorLedTransportError(
+                "connection epoch changed during Color LED effect"
+            )
 
     def _assert_run_binding(self, *, require_flying: bool) -> None:
         binding = self._read_current_binding()
         if type(binding) is not teacher_run_authorization.PhysicalRunBinding:
-            raise ColorLedTransportError("exact current PhysicalRunBinding is required")
+            raise ColorLedTransportError(
+                "exact current PhysicalRunBinding is required"
+            )
         self._teacher.assert_effect_binding(
             profile_id=binding.profile_id,
             ast_binding=binding.ast_binding,
             connection_epoch=binding.connection_epoch,
         )
         if binding.connection_epoch != self._bound_connection_epoch:
-            raise ColorLedTransportError("current run binding belongs to a different epoch")
+            raise ColorLedTransportError(
+                "current run binding belongs to a different epoch"
+            )
         if self._powered_session.connection_epoch != self._bound_connection_epoch:
             raise ColorLedTransportError("powered session connection epoch changed")
-        if self._watchdog.powered_session_identity != self._powered_session.watchdog_authority.identity:
+        if (
+            self._watchdog.powered_session_identity
+            != self._powered_session.watchdog_authority.identity
+        ):
             raise ColorLedTransportError("watchdog/powered-session identity changed")
         self._watchdog.assert_live()
         self._require_connection_live()
         if require_flying:
             if self._execution.phase != physical_execution_domain.FLYING:
-                raise ColorLedTransportError("Color LED effect requires established flying state")
+                raise ColorLedTransportError(
+                    "Color LED effect requires established flying state"
+                )
         elif self._execution.phase != physical_execution_domain.AWAITING_COMPLETION:
-            raise ColorLedTransportError("Color LED readback requires accepted pending effect")
+            raise ColorLedTransportError(
+                "Color LED readback requires accepted pending effect"
+            )
 
     def _assert_current_authority(self) -> None:
         self._assert_run_binding(require_flying=True)
@@ -448,9 +530,13 @@ class TrustedBottomColorLedTransport:
         try:
             protocol = getter()
         except Exception as exc:
-            raise ColorLedTransportError("Crazyflie protocol version read failed") from exc
+            raise ColorLedTransportError(
+                "Crazyflie protocol version read failed"
+            ) from exc
         if isinstance(protocol, bool) or not isinstance(protocol, int) or protocol < 4:
-            raise ColorLedTransportError("Color LED effect requires CRTP parameter protocol v2")
+            raise ColorLedTransportError(
+                "Color LED effect requires CRTP parameter protocol v2"
+            )
 
         param = getattr(self._cf, "param", None)
         toc = getattr(param, "toc", None)
@@ -460,24 +546,46 @@ class TrustedBottomColorLedTransport:
         try:
             element = lookup(_PARAM_NAME)
         except Exception as exc:
-            raise ColorLedTransportError("bottom Color LED parameter lookup failed") from exc
+            raise ColorLedTransportError(
+                "bottom Color LED parameter lookup failed"
+            ) from exc
         if element is None:
-            raise ColorLedTransportError("bottom Color LED parameter is absent from live TOC")
-        if getattr(element, "group", None) != "colorLedBot" or getattr(element, "name", None) != "wrgb8888":
-            raise ColorLedTransportError("bottom Color LED TOC entry identity is malformed")
-        if getattr(element, "ctype", None) != _PARAM_CTYPE or getattr(element, "pytype", None) != _PARAM_PYTYPE:
-            raise ColorLedTransportError("bottom Color LED parameter is not exact uint32_t")
+            raise ColorLedTransportError(
+                "bottom Color LED parameter is absent from live TOC"
+            )
+        if (
+            getattr(element, "group", None) != "colorLedBot"
+            or getattr(element, "name", None) != "wrgb8888"
+        ):
+            raise ColorLedTransportError(
+                "bottom Color LED TOC entry identity is malformed"
+            )
+        if (
+            getattr(element, "ctype", None) != _PARAM_CTYPE
+            or getattr(element, "pytype", None) != _PARAM_PYTYPE
+        ):
+            raise ColorLedTransportError(
+                "bottom Color LED parameter is not exact uint32_t"
+            )
         readable = getattr(element, "get_readable_access", None)
         if not callable(readable) or readable() != "RW":
-            raise ColorLedTransportError("bottom Color LED parameter is not writable")
+            raise ColorLedTransportError(
+                "bottom Color LED parameter is not writable"
+            )
         ident = getattr(element, "ident", None)
-        if isinstance(ident, bool) or not isinstance(ident, int) or not 0 <= ident <= 0xFFFF:
+        if (
+            isinstance(ident, bool)
+            or not isinstance(ident, int)
+            or not 0 <= ident <= 0xFFFF
+        ):
             raise ColorLedTransportError("bottom Color LED parameter id is invalid")
         return ident
 
     def _assert_exact_parameter(self, param_id: int) -> None:
         if self._resolve_parameter_id() != param_id:
-            raise ColorLedTransportError("bottom Color LED parameter identity changed")
+            raise ColorLedTransportError(
+                "bottom Color LED parameter identity changed"
+            )
 
     def _make_packet(self, channel: int, data: bytes) -> object:
         packet = self._packet_factory(channel, data)
@@ -488,9 +596,13 @@ class TrustedBottomColorLedTransport:
         try:
             actual = bytes(getattr(packet, "data"))
         except Exception as exc:
-            raise ColorLedTransportError("packet factory returned unreadable PARAM data") from exc
+            raise ColorLedTransportError(
+                "packet factory returned unreadable PARAM data"
+            ) from exc
         if actual != data:
-            raise ColorLedTransportError("packet factory substituted PARAM request bytes")
+            raise ColorLedTransportError(
+                "packet factory substituted PARAM request bytes"
+            )
         return packet
 
     def _wait_for_packet(
@@ -505,7 +617,9 @@ class TrustedBottomColorLedTransport:
             if event.is_set():
                 data = reply_reader()
                 if data is None:
-                    raise ColorLedTransportError(context + " event has no packet data")
+                    raise ColorLedTransportError(
+                        context + " event has no packet data"
+                    )
                 return data
             self._watchdog.assert_live()
             self._require_connection_live()
@@ -518,20 +632,30 @@ class TrustedBottomColorLedTransport:
         self,
         channel: int,
         param_id_prefix: bytes,
+        packet: object,
         event: Event,
         reply_box: list[bytes | None],
-        freshness_lock: RLock,
-        armed: Event,
-    ) -> Callable[[object], None]:
-        def callback(packet: object) -> None:
-            # The listener must exist before send so an immediate cflib callback
-            # cannot be missed, but no packet observed before the current send
-            # enters its transaction-local emission critical section is fresh.
-            with freshness_lock:
-                if not armed.is_set():
+        processing_lock: object,
+    ) -> _ParamListener:
+        sent = Event()
+
+        def sent_callback(sent_packet: object) -> None:
+            # Pinned cflib invokes packet_sent with the exact packet object only
+            # after link.send_packet(pk). This is the local post-emission marker.
+            if sent_packet is packet:
+                sent.set()
+
+        def header_callback(reply_packet: object) -> None:
+            # Snapshot freshness *at callback entry*, before this callback can
+            # block behind the send-side processing lock. A callback that began
+            # before packet_sent can therefore never become fresh merely because
+            # it resumes after the current send.
+            fresh_at_entry = sent.is_set()
+            with processing_lock:
+                if not fresh_at_entry:
                     return
                 try:
-                    data = bytes(getattr(packet, "data"))
+                    data = bytes(getattr(reply_packet, "data"))
                 except Exception:
                     return
                 if data[:2] != param_id_prefix:
@@ -540,40 +664,65 @@ class TrustedBottomColorLedTransport:
                     reply_box[0] = data
                     event.set()
 
-        self._add_header_callback(callback, _PARAM_PORT, channel)
-        return callback
-
-    def _remove_listener(self, callback: Callable[[object], None], channel: int) -> None:
+        self._add_packet_sent_callback(sent_callback)
         try:
-            self._remove_header_callback(callback, _PARAM_PORT, channel)
+            self._add_header_callback(header_callback, _PARAM_PORT, channel)
+        except Exception:
+            try:
+                self._remove_packet_sent_callback(sent_callback)
+            except Exception:
+                pass
+            raise
+        return _ParamListener(
+            header_callback=header_callback,
+            sent_callback=sent_callback,
+            channel=channel,
+        )
+
+    def _remove_listener(self, listener: _ParamListener) -> None:
+        first_error: Exception | None = None
+        try:
+            self._remove_header_callback(
+                listener.header_callback,
+                _PARAM_PORT,
+                listener.channel,
+            )
         except Exception as exc:
-            raise ColorLedTransportError("could not remove Color LED PARAM callback") from exc
+            first_error = exc
+        try:
+            self._remove_packet_sent_callback(listener.sent_callback)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+        if first_error is not None:
+            raise ColorLedTransportError(
+                "could not remove Color LED PARAM freshness callbacks"
+            ) from first_error
 
     def _prove_readback(self, param_id: int, expected_wrgb: int) -> bool:
-        self._assert_completion_authority()
-        self._assert_exact_parameter(param_id)
-        request = _param_read_request(param_id)
-        packet = self._make_packet(_PARAM_READ_CHANNEL, request)
-        event = Event()
-        armed = Event()
-        freshness_lock = RLock()
-        reply_box: list[bytes | None] = [None]
-        callback = self._listen_for_param(
-            _PARAM_READ_CHANNEL,
-            request,
-            event,
-            reply_box,
-            freshness_lock,
-            armed,
-        )
-        primary_error: Exception | None = None
+        listener: _ParamListener | None = None
         try:
-            # Hold the same re-entrant lock used by the callback while arming and
-            # invoking send_packet. A synchronous callback on this thread remains
-            # possible, while a stale callback from another thread cannot cross
-            # the freshness boundary before the current send has been invoked.
-            with freshness_lock:
-                armed.set()
+            self._assert_completion_authority()
+            self._assert_exact_parameter(param_id)
+            request = _param_read_request(param_id)
+            packet = self._make_packet(_PARAM_READ_CHANNEL, request)
+            event = Event()
+            processing_lock = RLock()
+            reply_box: list[bytes | None] = [None]
+            listener = self._listen_for_param(
+                _PARAM_READ_CHANNEL,
+                request,
+                packet,
+                event,
+                reply_box,
+                processing_lock,
+            )
+
+            # The listener is registered before send, but it accepts a reply only
+            # if pinned cflib has already emitted this exact packet and invoked
+            # packet_sent. Holding processing_lock makes the cross-thread race
+            # deterministic: entry freshness is captured before any later block.
+            with processing_lock:
                 self._send_packet(packet)
             reply = self._wait_for_packet(
                 event,
@@ -581,24 +730,38 @@ class TrustedBottomColorLedTransport:
                 context="Color LED PARAM readback",
             )
             if len(reply) != _READ_REPLY_SIZE or reply[:2] != request:
-                raise ColorLedTransportError("Color LED PARAM readback reply is malformed")
+                raise ColorLedTransportError(
+                    "Color LED PARAM readback reply is malformed"
+                )
             if reply[2] != 0:
-                raise ColorLedTransportError("Color LED PARAM readback returned an error")
+                raise ColorLedTransportError(
+                    "Color LED PARAM readback returned an error"
+                )
             actual = struct.unpack("<L", reply[3:7])[0]
             if actual != expected_wrgb:
-                raise ColorLedTransportError("Color LED PARAM readback value does not match effect")
+                raise ColorLedTransportError(
+                    "Color LED PARAM readback value does not match effect"
+                )
             self._assert_completion_authority()
             self._assert_exact_parameter(param_id)
+            self._remove_listener(listener)
+            listener = None
             return True
         except Exception as exc:
-            primary_error = exc
+            # Once the write has been positively acknowledged, any uncertain,
+            # malformed or missing causal readback invalidates PARAM freshness for
+            # the whole epoch. Recovery may proceed, but this same epoch can never
+            # authorize another Color LED effect and consume a delayed old reply.
+            _poison_ack_epoch(
+                self._bound_connection_epoch,
+                "Color LED readback became ambiguous: " + str(exc),
+            )
+            if listener is not None:
+                try:
+                    self._remove_listener(listener)
+                except Exception:
+                    pass
             raise
-        finally:
-            try:
-                self._remove_listener(callback, _PARAM_READ_CHANNEL)
-            except Exception:
-                if primary_error is None:
-                    raise
 
     def send_color(self, *, color: object) -> ColorLedEffectResult:
         normalized = color if isinstance(color, str) else None
@@ -607,19 +770,18 @@ class TrustedBottomColorLedTransport:
         request = _param_write_request(param_id, wrgb)
         packet = self._make_packet(_PARAM_WRITE_CHANNEL, request)
         event = Event()
-        armed = Event()
-        freshness_lock = RLock()
+        processing_lock = RLock()
         reply_box: list[bytes | None] = [None]
         permit = None
 
         with self._ack.transaction(request) as acknowledgement:
-            callback = self._listen_for_param(
+            listener = self._listen_for_param(
                 _PARAM_WRITE_CHANNEL,
                 acknowledgement.param_id_prefix,
+                packet,
                 event,
                 reply_box,
-                freshness_lock,
-                armed,
+                processing_lock,
             )
             listener_active = True
             primary_error: Exception | None = None
@@ -631,8 +793,7 @@ class TrustedBottomColorLedTransport:
                 ) as effect:
                     effect.mark_emitted()
                     acknowledgement.mark_emitted()
-                    with freshness_lock:
-                        armed.set()
+                    with processing_lock:
                         self._send_packet(packet)
                     reply = self._wait_for_packet(
                         event,
@@ -641,26 +802,38 @@ class TrustedBottomColorLedTransport:
                     )
                     acknowledgement.resolve_reply(reply)
 
-                    # Listener cleanup is still fallible. It must complete before
-                    # mark_accepted() mints the only completion permit; otherwise
-                    # an exception could strand the process in AWAITING_COMPLETION
-                    # with no caller able to recover that permit.
-                    self._remove_listener(callback, _PARAM_WRITE_CHANNEL)
+                    # All fallible listener cleanup precedes mark_accepted(). If
+                    # cleanup fails, the emitted effect exits unresolved and the
+                    # execution domain moves to RECOVERY_REQUIRED rather than
+                    # stranding the unique completion permit.
+                    self._remove_listener(listener)
                     listener_active = False
                     permit = effect.mark_accepted()
             except Exception as exc:
                 primary_error = exc
+                if acknowledgement.emitted:
+                    _poison_ack_epoch(
+                        self._bound_connection_epoch,
+                        "Color LED write outcome became ambiguous: " + str(exc),
+                    )
                 raise
             finally:
                 if listener_active:
                     try:
-                        self._remove_listener(callback, _PARAM_WRITE_CHANNEL)
-                    except Exception:
+                        self._remove_listener(listener)
+                    except Exception as cleanup_exc:
                         if primary_error is None:
+                            _poison_ack_epoch(
+                                self._bound_connection_epoch,
+                                "Color LED write listener cleanup failed: "
+                                + str(cleanup_exc),
+                            )
                             raise
 
         if permit is None:
-            raise ColorLedTransportError("Color LED accepted-effect permit is unavailable")
+            raise ColorLedTransportError(
+                "Color LED accepted-effect permit is unavailable"
+            )
         self._execution.complete_accepted_effect(
             permit,
             physical_execution_domain.FLYING,

--- a/tools/physical/color_led_transport.py
+++ b/tools/physical/color_led_transport.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import math
 import struct
-from threading import Event, Lock
+from threading import Event, Lock, RLock
 from time import monotonic
 from typing import Callable
 
@@ -520,17 +520,25 @@ class TrustedBottomColorLedTransport:
         param_id_prefix: bytes,
         event: Event,
         reply_box: list[bytes | None],
+        freshness_lock: RLock,
+        armed: Event,
     ) -> Callable[[object], None]:
         def callback(packet: object) -> None:
-            try:
-                data = bytes(getattr(packet, "data"))
-            except Exception:
-                return
-            if data[:2] != param_id_prefix:
-                return
-            if reply_box[0] is None:
-                reply_box[0] = data
-                event.set()
+            # The listener must exist before send so an immediate cflib callback
+            # cannot be missed, but no packet observed before the current send
+            # enters its transaction-local emission critical section is fresh.
+            with freshness_lock:
+                if not armed.is_set():
+                    return
+                try:
+                    data = bytes(getattr(packet, "data"))
+                except Exception:
+                    return
+                if data[:2] != param_id_prefix:
+                    return
+                if reply_box[0] is None:
+                    reply_box[0] = data
+                    event.set()
 
         self._add_header_callback(callback, _PARAM_PORT, channel)
         return callback
@@ -547,16 +555,26 @@ class TrustedBottomColorLedTransport:
         request = _param_read_request(param_id)
         packet = self._make_packet(_PARAM_READ_CHANNEL, request)
         event = Event()
+        armed = Event()
+        freshness_lock = RLock()
         reply_box: list[bytes | None] = [None]
         callback = self._listen_for_param(
             _PARAM_READ_CHANNEL,
             request,
             event,
             reply_box,
+            freshness_lock,
+            armed,
         )
         primary_error: Exception | None = None
         try:
-            self._send_packet(packet)
+            # Hold the same re-entrant lock used by the callback while arming and
+            # invoking send_packet. A synchronous callback on this thread remains
+            # possible, while a stale callback from another thread cannot cross
+            # the freshness boundary before the current send has been invoked.
+            with freshness_lock:
+                armed.set()
+                self._send_packet(packet)
             reply = self._wait_for_packet(
                 event,
                 lambda: reply_box[0],
@@ -589,6 +607,8 @@ class TrustedBottomColorLedTransport:
         request = _param_write_request(param_id, wrgb)
         packet = self._make_packet(_PARAM_WRITE_CHANNEL, request)
         event = Event()
+        armed = Event()
+        freshness_lock = RLock()
         reply_box: list[bytes | None] = [None]
         permit = None
 
@@ -598,7 +618,10 @@ class TrustedBottomColorLedTransport:
                 acknowledgement.param_id_prefix,
                 event,
                 reply_box,
+                freshness_lock,
+                armed,
             )
+            listener_active = True
             primary_error: Exception | None = None
             try:
                 with self._execution.effect_transaction(
@@ -608,23 +631,33 @@ class TrustedBottomColorLedTransport:
                 ) as effect:
                     effect.mark_emitted()
                     acknowledgement.mark_emitted()
-                    self._send_packet(packet)
+                    with freshness_lock:
+                        armed.set()
+                        self._send_packet(packet)
                     reply = self._wait_for_packet(
                         event,
                         lambda: reply_box[0],
                         context="Color LED PARAM acknowledgement",
                     )
                     acknowledgement.resolve_reply(reply)
+
+                    # Listener cleanup is still fallible. It must complete before
+                    # mark_accepted() mints the only completion permit; otherwise
+                    # an exception could strand the process in AWAITING_COMPLETION
+                    # with no caller able to recover that permit.
+                    self._remove_listener(callback, _PARAM_WRITE_CHANNEL)
+                    listener_active = False
                     permit = effect.mark_accepted()
             except Exception as exc:
                 primary_error = exc
                 raise
             finally:
-                try:
-                    self._remove_listener(callback, _PARAM_WRITE_CHANNEL)
-                except Exception:
-                    if primary_error is None:
-                        raise
+                if listener_active:
+                    try:
+                        self._remove_listener(callback, _PARAM_WRITE_CHANNEL)
+                    except Exception:
+                        if primary_error is None:
+                            raise
 
         if permit is None:
             raise ColorLedTransportError("Color LED accepted-effect permit is unavailable")

--- a/tools/physical/color_led_transport.py
+++ b/tools/physical/color_led_transport.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Trusted one-shot bottom Color LED effect for the physical Crazyflie.
+
+This module is a deliberately narrow physical-effect surface for issue #340.
+It accepts only the existing backend-neutral ``set_light(color)`` palette and
+writes only the exact bottom Color LED parameter ``colorLedBot.wrgb8888``.
+There is no generic parameter-write API and no browser/caller-selected parameter
+name, id or packed value.
+
+The normal cflib ``Param.set_value()`` path is intentionally not used here: it
+queues writes through the generic parameter updater and may ask ``send_packet``
+to resend while waiting for an expected reply.  The trusted path instead emits
+one direct PARAM write after live SafeLink, teacher, powered-session, watchdog,
+current-program and process-wide effect-exclusion checks.  A protocol-v2 valid
+write echoes the exact two-byte parameter id plus value; that exact reply is
+serialized per connection epoch and any post-send uncertainty poisons the epoch.
+A positive write acknowledgement is completed only by a fresh direct PARAM read
+of the same exact id/value on the same live run.
+
+The class owns no current-program source.  As with the SETPOINT_HL transport,
+the base ``_read_current_binding`` hook fails closed and production must supply a
+host-local lexical subclass that closes over the one trusted physical bridge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import struct
+from threading import Event, Lock
+from time import monotonic
+from typing import Callable
+
+import physical_execution_domain
+import powered_session_authority
+import safelink_precondition
+import teacher_run_authorization
+import watchdog_liveness
+
+_PARAM_PORT = 0x02
+_PARAM_READ_CHANNEL = 1
+_PARAM_WRITE_CHANNEL = 2
+_PARAM_NAME = "colorLedBot.wrgb8888"
+_PARAM_CTYPE = "uint32_t"
+_PARAM_PYTYPE = "<L"
+_WRITE_REQUEST_SIZE = 6
+_READ_REQUEST_SIZE = 2
+_READ_REPLY_SIZE = 7
+_DEFAULT_REPLY_TIMEOUT_SECONDS = 0.2
+_WAIT_SLICE_SECONDS = 0.01
+
+_COLOR_TO_WRGB = {
+    "off": 0x00000000,
+    "red": 0x00FF0000,
+    "green": 0x0000FF00,
+    "blue": 0x000000FF,
+    "yellow": 0x00FFFF00,
+    "white": 0xFF000000,
+}
+
+_ACK_STATE_LOCK = Lock()
+_ACK_POISONED_EPOCHS: dict[str, str] = {}
+_ACK_LOCKS: dict[str, Lock] = {}
+
+
+class ColorLedTransportError(RuntimeError):
+    """Fail-closed trusted bottom Color LED transport error."""
+
+
+def _require_callable(value: object, name: str) -> Callable:
+    if not callable(value):
+        raise ColorLedTransportError(f"{name} must be callable")
+    return value
+
+
+def _positive_timeout(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ColorLedTransportError(f"{name} must be positive")
+    number = float(value)
+    if not math.isfinite(number) or number <= 0.0:
+        raise ColorLedTransportError(f"{name} must be positive")
+    return number
+
+
+def _read_epoch(reader: Callable[[], str]) -> str:
+    try:
+        value = reader()
+    except Exception as exc:
+        raise ColorLedTransportError(
+            "connection epoch is unavailable for Color LED effect"
+        ) from exc
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise ColorLedTransportError(
+            "connection epoch is invalid for Color LED effect"
+        )
+    return value
+
+
+def color_to_wrgb8888(color: object) -> int:
+    """Map the exact Runtime v2 palette to the official bottom-deck WRGB value."""
+    if not isinstance(color, str) or color not in _COLOR_TO_WRGB:
+        raise ColorLedTransportError("unsupported physical Color LED color")
+    return _COLOR_TO_WRGB[color]
+
+
+def _poison_ack_epoch(epoch: str, reason: object) -> None:
+    message = str(reason).strip() or "ambiguous Color LED parameter acknowledgement"
+    with _ACK_STATE_LOCK:
+        _ACK_POISONED_EPOCHS.setdefault(epoch, message)
+
+
+def _ack_poison_reason(epoch: str) -> str | None:
+    with _ACK_STATE_LOCK:
+        return _ACK_POISONED_EPOCHS.get(epoch)
+
+
+def _ack_lock(epoch: str) -> Lock:
+    with _ACK_STATE_LOCK:
+        lock = _ACK_LOCKS.get(epoch)
+        if lock is None:
+            lock = Lock()
+            _ACK_LOCKS[epoch] = lock
+        return lock
+
+
+class _ColorParamAckDomain:
+    """Pure exact-reply freshness/serialization for one connection epoch."""
+
+    def __init__(self, connection_epoch_reader: Callable[[], str]) -> None:
+        self._reader = _require_callable(
+            connection_epoch_reader, "Color LED connection epoch reader"
+        )
+        self._epoch = _read_epoch(self._reader)
+        self._lock = _ack_lock(self._epoch)
+        self._raise_if_poisoned()
+
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._epoch
+
+    def _raise_if_poisoned(self) -> None:
+        reason = _ack_poison_reason(self._epoch)
+        if reason is not None:
+            raise ColorLedTransportError(
+                "Color LED acknowledgement freshness is poisoned for this connection epoch: "
+                + reason
+            )
+
+    def verify_epoch(self, *, poison_on_change: bool) -> None:
+        self._raise_if_poisoned()
+        current = _read_epoch(self._reader)
+        if current != self._epoch:
+            reason = "connection epoch changed during Color LED acknowledgement"
+            if poison_on_change:
+                _poison_ack_epoch(self._epoch, reason)
+            raise ColorLedTransportError(reason)
+
+    def transaction(self, request: bytes) -> "_ColorParamAckTransaction":
+        self.verify_epoch(poison_on_change=False)
+        if not isinstance(request, bytes) or len(request) != _WRITE_REQUEST_SIZE:
+            raise ColorLedTransportError("exact Color LED PARAM write request is required")
+        if not self._lock.acquire(blocking=False):
+            raise ColorLedTransportError(
+                "another Color LED acknowledgement transaction is already active"
+            )
+        try:
+            self.verify_epoch(poison_on_change=False)
+            return _ColorParamAckTransaction(self, request, self._lock)
+        except Exception:
+            self._lock.release()
+            raise
+
+
+class _ColorParamAckTransaction:
+    _PREPARED = "prepared"
+    _EMITTED = "emitted"
+    _RESOLVED = "resolved"
+    _AMBIGUOUS = "ambiguous"
+    _CLOSED = "closed"
+
+    def __init__(
+        self,
+        domain: _ColorParamAckDomain,
+        request: bytes,
+        lock: Lock,
+    ) -> None:
+        self._domain = domain
+        self._request = request
+        self._param_id = request[:2]
+        self._lock = lock
+        self._state = self._PREPARED
+        self._released = False
+
+    @property
+    def emitted(self) -> bool:
+        return self._state in (self._EMITTED, self._RESOLVED, self._AMBIGUOUS)
+
+    @property
+    def param_id_prefix(self) -> bytes:
+        return self._param_id
+
+    def __enter__(self) -> "_ColorParamAckTransaction":
+        return self
+
+    def mark_emitted(self) -> None:
+        if self._state != self._PREPARED:
+            raise ColorLedTransportError(
+                "Color LED acknowledgement transaction is not prepared for emission"
+            )
+        try:
+            self._domain.verify_epoch(poison_on_change=True)
+        except Exception:
+            self._state = self._AMBIGUOUS
+            raise
+        self._state = self._EMITTED
+
+    def resolve_reply(self, reply: object) -> None:
+        if self._state != self._EMITTED:
+            raise ColorLedTransportError(
+                "Color LED acknowledgement requires an emitted request"
+            )
+        try:
+            self._domain.verify_epoch(poison_on_change=True)
+            if isinstance(reply, bytearray):
+                data = bytes(reply)
+            elif isinstance(reply, bytes):
+                data = reply
+            else:
+                raise ColorLedTransportError(
+                    "Color LED PARAM acknowledgement must be bytes"
+                )
+            if data != self._request:
+                raise ColorLedTransportError(
+                    "Color LED PARAM acknowledgement does not exactly echo the request"
+                )
+        except Exception as exc:
+            _poison_ack_epoch(self._domain.bound_connection_epoch, exc)
+            self._state = self._AMBIGUOUS
+            raise
+        self._state = self._RESOLVED
+
+    def _release(self) -> None:
+        if not self._released:
+            self._released = True
+            self._lock.release()
+
+    def close(self) -> None:
+        if self._state == self._EMITTED:
+            _poison_ack_epoch(
+                self._domain.bound_connection_epoch,
+                "emitted Color LED PARAM request closed without definitive acknowledgement",
+            )
+            self._state = self._AMBIGUOUS
+        elif self._state in (self._PREPARED, self._RESOLVED, self._AMBIGUOUS):
+            self._state = self._CLOSED
+        self._release()
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        self.close()
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class ColorLedEffectResult:
+    accepted: bool
+    status: int
+    color: str
+    wrgb8888: int
+
+
+def _param_write_request(param_id: int, wrgb8888: int) -> bytes:
+    if isinstance(param_id, bool) or not isinstance(param_id, int) or not 0 <= param_id <= 0xFFFF:
+        raise ColorLedTransportError("Color LED parameter id is invalid")
+    if (
+        isinstance(wrgb8888, bool)
+        or not isinstance(wrgb8888, int)
+        or not 0 <= wrgb8888 <= 0xFFFFFFFF
+    ):
+        raise ColorLedTransportError("Color LED WRGB value is invalid")
+    return struct.pack("<HL", param_id, wrgb8888)
+
+
+def _param_read_request(param_id: int) -> bytes:
+    if isinstance(param_id, bool) or not isinstance(param_id, int) or not 0 <= param_id <= 0xFFFF:
+        raise ColorLedTransportError("Color LED parameter id is invalid")
+    return struct.pack("<H", param_id)
+
+
+def _default_packet_factory(channel: int, data: bytes) -> object:
+    try:
+        from cflib.crtp.crtpstack import CRTPPacket, CRTPPort
+    except Exception as exc:
+        raise ColorLedTransportError("pinned cflib CRTP packet types are unavailable") from exc
+    if getattr(CRTPPort, "PARAM", None) != _PARAM_PORT:
+        raise ColorLedTransportError("cflib PARAM port does not match pinned contract")
+    packet = CRTPPacket()
+    packet.set_header(CRTPPort.PARAM, channel)
+    packet.data = data
+    return packet
+
+
+class TrustedBottomColorLedTransport:
+    """Exact teacher-bound bottom Color LED effect with one-shot PARAM write."""
+
+    def __init__(
+        self,
+        *,
+        crazyflie: object,
+        execution_domain: physical_execution_domain.PhysicalExecutionDomain,
+        safelink_guard: safelink_precondition.LiveSafeLinkPrecondition,
+        teacher_authorization: teacher_run_authorization.TeacherRunAuthorization,
+        powered_session: powered_session_authority.EstablishedPoweredSession,
+        watchdog_guard: watchdog_liveness.EmergencyWatchdogLivenessGuard,
+        connection_epoch_reader: Callable[[], str],
+        packet_factory: Callable[[int, bytes], object] = _default_packet_factory,
+        reply_timeout_seconds: float = _DEFAULT_REPLY_TIMEOUT_SECONDS,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        if crazyflie is None:
+            raise ColorLedTransportError("exact live Crazyflie object is required")
+        if type(execution_domain) is not physical_execution_domain.PhysicalExecutionDomain:
+            raise ColorLedTransportError("exact process-wide PhysicalExecutionDomain is required")
+        if type(safelink_guard) is not safelink_precondition.LiveSafeLinkPrecondition:
+            raise ColorLedTransportError("exact LiveSafeLinkPrecondition is required")
+        if type(teacher_authorization) is not teacher_run_authorization.TeacherRunAuthorization:
+            raise ColorLedTransportError("exact TeacherRunAuthorization receipt is required")
+        if type(powered_session) is not powered_session_authority.EstablishedPoweredSession:
+            raise ColorLedTransportError("exact EstablishedPoweredSession is required")
+        if (
+            type(powered_session.watchdog_authority)
+            is not powered_session_authority.EphemeralPoweredSessionWatchdogAuthority
+        ):
+            raise ColorLedTransportError("powered session lacks watchdog authority")
+        if type(watchdog_guard) is not watchdog_liveness.EmergencyWatchdogLivenessGuard:
+            raise ColorLedTransportError("exact active watchdog guard is required")
+
+        self._cf = crazyflie
+        self._execution = execution_domain
+        self._safelink = safelink_guard
+        self._teacher = teacher_authorization
+        self._powered_session = powered_session
+        self._watchdog = watchdog_guard
+        self._epoch_reader = _require_callable(
+            connection_epoch_reader, "Color LED connection epoch reader"
+        )
+        self._packet_factory = _require_callable(packet_factory, "Color LED packet factory")
+        self._timeout = _positive_timeout(reply_timeout_seconds, "Color LED reply timeout")
+        self._clock = _require_callable(clock, "Color LED monotonic clock")
+        self._send_packet = _require_callable(
+            getattr(crazyflie, "send_packet", None), "Crazyflie send_packet"
+        )
+        self._add_header_callback = _require_callable(
+            getattr(crazyflie, "add_header_callback", None),
+            "Crazyflie add_header_callback",
+        )
+        self._remove_header_callback = _require_callable(
+            getattr(crazyflie, "remove_header_callback", None),
+            "Crazyflie remove_header_callback",
+        )
+
+        epoch = _read_epoch(self._epoch_reader)
+        if safelink_guard.bound_crazyflie is not crazyflie:
+            raise ColorLedTransportError("SafeLink precondition is not bound to exact Crazyflie")
+        if safelink_guard.bound_connection_epoch != epoch:
+            raise ColorLedTransportError("SafeLink belongs to a different connection epoch")
+        if teacher_authorization.binding.connection_epoch != epoch:
+            raise ColorLedTransportError("teacher run belongs to a different connection epoch")
+        if powered_session.connection_epoch != epoch:
+            raise ColorLedTransportError("powered session belongs to a different connection epoch")
+        if powered_session.session is not crazyflie:
+            raise ColorLedTransportError("powered session is not bound to exact Crazyflie")
+        if watchdog_guard.bound_connection_epoch != epoch:
+            raise ColorLedTransportError("watchdog belongs to a different connection epoch")
+        if watchdog_guard.bound_crazyflie is not crazyflie:
+            raise ColorLedTransportError("watchdog is not bound to exact Crazyflie")
+        if watchdog_guard.powered_session_identity != powered_session.watchdog_authority.identity:
+            raise ColorLedTransportError("watchdog/powered-session identity changed")
+
+        self._bound_connection_epoch = epoch
+        self._ack = _ColorParamAckDomain(self._epoch_reader)
+        if self._ack.bound_connection_epoch != epoch:
+            raise ColorLedTransportError("Color LED acknowledgement domain epoch mismatch")
+
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._bound_connection_epoch
+
+    @property
+    def teacher_binding(self) -> teacher_run_authorization.PhysicalRunBinding:
+        return self._teacher.binding
+
+    @property
+    def execution_domain(self) -> physical_execution_domain.PhysicalExecutionDomain:
+        return self._execution
+
+    def _read_current_binding(self) -> teacher_run_authorization.PhysicalRunBinding:
+        raise ColorLedTransportError(
+            "current-program assertion is not bound to the trusted physical host"
+        )
+
+    def _require_connection_live(self) -> None:
+        method = getattr(self._cf, "is_connected", None)
+        if not callable(method):
+            raise ColorLedTransportError("Crazyflie live connection state is unavailable")
+        try:
+            connected = method()
+        except Exception as exc:
+            raise ColorLedTransportError("Crazyflie live connection state became unavailable") from exc
+        if connected is not True:
+            raise ColorLedTransportError("Crazyflie disconnected during Color LED effect")
+        if _read_epoch(self._epoch_reader) != self._bound_connection_epoch:
+            raise ColorLedTransportError("connection epoch changed during Color LED effect")
+
+    def _assert_run_binding(self, *, require_flying: bool) -> None:
+        binding = self._read_current_binding()
+        if type(binding) is not teacher_run_authorization.PhysicalRunBinding:
+            raise ColorLedTransportError("exact current PhysicalRunBinding is required")
+        self._teacher.assert_effect_binding(
+            profile_id=binding.profile_id,
+            ast_binding=binding.ast_binding,
+            connection_epoch=binding.connection_epoch,
+        )
+        if binding.connection_epoch != self._bound_connection_epoch:
+            raise ColorLedTransportError("current run binding belongs to a different epoch")
+        if self._powered_session.connection_epoch != self._bound_connection_epoch:
+            raise ColorLedTransportError("powered session connection epoch changed")
+        if self._watchdog.powered_session_identity != self._powered_session.watchdog_authority.identity:
+            raise ColorLedTransportError("watchdog/powered-session identity changed")
+        self._watchdog.assert_live()
+        self._require_connection_live()
+        if require_flying:
+            if self._execution.phase != physical_execution_domain.FLYING:
+                raise ColorLedTransportError("Color LED effect requires established flying state")
+        elif self._execution.phase != physical_execution_domain.AWAITING_COMPLETION:
+            raise ColorLedTransportError("Color LED readback requires accepted pending effect")
+
+    def _assert_current_authority(self) -> None:
+        self._assert_run_binding(require_flying=True)
+
+    def _assert_completion_authority(self) -> None:
+        self._assert_run_binding(require_flying=False)
+
+    def _resolve_parameter_id(self) -> int:
+        platform = getattr(self._cf, "platform", None)
+        getter = getattr(platform, "get_protocol_version", None)
+        if not callable(getter):
+            raise ColorLedTransportError("Crazyflie protocol version is unavailable")
+        try:
+            protocol = getter()
+        except Exception as exc:
+            raise ColorLedTransportError("Crazyflie protocol version read failed") from exc
+        if isinstance(protocol, bool) or not isinstance(protocol, int) or protocol < 4:
+            raise ColorLedTransportError("Color LED effect requires CRTP parameter protocol v2")
+
+        param = getattr(self._cf, "param", None)
+        toc = getattr(param, "toc", None)
+        lookup = getattr(toc, "get_element_by_complete_name", None)
+        if not callable(lookup):
+            raise ColorLedTransportError("live parameter TOC is unavailable")
+        try:
+            element = lookup(_PARAM_NAME)
+        except Exception as exc:
+            raise ColorLedTransportError("bottom Color LED parameter lookup failed") from exc
+        if element is None:
+            raise ColorLedTransportError("bottom Color LED parameter is absent from live TOC")
+        if getattr(element, "group", None) != "colorLedBot" or getattr(element, "name", None) != "wrgb8888":
+            raise ColorLedTransportError("bottom Color LED TOC entry identity is malformed")
+        if getattr(element, "ctype", None) != _PARAM_CTYPE or getattr(element, "pytype", None) != _PARAM_PYTYPE:
+            raise ColorLedTransportError("bottom Color LED parameter is not exact uint32_t")
+        readable = getattr(element, "get_readable_access", None)
+        if not callable(readable) or readable() != "RW":
+            raise ColorLedTransportError("bottom Color LED parameter is not writable")
+        ident = getattr(element, "ident", None)
+        if isinstance(ident, bool) or not isinstance(ident, int) or not 0 <= ident <= 0xFFFF:
+            raise ColorLedTransportError("bottom Color LED parameter id is invalid")
+        return ident
+
+    def _assert_exact_parameter(self, param_id: int) -> None:
+        if self._resolve_parameter_id() != param_id:
+            raise ColorLedTransportError("bottom Color LED parameter identity changed")
+
+    def _make_packet(self, channel: int, data: bytes) -> object:
+        packet = self._packet_factory(channel, data)
+        if getattr(packet, "port", None) != _PARAM_PORT:
+            raise ColorLedTransportError("packet factory substituted non-PARAM port")
+        if getattr(packet, "channel", None) != channel:
+            raise ColorLedTransportError("packet factory substituted PARAM channel")
+        try:
+            actual = bytes(getattr(packet, "data"))
+        except Exception as exc:
+            raise ColorLedTransportError("packet factory returned unreadable PARAM data") from exc
+        if actual != data:
+            raise ColorLedTransportError("packet factory substituted PARAM request bytes")
+        return packet
+
+    def _wait_for_packet(
+        self,
+        event: Event,
+        reply_reader: Callable[[], bytes | None],
+        *,
+        context: str,
+    ) -> bytes:
+        deadline = float(self._clock()) + self._timeout
+        while True:
+            if event.is_set():
+                data = reply_reader()
+                if data is None:
+                    raise ColorLedTransportError(context + " event has no packet data")
+                return data
+            self._watchdog.assert_live()
+            self._require_connection_live()
+            remaining = deadline - float(self._clock())
+            if remaining <= 0.0:
+                raise ColorLedTransportError(context + " timeout")
+            event.wait(min(_WAIT_SLICE_SECONDS, remaining))
+
+    def _listen_for_param(
+        self,
+        channel: int,
+        param_id_prefix: bytes,
+        event: Event,
+        reply_box: list[bytes | None],
+    ) -> Callable[[object], None]:
+        def callback(packet: object) -> None:
+            try:
+                data = bytes(getattr(packet, "data"))
+            except Exception:
+                return
+            if data[:2] != param_id_prefix:
+                return
+            if reply_box[0] is None:
+                reply_box[0] = data
+                event.set()
+
+        self._add_header_callback(callback, _PARAM_PORT, channel)
+        return callback
+
+    def _remove_listener(self, callback: Callable[[object], None], channel: int) -> None:
+        try:
+            self._remove_header_callback(callback, _PARAM_PORT, channel)
+        except Exception as exc:
+            raise ColorLedTransportError("could not remove Color LED PARAM callback") from exc
+
+    def _prove_readback(self, param_id: int, expected_wrgb: int) -> bool:
+        self._assert_completion_authority()
+        self._assert_exact_parameter(param_id)
+        request = _param_read_request(param_id)
+        packet = self._make_packet(_PARAM_READ_CHANNEL, request)
+        event = Event()
+        reply_box: list[bytes | None] = [None]
+        callback = self._listen_for_param(
+            _PARAM_READ_CHANNEL,
+            request,
+            event,
+            reply_box,
+        )
+        primary_error: Exception | None = None
+        try:
+            self._send_packet(packet)
+            reply = self._wait_for_packet(
+                event,
+                lambda: reply_box[0],
+                context="Color LED PARAM readback",
+            )
+            if len(reply) != _READ_REPLY_SIZE or reply[:2] != request:
+                raise ColorLedTransportError("Color LED PARAM readback reply is malformed")
+            if reply[2] != 0:
+                raise ColorLedTransportError("Color LED PARAM readback returned an error")
+            actual = struct.unpack("<L", reply[3:7])[0]
+            if actual != expected_wrgb:
+                raise ColorLedTransportError("Color LED PARAM readback value does not match effect")
+            self._assert_completion_authority()
+            self._assert_exact_parameter(param_id)
+            return True
+        except Exception as exc:
+            primary_error = exc
+            raise
+        finally:
+            try:
+                self._remove_listener(callback, _PARAM_READ_CHANNEL)
+            except Exception:
+                if primary_error is None:
+                    raise
+
+    def send_color(self, *, color: object) -> ColorLedEffectResult:
+        normalized = color if isinstance(color, str) else None
+        wrgb = color_to_wrgb8888(normalized)
+        param_id = self._resolve_parameter_id()
+        request = _param_write_request(param_id, wrgb)
+        packet = self._make_packet(_PARAM_WRITE_CHANNEL, request)
+        event = Event()
+        reply_box: list[bytes | None] = [None]
+        permit = None
+
+        with self._ack.transaction(request) as acknowledgement:
+            callback = self._listen_for_param(
+                _PARAM_WRITE_CHANNEL,
+                acknowledgement.param_id_prefix,
+                event,
+                reply_box,
+            )
+            primary_error: Exception | None = None
+            try:
+                with self._execution.effect_transaction(
+                    self._assert_current_authority,
+                    self._safelink.assert_ready,
+                    lambda: self._assert_exact_parameter(param_id),
+                ) as effect:
+                    effect.mark_emitted()
+                    acknowledgement.mark_emitted()
+                    self._send_packet(packet)
+                    reply = self._wait_for_packet(
+                        event,
+                        lambda: reply_box[0],
+                        context="Color LED PARAM acknowledgement",
+                    )
+                    acknowledgement.resolve_reply(reply)
+                    permit = effect.mark_accepted()
+            except Exception as exc:
+                primary_error = exc
+                raise
+            finally:
+                try:
+                    self._remove_listener(callback, _PARAM_WRITE_CHANNEL)
+                except Exception:
+                    if primary_error is None:
+                        raise
+
+        if permit is None:
+            raise ColorLedTransportError("Color LED accepted-effect permit is unavailable")
+        self._execution.complete_accepted_effect(
+            permit,
+            physical_execution_domain.FLYING,
+            lambda: self._prove_readback(param_id, wrgb),
+        )
+        return ColorLedEffectResult(
+            accepted=True,
+            status=0,
+            color=normalized,
+            wrgb8888=wrgb,
+        )

--- a/tools/physical/physical_program_sequence.py
+++ b/tools/physical/physical_program_sequence.py
@@ -3,29 +3,30 @@
 
 The #287 takeoff consumer derives its effect from the first statement in the
 exact teacher-authorized canonical AST. Later effects and no-effect semantic
-steps must preserve that property: a bounded caller-selected motion, wait,
-speed state or landing request is not equivalent to the next statement of the
-authorized program.
+steps must preserve that property: a bounded caller-selected motion, light,
+wait, speed state or landing request is not equivalent to the next statement of
+the authorized program.
 
 This module provides the small non-effect state machine needed by the physical
 host. It starts only after a caller has already established the first takeoff
 statement by other trusted means, eagerly validates the complete currently
-supported envelope (horizontal/vertical move, turn, wait and set_speed
-statements followed by one exact terminal land), reserves exactly the next
-statement, and advances only after the trusted consumer reports definitive
-completion. A rejected/unemitted physical effect may be released without
-advancing; an ambiguous emitted outcome makes the sequence terminal. Failed
-exact wait/speed no-effect steps are terminal without being classified as
+supported envelope (horizontal/vertical move, turn, bottom Color LED set_light,
+wait and set_speed statements followed by one exact terminal land), reserves
+exactly the next statement, and advances only after the trusted consumer reports
+definitive completion. A rejected/unemitted physical effect may be released
+without advancing; an ambiguous emitted outcome makes the sequence terminal.
+Failed exact wait/speed no-effect steps are terminal without being classified as
 emitted physical effects.
 
 Vertical statements additionally maintain a host-owned nominal world-Z state.
 The complete nominal altitude path is checked before reset/takeoff and every
 intermediate altitude must stay inside the established 0.2--1.5 m envelope.
-The runtime altitude state advances only after definitive vertical completion.
+Light, wait, speed, horizontal and turn statements are altitude-neutral. The
+runtime altitude state advances only after definitive vertical completion.
 
-It emits no CRTP command and accepts no caller-selected motion, wait duration,
-speed, altitude, program index, landing parameter, completion proof or authority
-object.
+It emits no CRTP command and accepts no caller-selected motion, color, wait
+duration, speed, altitude, program index, landing parameter, completion proof or
+authority object.
 """
 
 from __future__ import annotations
@@ -42,6 +43,7 @@ MIN_WAIT_SECONDS = 0.1
 MAX_WAIT_SECONDS = 5.0
 MIN_NOMINAL_ALTITUDE_M = 0.2
 MAX_NOMINAL_ALTITUDE_M = 1.5
+LIGHT_COLORS = ("off", "red", "green", "blue", "yellow", "white")
 
 
 class PhysicalProgramSequenceError(RuntimeError):
@@ -70,6 +72,12 @@ class SequencedSpeed:
 
 
 @dataclass(frozen=True, slots=True)
+class SequencedLight:
+    index: int
+    color: str
+
+
+@dataclass(frozen=True, slots=True)
 class SequencedTerminalLanding:
     index: int
 
@@ -93,6 +101,13 @@ class _SpeedClaim:
 
     def __init__(self, speed: SequencedSpeed) -> None:
         self.speed = speed
+
+
+class _LightClaim:
+    __slots__ = ("light",)
+
+    def __init__(self, light: SequencedLight) -> None:
+        self.light = light
 
 
 class _LandingClaim:
@@ -137,6 +152,8 @@ class PhysicalProgramSequence:
                 self._wait_at(index)
             elif kind == "set_speed":
                 self._speed_at(index)
+            elif kind == "set_light":
+                self._light_at(index)
             else:
                 motion = self._motion_at(index)
                 if motion.kind == "vertical":
@@ -149,7 +166,9 @@ class PhysicalProgramSequence:
         self._planned_terminal_altitude_m = planned_altitude
         self._nominal_altitude_m = float(takeoff.height_m)
         self._next_index = 1
-        self._pending: _MotionClaim | _WaitClaim | _SpeedClaim | _LandingClaim | None = None
+        self._pending: (
+            _MotionClaim | _WaitClaim | _SpeedClaim | _LightClaim | _LandingClaim | None
+        ) = None
         self._terminal_reason: str | None = None
         self._lock = Lock()
 
@@ -206,12 +225,18 @@ class PhysicalProgramSequence:
                     "physical program sequence is terminal: " + self._terminal_reason
                 )
             if self._pending is not None:
-                raise PhysicalProgramSequenceError("physical program already has a pending step")
+                raise PhysicalProgramSequenceError(
+                    "physical program already has a pending step"
+                )
             if self._next_index >= len(self._program):
                 return None
             statement = self._program[self._next_index]
-            if not isinstance(statement, dict) or not isinstance(statement.get("kind"), str):
-                raise PhysicalProgramSequenceError("next physical statement is malformed")
+            if not isinstance(statement, dict) or not isinstance(
+                statement.get("kind"), str
+            ):
+                raise PhysicalProgramSequenceError(
+                    "next physical statement is malformed"
+                )
             return statement["kind"]
 
     @property
@@ -252,7 +277,9 @@ class PhysicalProgramSequence:
                 direction = statement["direction"]
                 distance = statement["distance_m"]
                 if not isinstance(direction, str):
-                    raise PhysicalProgramSequenceError("next move direction is malformed")
+                    raise PhysicalProgramSequenceError(
+                        "next move direction is malformed"
+                    )
                 high_level_semantics.body_relative_move(direction, distance, 0.0)
                 return SequencedInflightMotion(
                     index=index,
@@ -270,7 +297,9 @@ class PhysicalProgramSequence:
                 direction = statement["direction"]
                 distance = statement["distance_m"]
                 if not isinstance(direction, str):
-                    raise PhysicalProgramSequenceError("next vertical direction is malformed")
+                    raise PhysicalProgramSequenceError(
+                        "next vertical direction is malformed"
+                    )
                 high_level_semantics.vertical_move(direction, distance)
                 return SequencedInflightMotion(
                     index=index,
@@ -294,7 +323,11 @@ class PhysicalProgramSequence:
                     distance_m=None,
                     angle_deg=float(angle),
                 )
-        except (TypeError, ValueError, high_level_semantics.HighLevelSemanticError) as exc:
+        except (
+            TypeError,
+            ValueError,
+            high_level_semantics.HighLevelSemanticError,
+        ) as exc:
             raise PhysicalProgramSequenceError(
                 "next in-flight motion violates integrated #256 semantics"
             ) from exc
@@ -305,20 +338,28 @@ class PhysicalProgramSequence:
 
     def _wait_at(self, index: int) -> SequencedWait:
         if index >= len(self._program) - 1:
-            raise PhysicalProgramSequenceError("no wait remains before the final landing boundary")
+            raise PhysicalProgramSequenceError(
+                "no wait remains before the final landing boundary"
+            )
         statement = self._program[index]
         if not isinstance(statement, dict) or set(statement) != {"kind", "seconds"}:
             raise PhysicalProgramSequenceError(
                 "next wait statement contains unsupported fields"
             )
         if statement.get("kind") != "wait":
-            raise PhysicalProgramSequenceError("next exact AST statement is not a wait")
+            raise PhysicalProgramSequenceError(
+                "next exact AST statement is not a wait"
+            )
         seconds = statement["seconds"]
         if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
-            raise PhysicalProgramSequenceError("next wait seconds must be finite")
+            raise PhysicalProgramSequenceError(
+                "next wait seconds must be finite"
+            )
         parsed = float(seconds)
         if not isfinite(parsed):
-            raise PhysicalProgramSequenceError("next wait seconds must be finite")
+            raise PhysicalProgramSequenceError(
+                "next wait seconds must be finite"
+            )
         if parsed < MIN_WAIT_SECONDS or parsed > MAX_WAIT_SECONDS:
             raise PhysicalProgramSequenceError(
                 "next wait seconds violate established Runtime v2 bounds"
@@ -341,10 +382,14 @@ class PhysicalProgramSequence:
             )
         speed = statement["speed_m_s"]
         if isinstance(speed, bool) or not isinstance(speed, (int, float)):
-            raise PhysicalProgramSequenceError("next set_speed speed_m_s must be finite")
+            raise PhysicalProgramSequenceError(
+                "next set_speed speed_m_s must be finite"
+            )
         parsed = float(speed)
         if not isfinite(parsed):
-            raise PhysicalProgramSequenceError("next set_speed speed_m_s must be finite")
+            raise PhysicalProgramSequenceError(
+                "next set_speed speed_m_s must be finite"
+            )
         if (
             parsed < high_level_timing.MIN_HORIZONTAL_SPEED_M_S
             or parsed > high_level_timing.MAX_HORIZONTAL_SPEED_M_S
@@ -354,13 +399,36 @@ class PhysicalProgramSequence:
             )
         return SequencedSpeed(index=index, speed_m_s=parsed)
 
+    def _light_at(self, index: int) -> SequencedLight:
+        if index >= len(self._program) - 1:
+            raise PhysicalProgramSequenceError(
+                "no set_light remains before the final landing boundary"
+            )
+        statement = self._program[index]
+        if not isinstance(statement, dict) or set(statement) != {"kind", "color"}:
+            raise PhysicalProgramSequenceError(
+                "next set_light statement contains unsupported fields"
+            )
+        if statement.get("kind") != "set_light":
+            raise PhysicalProgramSequenceError(
+                "next exact AST statement is not a set_light effect"
+            )
+        color = statement["color"]
+        if not isinstance(color, str) or color not in LIGHT_COLORS:
+            raise PhysicalProgramSequenceError(
+                "next set_light color violates established Runtime v2 palette"
+            )
+        return SequencedLight(index=index, color=color)
+
     def _check_reservable(self) -> None:
         if self._terminal_reason is not None:
             raise PhysicalProgramSequenceError(
                 "physical program sequence is terminal: " + self._terminal_reason
             )
         if self._pending is not None:
-            raise PhysicalProgramSequenceError("physical program already has a pending step")
+            raise PhysicalProgramSequenceError(
+                "physical program already has a pending step"
+            )
 
     def reserve_next_motion(self) -> object:
         with self._lock:
@@ -478,6 +546,34 @@ class PhysicalProgramSequence:
             self._terminal_reason = reason.strip()
             self._pending = None
 
+    def reserve_next_light(self) -> object:
+        with self._lock:
+            self._check_reservable()
+            claim = _LightClaim(self._light_at(self._next_index))
+            self._pending = claim
+            return claim
+
+    def light_for_claim(self, claim: object) -> SequencedLight:
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _LightClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program set_light claim is required"
+                )
+            return claim.light
+
+    def complete_light(self, claim: object) -> None:
+        with self._lock:
+            if claim is not self._pending or not isinstance(claim, _LightClaim):
+                raise PhysicalProgramSequenceError(
+                    "exact pending physical-program set_light claim is required"
+                )
+            if claim.light.index != self._next_index:
+                raise PhysicalProgramSequenceError(
+                    "pending physical-program set_light claim no longer matches the cursor"
+                )
+            self._next_index += 1
+            self._pending = None
+
     def reserve_terminal_landing(self) -> object:
         with self._lock:
             self._check_reservable()
@@ -530,7 +626,7 @@ class PhysicalProgramSequence:
     def release_unemitted(self, claim: object) -> None:
         with self._lock:
             if claim is not self._pending or not isinstance(
-                claim, (_MotionClaim, _LandingClaim)
+                claim, (_MotionClaim, _LightClaim, _LandingClaim)
             ):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program effect claim is required"
@@ -544,7 +640,7 @@ class PhysicalProgramSequence:
             )
         with self._lock:
             if claim is not self._pending or not isinstance(
-                claim, (_MotionClaim, _LandingClaim)
+                claim, (_MotionClaim, _LightClaim, _LandingClaim)
             ):
                 raise PhysicalProgramSequenceError(
                     "exact pending physical-program effect claim is required"

--- a/tools/physical/physical_run_activation.py
+++ b/tools/physical/physical_run_activation.py
@@ -7,8 +7,8 @@ teacher socket and the shared #273 execution domain. The generic takeoff
 lifecycle remains in ``production_takeoff_run``. The exact canonical AST is
 validated against the integrated sequencing boundary before any reset or flight
 effect; after exact takeoff has causally completed, the same sequence owns each
-bounded horizontal/vertical move, turn, no-effect wait/set_speed state and the
-one terminal controlled landing.
+bounded horizontal/vertical move, turn, bottom Color LED effect, no-effect
+wait/set_speed state and the one terminal controlled landing.
 
 Importing this module performs no physical effect.
 """
@@ -20,6 +20,10 @@ from math import isfinite
 import socket
 from time import monotonic, sleep
 
+from color_led_transport import (
+    ColorLedTransportError,
+    TrustedBottomColorLedTransport,
+)
 from controlled_landing_transport import (
     ControlledLandingTransportError,
     TrustedControlledLandingTransport,
@@ -227,9 +231,9 @@ def activate_validated_run(
 
     ``execute_next_inflight()`` on the returned process-local object accepts no
     semantic parameters. It reserves only the next exact top-level horizontal or
-    vertical move, turn, no-effect wait/set_speed state or terminal land from the
-    post-reset #267 binding and keeps every positive provenance/effect path
-    lexical to this adapter's host-owned bridge.
+    vertical move, turn, bottom Color LED effect, no-effect wait/set_speed state
+    or terminal land from the post-reset #267 binding and keeps every positive
+    provenance/effect path lexical to this adapter's host-owned bridge.
     """
     if not isinstance(uri, str) or not uri.startswith("radio://"):
         raise PhysicalRunActivationError("physical activation requires explicit radio:// URI")
@@ -431,14 +435,28 @@ def activate_validated_run(
                 raise ControlledLandingTransportError(str(exc)) from exc
             return binding
 
+    class _HostBoundColorLedTransport(TrustedBottomColorLedTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            binding = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise ColorLedTransportError(str(exc)) from exc
+            return binding
+
     timing_policy = HighLevelTimingPolicy()
 
     class _ActivatedRunController:
-        __slots__ = ("_yaw_reader", "_transport")
+        __slots__ = ("_yaw_reader", "_transport", "_color_transport")
 
         def __init__(self) -> None:
             self._yaw_reader = None
             self._transport = None
+            self._color_transport = None
 
         @property
         def active_run(self):
@@ -463,6 +481,25 @@ def activate_validated_run(
                     "physical effect transport is not bound to the exact active host epoch"
                 )
             self._transport = transport
+            return transport
+
+        def _ensure_color_transport(self):
+            if self._color_transport is not None:
+                return self._color_transport
+            transport = _HostBoundColorLedTransport(
+                crazyflie=active_run.crazyflie,
+                execution_domain=active_run.execution_domain,
+                safelink_guard=active_run.safelink_guard,
+                teacher_authorization=active_run.teacher_authorization,
+                powered_session=active_run.powered_session,
+                watchdog_guard=active_run.watchdog_guard,
+                connection_epoch_reader=session.read_connection_epoch,
+            )
+            if transport.bound_connection_epoch != session.read_connection_epoch():
+                raise PhysicalRunActivationError(
+                    "Color LED effect transport is not bound to the exact active host epoch"
+                )
+            self._color_transport = transport
             return transport
 
         def _ensure_yaw_reader(self):
@@ -574,6 +611,51 @@ def activate_validated_run(
             sequence.complete_speed(claim)
             return _NoEffectStepResult()
 
+        def _execute_light(self):
+            claim = sequence.reserve_next_light()
+            light_step = sequence.light_for_claim(claim)
+            try:
+                result = self._ensure_color_transport().send_color(
+                    color=light_step.color
+                )
+            except Exception:
+                self._release_or_poison_sequence(
+                    claim,
+                    "bottom Color LED effect outcome is not definitively retryable",
+                )
+                raise
+
+            accepted = getattr(result, "accepted", None)
+            if accepted is True:
+                if active_run.execution_domain.phase != FLYING:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "accepted bottom Color LED effect did not causally return to flying",
+                    )
+                    raise PhysicalRunActivationError(
+                        "accepted bottom Color LED completion is not causally established"
+                    )
+                sequence.complete_light(claim)
+            elif accepted is False:
+                if active_run.execution_domain.phase != FLYING:
+                    sequence.mark_ambiguous(
+                        claim,
+                        "rejected bottom Color LED effect did not restore the flying phase",
+                    )
+                    raise PhysicalRunActivationError(
+                        "definitive bottom Color LED rejection did not restore physical state"
+                    )
+                sequence.release_unemitted(claim)
+            else:
+                sequence.mark_ambiguous(
+                    claim,
+                    "trusted bottom Color LED transport returned an indeterminate result",
+                )
+                raise PhysicalRunActivationError(
+                    "trusted bottom Color LED transport returned no definitive acknowledgement"
+                )
+            return result
+
         def execute_next_inflight(self):
             """Advance one exact AST step; accepts no caller semantic data."""
             step_kind = sequence.next_step_kind
@@ -581,6 +663,8 @@ def activate_validated_run(
                 return self._execute_wait()
             if step_kind == "set_speed":
                 return self._execute_speed()
+            if step_kind == "set_light":
+                return self._execute_light()
 
             terminal_landing = step_kind == "land"
             if terminal_landing:


### PR DESCRIPTION
Refs #157 #340.

## Scope

This candidate closes the bounded deterministic trusted-host slice for the already-generic bottom Color LED semantic.

- adds a narrow one-shot `colorLedBot.wrgb8888` PARAM transport surface for the existing Runtime v2 palette only;
- maps exactly `off`, `red`, `green`, `blue`, `yellow`, `white` to the official `0xWWRRGGBB` bottom-deck representation;
- resolves only the exact live writable `uint32_t` parameter from the cflib TOC and requires parameter protocol v2;
- avoids normal cflib `Param.set_value()` and its generic `expected_reply` resend path;
- serializes exact same-epoch Color LED PARAM transactions and requires live SafeLink, current teacher run, powered session, watchdog and process-wide effect exclusion;
- establishes a causal receive-freshness fence before each effect using a never-before-requested absent PARAM id on the pinned `radio://` path; only the exact firmware `ENOENT` response permits installing the target-write listener, while fence/write/readback uncertainty poisons the connection epoch;
- removes fallible write-listener teardown before minting the accepted-effect completion permit and treats later teardown/readback uncertainty as recovery-required rather than silently advancing;
- after exact write echo, requires a direct same-id PARAM readback of the exact value before restoring `FLYING` completion state;
- extends `PhysicalProgramSequence` with exact teacher-bound `set_light` claims; rejected/unemitted effects do not advance, ambiguity is terminal, and light is altitude/motion/speed neutral;
- composes the effect through the production host with ordinary `execute-next-inflight` IPC still parameter-free; caller-selected color/value/parameter/id/index/completion data remains rejected;
- adds deterministic transport, sequence and production-host regressions and wires them into the Runtime gate.

The causal-fence design specifically avoids treating cflib `Crazyflie.packet_sent` as an on-air boundary: on the pinned Crazyradio path that callback is only downstream of local enqueue. The unique invalid-id response is instead used as the receive-side ordering fence before any target reply can be accepted.

The production-host composition harness intentionally installs `FakeExecutionDomain`. Its ambiguity regression uses an explicit faithful fake transaction that starts in `FLYING`, records the one emitted effect as `EFFECT_UNRESOLVED`, and closes exceptional unresolved emission as `RECOVERY_REQUIRED`; the black-box assertions require the ambiguous request and every later request to fail closed, exactly one transport attempt, and no terminal landing. The production execution-domain lifecycle itself remains covered independently by its dedicated deterministic contract tests.

No generic physical parameter API, new Blockly vocabulary, top-deck light support, real-device qualification, checkpoint request or `TEST_REQUIRED` is introduced by this deterministic integration slice.

Exact Ready candidate: `7b9ec2e405161cfcac27317f6c7a3cd476ce3063`, containing current `main@b910d8edd9d922b93fd0600c8f933772faad89a9`. A fresh canonical Ready `CI Gate` on this exact head and an independent exact-head review resolving every still-applicable prior finding are required before integration.