### PR TITLE
Refresh X3 checkpoint artifact boundary

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/X3_CHECKPOINT_SUPPORT.md
+++ b/experiments/crazyflie-ukf-surface-range/X3_CHECKPOINT_SUPPORT.md
@@ -3,25 +3,27 @@
 This document is the post-#326 preparation boundary for #70. It does **not**
 enable a human-checkpoint profile and it does not request a physical test.
 
-The repository now contains the four offline/acquisition components that were
-missing after the archived-input audit:
+The repository now contains the offline/acquisition components that were missing
+after the archived-input audit:
 
-- continuous raw barometer/IMU acquisition on the unchanged #251 firmware
+- continuous barometer/IMU acquisition on the exact #251 physical firmware
   (`capture_independent_inputs.py`, integrated by #299);
 - the frozen pressure-window calculation (`frozen_pressure_probe.py`, #300);
 - hash-bound conditional external metric-reference envelopes
   (`metric_reference.py`, #311);
-- the independent barometer/raw-accelerometer replay with explicit deterministic
-  timing/intersample bounds (`frozen_vertical_predictor.py`, #326).
+- the independent barometer/accelerometer replay with explicit deterministic
+  timing/intersample bounds (`frozen_vertical_predictor.py`, #326);
+- the logging-only pre-LPF/read-window observer for exact pinned Crazyflie source
+  (`apply_x3_prelpf_timing_observer.py`, integrated by #339).
 
 The generic Git-backed physical evidence path from #298 is also integrated. These
 are component proofs only. They do not validate any real reference, clock model,
 sensor bound or 5 cm / 1 s physical result.
 
-## Exact physical artifact boundary
+## Physical artifact decision boundary
 
-The next #70 checkpoint, if it later becomes eligible, must stay on the exact
-#251 experimental firmware and parameters already used for the timing checkpoint:
+The exact #251 checkpoint binary remains the only currently established physical
+artifact for this #70 line:
 
 - firmware source/request target:
   `6562ad827bf0c8bf2c9b609edad36f3e15652133`;
@@ -35,16 +37,37 @@ The next #70 checkpoint, if it later becomes eligible, must stay on the exact
 - no firmware retuning, estimator-structure change, Runtime/controller change or
   motorized action.
 
-No new flash *content* is justified. A future procedure may require flashing the
-exact bundled binary solely to establish the known checkpoint artifact on the
-physical device before acquisition.
+The #339 observer does **not** silently replace that artifact. Its canonical CI
+path proves only that the logging overlay applies to the exact pinned Crazyflie
+source and compiles. The diagnostic binary is not retained as the #251 artifact,
+is not bound to `s3-props-off`, and no `x3-independent-props-off` trusted profile
+is enabled for it. #342 additionally leaves the electrical source of
+`sensorData.interruptTimestamp` UNPROVEN; neither that value nor the observer's
+MCU read windows may be promoted to sensor producer timestamps.
 
-## Runtime closure prepared by this branch
+There are therefore two reviewable future paths, and neither is selected merely
+because the observer exists:
+
+1. stay on exact #251 only if the pre-registered deterministic predictor bounds
+   explicitly cover the existing post-firmware-LPF acceleration path together
+   with all producer/filter/timing uncertainty; or
+2. if those bounds cannot be justified tightly enough without pre-LPF evidence,
+   prepare a **separate** exact instrumented physical artifact from the integrated
+   #339 overlay, with a new artifact identity, exact source/applicator/binary
+   digests, compatible capture support and a separately reviewed trusted
+   checkpoint profile.
+
+The choice must be made from pre-registered bound/reference feasibility, not from
+the target terrain/mixed outcome. Never overwrite, rename or repurpose the #251
+artifact or the historical `s3-props-off` identity to carry instrumented firmware.
+No new flash content is authorized by this document.
+
+## Existing #251 runtime closure
 
 `tools/physical/run_x3_independent_capture.sh` defines the deterministic local
-runner to be copied into a future trusted checkpoint bundle. The bundle contract
-is intentionally compatible with the already integrated read-only Crazyflie
-runtime closure:
+runner prepared for the exact #251 acquisition path. The bundle contract is
+intentionally compatible with the already integrated read-only Crazyflie runtime
+closure:
 
 - Linux x86-64 / Python 3.10;
 - exact cflib source commit
@@ -54,7 +77,7 @@ runtime closure:
   `750e850390753de14019f0e1f55d4fbc44317699`;
 - the same four exact offline wheels already pinned by
   `tools/physical/reference_probe_lock.txt`;
-- bundled `cf2.bin`, `capture_independent_inputs.py`, `PROVENANCE.txt` and
+- bundled #251 `cf2.bin`, `capture_independent_inputs.py`, `PROVENANCE.txt` and
   `SHA256SUMS`.
 
 The runner verifies the complete bundle manifest, exact firmware hash, exact
@@ -65,6 +88,12 @@ exact request SHA, duration and new output directory. It invokes the collector
 with `--props-removed --installed-bin-confirmed`; it does not flash, write a
 parameter, reset the estimator, issue commander motion, publish evidence or
 manufacture a physical verdict.
+
+This runner currently records the stock #251 log groups, not the `x3AccObs` /
+`x3BaroObs` groups introduced by the #339 source overlay. If the instrumented path
+is selected later, its capture client/bundle must be extended and reviewed under
+that new exact artifact identity rather than treating this #251 runner as
+implicitly compatible.
 
 This runtime runner is support code only until a trusted checkpoint profile
 packages and verifies the stated bundle. Do not treat the presence of the script
@@ -90,6 +119,14 @@ cadence and the existing gap checks do not bound between-sample acceleration;
 basis. Likewise, Crazyflie log time is not a per-sensor producer timestamp, so a
 small `sensor_time_error_s` cannot be inferred merely from the log period.
 
+The #339 observer narrows one software-observability problem by retaining
+acceleration before the Crazyflie 30 Hz software LPF and by retaining CPU register
+read windows. It does not validate BMI088 internal sample/filter timing, BMP3xx
+conversion/IIR timing, specific-force accuracy, physical motion between retained
+samples or delivery latency. On the #251 path, any deterministic bound must also
+cover the existing post-LPF acceleration semantics rather than pretending those
+logs are raw sensor samples.
+
 A future checkpoint candidate must therefore make the following reviewable before
 it is enabled:
 
@@ -98,7 +135,8 @@ it is enabled:
   every value;
 - which assumptions remain unvalidated and therefore keep the result
   `UNPROVEN`;
-- proof that no value was selected from the target confirmation outcome.
+- proof that no value was selected from the target confirmation outcome;
+- the exact physical artifact/capture path to which those bounds apply.
 
 If a defensible bound cannot be supplied, the checkpoint remains ineligible; do
 not substitute a favorable number just to make the 5 cm / 1 s conditional checks
@@ -126,13 +164,13 @@ precondition.
 
 ## One future information checkpoint only
 
-Once runtime packaging, bound provenance and metric-reference publication are all
-reviewed and integrated, the next physical action should be one bounded props-off
-information checkpoint, not another S3 tuning loop. Its pre-registered procedure
-must retain enough prior stationary calibration (at least 30 s for the current
-calculations) and apply the same calculation path across stationary, terrain,
-true-vertical and mixed episodes, with both movement signs where the event kind
-has a sign.
+Once artifact/capture selection, runtime packaging, bound provenance and metric-
+reference publication are all reviewed and integrated, the next physical action
+should be one bounded props-off information checkpoint, not another S3 tuning
+loop. Its pre-registered procedure must retain enough prior stationary calibration
+(at least 30 s for the current calculations) and apply the same calculation path
+across stationary, terrain, true-vertical and mixed episodes, with both movement
+signs where the event kind has a sign.
 
 The raw capture must be published through the integrated generic evidence bridge
 and bound to the exact checkpoint/request and tested Git SHA. Derived reference


### PR DESCRIPTION
Refs #70.

## Scope

Documentation-only checkpoint-support correction after #339/#342 and the integrated X3 roadmap refresh.

- keeps exact #251 as the only currently established physical artifact, without claiming it must remain the future confirmation artifact under all bound models;
- records that #339 is a logging-only source/build diagnostic, not a silent replacement for #251 and not an enabled trusted checkpoint profile;
- makes the two future paths explicit: exact #251 is usable only if deterministic bounds cover its post-LPF acceleration/timing semantics; otherwise a separately identified instrumented artifact/capture/profile must be prepared from the integrated observer;
- records that the existing `run_x3_independent_capture.sh` bundle is #251-specific and does not implicitly capture `x3AccObs` / `x3BaroObs`;
- preserves the hard deterministic-bound, metric-reference/publication, one bounded props-off checkpoint and no-motorized-test boundaries.

No firmware binary, Runtime, estimator/controller, parameter, CI workflow, trusted checkpoint profile or physical authority changes. No `TEST_REQUIRED` follows.

Exact Draft candidate: `2c27ab196070996e39551f0a359d56721d6b970a`, based directly on `main@04fbd3156d58f080e11d44ec47f4133534827d4b`. This execution mutated the candidate and therefore cannot provide independent review.