### PR TITLE
Add read-only X3 STM32 OTP provenance probe

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/X3_PLATFORM_PROVENANCE.md
+++ b/experiments/crazyflie-ukf-surface-range/X3_PLATFORM_PROVENANCE.md
@@ -1,0 +1,55 @@
+# X3 STM32 OTP platform provenance probe
+
+This support slice narrows one provenance question discovered while reviewing the
+Crazyflie 2.1 BMI088 interrupt path for #70. It does **not** resolve that interrupt
+wiring contradiction and does not enable a checkpoint.
+
+The exact pinned Crazyflie firmware
+`54f31e243a0b28b67efef5ba20dbb6d9890a5478` reads its platform string from STM32
+OTP at `0x1fff7800`: 16 blocks of 32 bytes, selecting the first block whose first
+byte is non-zero. If there is no such block, or if that first non-zero byte is
+`0xff`, the firmware falls back to `0;CF20`. The X3 probe mirrors only that
+selection rule and retains the observed bytes.
+
+`probe_x3_platform_otp.py` uses pinned-cflib-compatible `LogConfig.add_memory()`
+raw-memory log variables. It deliberately limits each log-control configuration
+to at most five memory descriptors, takes three identical observations of every
+byte group, and fails closed if a group changes or is malformed. It then reads the
+selected 32-byte OTP block and accepts platform identity only when the observed
+STM32 OTP string explicitly reports device type `CF21`. An `R=` field is retained
+only when actually present in those observed bytes.
+
+The probe never flashes firmware, writes parameters, writes memory, resets the
+estimator or invokes a commander. It does send the ordinary CRTP log-control
+packets needed to read memory; normal cflib link close may still emit its documented
+safety-zero commander setpoint. The expected cflib source is
+`45fdb784c9d13074c42835f3b5ac1d12133bf873`, but the standalone script does not
+itself attest the complete installed Python runtime. A later trusted bundle must
+pin and verify that closure before relying on a physical observation.
+
+Most importantly, an observed `0;CF21` or even `0;CF21;R=B1` proves only the
+unit-reported STM32 OTP platform string. It does **not** prove BMI088 INT2/INT3 net
+continuity, rehabilitate `sensorData.interruptTimestamp` as gyro or accelerometer
+producer time, validate any frozen-predictor uncertainty bound, or establish a
+physical verdict. `electrical_interrupt_source` therefore remains `UNPROVEN`.
+
+Offline inspection and tests require no cflib, radio or hardware:
+
+```sh
+python3 experiments/crazyflie-ukf-surface-range/probe_x3_platform_otp.py --describe
+python3 experiments/crazyflie-ukf-surface-range/test_probe_x3_platform_otp.py
+```
+
+A future read-only observation, if separately justified, uses an explicit
+Crazyradio URI and a new output directory:
+
+```sh
+python3 experiments/crazyflie-ukf-surface-range/probe_x3_platform_otp.py \
+  --uri radio://0/80/2M --output ./x3-platform-otp
+```
+
+The command writes `probe-start.json` and `platform-otp.json`. Exit status 0 means
+only that the selected observed STM32 OTP string explicitly reported `CF21`; exit
+status 2 means the read completed but platform identity remained unproven. Neither
+status is `TEST_REQUIRED`, PASS/FAIL for #70, or permission for firmware changes or
+motorized action.

--- a/experiments/crazyflie-ukf-surface-range/probe_x3_platform_otp.py
+++ b/experiments/crazyflie-ukf-surface-range/probe_x3_platform_otp.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Read the Crazyflie STM32 OTP platform string without firmware or parameter writes.
+
+This is X3 provenance support only. It does not prove PCB net continuity, sensor
+interrupt provenance, sensor producer timing, or any physical result. The normal
+cflib link-close path may still emit its documented safety-zero commander setpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import threading
+import time
+from typing import Iterable, Sequence
+
+
+PINNED_CFLIB_COMMIT = "45fdb784c9d13074c42835f3b5ac1d12133bf873"
+PINNED_FIRMWARE_COMMIT = "54f31e243a0b28b67efef5ba20dbb6d9890a5478"
+OTP_BASE = 0x1FFF7800
+OTP_BLOCK_COUNT = 16
+OTP_BLOCK_LEN = 32
+MAX_MEMORY_VARIABLES_PER_LOG_CONFIG = 5
+LOG_PERIOD_MS = 10
+REPEATED_SAMPLES = 3
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def chunks(values: Sequence[int], size: int) -> Iterable[Sequence[int]]:
+    for start in range(0, len(values), size):
+        yield values[start:start + size]
+
+
+def otp_block_address(index: int) -> int:
+    if not 0 <= index < OTP_BLOCK_COUNT:
+        raise ValueError("OTP block index out of range")
+    return OTP_BASE + index * OTP_BLOCK_LEN
+
+
+def select_platform_block(start_bytes: bytes) -> tuple[int | None, str]:
+    if len(start_bytes) != OTP_BLOCK_COUNT:
+        raise ValueError("exactly 16 OTP block-start bytes are required")
+    for index, value in enumerate(start_bytes):
+        if value != 0:
+            if value == 0xFF:
+                return None, "firmware-fallback-first-nonzero-is-ff"
+            return index, "selected-first-nonzero-block"
+    return None, "firmware-fallback-no-nonzero-block"
+
+
+def parse_platform_block(block: bytes) -> dict[str, object]:
+    if len(block) != OTP_BLOCK_LEN:
+        raise ValueError("exactly one 32-byte OTP block is required")
+    raw_string = block.split(b"\0", 1)[0]
+    try:
+        platform_string = raw_string.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("selected OTP platform block is not ASCII") from exc
+
+    device_type = None
+    fields: list[str] = []
+    if platform_string.startswith("0;"):
+        fields = platform_string.split(";")
+        if len(fields) >= 2 and fields[1]:
+            device_type = fields[1]
+    revision = next((field[2:] for field in fields[2:] if field.startswith("R=") and len(field) > 2), None)
+    explicit_cf21 = device_type == "CF21"
+    return {
+        "platform_string": platform_string,
+        "device_type": device_type,
+        "revision_field": revision,
+        "identity_verdict": "EXPLICIT_CF21" if explicit_cf21 else "UNPROVEN",
+        "explicit_cf21": explicit_cf21,
+    }
+
+
+def _coerce_memory_sample(data: dict[str, object], names: Sequence[str]) -> tuple[int, ...]:
+    sample: list[int] = []
+    for name in names:
+        value = data.get(name)
+        if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 0xFF:
+            raise ValueError(f"malformed raw-memory byte for {name}")
+        sample.append(value)
+    return tuple(sample)
+
+
+def read_memory_group(cf: object, log_config_cls: object, *, name: str,
+                      addresses: Sequence[int], timeout_s: float = 2.0) -> bytes:
+    if not 1 <= len(addresses) <= MAX_MEMORY_VARIABLES_PER_LOG_CONFIG:
+        raise ValueError("raw-memory log group must contain 1..5 variables")
+    config = log_config_cls(name, LOG_PERIOD_MS)
+    variable_names = [f"mem_{address:08x}" for address in addresses]
+    for variable_name, address in zip(variable_names, addresses):
+        config.add_memory(variable_name, "uint8_t", "uint8_t", address)
+
+    samples: list[tuple[int, ...]] = []
+    errors: list[str] = []
+    done = threading.Event()
+
+    def received(_timestamp, data, _config):
+        if done.is_set():
+            return
+        try:
+            sample = _coerce_memory_sample(data, variable_names)
+        except ValueError as exc:
+            errors.append(str(exc))
+            done.set()
+            return
+        samples.append(sample)
+        if len(samples) >= REPEATED_SAMPLES:
+            done.set()
+
+    def failed(_config, message):
+        errors.append(f"log error: {message}")
+        done.set()
+
+    config.data_received_cb.add_callback(received)
+    config.error_cb.add_callback(failed)
+    cf.log.add_config(config)
+    started = False
+    try:
+        config.start()
+        started = True
+        if not done.wait(timeout_s):
+            raise RuntimeError("timed out waiting for repeated OTP observations")
+        if errors:
+            raise RuntimeError(errors[0])
+        if len(samples) < REPEATED_SAMPLES:
+            raise RuntimeError("insufficient repeated OTP observations")
+        if any(sample != samples[0] for sample in samples[1:]):
+            raise RuntimeError("OTP observations changed while being read")
+        return bytes(samples[0])
+    finally:
+        if started:
+            try:
+                config.stop()
+            except Exception as exc:
+                raise RuntimeError(f"OTP log stop failed: {exc}") from exc
+
+
+def read_memory(cf: object, log_config_cls: object, addresses: Sequence[int], *, prefix: str) -> bytes:
+    values = bytearray()
+    for index, group in enumerate(chunks(addresses, MAX_MEMORY_VARIABLES_PER_LOG_CONFIG)):
+        values.extend(read_memory_group(
+            cf, log_config_cls, name=f"{prefix}{index}", addresses=group,
+        ))
+    return bytes(values)
+
+
+def observe_otp(cf: object, log_config_cls: object) -> dict[str, object]:
+    start_addresses = [otp_block_address(index) for index in range(OTP_BLOCK_COUNT)]
+    starts = read_memory(cf, log_config_cls, start_addresses, prefix="X3OtpS")
+    selected_index, selection_reason = select_platform_block(starts)
+
+    result: dict[str, object] = {
+        "schema": "webeeblocks.x3.platform-otp-provenance.v1",
+        "pinned_firmware_commit": PINNED_FIRMWARE_COMMIT,
+        "pinned_cflib_commit_required": PINNED_CFLIB_COMMIT,
+        "otp_base": f"0x{OTP_BASE:08x}",
+        "otp_block_count": OTP_BLOCK_COUNT,
+        "otp_block_len": OTP_BLOCK_LEN,
+        "block_start_bytes_hex": starts.hex(),
+        "selection_reason": selection_reason,
+        "selected_block_index": selected_index,
+        "selected_block_address": None,
+        "selected_block_hex": None,
+        "platform_string": None,
+        "device_type": None,
+        "revision_field": None,
+        "identity_verdict": "UNPROVEN",
+        "electrical_interrupt_source": "UNPROVEN",
+        "physical_verdict": None,
+        "observation_boundary": (
+            "read-only STM32 OTP platform-string provenance only; does not prove PCB net continuity, "
+            "BMI088 interrupt source, sensor timing, or firmware installation identity"
+        ),
+    }
+    if selected_index is None:
+        return result
+
+    selected_address = otp_block_address(selected_index)
+    block_addresses = [selected_address + offset for offset in range(OTP_BLOCK_LEN)]
+    block = read_memory(cf, log_config_cls, block_addresses, prefix="X3OtpB")
+    parsed = parse_platform_block(block)
+    result.update(parsed)
+    result["selected_block_address"] = f"0x{selected_address:08x}"
+    result["selected_block_hex"] = block.hex()
+    return result
+
+
+def write_json_once(path: Path, value: object) -> None:
+    with path.open("x", encoding="utf-8") as stream:
+        json.dump(value, stream, indent=2, sort_keys=True, allow_nan=False)
+        stream.write("\n")
+
+
+def run_probe(uri: str, output: Path) -> int:
+    if not re.fullmatch(r"radio://[0-9]+/[0-9]+/(250K|1M|2M)(/[0-9A-Fa-f]+)?", uri):
+        raise ValueError("one explicit Crazyradio URI is required")
+
+    import cflib
+    import cflib.crtp
+    from cflib.crazyflie import Crazyflie
+    from cflib.crazyflie.log import LogConfig
+
+    output.mkdir(parents=True, exist_ok=False)
+    write_json_once(output / "probe-start.json", {
+        "schema": "webeeblocks.x3.platform-otp-probe-start.v1",
+        "uri": uri,
+        "pinned_firmware_commit": PINNED_FIRMWARE_COMMIT,
+        "pinned_cflib_commit_required": PINNED_CFLIB_COMMIT,
+        "probe_script_sha256": file_digest(Path(__file__)),
+        "cflib_module_sha256": file_digest(Path(cflib.__file__)),
+        "runtime_boundary": "module fingerprints are not a complete cflib source/runtime attestation",
+        "started_host_monotonic_s": time.monotonic(),
+        "physical_verdict": None,
+    })
+
+    cflib.crtp.init_drivers()
+    cf = Crazyflie(rw_cache=None)
+    connected = threading.Event()
+    failures: list[str] = []
+    cf.fully_connected.add_callback(lambda *_: connected.set())
+    cf.connection_failed.add_callback(lambda _, message: failures.append(f"connection failed: {message}"))
+    cf.connection_lost.add_callback(lambda *_: failures.append("Crazyradio connection lost"))
+    try:
+        cf.open_link(uri)
+        deadline = time.monotonic() + 30.0
+        while not connected.is_set():
+            if failures:
+                raise RuntimeError(failures[0])
+            if time.monotonic() >= deadline:
+                raise RuntimeError("connection/TOC download did not complete within 30 s")
+            time.sleep(0.02)
+        if failures:
+            raise RuntimeError(failures[0])
+        result = observe_otp(cf, LogConfig)
+        if failures:
+            raise RuntimeError(failures[0])
+        write_json_once(output / "platform-otp.json", result)
+        return 0 if result["identity_verdict"] == "EXPLICIT_CF21" else 2
+    finally:
+        cf.close_link()
+
+
+def describe() -> dict[str, object]:
+    return {
+        "schema": "webeeblocks.x3.platform-otp-probe-plan.v1",
+        "pinned_firmware_commit": PINNED_FIRMWARE_COMMIT,
+        "pinned_cflib_commit_required": PINNED_CFLIB_COMMIT,
+        "otp_base": f"0x{OTP_BASE:08x}",
+        "otp_blocks": OTP_BLOCK_COUNT,
+        "otp_block_len": OTP_BLOCK_LEN,
+        "max_memory_variables_per_log_config": MAX_MEMORY_VARIABLES_PER_LOG_CONFIG,
+        "repeated_samples_per_group": REPEATED_SAMPLES,
+        "writes": "none to firmware/parameters/memory; log-control packets only",
+        "identity_acceptance": "explicit selected STM32 OTP device type CF21 only",
+        "electrical_interrupt_source": "UNPROVEN",
+        "physical_verdict": None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--describe", action="store_true")
+    parser.add_argument("--uri")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.describe:
+        print(json.dumps(describe(), indent=2, sort_keys=True))
+        return 0
+    if not args.uri or args.output is None:
+        parser.error("probe requires --uri and a new --output directory")
+    try:
+        return run_probe(args.uri, args.output)
+    except (OSError, ValueError, RuntimeError, ImportError) as exc:
+        print(f"PROBE_ERROR: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/crazyflie-ukf-surface-range/run_x3_prelpf_build_oracle.sh
+++ b/experiments/crazyflie-ukf-surface-range/run_x3_prelpf_build_oracle.sh
@@ -8,6 +8,7 @@ EXPECTED_SENSOR_BLOB=b183285c999335ca258b5131b1a835473473c078
 S3_ORACLE="$ROOT/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh"
 OBSERVER="$ROOT/experiments/crazyflie-ukf-surface-range/apply_x3_prelpf_timing_observer.py"
 OBSERVER_TEST="$ROOT/experiments/crazyflie-ukf-surface-range/test_x3_prelpf_timing_observer.py"
+OTP_PROVENANCE_TEST="$ROOT/experiments/crazyflie-ukf-surface-range/test_probe_x3_platform_otp.py"
 
 test -d "$UPSTREAM/.git"
 test "$(git -C "$UPSTREAM" rev-parse HEAD)" = "$EXPECTED_COMMIT"
@@ -15,6 +16,7 @@ test "$(git -C "$UPSTREAM" hash-object src/hal/src/sensors_bmi088_bmp3xx.c)" = "
 test -z "$(git -C "$UPSTREAM" status --porcelain -- src/modules/src/estimator/estimator_ukf.c src/hal/src/sensors_bmi088_bmp3xx.c)"
 
 python3 "$OBSERVER_TEST"
+python3 "$OTP_PROVENANCE_TEST"
 
 # Reuse the exact canonical S3 configuration, but only inside this dedicated
 # diagnostic checkout. The trusted s3-props-off workflow/artifact path is never

--- a/experiments/crazyflie-ukf-surface-range/test_probe_x3_platform_otp.py
+++ b/experiments/crazyflie-ukf-surface-range/test_probe_x3_platform_otp.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the X3 STM32 OTP provenance probe."""
+
+from types import SimpleNamespace
+import unittest
+
+import probe_x3_platform_otp as probe
+
+
+class Event:
+    def __init__(self):
+        self.callbacks = []
+
+    def add_callback(self, callback):
+        self.callbacks.append(callback)
+
+    def emit(self, *args):
+        for callback in list(self.callbacks):
+            callback(*args)
+
+
+class FakeLogConfig:
+    memory = {}
+    mutate_address = None
+    instances = []
+
+    def __init__(self, name, period):
+        self.name = name
+        self.period = period
+        self.vars = []
+        self.data_received_cb = Event()
+        self.error_cb = Event()
+        self.stopped = False
+        type(self).instances.append(self)
+
+    def add_memory(self, name, fetch_as, stored_as, address):
+        self.vars.append((name, fetch_as, stored_as, address))
+
+    def start(self):
+        for sample_no in range(probe.REPEATED_SAMPLES):
+            data = {}
+            for name, fetch_as, stored_as, address in self.vars:
+                assert fetch_as == stored_as == "uint8_t"
+                value = type(self).memory[address]
+                if type(self).mutate_address == address and sample_no == probe.REPEATED_SAMPLES - 1:
+                    value ^= 1
+                data[name] = value
+            self.data_received_cb.emit(sample_no, data, self)
+
+    def stop(self):
+        self.stopped = True
+
+
+class OtpProbeTests(unittest.TestCase):
+    def setUp(self):
+        FakeLogConfig.memory = {}
+        FakeLogConfig.mutate_address = None
+        FakeLogConfig.instances = []
+        self.cf = SimpleNamespace(log=SimpleNamespace(add_config=lambda _: None))
+        for index in range(probe.OTP_BLOCK_COUNT):
+            base = probe.otp_block_address(index)
+            for offset in range(probe.OTP_BLOCK_LEN):
+                FakeLogConfig.memory[base + offset] = 0
+
+    def install_block(self, index, payload: bytes):
+        self.assertLessEqual(len(payload), probe.OTP_BLOCK_LEN)
+        base = probe.otp_block_address(index)
+        data = payload + bytes(probe.OTP_BLOCK_LEN - len(payload))
+        for offset, value in enumerate(data):
+            FakeLogConfig.memory[base + offset] = value
+
+    def test_exact_firmware_block_selection_and_fallback(self):
+        starts = bytes([0, 0, ord("0")] + [0] * 13)
+        self.assertEqual(probe.select_platform_block(starts), (2, "selected-first-nonzero-block"))
+        starts = bytes([0, 0xFF] + [0] * 14)
+        self.assertEqual(probe.select_platform_block(starts), (None, "firmware-fallback-first-nonzero-is-ff"))
+        self.assertEqual(probe.select_platform_block(bytes(16)), (None, "firmware-fallback-no-nonzero-block"))
+
+    def test_parse_accepts_only_explicit_cf21_and_retains_revision(self):
+        parsed = probe.parse_platform_block(b"0;CF21;R=B1\0" + bytes(20))
+        self.assertEqual(parsed["device_type"], "CF21")
+        self.assertEqual(parsed["revision_field"], "B1")
+        self.assertEqual(parsed["identity_verdict"], "EXPLICIT_CF21")
+        other = probe.parse_platform_block(b"0;CF20\0" + bytes(25))
+        self.assertEqual(other["identity_verdict"], "UNPROVEN")
+
+    def test_probe_reads_selected_cf21_block_in_bounded_groups(self):
+        self.install_block(3, b"0;CF21;R=B1\0")
+        result = probe.observe_otp(self.cf, FakeLogConfig)
+        self.assertEqual(result["selected_block_index"], 3)
+        self.assertEqual(result["platform_string"], "0;CF21;R=B1")
+        self.assertEqual(result["identity_verdict"], "EXPLICIT_CF21")
+        self.assertEqual(result["electrical_interrupt_source"], "UNPROVEN")
+        self.assertIsNone(result["physical_verdict"])
+        self.assertEqual(len(FakeLogConfig.instances), 11)  # 4 start groups + 7 block groups
+        self.assertTrue(all(1 <= len(config.vars) <= 5 for config in FakeLogConfig.instances))
+        self.assertTrue(all(config.period == probe.LOG_PERIOD_MS for config in FakeLogConfig.instances))
+        self.assertTrue(all(config.stopped for config in FakeLogConfig.instances))
+
+    def test_fallback_does_not_invent_cf20_or_revision(self):
+        FakeLogConfig.memory[probe.otp_block_address(1)] = 0xFF
+        result = probe.observe_otp(self.cf, FakeLogConfig)
+        self.assertIsNone(result["selected_block_index"])
+        self.assertIsNone(result["platform_string"])
+        self.assertEqual(result["identity_verdict"], "UNPROVEN")
+        self.assertEqual(len(FakeLogConfig.instances), 4)
+
+    def test_changed_repeated_memory_observation_fails_closed(self):
+        self.install_block(2, b"0;CF21\0")
+        FakeLogConfig.mutate_address = probe.otp_block_address(2)
+        with self.assertRaisesRegex(RuntimeError, "changed"):
+            probe.observe_otp(self.cf, FakeLogConfig)
+
+    def test_describe_preserves_scope_and_packet_limit(self):
+        description = probe.describe()
+        self.assertEqual(description["pinned_firmware_commit"], probe.PINNED_FIRMWARE_COMMIT)
+        self.assertEqual(description["pinned_cflib_commit_required"], probe.PINNED_CFLIB_COMMIT)
+        self.assertEqual(description["max_memory_variables_per_log_config"], 5)
+        self.assertEqual(description["electrical_interrupt_source"], "UNPROVEN")
+        self.assertIsNone(description["physical_verdict"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #70.

This bounded X3 support slice turns the source-only STM32 OTP provenance finding into deterministic, fail-closed acquisition support without changing firmware or enabling a physical checkpoint.

- reads the exact platform-string OTP layout used by pinned Crazyflie firmware `54f31e243a0b28b67efef5ba20dbb6d9890a5478` (`0x1fff7800`, 16 × 32-byte blocks);
- mirrors the firmware's first-nonzero-block / `0xff` fallback rule without manufacturing fallback identity;
- uses pinned-cflib-compatible `LogConfig.add_memory()` raw-memory observations in groups of at most five descriptors, with three identical observations required per group;
- retains the exact selected 32-byte block and accepts unit-reported platform identity only for an explicitly observed `CF21`; an `R=` field is retained only when actually present;
- keeps `electrical_interrupt_source: UNPROVEN` and `physical_verdict: null`: STM32 OTP identity does not prove BMI088 INT2/INT3 net continuity, sensor interrupt provenance, producer timing or any frozen-predictor bound;
- adds deterministic no-radio tests for selection/fallback, bounded packet grouping, repeated-observation coherence and fail-closed identity;
- runs those tests from the existing isolated X3 pre-LPF diagnostic oracle, without changing the canonical S3 firmware source/artifact identity.

The standalone physical probe is read-only with respect to firmware, parameters and memory; it sends only CRTP log-control traffic needed for raw-memory observation. Normal cflib link close retains its documented safety-zero setpoint boundary. Its standalone runtime fingerprints are explicitly not a complete cflib source/runtime attestation; any later trusted physical use must package and verify the pinned closure separately.

Exact candidate HEAD: `62defe6701ff5d8ccbed9080ebdae8bd1798147e`, based directly on current `main@4c835b3407e66fbbcf266ff07c64e3e653b24ff8`.

No bound is narrowed, no interrupt source is asserted, no checkpoint profile is enabled, and no `TEST_REQUIRED`, flash, parameter write, reset, commander action or motorized test follows. Fresh canonical Ready `CI Gate` and independent exact-head review are required before integration.