### PR TITLE
Serialize fresh physical observations with reset/effect exclusion

### DIFF
--- a/tools/ci/test_physical_execution_domain.py
+++ b/tools/ci/test_physical_execution_domain.py
@@ -41,6 +41,31 @@ def reset_ok(
     return marker
 
 
+def establish_flying(execution: domain.PhysicalExecutionDomain) -> None:
+    reset_ok(execution)
+    with execution.effect_transaction(lambda: None) as takeoff:
+        takeoff.mark_emitted()
+        permit = takeoff.mark_accepted()
+    execution.complete_accepted_effect(
+        permit,
+        domain.FLYING,
+        lambda: True,
+    )
+    require(execution.phase == domain.FLYING, "fixture established flying")
+
+
+def land_inactive(execution: domain.PhysicalExecutionDomain) -> None:
+    with execution.effect_transaction(lambda: None) as landing:
+        landing.mark_emitted()
+        permit = landing.mark_accepted()
+    execution.complete_accepted_effect(
+        permit,
+        domain.INACTIVE,
+        lambda: True,
+    )
+    require(execution.phase == domain.INACTIVE, "fixture restored inactive")
+
+
 def test_new_process_requires_reset_establishment() -> None:
     execution = domain.PhysicalExecutionDomain()
     require(
@@ -448,6 +473,135 @@ def test_independent_handles_share_process_wide_exclusion() -> None:
     )
 
 
+def test_observation_is_flying_only_phase_neutral_and_precondition_bound() -> None:
+    execution = domain.PhysicalExecutionDomain()
+    reset_ok(execution)
+    expect_error(
+        lambda: execution.observation_transaction(lambda: None).__enter__(),
+        "requires causally established flying",
+    )
+    require(
+        execution.phase == domain.INACTIVE,
+        "ineligible observation must not alter inactive phase",
+    )
+
+    with execution.effect_transaction(lambda: None) as takeoff:
+        takeoff.mark_emitted()
+        permit = takeoff.mark_accepted()
+    execution.complete_accepted_effect(permit, domain.FLYING, lambda: True)
+
+    calls: list[str] = []
+    try:
+        with execution.observation_transaction(
+            lambda: calls.append("first"),
+            lambda: (_ for _ in ()).throw(RuntimeError("stale epoch")),
+            lambda: calls.append("late"),
+        ):
+            raise AssertionError("failed observation precondition reached body")
+    except RuntimeError as exc:
+        require("stale epoch" in str(exc), "observation preserves precondition failure")
+    require(calls == ["first"], "observation stops at first failed precondition")
+    require(execution.phase == domain.FLYING, "failed observation remains phase-neutral")
+
+    calls.clear()
+    with execution.observation_transaction(
+        lambda: calls.append("epoch"),
+        lambda: calls.append("watchdog"),
+    ):
+        require(execution.phase == domain.FLYING, "observation body sees stable flying")
+        calls.append("read")
+        expect_error(
+            lambda: execution.effect_transaction(lambda: None).__enter__(),
+            "exclusion is already active",
+        )
+    require(
+        calls == ["epoch", "watchdog", "read"],
+        "observation preconditions and read preserve exact order",
+    )
+    require(execution.phase == domain.FLYING, "successful observation remains phase-neutral")
+    land_inactive(execution)
+
+
+def test_observation_blocks_independent_effect_and_reset_sections() -> None:
+    observation_execution = domain.PhysicalExecutionDomain()
+    effect_execution = domain.PhysicalExecutionDomain()
+    reset_execution = domain.PhysicalExecutionDomain()
+    establish_flying(observation_execution)
+
+    observation_entered = Event()
+    release_observation = Event()
+    effect_entered = Event()
+    reset_callback_entered = Event()
+    failures: list[BaseException] = []
+
+    def held_observation():
+        try:
+            with observation_execution.observation_transaction(lambda: None):
+                observation_entered.set()
+                require(
+                    release_observation.wait(1.0),
+                    "test observation release signal",
+                )
+        except BaseException as exc:
+            failures.append(exc)
+
+    def effect_attempt():
+        try:
+            with effect_execution.effect_transaction(lambda: None):
+                effect_entered.set()
+        except BaseException as exc:
+            failures.append(exc)
+
+    def reset_attempt():
+        try:
+            reset_execution.run_reset_establishment(
+                lambda: (reset_callback_entered.set(), object())[1]
+            )
+        except domain.PhysicalExecutionDomainError as exc:
+            require("blocked" in str(exc), "post-observation flying reset fails by phase")
+        except BaseException as exc:
+            failures.append(exc)
+
+    observation_thread = Thread(target=held_observation)
+    observation_thread.start()
+    require(observation_entered.wait(1.0), "observation owns process-wide exclusion")
+
+    effect_thread = Thread(target=effect_attempt)
+    reset_thread = Thread(target=reset_attempt)
+    effect_thread.start()
+    reset_thread.start()
+    require(
+        not effect_entered.wait(0.05),
+        "independent effect cannot enter while observation owns exclusion",
+    )
+    require(
+        not reset_callback_entered.wait(0.05),
+        "independent reset callback cannot enter while observation owns exclusion",
+    )
+
+    release_observation.set()
+    observation_thread.join(1.0)
+    effect_thread.join(1.0)
+    reset_thread.join(1.0)
+    require(
+        not observation_thread.is_alive()
+        and not effect_thread.is_alive()
+        and not reset_thread.is_alive(),
+        "observation/execution concurrency fixture completed",
+    )
+    require(not failures, f"observation exclusion fixture failed: {failures!r}")
+    require(effect_entered.is_set(), "effect may enter after observation releases exclusion")
+    require(
+        not reset_callback_entered.is_set(),
+        "flying-state reset remains ineligible after observation",
+    )
+    require(
+        observation_execution.phase == domain.FLYING,
+        "observation plus unemitted effect preserve established flying",
+    )
+    land_inactive(observation_execution)
+
+
 def test_no_physical_effect_or_browser_surface() -> None:
     source = MODULE_PATH.read_text(encoding="utf-8")
     for forbidden in (
@@ -479,10 +633,12 @@ def main() -> int:
     test_completion_uncertainty_forces_recovery()
     test_reset_and_effect_boundary_are_mutually_exclusive()
     test_independent_handles_share_process_wide_exclusion()
+    test_observation_is_flying_only_phase_neutral_and_precondition_bound()
+    test_observation_blocks_independent_effect_and_reset_sections()
     test_no_physical_effect_or_browser_surface()
     print(
-        "PASS trusted physical reset/effect exclusion is process-local, fail-closed "
-        "and emits no physical effect"
+        "PASS trusted physical reset/effect/observation exclusion is process-local, "
+        "fail-closed, phase-neutral for fresh observations and emits no physical effect"
     )
     return 0
 

--- a/tools/physical/physical_execution_domain.py
+++ b/tools/physical/physical_execution_domain.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Process-local reset/effect exclusion for the trusted Crazyflie host path.
+"""Process-local reset/effect/observation exclusion for the trusted Crazyflie host path.
 
 This module is deliberately a no-effect prerequisite. It owns one
 process-wide lifecycle, shared by every `PhysicalExecutionDomain` handle, needed
 to compose the already established physical safety primitives without allowing
-reset and flight-capable command emission to race through independently
-constructed handles.
+reset, fresh physical observation and flight-capable command emission to race
+through independently constructed handles.
 
 A fresh process starts in ``recovery-required``. It may not emit a physical
 effect until the caller has completed the trusted #266 reset-establishment
 transaction under :meth:`run_reset_establishment`. That transaction's own
 fresh flight-inactive gate therefore executes while this domain holds the same
-exclusion used by every later effect boundary.
+exclusion used by every later effect or observation boundary.
 
 An effect transaction holds that exclusion across all supplied immediate
 preconditions and the caller's emission/acknowledgement boundary. Once emission
@@ -21,6 +21,13 @@ stable phase. A positive acknowledgement moves to ``awaiting-completion`` and mi
 opaque one-shot completion permit. No reset or later effect is eligible until
 the trusted consumer presents that exact permit together with a fresh completion
 proof establishing either ``flying`` or ``inactive``.
+
+A physical observation transaction is deliberately different: it is eligible
+only from causally established ``flying``, shares the exact same process-wide
+exclusion, runs its immediate trusted preconditions under that exclusion and
+never changes lifecycle phase or mints effect/completion authority. It exists so
+a fresh sensor read cannot race reset/effect transitions without being falsely
+classified as a physical effect.
 
 The module imports no cflib/CRTP command API and emits no packet. The later
 trusted transport must compose exact preflight, #267 teacher binding, #266/#262
@@ -155,6 +162,54 @@ class PhysicalExecutionDomain:
             return result
         finally:
             self._leave_section("reset")
+
+    def observation_transaction(
+        self,
+        *immediate_preconditions: Callable[[], object],
+    ) -> "PhysicalObservationTransaction":
+        """Create one exclusion-held, phase-neutral trusted sensor observation.
+
+        Observation preconditions are assertion-style trusted-host callables and
+        run only after the same process-wide exclusion used by reset/effects is
+        held. The observation itself is eligible only while the established run
+        is ``flying``. It has no emission/acknowledgement/completion lifecycle and
+        therefore cannot mint or substitute physical execution authority.
+        """
+        checks = tuple(
+            _require_callable(check, "physical observation precondition")
+            for check in immediate_preconditions
+        )
+        if not checks:
+            raise PhysicalExecutionDomainError(
+                "at least one immediate physical observation precondition is required"
+            )
+        return PhysicalObservationTransaction(self, checks)
+
+    def _begin_observation(
+        self,
+        checks: tuple[Callable[[], object], ...],
+    ) -> None:
+        self._enter_section("observation")
+        try:
+            if _PROCESS_STATE.phase != FLYING:
+                raise PhysicalExecutionDomainError(
+                    "physical observation requires causally established flying state"
+                )
+            for check in checks:
+                check()
+        except Exception:
+            self._leave_section("observation")
+            raise
+
+    def _close_observation(self) -> None:
+        if _PROCESS_STATE.phase != FLYING:
+            try:
+                raise PhysicalExecutionDomainError(
+                    "physical execution phase changed during observation"
+                )
+            finally:
+                self._leave_section("observation")
+        self._leave_section("observation")
 
     def effect_transaction(
         self,
@@ -302,6 +357,42 @@ class PhysicalExecutionDomain:
             _PROCESS_STATE.phase = next_phase
         finally:
             self._leave_section("completion")
+
+
+class PhysicalObservationTransaction:
+    """One process-wide exclusion-held physical observation with no effect state."""
+
+    def __init__(
+        self,
+        domain: PhysicalExecutionDomain,
+        checks: tuple[Callable[[], object], ...],
+    ) -> None:
+        self._domain = domain
+        self._checks = checks
+        self._entered = False
+        self._closed = False
+
+    def __enter__(self) -> "PhysicalObservationTransaction":
+        if self._entered or self._closed:
+            raise PhysicalExecutionDomainError(
+                "physical observation transaction cannot be re-entered"
+            )
+        self._domain._begin_observation(self._checks)
+        self._entered = True
+        return self
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if not self._entered:
+            self._closed = True
+            return
+        self._domain._close_observation()
+        self._closed = True
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        self.close()
+        return False
 
 
 class PhysicalEffectTransaction:


### PR DESCRIPTION
Refs #345 #157.

This bounded infrastructure slice prepares trusted-host physical sensor consumption without exposing sensor values or student/browser execution authority.

Complete scope of this candidate:
- adds a phase-neutral `PhysicalExecutionDomain.observation_transaction(...)` that shares the existing single process-wide exclusion used by reset, physical effects and accepted-effect completion;
- admits observation only from causally established `FLYING` state;
- runs immediate trusted observation preconditions only after that exclusion is held;
- observation success or pre-effect/pre-read failure preserves the established flying lifecycle state and mints no effect/completion permit;
- reset/effect transitions from independent execution-domain handles cannot enter while an observation owns the process-wide exclusion;
- observation exposes no `mark_emitted`, acknowledgement, command, CRTP, cflib, browser or generic sensor-variable authority surface;
- deterministic execution-domain regressions cover inactive rejection, precondition failure, phase neutrality and independent reset/effect exclusion.

This does **not** expose physical `range(direction)` to the shared interpreter and does not complete #345. Later trusted-host work must compose the already integrated fresh Multi-ranger observer with exact host-owned expression/control-flow execution and downstream effect selection while the ordinary caller remains parameter-free.

No real-device qualification, flight, checkpoint or `TEST_REQUIRED` is claimed. Exact candidate HEAD must receive canonical Ready `CI Gate` and an independent exact-head review before integration.