### PR TITLE
Add X3 accelerometer DRDY provenance observer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             while IFS= read -r path; do
               case "$path" in
-                experiments/crazyflie-ukf-surface-range/X3_PRELPF_TIMING_OBSERVER.md|experiments/crazyflie-ukf-surface-range/apply_x3_prelpf_timing_observer.py|experiments/crazyflie-ukf-surface-range/run_x3_prelpf_build_oracle.sh|experiments/crazyflie-ukf-surface-range/test_x3_prelpf_timing_observer.py|experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh|experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3.py|experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_veto_discriminator.py|experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_timing_observer.py|.github/workflows/ci.yml)
+                experiments/crazyflie-ukf-surface-range/X3_PRELPF_TIMING_OBSERVER.md|experiments/crazyflie-ukf-surface-range/X3_ACCEL_DRDY_OBSERVER.md|experiments/crazyflie-ukf-surface-range/apply_x3_prelpf_timing_observer.py|experiments/crazyflie-ukf-surface-range/apply_x3_accel_drdy_observer.py|experiments/crazyflie-ukf-surface-range/run_x3_prelpf_build_oracle.sh|experiments/crazyflie-ukf-surface-range/test_x3_prelpf_timing_observer.py|experiments/crazyflie-ukf-surface-range/test_x3_accel_drdy_observer.py|experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh|experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3.py|experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_veto_discriminator.py|experiments/crazyflie-ukf-surface-range/apply_surface_offset_s3_timing_observer.py|.github/workflows/ci.yml)
                   run=true
                   break
                   ;;
@@ -93,6 +93,9 @@ jobs:
           git -C .x3-crazyflie-firmware rev-parse HEAD > ci-artifacts/x3-prelpf-observer/upstream-sha.txt
           git -C .x3-crazyflie-firmware diff -- src/modules/src/estimator/estimator_ukf.c > ci-artifacts/x3-prelpf-observer/estimator_ukf.patch || true
           git -C .x3-crazyflie-firmware diff -- src/hal/src/sensors_bmi088_bmp3xx.c > ci-artifacts/x3-prelpf-observer/sensors_bmi088_bmp3xx.patch || true
+          if [ -f .x3-crazyflie-firmware/build/.config ]; then
+            cp .x3-crazyflie-firmware/build/.config ci-artifacts/x3-prelpf-observer/diagnostic.config
+          fi
           if [ -f .x3-crazyflie-firmware/build/cf2.elf ]; then
             sha256sum .x3-crazyflie-firmware/build/cf2.elf > ci-artifacts/x3-prelpf-observer/cf2.elf.sha256
           fi

--- a/experiments/crazyflie-ukf-surface-range/X3_ACCEL_DRDY_OBSERVER.md
+++ b/experiments/crazyflie-ukf-surface-range/X3_ACCEL_DRDY_OBSERVER.md
@@ -1,0 +1,88 @@
+# X3 BMI088 accelerometer data-ready provenance observer
+
+This diagnostic-only X3 overlay narrows one timing/provenance question from #70.
+It does **not** change the estimator/controller/Flow/S3 equations, does not enable
+a physical checkpoint, and does not turn an MCU interrupt timestamp into sensor
+producer time.
+
+## Exact source and purpose
+
+The overlay targets Crazyflie firmware
+`2026.08@54f31e243a0b28b67efef5ba20dbb6d9890a5478` after
+`apply_x3_prelpf_timing_observer.py` has been applied.
+
+The pinned operational BMI088 path configures gyro data-ready on BMI088 INT3 but
+waits on STM32 PC14/EXTI14. Published Crazyflie 2.1 Rev.B hardware documentation
+instead labels PC14/`INT_GYR` on BMI088 pin 1 (INT2, an accelerometer interrupt
+pin) and leaves the BMI088 gyro INT3 pin unconnected. Consequently the electrical
+source of the operational `sensorData.interruptTimestamp` remains `UNPROVEN`.
+
+This overlay therefore creates a **separate observation path** whose source is
+explicit in both firmware configuration and the published schematic:
+
+- configure BMI088 accelerometer data-ready on **INT1**;
+- observe the published INT1 → STM32 **PC13 / EXTI13** route;
+- increment only a diagnostic sequence and timestamp in the EXTI13 ISR;
+- do **not** notify, wake, yield to, or otherwise retime the existing sensor task;
+- retain the operational PC14 path unchanged.
+
+The isolated diagnostic build is deliberately CF21/BMI088-only. It disables the
+legacy `CONFIG_SENSORS_MPU9250_LPS25H` implementation because that implementation
+owns a strong `EXTI13_Callback` for Crazyflie 2.0. This avoids silently replacing
+or multiplexing a legacy production interrupt path merely to obtain diagnostic
+evidence. The canonical S3 build/artifact remains unchanged.
+
+## Observed fields
+
+The existing `x3AccObs` group still contains the aligned/gravity-corrected
+pre-30-Hz-LPF acceleration, firmware sequence, and CPU register-read window.
+
+The new `x3AccDrdy` group contains five `uint32_t` fields (20-byte payload):
+
+- `accSeq`: the matching `x3AccObs.seq`;
+- `irqBeg`: latest accelerometer-DRDY interrupt sequence observed immediately
+  before the accelerometer register read;
+- `irqUsBeg`: low 32 bits of its MCU `usecTimestamp()`;
+- `irqEnd`: interrupt sequence observed immediately after that register read;
+- `irqUsEnd`: low 32 bits of its MCU timestamp.
+
+Each group is packet-latched through `LOG_ADD_BY_FUNCTION`; `accSeq` is the
+cross-group join key. A row with `irqBeg != irqEnd` is timing-ambiguous because a
+new accelerometer DRDY arrived during the CPU read and must not be promoted into
+a producer-timing calibration point. Equality means only that no observed PC13
+DRDY edge arrived during that CPU read. It does **not** prove the BMI088 internal
+filter/sample production instant, interrupt latency, or a deterministic
+`sensor_time_error_s`.
+
+The extra EXTI13 ISR itself adds CPU load and can perturb timing. Any later
+physical use must retain that instrumentation effect in its uncertainty model.
+
+## Deterministic build oracle
+
+`run_x3_prelpf_build_oracle.sh`:
+
+1. verifies the exact pinned upstream commit/source;
+2. runs the existing pre-LPF observer contract tests and the new DRDY tests;
+3. builds the unchanged canonical S3 artifact first and records its binary hash;
+4. applies the pre-LPF observer, then this DRDY overlay;
+5. switches only the isolated diagnostic build to CF21/BMI088-only sensor
+   support (`CONFIG_SENSORS_BMI088_BMP3XX=y`,
+   `CONFIG_SENSORS_MPU9250_LPS25H=n`);
+6. rebuilds and checks the PC13 observer/log symbols and configuration;
+7. requires the diagnostic binary hash to differ from the canonical S3 binary.
+
+CI retains source patches, the final diagnostic `.config`, hashes and build log.
+The flashable binary is not a checkpoint artifact.
+
+## Boundary
+
+A future physical observation in which `irqBeg/irqEnd` advance coherently would
+establish that the **instrumented unit** produced observable PC13 edges after the
+firmware explicitly mapped BMI088 accelerometer DRDY to INT1. It would not
+rehabilitate the operational PC14 timestamp, prove board net continuity outside
+that observed path, remove BMI088 internal filter/group-delay uncertainty, or
+validate any frozen-predictor bound.
+
+No `TEST_REQUIRED`, flash, reset, parameter write, commander action, motorized
+test, threshold tuning, or world-altitude capability claim follows from this
+support slice alone.

--- a/experiments/crazyflie-ukf-surface-range/apply_x3_accel_drdy_observer.py
+++ b/experiments/crazyflie-ukf-surface-range/apply_x3_accel_drdy_observer.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Add a diagnostic-only BMI088 accelerometer-DRDY observer to the X3 overlay.
+
+This overlay is applied only after ``apply_x3_prelpf_timing_observer.py`` on the
+exact pinned Crazyflie 2026.08 source. It configures BMI088 accelerometer INT1,
+observes its published CF2.1 PC13 path through EXTI13, and records the latest
+interrupt sequence/timestamp immediately before and after each accelerometer
+register read.
+
+The observer never wakes or retimes the existing sensor task. Its interrupt
+timestamps are MCU data-ready observations only: they do not prove BMI088
+internal sample/filter producer time or validate a predictor timing bound.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+
+EXPECTED_COMMIT = "54f31e243a0b28b67efef5ba20dbb6d9890a5478"
+TARGET = Path("src/hal/src/sensors_bmi088_bmp3xx.c")
+
+STATE_OLD = """static uint32_t x3AccObserverLatchTimestamp = 0xffffffffU;
+static uint32_t x3BaroObserverLatchTimestamp = 0xffffffffU;
+
+static void x3LatchAccObserver(uint32_t timestamp)
+"""
+
+STATE_NEW = """static uint32_t x3AccObserverLatchTimestamp = 0xffffffffU;
+static uint32_t x3BaroObserverLatchTimestamp = 0xffffffffU;
+
+// X3 accelerometer data-ready provenance observer. This is intentionally
+// independent from the existing PC14 sensor-task wake path.
+typedef struct
+{
+  uint32_t accSequence;
+  uint32_t drdySequenceBefore;
+  uint32_t drdyTimestampBeforeUsLow;
+  uint32_t drdySequenceAfter;
+  uint32_t drdyTimestampAfterUsLow;
+} x3AccDrdyObserverSnapshot_t;
+
+static volatile uint32_t x3AccelDrdySequence = 0;
+static volatile uint32_t x3AccelDrdyTimestampUsLow = 0;
+static x3AccDrdyObserverSnapshot_t x3AccDrdyObserverSnapshot;
+static x3AccDrdyObserverSnapshot_t x3AccDrdyObserverLatch;
+static uint32_t x3AccDrdyObserverLatchTimestamp = 0xffffffffU;
+
+static void x3LatchAccDrdyObserver(uint32_t timestamp)
+{
+  if (timestamp != x3AccDrdyObserverLatchTimestamp)
+  {
+    taskENTER_CRITICAL();
+    x3AccDrdyObserverLatch = x3AccDrdyObserverSnapshot;
+    taskEXIT_CRITICAL();
+    x3AccDrdyObserverLatchTimestamp = timestamp;
+  }
+}
+
+static uint32_t x3LogAccDrdyAccSequence(uint32_t timestamp, void* data)
+{
+  (void)data;
+  x3LatchAccDrdyObserver(timestamp);
+  return x3AccDrdyObserverLatch.accSequence;
+}
+
+static uint32_t x3LogAccDrdySequenceBefore(uint32_t timestamp, void* data)
+{
+  (void)data;
+  x3LatchAccDrdyObserver(timestamp);
+  return x3AccDrdyObserverLatch.drdySequenceBefore;
+}
+
+static uint32_t x3LogAccDrdyTimestampBefore(uint32_t timestamp, void* data)
+{
+  (void)data;
+  x3LatchAccDrdyObserver(timestamp);
+  return x3AccDrdyObserverLatch.drdyTimestampBeforeUsLow;
+}
+
+static uint32_t x3LogAccDrdySequenceAfter(uint32_t timestamp, void* data)
+{
+  (void)data;
+  x3LatchAccDrdyObserver(timestamp);
+  return x3AccDrdyObserverLatch.drdySequenceAfter;
+}
+
+static uint32_t x3LogAccDrdyTimestampAfter(uint32_t timestamp, void* data)
+{
+  (void)data;
+  x3LatchAccDrdyObserver(timestamp);
+  return x3AccDrdyObserverLatch.drdyTimestampAfterUsLow;
+}
+
+static logByFunction_t x3AccDrdyLogAccSequence = {.acquireUInt32 = x3LogAccDrdyAccSequence, .data = NULL};
+static logByFunction_t x3AccDrdyLogSequenceBefore = {.acquireUInt32 = x3LogAccDrdySequenceBefore, .data = NULL};
+static logByFunction_t x3AccDrdyLogTimestampBefore = {.acquireUInt32 = x3LogAccDrdyTimestampBefore, .data = NULL};
+static logByFunction_t x3AccDrdyLogSequenceAfter = {.acquireUInt32 = x3LogAccDrdySequenceAfter, .data = NULL};
+static logByFunction_t x3AccDrdyLogTimestampAfter = {.acquireUInt32 = x3LogAccDrdyTimestampAfter, .data = NULL};
+
+static void x3LatchAccObserver(uint32_t timestamp)
+"""
+
+READ_OLD = """      /* get data from chosen sensors */
+      sensorsGyroGet(&gyroRaw);
+      const uint64_t x3AccReadStartUs = usecTimestamp();
+      sensorsAccelGet(&accelRaw);
+      const uint64_t x3AccReadEndUs = usecTimestamp();
+
+      /* calibrate if necessary */
+"""
+
+READ_NEW = """      /* get data from chosen sensors */
+      sensorsGyroGet(&gyroRaw);
+
+      uint32_t x3AccDrdySequenceBefore;
+      uint32_t x3AccDrdyTimestampBeforeUsLow;
+      taskENTER_CRITICAL();
+      x3AccDrdySequenceBefore = x3AccelDrdySequence;
+      x3AccDrdyTimestampBeforeUsLow = x3AccelDrdyTimestampUsLow;
+      taskEXIT_CRITICAL();
+
+      const uint64_t x3AccReadStartUs = usecTimestamp();
+      sensorsAccelGet(&accelRaw);
+      const uint64_t x3AccReadEndUs = usecTimestamp();
+
+      uint32_t x3AccDrdySequenceAfter;
+      uint32_t x3AccDrdyTimestampAfterUsLow;
+      taskENTER_CRITICAL();
+      x3AccDrdySequenceAfter = x3AccelDrdySequence;
+      x3AccDrdyTimestampAfterUsLow = x3AccelDrdyTimestampUsLow;
+      taskEXIT_CRITICAL();
+
+      /* calibrate if necessary */
+"""
+
+SNAPSHOT_OLD = """      x3AccObserverSnapshot.accPreLpf = sensorData.acc;
+      x3AccObserverSnapshot.sequence++;
+      x3AccObserverSnapshot.readStartUsLow = (uint32_t)x3AccReadStartUs;
+      x3AccObserverSnapshot.readEndUsLow = (uint32_t)x3AccReadEndUs;
+      taskEXIT_CRITICAL();
+"""
+
+SNAPSHOT_NEW = """      x3AccObserverSnapshot.accPreLpf = sensorData.acc;
+      x3AccObserverSnapshot.sequence++;
+      x3AccObserverSnapshot.readStartUsLow = (uint32_t)x3AccReadStartUs;
+      x3AccObserverSnapshot.readEndUsLow = (uint32_t)x3AccReadEndUs;
+
+      x3AccDrdyObserverSnapshot.accSequence = x3AccObserverSnapshot.sequence;
+      x3AccDrdyObserverSnapshot.drdySequenceBefore = x3AccDrdySequenceBefore;
+      x3AccDrdyObserverSnapshot.drdyTimestampBeforeUsLow = x3AccDrdyTimestampBeforeUsLow;
+      x3AccDrdyObserverSnapshot.drdySequenceAfter = x3AccDrdySequenceAfter;
+      x3AccDrdyObserverSnapshot.drdyTimestampAfterUsLow = x3AccDrdyTimestampAfterUsLow;
+      taskEXIT_CRITICAL();
+"""
+
+ACCEL_CONFIG_OLD = """    bmi088Dev.accel_cfg.odr = BMI088_ACCEL_ODR_1600_HZ;
+    rslt |= bmi088_set_accel_meas_conf(&bmi088Dev);
+
+    struct bmi088_sensor_data acc;
+"""
+
+ACCEL_CONFIG_NEW = """    bmi088Dev.accel_cfg.odr = BMI088_ACCEL_ODR_1600_HZ;
+    rslt |= bmi088_set_accel_meas_conf(&bmi088Dev);
+
+    // Diagnostic-only producer-availability observation: explicitly map accel
+    // data-ready to BMI088 INT1. Published CF2.1 Rev.B routes INT1 to MCU PC13.
+    struct bmi088_int_cfg x3AccelIntConfig = {0};
+    x3AccelIntConfig.accel_int_channel = BMI088_INT_CHANNEL_1;
+    x3AccelIntConfig.accel_int_type = BMI088_ACCEL_DATA_RDY_INT;
+    x3AccelIntConfig.accel_int_pin_cfg.enable_int_pin = 1;
+    x3AccelIntConfig.accel_int_pin_cfg.lvl = 1;
+    x3AccelIntConfig.accel_int_pin_cfg.output_mode = 0;
+    rslt |= bmi088_set_accel_int_config(&x3AccelIntConfig, &bmi088Dev);
+
+    struct bmi088_sensor_data acc;
+"""
+
+INTERRUPT_OLD = """  // Enable the interrupt on PC14
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_14;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL; //GPIO_PuPd_DOWN;
+  GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+  SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource14);
+
+  EXTI_InitStructure.EXTI_Line = EXTI_Line14;
+  EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
+  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+  EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+  portDISABLE_INTERRUPTS();
+  EXTI_Init(&EXTI_InitStructure);
+  EXTI_ClearITPendingBit(EXTI_Line14);
+  portENABLE_INTERRUPTS();
+"""
+
+INTERRUPT_NEW = """  // Diagnostic-only accelerometer DRDY observer on published CF2.1 INT1/PC13.
+  // It does not wake the sensor task; PC14 below remains the operational path.
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+  GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+  SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource13);
+
+  EXTI_InitStructure.EXTI_Line = EXTI_Line13;
+  EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
+  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+  EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+  portDISABLE_INTERRUPTS();
+  EXTI_Init(&EXTI_InitStructure);
+  EXTI_ClearITPendingBit(EXTI_Line13);
+  portENABLE_INTERRUPTS();
+
+  // Existing operational interrupt path on PC14 remains unchanged.
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_14;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL; //GPIO_PuPd_DOWN;
+  GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+  SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource14);
+
+  EXTI_InitStructure.EXTI_Line = EXTI_Line14;
+  EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
+  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+  EXTI_InitStructure.EXTI_LineCmd = ENABLE;
+  portDISABLE_INTERRUPTS();
+  EXTI_Init(&EXTI_InitStructure);
+  EXTI_ClearITPendingBit(EXTI_Line14);
+  portENABLE_INTERRUPTS();
+"""
+
+CALLBACK_OLD = """static void applyAxis3fLpf(lpf2pData *data, Axis3f* in)
+{
+  for (uint8_t i = 0; i < 3; i++) {
+    in->axis[i] = lpf2pApply(&data[i], in->axis[i]);
+  }
+}
+
+void sensorsBmi088Bmp3xxDataAvailableCallback(void)
+{
+"""
+
+CALLBACK_NEW = """static void applyAxis3fLpf(lpf2pData *data, Axis3f* in)
+{
+  for (uint8_t i = 0; i < 3; i++) {
+    in->axis[i] = lpf2pApply(&data[i], in->axis[i]);
+  }
+}
+
+void __attribute__((used)) EXTI13_Callback(void)
+{
+  // Observation only: do not notify/yield or otherwise retime the sensor task.
+  x3AccelDrdyTimestampUsLow = (uint32_t)usecTimestamp();
+  x3AccelDrdySequence++;
+}
+
+void sensorsBmi088Bmp3xxDataAvailableCallback(void)
+{
+"""
+
+LOG_OLD = """LOG_GROUP_STOP(x3AccObs)
+
+LOG_GROUP_START(x3BaroObs)
+"""
+
+LOG_NEW = """LOG_GROUP_STOP(x3AccObs)
+
+LOG_GROUP_START(x3AccDrdy)
+LOG_ADD_BY_FUNCTION(LOG_UINT32, accSeq, &x3AccDrdyLogAccSequence)
+LOG_ADD_BY_FUNCTION(LOG_UINT32, irqBeg, &x3AccDrdyLogSequenceBefore)
+LOG_ADD_BY_FUNCTION(LOG_UINT32, irqUsBeg, &x3AccDrdyLogTimestampBefore)
+LOG_ADD_BY_FUNCTION(LOG_UINT32, irqEnd, &x3AccDrdyLogSequenceAfter)
+LOG_ADD_BY_FUNCTION(LOG_UINT32, irqUsEnd, &x3AccDrdyLogTimestampAfter)
+LOG_GROUP_STOP(x3AccDrdy)
+
+LOG_GROUP_START(x3BaroObs)
+"""
+
+MARKERS = (
+    ("observer state/functions", STATE_OLD, STATE_NEW, 1),
+    ("accelerometer read bracketing", READ_OLD, READ_NEW, 1),
+    ("DRDY snapshot publication", SNAPSHOT_OLD, SNAPSHOT_NEW, 1),
+    ("BMI088 accelerometer INT1 configuration", ACCEL_CONFIG_OLD, ACCEL_CONFIG_NEW, 1),
+    ("PC13 EXTI observer configuration", INTERRUPT_OLD, INTERRUPT_NEW, 1),
+    ("PC13 observer ISR", CALLBACK_OLD, CALLBACK_NEW, 1),
+    ("DRDY log group", LOG_OLD, LOG_NEW, 1),
+)
+
+
+def git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def marker_state(text: str) -> str:
+    states: list[str] = []
+    for label, old, new, count in MARKERS:
+        old_count = text.count(old)
+        new_count = text.count(new)
+        if old_count == count and new_count == 0:
+            states.append("old")
+        elif old_count == 0 and new_count == count:
+            states.append("new")
+        else:
+            raise SystemExit(
+                f"{label}: expected old={count}/new=0 or old=0/new={count}, "
+                f"found old={old_count}, new={new_count}; no file written"
+            )
+    if all(state == "old" for state in states):
+        return "applicable"
+    if all(state == "new" for state in states):
+        return "applied"
+    raise SystemExit("partial X3 accelerometer-DRDY observer detected; no file written")
+
+
+def require_exact_context(text: str) -> str:
+    if git("rev-parse", "HEAD") != EXPECTED_COMMIT:
+        raise SystemExit("wrong upstream commit; no file written")
+    if "LOG_GROUP_START(x3AccObs)" not in text:
+        raise SystemExit("pre-LPF X3 observer must be applied first; no file written")
+    if "BMI088_GYRO_DATA_RDY_INT" not in text:
+        raise SystemExit("expected operational gyro DRDY configuration missing; no file written")
+    if "EXTI_PinSource14" not in text:
+        raise SystemExit("expected operational PC14 path missing; no file written")
+    return marker_state(text)
+
+
+def transform(text: str) -> str:
+    state = require_exact_context(text)
+    if state == "applied":
+        return text
+    for _label, old, new, count in MARKERS:
+        text = text.replace(old, new, count)
+    if require_exact_context(text) != "applied":
+        raise SystemExit("X3 accelerometer-DRDY observer failed postcondition; no file written")
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify exact 2026.08 post-pre-LPF source and DRDY observer applicability",
+    )
+    args = parser.parse_args()
+
+    if not TARGET.is_file():
+        raise SystemExit(f"missing target: {TARGET}")
+    original = TARGET.read_text(encoding="utf-8")
+    state = require_exact_context(original)
+    transformed = transform(original)
+    if args.check:
+        print(f"X3 accelerometer-DRDY observer: {state}")
+        return
+    if transformed == original:
+        print("X3 accelerometer-DRDY observer already applied; no file written")
+        return
+    TARGET.write_text(transformed, encoding="utf-8")
+    print(
+        "Applied X3 accelerometer-DRDY observer: BMI088 INT1/PC13 evidence only; "
+        "sensor-task PC14 behavior unchanged"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/crazyflie-ukf-surface-range/run_x3_prelpf_build_oracle.sh
+++ b/experiments/crazyflie-ukf-surface-range/run_x3_prelpf_build_oracle.sh
@@ -8,6 +8,8 @@ EXPECTED_SENSOR_BLOB=b183285c999335ca258b5131b1a835473473c078
 S3_ORACLE="$ROOT/experiments/crazyflie-ukf-surface-range/run_s3_build_oracle.sh"
 OBSERVER="$ROOT/experiments/crazyflie-ukf-surface-range/apply_x3_prelpf_timing_observer.py"
 OBSERVER_TEST="$ROOT/experiments/crazyflie-ukf-surface-range/test_x3_prelpf_timing_observer.py"
+DRDY_OBSERVER="$ROOT/experiments/crazyflie-ukf-surface-range/apply_x3_accel_drdy_observer.py"
+DRDY_OBSERVER_TEST="$ROOT/experiments/crazyflie-ukf-surface-range/test_x3_accel_drdy_observer.py"
 
 test -d "$UPSTREAM/.git"
 test "$(git -C "$UPSTREAM" rev-parse HEAD)" = "$EXPECTED_COMMIT"
@@ -15,6 +17,7 @@ test "$(git -C "$UPSTREAM" hash-object src/hal/src/sensors_bmi088_bmp3xx.c)" = "
 test -z "$(git -C "$UPSTREAM" status --porcelain -- src/modules/src/estimator/estimator_ukf.c src/hal/src/sensors_bmi088_bmp3xx.c)"
 
 python3 "$OBSERVER_TEST"
+python3 "$DRDY_OBSERVER_TEST"
 
 # Reuse the exact canonical S3 configuration, but only inside this dedicated
 # diagnostic checkout. The trusted s3-props-off workflow/artifact path is never
@@ -29,27 +32,57 @@ test -z "$(git -C "$UPSTREAM" diff -- src/hal/src/sensors_bmi088_bmp3xx.c)"
   cd "$UPSTREAM"
   python3 "$OBSERVER" --check
   python3 "$OBSERVER"
+  python3 "$DRDY_OBSERVER" --check
+  python3 "$DRDY_OBSERVER"
   git diff --check
 
   grep -Fq 'LOG_GROUP_START(x3AccObs)' src/hal/src/sensors_bmi088_bmp3xx.c
   grep -Fq 'LOG_ADD_BY_FUNCTION(LOG_UINT32, readBeg, &x3AccLogReadStart)' src/hal/src/sensors_bmi088_bmp3xx.c
+  grep -Fq 'LOG_GROUP_START(x3AccDrdy)' src/hal/src/sensors_bmi088_bmp3xx.c
+  grep -Fq 'LOG_ADD_BY_FUNCTION(LOG_UINT32, irqBeg, &x3AccDrdyLogSequenceBefore)' src/hal/src/sensors_bmi088_bmp3xx.c
+  grep -Fq 'x3AccelIntConfig.accel_int_channel = BMI088_INT_CHANNEL_1;' src/hal/src/sensors_bmi088_bmp3xx.c
+  grep -Fq 'SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource13);' src/hal/src/sensors_bmi088_bmp3xx.c
   grep -Fq 'LOG_GROUP_START(x3BaroObs)' src/hal/src/sensors_bmi088_bmp3xx.c
   grep -Fq 'LOG_ADD_BY_FUNCTION(LOG_UINT8, chipId, &x3BaroLogChipId)' src/hal/src/sensors_bmi088_bmp3xx.c
   grep -Fq 'x3AccObserverSnapshot.accPreLpf = sensorData.acc;' src/hal/src/sensors_bmi088_bmp3xx.c
 
   python3 - <<'PY'
 from pathlib import Path
+import re
 text = Path("src/hal/src/sensors_bmi088_bmp3xx.c").read_text()
 snapshot = text.index("x3AccObserverSnapshot.accPreLpf = sensorData.acc;")
 lpf = text.index("applyAxis3fLpf((lpf2pData*)(&accLpf), &sensorData.acc);", snapshot)
 assert snapshot < lpf
+
+m = re.search(
+    r"void __attribute__\(\(used\)\) EXTI13_Callback\(void\)\n\{(.*?)\n\}\n\n"
+    r"void sensorsBmi088Bmp3xxDataAvailableCallback",
+    text,
+    re.S,
+)
+assert m
+body = m.group(1)
+assert "x3AccelDrdySequence++;" in body
+assert "vTaskNotifyGiveFromISR" not in body
+assert "portYIELD" not in body
+assert "imuIntTimestamp" not in body
 PY
 
   docker run --rm -v "$PWD:/module" bitcraze/builder bash -lc '
     set -euo pipefail
+    cat > /tmp/x3-cf21-drdy.config <<'"'"'EOF'"'"'
+# CONFIG_SENSORS_MPU9250_LPS25H is not set
+CONFIG_SENSORS_BMI088_BMP3XX=y
+EOF
+    ./scripts/kconfig/merge_config.sh -O build -m build/.config /tmp/x3-cf21-drdy.config
+    make olddefconfig
+    grep -q "^# CONFIG_SENSORS_MPU9250_LPS25H is not set$" build/.config
+    grep -q "^CONFIG_SENSORS_BMI088_BMP3XX=y$" build/.config
     make -j"$(nproc)"
     arm-none-eabi-nm --defined-only build/cf2.elf | grep -Eq "[[:space:]]x3LogAccX$"
     arm-none-eabi-nm --defined-only build/cf2.elf | grep -Eq "[[:space:]]x3LogBaroChipId$"
+    arm-none-eabi-nm --defined-only build/cf2.elf | grep -Eq "[[:space:]]x3LogAccDrdySequenceBefore$"
+    arm-none-eabi-nm --defined-only build/cf2.elf | grep -Eq "[[:space:]]EXTI13_Callback$"
   '
 
   test -s build/cf2.elf
@@ -58,4 +91,4 @@ PY
   test "$(sha256sum build/cf2.bin | awk '{print $1}')" != "$CANONICAL_S3_BIN_SHA"
 )
 
-printf '%s\n' "PASS: X3 pre-LPF/read-window observer compiled in a dedicated diagnostic checkout; canonical s3-props-off workflow/artifact identity was not reused."
+printf '%s\n' "PASS: X3 pre-LPF/read-window plus explicit BMI088 accel-DRDY INT1/PC13 observer compiled in a CF21-only diagnostic checkout; canonical s3-props-off workflow/artifact identity was not reused."

--- a/experiments/crazyflie-ukf-surface-range/test_x3_accel_drdy_observer.py
+++ b/experiments/crazyflie-ukf-surface-range/test_x3_accel_drdy_observer.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Deterministic contract tests for the X3 BMI088 accelerometer-DRDY observer."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import re
+import unittest
+
+HERE = Path(__file__).resolve().parent
+APPLICATOR = HERE / "apply_x3_accel_drdy_observer.py"
+SPEC = importlib.util.spec_from_file_location("x3_accel_drdy_observer", APPLICATOR)
+assert SPEC is not None and SPEC.loader is not None
+observer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(observer)
+
+
+class X3AccelDrdyObserverContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_git = observer.git
+        observer.git = lambda *args: observer.EXPECTED_COMMIT
+        self.fixture = "\n".join(
+            old for _label, old, _new, _count in observer.MARKERS
+        ) + "\nLOG_GROUP_START(x3AccObs)\nBMI088_GYRO_DATA_RDY_INT\nEXTI_PinSource14\n"
+
+    def tearDown(self) -> None:
+        observer.git = self.original_git
+
+    def transformed(self) -> str:
+        return observer.transform(self.fixture)
+
+    def test_exact_transform_is_idempotent_and_fail_closed_on_partial_state(self) -> None:
+        transformed = self.transformed()
+        self.assertEqual("applied", observer.marker_state(transformed))
+        self.assertEqual(transformed, observer.transform(transformed))
+
+        _label, old, new, _count = observer.MARKERS[0]
+        partial = transformed.replace(new, old, 1)
+        with self.assertRaisesRegex(SystemExit, "partial X3 accelerometer-DRDY observer"):
+            observer.marker_state(partial)
+
+    def test_accelerometer_drdy_is_explicitly_mapped_to_int1(self) -> None:
+        transformed = self.transformed()
+        self.assertIn(
+            "x3AccelIntConfig.accel_int_channel = BMI088_INT_CHANNEL_1;",
+            transformed,
+        )
+        self.assertIn(
+            "x3AccelIntConfig.accel_int_type = BMI088_ACCEL_DATA_RDY_INT;",
+            transformed,
+        )
+        self.assertIn(
+            "rslt |= bmi088_set_accel_int_config(&x3AccelIntConfig, &bmi088Dev);",
+            transformed,
+        )
+
+    def test_pc13_observer_does_not_wake_or_retime_sensor_task(self) -> None:
+        transformed = self.transformed()
+        match = re.search(
+            r"void __attribute__\(\(used\)\) EXTI13_Callback\(void\)\n"
+            r"\{(.*?)\n\}\n\nvoid sensorsBmi088Bmp3xxDataAvailableCallback",
+            transformed,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("x3AccelDrdyTimestampUsLow = (uint32_t)usecTimestamp();", body)
+        self.assertIn("x3AccelDrdySequence++;", body)
+        self.assertNotIn("vTaskNotifyGiveFromISR", body)
+        self.assertNotIn("portYIELD", body)
+        self.assertNotIn("imuIntTimestamp", body)
+        self.assertIn("void sensorsBmi088Bmp3xxDataAvailableCallback(void)", transformed)
+
+    def test_pc13_and_existing_pc14_paths_are_both_configured(self) -> None:
+        transformed = self.transformed()
+        self.assertIn("GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13;", transformed)
+        self.assertIn(
+            "SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource13);",
+            transformed,
+        )
+        self.assertIn("EXTI_InitStructure.EXTI_Line = EXTI_Line13;", transformed)
+        self.assertIn("GPIO_InitStructure.GPIO_Pin = GPIO_Pin_14;", transformed)
+        self.assertIn(
+            "SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource14);",
+            transformed,
+        )
+        self.assertIn("EXTI_InitStructure.EXTI_Line = EXTI_Line14;", transformed)
+
+    def test_each_accel_read_is_bracketed_by_coherent_drdy_observations(self) -> None:
+        transformed = self.transformed()
+        before = transformed.index("x3AccDrdySequenceBefore = x3AccelDrdySequence;")
+        read = transformed.index("sensorsAccelGet(&accelRaw);", before)
+        after = transformed.index("x3AccDrdySequenceAfter = x3AccelDrdySequence;", read)
+        publish = transformed.index(
+            "x3AccDrdyObserverSnapshot.accSequence = x3AccObserverSnapshot.sequence;",
+            after,
+        )
+        self.assertLess(before, read)
+        self.assertLess(read, after)
+        self.assertLess(after, publish)
+        self.assertIn(
+            "x3AccDrdyObserverSnapshot.drdyTimestampBeforeUsLow = "
+            "x3AccDrdyTimestampBeforeUsLow;",
+            transformed,
+        )
+        self.assertIn(
+            "x3AccDrdyObserverSnapshot.drdyTimestampAfterUsLow = "
+            "x3AccDrdyTimestampAfterUsLow;",
+            transformed,
+        )
+
+    def test_drdy_group_fits_one_log_packet_and_joins_by_acc_sequence(self) -> None:
+        transformed = self.transformed()
+        match = re.search(
+            r"LOG_GROUP_START\(x3AccDrdy\)(.*?)LOG_GROUP_STOP\(x3AccDrdy\)",
+            transformed,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        entries = re.findall(
+            r"LOG_ADD_BY_FUNCTION\((LOG_[A-Z0-9]+), ([A-Za-z0-9_]+),", body
+        )
+        self.assertEqual(5, len(entries))
+        self.assertEqual(20, sum(4 for type_name, _name in entries if type_name == "LOG_UINT32"))
+        self.assertIn(("LOG_UINT32", "accSeq"), entries)
+
+    def test_build_oracle_requires_cf21_only_sensor_configuration(self) -> None:
+        oracle = (HERE / "run_x3_prelpf_build_oracle.sh").read_text(encoding="utf-8")
+        self.assertIn("# CONFIG_SENSORS_MPU9250_LPS25H is not set", oracle)
+        self.assertIn("CONFIG_SENSORS_BMI088_BMP3XX=y", oracle)
+        self.assertIn("apply_x3_accel_drdy_observer.py", oracle)
+        self.assertIn("test_x3_accel_drdy_observer.py", oracle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #70.

This bounded firmware-support slice adds a diagnostic-only accelerometer data-ready provenance path on exact Crazyflie firmware `2026.08@54f31e243a0b28b67efef5ba20dbb6d9890a5478`, layered after the existing X3 pre-LPF/read-window observer.

- explicitly maps BMI088 accelerometer DRDY to INT1 and observes the published Crazyflie 2.1 INT1 → STM32 PC13/EXTI13 route;
- the new EXTI13 ISR only records an MCU timestamp/sequence and never notifies, yields to, or retimes the operational sensor task; PC14 remains the operational wake path;
- snapshots the latest PC13 DRDY sequence/timestamp immediately before and after each accelerometer register read and exposes a separate 20-byte `x3AccDrdy` log group joined to `x3AccObs` by acceleration sequence;
- treats any row whose interrupt sequence changes during the register read as timing-ambiguous, and does not promote an observed DRDY edge into BMI088 internal producer/filter time;
- builds the diagnostic image as CF21/BMI088-only by disabling legacy MPU9250 support, avoiding the existing Crazyflie 2.0 strong `EXTI13_Callback` instead of multiplexing that production path;
- preserves the canonical S3 build first, then proves the diagnostic binary differs; CI retains the source patch, final diagnostic `.config`, hashes, and build log;
- extends the X3 CI selector so future changes to this observer or its contract test cannot bypass the isolated firmware build oracle.

The instrumentation itself can perturb timing and remains part of any later uncertainty model. This slice does not rehabilitate the current PC14 `sensorData.interruptTimestamp`, prove BMI088 internal sample/filter timing, narrow `sensor_time_error_s`, enable a checkpoint, or authorize a flash/motorized test/`TEST_REQUIRED`.

Exact Draft candidate: `3f6b2c6009cafdd3464b69835ec13ea76aaab7d6`, based directly on current `main@9dd344acd83385b97311855a22ddb3c099928d58`.