### PR TITLE
Prove dynamic physical paths safe before takeoff

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -121,6 +121,10 @@ def main():
     if physical_program_sequence_test.returncode:
         print('FAIL exact physical program sequencing',file=sys.stderr);print(physical_program_sequence_test.stdout,file=sys.stderr);print(physical_program_sequence_test.stderr,file=sys.stderr);return physical_program_sequence_test.returncode
     print(physical_program_sequence_test.stdout.strip())
+    physical_dynamic_preflight_test=subprocess.run([sys.executable,'tools/ci/test_physical_dynamic_preflight.py'],text=True,capture_output=True)
+    if physical_dynamic_preflight_test.returncode:
+        print('FAIL conservative dynamic physical pre-takeoff envelope',file=sys.stderr);print(physical_dynamic_preflight_test.stdout,file=sys.stderr);print(physical_dynamic_preflight_test.stderr,file=sys.stderr);return physical_dynamic_preflight_test.returncode
+    print(physical_dynamic_preflight_test.stdout.strip())
     physical_color_led_transport_test=subprocess.run([sys.executable,'tools/ci/test_physical_color_led_transport.py'],text=True,capture_output=True)
     if physical_color_led_transport_test.returncode:
         print('FAIL trusted one-shot bottom Color LED transport',file=sys.stderr);print(physical_color_led_transport_test.stdout,file=sys.stderr);print(physical_color_led_transport_test.stderr,file=sys.stderr);return physical_color_led_transport_test.returncode

--- a/tools/ci/test_physical_dynamic_preflight.py
+++ b/tools/ci/test_physical_dynamic_preflight.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools/physical"
+if str(PHYSICAL) not in sys.path:
+    sys.path.insert(0, str(PHYSICAL))
+
+from physical_dynamic_preflight import (  # noqa: E402
+    DynamicPhysicalPreflightError,
+    validate_bound_dynamic_program,
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical(program: list[dict[str, object]]) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "semantics": "webeeblocks-ast-v1",
+            "program": program,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def expect_error(program: list[dict[str, object]], pattern: str) -> None:
+    try:
+        validate_bound_dynamic_program(canonical(program))
+    except DynamicPhysicalPreflightError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {str(exc)!r}")
+        return
+    raise AssertionError("expected DynamicPhysicalPreflightError containing " + repr(pattern))
+
+
+def number(value: float) -> dict[str, object]:
+    return {"kind": "number", "value": value}
+
+
+def variable(identifier: str = "distance", name: str = "distance") -> dict[str, str]:
+    return {"id": identifier, "name": name}
+
+
+def representative_dynamic_program() -> list[dict[str, object]]:
+    ref = variable()
+    return [
+        {"kind": "takeoff", "height_m": 0.8},
+        {
+            "kind": "set_variable",
+            "variable": ref,
+            "value": {"kind": "range", "direction": "front", "unit": "m"},
+        },
+        {
+            "kind": "if",
+            "condition": {
+                "kind": "compare",
+                "op": "LT",
+                "left": {"kind": "variable_get", "variable": ref},
+                "right": number(1.0),
+            },
+            "then": [
+                {"kind": "vertical", "direction": "up", "distance_m": 0.2},
+                {"kind": "set_light", "color": "green"},
+            ],
+            "else": [
+                {"kind": "vertical", "direction": "down", "distance_m": 0.1},
+                {"kind": "set_light", "color": "red"},
+            ],
+        },
+        {
+            "kind": "repeat",
+            "count": 2,
+            "body": [
+                {"kind": "move", "direction": "forward", "distance_m": 0.3},
+                {"kind": "wait", "seconds": 0.1},
+            ],
+        },
+        {"kind": "set_speed", "speed_m_s": 0.2},
+        {"kind": "turn", "angle_deg": -90.0},
+        {"kind": "land"},
+    ]
+
+
+def test_representative_dynamic_program_is_proven_conservatively() -> None:
+    binding = canonical(representative_dynamic_program())
+    envelope = validate_bound_dynamic_program(binding)
+    require(envelope.ast_binding == binding, "exact AST binding identity was not preserved")
+    require(envelope.initial_altitude_m == 0.8, "takeoff altitude changed")
+    require(abs(envelope.min_altitude_m - 0.7) < 1e-12, "reachable lower branch altitude was not retained")
+    require(envelope.max_altitude_m == 1.0, "reachable upper branch altitude was not retained")
+    require(
+        abs(envelope.terminal_min_altitude_m - 0.7) < 1e-12
+        and envelope.terminal_max_altitude_m == 1.0,
+        "terminal reachable altitude interval is wrong",
+    )
+
+
+def test_any_unsafe_if_branch_rejects_before_effect() -> None:
+    expect_error(
+        [
+            {"kind": "takeoff", "height_m": 1.4},
+            {
+                "kind": "if",
+                "condition": {
+                    "kind": "range",
+                    "direction": "front",
+                    "unit": "m",
+                },
+                "then": [
+                    {"kind": "vertical", "direction": "up", "distance_m": 0.2}
+                ],
+                "else": [],
+            },
+            {"kind": "land"},
+        ],
+        "reachable physical path violates",
+    )
+
+
+def test_repeat_expands_the_full_altitude_path() -> None:
+    expect_error(
+        [
+            {"kind": "takeoff", "height_m": 0.3},
+            {
+                "kind": "repeat",
+                "count": 2,
+                "body": [
+                    {"kind": "vertical", "direction": "down", "distance_m": 0.1}
+                ],
+            },
+            {"kind": "land"},
+        ],
+        "reachable physical path violates",
+    )
+
+
+def test_nested_flight_boundaries_and_unknown_statements_fail_closed() -> None:
+    for statement, pattern in (
+        ({"kind": "takeoff", "height_m": 0.8}, "top-level boundaries"),
+        ({"kind": "land"}, "top-level boundaries"),
+        ({"kind": "future_action"}, "unsupported dynamic physical statement kind"),
+    ):
+        expect_error(
+            [
+                {"kind": "takeoff", "height_m": 0.8},
+                {"kind": "repeat", "count": 1, "body": [statement]},
+                {"kind": "land"},
+            ],
+            pattern,
+        )
+
+
+def test_all_existing_action_bounds_apply_inside_dynamic_control_flow() -> None:
+    cases = [
+        (
+            {"kind": "move", "direction": "forward", "distance_m": 2.1},
+            "reachable physical action violates",
+        ),
+        (
+            {"kind": "vertical", "direction": "up", "distance_m": 0.9},
+            "reachable physical action violates",
+        ),
+        (
+            {"kind": "turn", "angle_deg": 180.0},
+            "reachable physical action violates",
+        ),
+        (
+            {"kind": "wait", "seconds": 0.05},
+            "wait seconds violate",
+        ),
+        (
+            {"kind": "set_speed", "speed_m_s": 10.0},
+            "set_speed violates",
+        ),
+        (
+            {"kind": "set_light", "color": "magenta"},
+            "set_light color violates",
+        ),
+    ]
+    for statement, pattern in cases:
+        expect_error(
+            [
+                {"kind": "takeoff", "height_m": 0.8},
+                {
+                    "kind": "if",
+                    "condition": number(1.0),
+                    "then": [statement],
+                    "else": [],
+                },
+                {"kind": "land"},
+            ],
+            pattern,
+        )
+
+
+def test_control_flow_metadata_cannot_hide_unsupported_fields() -> None:
+    expect_error(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {
+                "kind": "repeat",
+                "count": 1,
+                "body": [],
+                "callerBranch": "left",
+            },
+            {"kind": "land"},
+        ],
+        "repeat statement contains unsupported fields",
+    )
+    expect_error(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {
+                "kind": "if",
+                "condition": number(1.0),
+                "then": [],
+                "else": [],
+                "selected": "then",
+            },
+            {"kind": "land"},
+        ],
+        "if statement contains unsupported fields",
+    )
+
+
+def test_noncanonical_or_malformed_binding_fails_closed() -> None:
+    program = representative_dynamic_program()
+    noncanonical = json.dumps(
+        {
+            "program": program,
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        ensure_ascii=False,
+    )
+    try:
+        validate_bound_dynamic_program(noncanonical)
+    except DynamicPhysicalPreflightError as exc:
+        require("canonical" in str(exc), "noncanonical binding failed for the wrong reason")
+    else:
+        raise AssertionError("noncanonical AST binding was accepted")
+
+    malformed = canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "set_variable", "variable": {"id": "", "name": "x"}, "value": number(1)},
+            {"kind": "land"},
+        ]
+    )
+    try:
+        validate_bound_dynamic_program(malformed)
+    except DynamicPhysicalPreflightError as exc:
+        require("reference is malformed" in str(exc), "malformed variable failed for wrong reason")
+    else:
+        raise AssertionError("malformed set_variable reference was accepted")
+
+
+def main() -> int:
+    test_representative_dynamic_program_is_proven_conservatively()
+    test_any_unsafe_if_branch_rejects_before_effect()
+    test_repeat_expands_the_full_altitude_path()
+    test_nested_flight_boundaries_and_unknown_statements_fail_closed()
+    test_all_existing_action_bounds_apply_inside_dynamic_control_flow()
+    test_control_flow_metadata_cannot_hide_unsupported_fields()
+    test_noncanonical_or_malformed_binding_fails_closed()
+    print(
+        "PASS dynamic physical preflight: every reachable control-flow path "
+        "stays inside integrated action and altitude bounds before effect"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_dynamic_preflight.py
+++ b/tools/ci/test_physical_dynamic_preflight.py
@@ -10,6 +10,7 @@ PHYSICAL = ROOT / "tools/physical"
 if str(PHYSICAL) not in sys.path:
     sys.path.insert(0, str(PHYSICAL))
 
+import takeoff_command  # noqa: E402
 from physical_dynamic_preflight import (  # noqa: E402
     DynamicPhysicalPreflightError,
     validate_bound_dynamic_program,
@@ -22,15 +23,12 @@ def require(condition: bool, message: str) -> None:
 
 
 def canonical(program: list[dict[str, object]]) -> str:
-    return json.dumps(
+    return takeoff_command._canonical_json(
         {
             "version": 1,
             "semantics": "webeeblocks-ast-v1",
             "program": program,
-        },
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
+        }
     )
 
 

--- a/tools/physical/physical_dynamic_preflight.py
+++ b/tools/physical/physical_dynamic_preflight.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Conservative pre-takeoff safety envelope for dynamic physical programs.
+
+This module is deliberately non-authority and emits no physical effect. It
+consumes only the exact canonical AST binding already established by trusted
+current-program provenance and proves that every dynamically reachable physical
+path remains inside the already integrated action and nominal-altitude bounds.
+
+It does not evaluate expressions or choose branches. `if` is treated as either
+branch being reachable and `repeat` is expanded for its exact bounded count.
+The shared Runtime interpreter remains the sole language evaluator; this module
+only supplies a conservative physical safety proof before reset/takeoff.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+
+import high_level_semantics
+import high_level_timing
+import physical_program_sequence
+import takeoff_command
+
+MAX_CONTROL_DEPTH = 20
+
+
+class DynamicPhysicalPreflightError(RuntimeError):
+    """Fail-closed error for an unsafe or unsupported dynamic physical program."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReachablePhysicalEnvelope:
+    """Bounded world-Z envelope proven across every admitted control-flow path."""
+
+    ast_binding: str
+    initial_altitude_m: float
+    min_altitude_m: float
+    max_altitude_m: float
+    terminal_min_altitude_m: float
+    terminal_max_altitude_m: float
+
+
+@dataclass(frozen=True, slots=True)
+class _Bounds:
+    low: float
+    high: float
+    seen_low: float
+    seen_high: float
+
+
+def _error(message: str) -> DynamicPhysicalPreflightError:
+    return DynamicPhysicalPreflightError(message)
+
+
+def _exact_fields(statement: dict[str, object], fields: set[str], context: str) -> None:
+    if set(statement) != fields:
+        raise _error(context + " contains unsupported fields")
+
+
+def _number(value: object, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _error(context + " must be finite")
+    parsed = float(value)
+    if not isfinite(parsed):
+        raise _error(context + " must be finite")
+    return parsed
+
+
+def _require_altitude(low: float, high: float) -> None:
+    if (
+        not isfinite(low)
+        or not isfinite(high)
+        or low < physical_program_sequence.MIN_NOMINAL_ALTITUDE_M
+        or high > physical_program_sequence.MAX_NOMINAL_ALTITUDE_M
+    ):
+        raise _error(
+            "a reachable physical path violates established 0.2-1.5 m nominal-altitude bounds"
+        )
+
+
+def _validate_action(statement: dict[str, object], bounds: _Bounds) -> _Bounds | None:
+    kind = statement.get("kind")
+    try:
+        if kind == "move":
+            _exact_fields(statement, {"kind", "direction", "distance_m"}, "move statement")
+            direction = statement["direction"]
+            if not isinstance(direction, str):
+                raise _error("move direction is malformed")
+            high_level_semantics.body_relative_move(
+                direction,
+                statement["distance_m"],
+                0.0,
+            )
+            return bounds
+
+        if kind == "vertical":
+            _exact_fields(
+                statement,
+                {"kind", "direction", "distance_m"},
+                "vertical statement",
+            )
+            direction = statement["direction"]
+            if not isinstance(direction, str):
+                raise _error("vertical direction is malformed")
+            target = high_level_semantics.vertical_move(
+                direction,
+                statement["distance_m"],
+            )
+            low = bounds.low + target.z_m
+            high = bounds.high + target.z_m
+            _require_altitude(low, high)
+            return _Bounds(
+                low=low,
+                high=high,
+                seen_low=min(bounds.seen_low, low),
+                seen_high=max(bounds.seen_high, high),
+            )
+
+        if kind == "turn":
+            _exact_fields(statement, {"kind", "angle_deg"}, "turn statement")
+            high_level_semantics.relative_turn(statement["angle_deg"])
+            return bounds
+
+        if kind == "wait":
+            _exact_fields(statement, {"kind", "seconds"}, "wait statement")
+            seconds = _number(statement["seconds"], "wait seconds")
+            if (
+                seconds < physical_program_sequence.MIN_WAIT_SECONDS
+                or seconds > physical_program_sequence.MAX_WAIT_SECONDS
+            ):
+                raise _error("wait seconds violate established Runtime v2 bounds")
+            return bounds
+
+        if kind == "set_speed":
+            _exact_fields(statement, {"kind", "speed_m_s"}, "set_speed statement")
+            speed = _number(statement["speed_m_s"], "set_speed speed_m_s")
+            if (
+                speed < high_level_timing.MIN_HORIZONTAL_SPEED_M_S
+                or speed > high_level_timing.MAX_HORIZONTAL_SPEED_M_S
+            ):
+                raise _error(
+                    "set_speed violates established physical horizontal-speed bounds"
+                )
+            return bounds
+
+        if kind == "set_light":
+            _exact_fields(statement, {"kind", "color"}, "set_light statement")
+            color = statement["color"]
+            if (
+                not isinstance(color, str)
+                or color not in physical_program_sequence.LIGHT_COLORS
+            ):
+                raise _error("set_light color violates established Runtime v2 palette")
+            return bounds
+    except DynamicPhysicalPreflightError:
+        raise
+    except (
+        TypeError,
+        ValueError,
+        high_level_semantics.HighLevelSemanticError,
+    ) as exc:
+        raise _error("reachable physical action violates integrated semantics") from exc
+
+    return None
+
+
+def _validate_sequence(
+    sequence: object,
+    bounds: _Bounds,
+    *,
+    depth: int,
+) -> _Bounds:
+    if depth > MAX_CONTROL_DEPTH:
+        raise _error("dynamic physical control-flow nesting is too deep")
+    if not isinstance(sequence, list):
+        raise _error("dynamic physical statement sequence must be an array")
+
+    current = bounds
+    for statement in sequence:
+        if not isinstance(statement, dict) or not isinstance(statement.get("kind"), str):
+            raise _error("dynamic physical statement is malformed")
+
+        action = _validate_action(statement, current)
+        if action is not None:
+            current = action
+            continue
+
+        kind = statement["kind"]
+        if kind == "set_variable":
+            _exact_fields(
+                statement,
+                {"kind", "variable", "value"},
+                "set_variable statement",
+            )
+            variable = statement["variable"]
+            if (
+                not isinstance(variable, dict)
+                or set(variable) != {"id", "name"}
+                or not isinstance(variable.get("id"), str)
+                or not variable["id"]
+                or not isinstance(variable.get("name"), str)
+                or not variable["name"].strip()
+            ):
+                raise _error("set_variable reference is malformed")
+            if not isinstance(statement["value"], dict):
+                raise _error("set_variable expression is malformed")
+            continue
+
+        if kind == "if":
+            allowed = {"kind", "condition", "then", "else"}
+            if set(statement) not in ({"kind", "condition", "then"}, allowed):
+                raise _error("if statement contains unsupported fields")
+            if not isinstance(statement["condition"], dict):
+                raise _error("if condition is malformed")
+            then_bounds = _validate_sequence(
+                statement["then"],
+                current,
+                depth=depth + 1,
+            )
+            else_bounds = _validate_sequence(
+                statement.get("else", []),
+                current,
+                depth=depth + 1,
+            )
+            current = _Bounds(
+                low=min(then_bounds.low, else_bounds.low),
+                high=max(then_bounds.high, else_bounds.high),
+                seen_low=min(
+                    current.seen_low,
+                    then_bounds.seen_low,
+                    else_bounds.seen_low,
+                ),
+                seen_high=max(
+                    current.seen_high,
+                    then_bounds.seen_high,
+                    else_bounds.seen_high,
+                ),
+            )
+            _require_altitude(current.low, current.high)
+            continue
+
+        if kind == "repeat":
+            _exact_fields(statement, {"kind", "count", "body"}, "repeat statement")
+            count_value = statement["count"]
+            if (
+                isinstance(count_value, bool)
+                or not isinstance(count_value, (int, float))
+                or not float(count_value).is_integer()
+            ):
+                raise _error("repeat count must be an integer")
+            count = int(count_value)
+            if count < 1 or count > 20:
+                raise _error("repeat count violates established Runtime v2 bounds")
+            if not isinstance(statement["body"], list):
+                raise _error("repeat body is malformed")
+            for _ in range(count):
+                current = _validate_sequence(
+                    statement["body"],
+                    current,
+                    depth=depth + 1,
+                )
+            continue
+
+        if kind in {"takeoff", "land"}:
+            raise _error("takeoff and land are only allowed at top-level boundaries")
+
+        raise _error("unsupported dynamic physical statement kind: " + kind)
+
+    return current
+
+
+def validate_bound_dynamic_program(ast_binding: object) -> ReachablePhysicalEnvelope:
+    """Prove every reachable physical path before reset/takeoff.
+
+    Expression evaluation and branch selection remain exclusively owned by the
+    shared Runtime interpreter. This proof assumes either branch of every `if`
+    can be selected and therefore cannot be weakened by a sensor value.
+    """
+
+    try:
+        takeoff = takeoff_command.derive_bound_takeoff_command(ast_binding)
+        parsed = takeoff_command._parse_ast_binding(ast_binding)
+    except takeoff_command.TakeoffCommandError as exc:
+        raise _error(str(exc)) from exc
+
+    program = parsed["program"]
+    if not isinstance(program, list):
+        raise _error("physical AST program is unavailable")
+    final = program[-1]
+    if (
+        not isinstance(final, dict)
+        or set(final) != {"kind"}
+        or final.get("kind") != "land"
+    ):
+        raise _error("physical AST must end with the exact landing statement")
+
+    initial = float(takeoff.height_m)
+    _require_altitude(initial, initial)
+    start = _Bounds(
+        low=initial,
+        high=initial,
+        seen_low=initial,
+        seen_high=initial,
+    )
+    terminal = _validate_sequence(
+        program[1:-1],
+        start,
+        depth=0,
+    )
+    return ReachablePhysicalEnvelope(
+        ast_binding=str(ast_binding),
+        initial_altitude_m=initial,
+        min_altitude_m=terminal.seen_low,
+        max_altitude_m=terminal.seen_high,
+        terminal_min_altitude_m=terminal.low,
+        terminal_max_altitude_m=terminal.high,
+    )


### PR DESCRIPTION
Refs #345 #157.

This bounded infrastructure slice establishes the conservative pre-takeoff safety prerequisite for later trusted-host shared-interpreter composition. It does not execute the shared interpreter or expose physical sensor values.

Complete scope of this candidate:
- consumes only the exact canonical teacher/current-program `astBinding` and emits no CRTP/cflib/commander effect;
- reuses the already integrated move/vertical/turn, wait, horizontal-speed, light-palette and 0.2–1.5 m nominal-altitude bounds rather than inventing a second physical semantics;
- treats both branches of every `if` as reachable and expands each exact bounded `repeat` count, so a sensor/variable decision can never hide an unsafe physical path from pre-takeoff validation;
- tracks a conservative reachable altitude interval through nested branch/repeat composition and rejects before effect if any reachable intermediate path can leave the established physical envelope;
- keeps expression evaluation and branch selection explicitly outside this module: the existing shared Runtime `interpreter.js` remains the sole language evaluator;
- rejects nested takeoff/land, unknown statement kinds, unsupported control metadata and out-of-bounds physical actions fail-closed;
- adds deterministic regressions for representative range/variable/if/repeat structure, unsafe branches, repeated altitude drift, action bounds and exact canonical binding, wired into the Runtime v2 core harness;
- after Ready CI exposed a test-fixture serialization mismatch, the regression now uses the same exact JS-compatible canonical JSON serializer already enforced by the physical AST binding, without changing the production safety proof.

This deliberately does **not** complete #345. Later work must still run the existing shared interpreter inside the trusted host, derive each `range(direction)` only from that bound interpreter, execute the fresh observer under the integrated observation exclusion, and preserve independent downstream effect authority. No caller-facing direction/result/branch/action parameter is introduced here.

No real-device qualification, motorized flight, checkpoint or `TEST_REQUIRED` is claimed. Current candidate HEAD `f934e1614fac83d05b4730e893ded1203ff99080` is based directly on `main@9dd344acd83385b97311855a22ddb3c099928d58`. Promotion requires a fresh canonical Ready `CI Gate` and an independent exact-head review.