### PR TITLE
Prove dynamic physical paths safe before takeoff

### DIFF
--- a/tools/ci/test_runtime_v2_variables.js
+++ b/tools/ci/test_runtime_v2_variables.js
@@ -8,6 +8,7 @@ const Profiles = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblo
 const Activities = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/activities.js'));
 const SemanticAst = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/semantic_ast.js'));
 const Interpreter = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/interpreter.js'));
+const PhysicalDynamicPreflight = require(path.join(ROOT, 'tools/physical/physical_dynamic_preflight.js'));
 const ActivityContract = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/activity_contract.js'));
 const ExecutionObserver = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/execution_observer.js'));
 const ProjectFiles = require(path.join(ROOT, 'plugins/robot_windows/blockly/webeeblocks/project_files.js'));
@@ -61,6 +62,47 @@ function arithmeticBlock(workspace,op,leftValue,rightValue){
   arithmetic.getInput('A').connection.connect(left.outputConnection);arithmetic.getInput('B').connection.connect(right.outputConnection);
   return arithmetic;
 }
+function dynamicPhysicalProgram(){
+  return {
+    version:1,
+    semantics:'webeeblocks-ast-v1',
+    program:[
+      {kind:'takeoff',height_m:0.5},
+      {kind:'set_variable',variable:{id:'r',name:'r'},value:{kind:'range',direction:'front',unit:'m'}},
+      {kind:'repeat',count:2,body:[
+        {kind:'if',condition:{kind:'logic',op:'AND',left:{kind:'compare',op:'LT',left:{kind:'variable_get',variable:{id:'r',name:'r'}},right:{kind:'number',value:0.5}},right:{kind:'compare',op:'GT',left:{kind:'range',direction:'left',unit:'m'},right:{kind:'number',value:0.2}}},then:[{kind:'vertical',direction:'up',distance_m:0.1}],else:[{kind:'vertical',direction:'down',distance_m:0.1}]}
+      ]},
+      {kind:'land'}
+    ]
+  };
+}
+function testPhysicalDynamicPreflight(){
+  const proof=PhysicalDynamicPreflight.validatePhysicalProgram(dynamicPhysicalProgram());
+  assert.strictEqual(proof.initialAltitudeM,0.5,'dynamic physical preflight lost exact takeoff altitude');
+  assert(Math.abs(proof.terminalAltitudeMinM-0.3)<1e-12,'all-branch minimum altitude was not conservatively propagated');
+  assert(Math.abs(proof.terminalAltitudeMaxM-0.7)<1e-12,'all-branch maximum altitude was not conservatively propagated');
+  assert.strictEqual(proof.executionAuthority,false,'static physical proof must never mint execution authority');
+
+  const unsafeBranch=dynamicPhysicalProgram();
+  unsafeBranch.program[0].height_m=0.3;
+  unsafeBranch.program[2]={kind:'if',condition:{kind:'compare',op:'LT',left:{kind:'range',direction:'front',unit:'m'},right:{kind:'number',value:0.5}},then:[{kind:'vertical',direction:'down',distance_m:0.2}],else:[{kind:'wait',seconds:0.1}]};
+  assert.throws(()=>PhysicalDynamicPreflight.validatePhysicalProgram(unsafeBranch),/nominal-altitude envelope/,'one unsafe sensor-selected branch must reject before takeoff');
+
+  const unsafeRepeat={version:1,semantics:'webeeblocks-ast-v1',program:[{kind:'takeoff',height_m:0.5},{kind:'repeat',count:4,body:[{kind:'vertical',direction:'up',distance_m:0.3}]},{kind:'land'}]};
+  assert.throws(()=>PhysicalDynamicPreflight.validatePhysicalProgram(unsafeRepeat),/nominal-altitude envelope/,'repeat accumulation must be proven across every iteration');
+
+  const extraField=dynamicPhysicalProgram();
+  extraField.program[2].body[0].then=[{kind:'move',direction:'forward',distance_m:0.3,callerDistance_m:0.2}];
+  assert.throws(()=>PhysicalDynamicPreflight.validatePhysicalProgram(extraField),/unsupported fields/,'physical preflight accepted caller-shaped extra semantics');
+
+  const outOfBoundsMove=dynamicPhysicalProgram();
+  outOfBoundsMove.program[2].body[0].then=[{kind:'move',direction:'forward',distance_m:2.1}];
+  assert.throws(()=>PhysicalDynamicPreflight.validatePhysicalProgram(outOfBoundsMove),/move distance_m violates established physical bounds/,'dynamic branch bypassed physical action bounds');
+
+  const unsupportedRange=dynamicPhysicalProgram();
+  unsupportedRange.program[1].value={kind:'range',direction:'down',unit:'m'};
+  assert.throws(()=>PhysicalDynamicPreflight.validatePhysicalProgram(unsupportedRange),/unsupported range expression/,'physical preflight did not delegate language validity to the shared interpreter');
+}
 
 (async function(){
   const p4=Profiles.resolveById(Activities.DOCUMENT,'progression-combined-decisions-v1',Activities.BLOCK_CATALOG),p5=profile();
@@ -108,6 +150,7 @@ function arithmeticBlock(workspace,op,leftValue,rightValue){
     error=>error&&error.code==='PROGRAM_INVALID'&&/division by zero/.test(error.message)&&/division par zéro/.test(error.studentDetail),
     'division by zero must fail with a correctable student outcome'
   );
+  testPhysicalDynamicPreflight();
   arithmeticWorkspace.dispose();
-  console.log('PASS variables-memory: Blockly model -> stable AST -> fail-closed interpreter -> execution observer -> project round-trip -> finite basic arithmetic');
+  console.log('PASS variables-memory: Blockly model -> stable AST -> fail-closed interpreter -> conservative dynamic physical path preflight -> execution observer -> project round-trip -> finite basic arithmetic');
 })().catch(error=>{console.error(error);process.exit(1);});

--- a/tools/physical/physical_dynamic_preflight.js
+++ b/tools/physical/physical_dynamic_preflight.js
@@ -1,0 +1,289 @@
+'use strict';
+
+/**
+ * Conservative no-effect safety proof for dynamic physical Runtime v2 programs.
+ *
+ * This module deliberately does not execute the student program and exposes no
+ * backend, sensor, command or authority surface. It first delegates language
+ * validity to the existing shared interpreter, then proves the physical safety
+ * envelope for every syntactically reachable control-flow path. Conditions are
+ * treated as nondeterministic: both branches are analysed, and repeat bodies are
+ * analysed for every statically bounded iteration. The resulting altitude
+ * interval is therefore an over-approximation; uncertainty rejects rather than
+ * defers an unsafe path until after takeoff.
+ */
+
+const path = require('path');
+const ROOT = path.resolve(__dirname, '../..');
+const Interpreter = require(path.join(
+  ROOT,
+  'plugins/robot_windows/blockly/webeeblocks/interpreter.js'
+));
+
+const MIN_ALTITUDE_M = 0.2;
+const MAX_ALTITUDE_M = 1.5;
+const MIN_MOVE_DISTANCE_M = 0.10;
+const MAX_MOVE_DISTANCE_M = 2.00;
+const MIN_VERTICAL_DISTANCE_M = 0.10;
+const MAX_VERTICAL_DISTANCE_M = 0.80;
+const MIN_TURN_DEG = 1.0;
+const MAX_TURN_DEG = 179.0;
+const MIN_WAIT_SECONDS = 0.1;
+const MAX_WAIT_SECONDS = 5.0;
+const MIN_HORIZONTAL_SPEED_M_S = 0.10;
+const MAX_HORIZONTAL_SPEED_M_S = 0.35;
+const LIGHT_COLORS = new Set(['off', 'red', 'green', 'blue', 'yellow', 'white']);
+
+function fail(message) {
+  throw new Error('physical dynamic preflight: ' + message);
+}
+
+function exactKeys(value, keys, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    fail(label + ' must be an object');
+  const actual = Object.keys(value).sort();
+  const expected = keys.slice().sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index]))
+    fail(label + ' contains unsupported fields');
+}
+
+function exactOneOfKeySets(value, keySets, label) {
+  for (const keys of keySets) {
+    const actual = Object.keys(value).sort();
+    const expected = keys.slice().sort();
+    if (actual.length === expected.length && actual.every((key, index) => key === expected[index]))
+      return;
+  }
+  fail(label + ' contains unsupported fields');
+}
+
+function finiteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value))
+    fail(label + ' must be a finite number');
+  return value;
+}
+
+function bounded(value, label, minimum, maximum) {
+  const number = finiteNumber(value, label);
+  if (number < minimum || number > maximum)
+    fail(label + ' violates established physical bounds');
+  return number;
+}
+
+function exactVariable(variable) {
+  exactKeys(variable, ['id', 'name'], 'variable reference');
+  if (typeof variable.id !== 'string' || !variable.id)
+    fail('variable reference id is invalid');
+  if (typeof variable.name !== 'string' || !variable.name.trim())
+    fail('variable reference name is invalid');
+}
+
+function exactExpression(expression, depth) {
+  if (depth > 20)
+    fail('expression nesting is too deep');
+  if (!expression || typeof expression !== 'object' || Array.isArray(expression))
+    fail('expression must be an object');
+  switch (expression.kind) {
+    case 'number':
+      exactKeys(expression, ['kind', 'value'], 'number expression');
+      finiteNumber(expression.value, 'number expression value');
+      return;
+    case 'range':
+      exactKeys(expression, ['kind', 'direction', 'unit'], 'range expression');
+      return;
+    case 'variable_get':
+      exactKeys(expression, ['kind', 'variable'], 'variable expression');
+      exactVariable(expression.variable);
+      return;
+    case 'arithmetic':
+    case 'compare':
+    case 'logic':
+      exactKeys(expression, ['kind', 'op', 'left', 'right'], expression.kind + ' expression');
+      exactExpression(expression.left, depth + 1);
+      exactExpression(expression.right, depth + 1);
+      return;
+    default:
+      fail('unsupported expression kind ' + String(expression.kind));
+  }
+}
+
+function requireAltitude(interval, context) {
+  if (!interval || typeof interval.min !== 'number' || typeof interval.max !== 'number')
+    fail('internal altitude interval is invalid');
+  if (
+    !Number.isFinite(interval.min) ||
+    !Number.isFinite(interval.max) ||
+    interval.min < MIN_ALTITUDE_M ||
+    interval.max > MAX_ALTITUDE_M
+  )
+    fail(context + ' can leave the established 0.2-1.5 m nominal-altitude envelope');
+  return interval;
+}
+
+function exactStatementShape(statement, nested) {
+  if (!statement || typeof statement !== 'object' || Array.isArray(statement))
+    fail('statement must be an object');
+  const kind = statement.kind;
+  if (nested && (kind === 'takeoff' || kind === 'land'))
+    fail('takeoff and land are only allowed at top-level boundaries');
+  switch (kind) {
+    case 'takeoff':
+      exactKeys(statement, ['kind', 'height_m'], 'takeoff statement');
+      bounded(statement.height_m, 'takeoff height_m', MIN_ALTITUDE_M, MAX_ALTITUDE_M);
+      return;
+    case 'land':
+      exactKeys(statement, ['kind'], 'land statement');
+      return;
+    case 'move':
+      exactKeys(statement, ['kind', 'direction', 'distance_m'], 'move statement');
+      bounded(statement.distance_m, 'move distance_m', MIN_MOVE_DISTANCE_M, MAX_MOVE_DISTANCE_M);
+      return;
+    case 'vertical':
+      exactKeys(statement, ['kind', 'direction', 'distance_m'], 'vertical statement');
+      bounded(statement.distance_m, 'vertical distance_m', MIN_VERTICAL_DISTANCE_M, MAX_VERTICAL_DISTANCE_M);
+      return;
+    case 'turn': {
+      exactKeys(statement, ['kind', 'angle_deg'], 'turn statement');
+      const angle = finiteNumber(statement.angle_deg, 'turn angle_deg');
+      const magnitude = Math.abs(angle);
+      if (magnitude < MIN_TURN_DEG || magnitude > MAX_TURN_DEG)
+        fail('turn angle_deg violates established physical bounds');
+      return;
+    }
+    case 'wait':
+      exactKeys(statement, ['kind', 'seconds'], 'wait statement');
+      bounded(statement.seconds, 'wait seconds', MIN_WAIT_SECONDS, MAX_WAIT_SECONDS);
+      return;
+    case 'set_speed':
+      exactKeys(statement, ['kind', 'speed_m_s'], 'set_speed statement');
+      bounded(
+        statement.speed_m_s,
+        'set_speed speed_m_s',
+        MIN_HORIZONTAL_SPEED_M_S,
+        MAX_HORIZONTAL_SPEED_M_S
+      );
+      return;
+    case 'set_light':
+      exactKeys(statement, ['kind', 'color'], 'set_light statement');
+      if (typeof statement.color !== 'string' || !LIGHT_COLORS.has(statement.color))
+        fail('set_light color violates established physical palette');
+      return;
+    case 'set_variable':
+      exactKeys(statement, ['kind', 'variable', 'value'], 'set_variable statement');
+      exactVariable(statement.variable);
+      exactExpression(statement.value, 0);
+      return;
+    case 'if':
+      exactOneOfKeySets(
+        statement,
+        [
+          ['kind', 'condition', 'then'],
+          ['kind', 'condition', 'then', 'else']
+        ],
+        'if statement'
+      );
+      exactExpression(statement.condition, 0);
+      if (!Array.isArray(statement.then) || (statement.else !== undefined && !Array.isArray(statement.else)))
+        fail('if branches must be statement arrays');
+      return;
+    case 'repeat':
+      exactKeys(statement, ['kind', 'count', 'body'], 'repeat statement');
+      if (!Number.isInteger(statement.count) || statement.count < 1 || statement.count > 20)
+        fail('repeat count violates shared interpreter bounds');
+      if (!Array.isArray(statement.body))
+        fail('repeat body must be a statement array');
+      return;
+    default:
+      fail('unsupported physical statement kind ' + String(kind));
+  }
+}
+
+function analyseSequence(sequence, interval, depth) {
+  if (!Array.isArray(sequence))
+    fail('statement sequence must be an array');
+  if (depth > 20)
+    fail('statement nesting is too deep');
+  let current = {min: interval.min, max: interval.max};
+  for (const statement of sequence) {
+    exactStatementShape(statement, true);
+    switch (statement.kind) {
+      case 'vertical': {
+        const distance = statement.distance_m;
+        const delta = statement.direction === 'up' ? distance : -distance;
+        current = requireAltitude(
+          {min: current.min + delta, max: current.max + delta},
+          'vertical path'
+        );
+        break;
+      }
+      case 'if': {
+        const thenResult = analyseSequence(statement.then, current, depth + 1);
+        const elseResult = analyseSequence(statement.else || [], current, depth + 1);
+        current = requireAltitude(
+          {
+            min: Math.min(thenResult.min, elseResult.min),
+            max: Math.max(thenResult.max, elseResult.max)
+          },
+          'conditional path'
+        );
+        break;
+      }
+      case 'repeat':
+        for (let iteration = 0; iteration < statement.count; iteration += 1)
+          current = analyseSequence(statement.body, current, depth + 1);
+        break;
+      case 'takeoff':
+      case 'land':
+        fail('takeoff and land cannot occur inside the in-flight dynamic body');
+        break;
+      default:
+        // Non-vertical effects, observations, variables and host-local state are
+        // nominal-altitude neutral. Their exact physical bounds were checked above.
+        break;
+    }
+  }
+  return current;
+}
+
+function validatePhysicalProgram(ast) {
+  // Language/control-flow validity remains owned by the shared interpreter.
+  Interpreter.validateProgram(ast);
+
+  exactKeys(ast, ['version', 'semantics', 'program'], 'physical AST envelope');
+  if (!Array.isArray(ast.program) || ast.program.length < 2)
+    fail('physical program must contain flight boundaries');
+
+  const first = ast.program[0];
+  const last = ast.program[ast.program.length - 1];
+  exactStatementShape(first, false);
+  exactStatementShape(last, false);
+  if (first.kind !== 'takeoff')
+    fail('physical program must begin with exact takeoff');
+  if (last.kind !== 'land')
+    fail('physical program must end with exact land');
+
+  const initialAltitude = bounded(
+    first.height_m,
+    'takeoff height_m',
+    MIN_ALTITUDE_M,
+    MAX_ALTITUDE_M
+  );
+  const terminal = analyseSequence(
+    ast.program.slice(1, -1),
+    {min: initialAltitude, max: initialAltitude},
+    0
+  );
+
+  return Object.freeze({
+    initialAltitudeM: initialAltitude,
+    terminalAltitudeMinM: terminal.min,
+    terminalAltitudeMaxM: terminal.max,
+    executionAuthority: false
+  });
+}
+
+module.exports = Object.freeze({
+  validatePhysicalProgram,
+  MIN_ALTITUDE_M,
+  MAX_ALTITUDE_M
+});


### PR DESCRIPTION
Refs #345 #157.

Superseded as an active candidate by PR #353, which independently implements the same conservative all-reachable-path pre-takeoff safety prerequisite while reusing the integrated Python physical semantics/constants and already wires its dedicated regression into the Runtime v2 core harness.

This Draft is therefore closed to reduce duplicate engaged work. Its branch is left intact as durable comparison evidence for the narrower design difference explored here: delegating language/control-flow validity directly to the existing shared `interpreter.js` before applying a conservative no-effect physical path proof. No code from this branch is claimed integrated and no #345 completion, real-device qualification, checkpoint or `TEST_REQUIRED` follows from closing it.