### PR TITLE
Run bound physical control flow through shared interpreter

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -125,6 +125,10 @@ def main():
     if physical_dynamic_preflight_test.returncode:
         print('FAIL conservative dynamic physical pre-takeoff envelope',file=sys.stderr);print(physical_dynamic_preflight_test.stdout,file=sys.stderr);print(physical_dynamic_preflight_test.stderr,file=sys.stderr);return physical_dynamic_preflight_test.returncode
     print(physical_dynamic_preflight_test.stdout.strip())
+    physical_shared_interpreter_test=subprocess.run([sys.executable,'tools/ci/test_physical_shared_interpreter.py'],text=True,capture_output=True)
+    if physical_shared_interpreter_test.returncode:
+        print('FAIL trusted shared Runtime interpreter physical core',file=sys.stderr);print(physical_shared_interpreter_test.stdout,file=sys.stderr);print(physical_shared_interpreter_test.stderr,file=sys.stderr);return physical_shared_interpreter_test.returncode
+    print(physical_shared_interpreter_test.stdout.strip())
     physical_color_led_transport_test=subprocess.run([sys.executable,'tools/ci/test_physical_color_led_transport.py'],text=True,capture_output=True)
     if physical_color_led_transport_test.returncode:
         print('FAIL trusted one-shot bottom Color LED transport',file=sys.stderr);print(physical_color_led_transport_test.stdout,file=sys.stderr);print(physical_color_led_transport_test.stderr,file=sys.stderr);return physical_color_led_transport_test.returncode

--- a/tools/ci/test_physical_shared_interpreter.py
+++ b/tools/ci/test_physical_shared_interpreter.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+if str(PHYSICAL) not in sys.path:
+    sys.path.insert(0, str(PHYSICAL))
+
+import takeoff_command
+from physical_dynamic_preflight import DynamicPhysicalPreflightError
+import shared_interpreter_host as subject
+from shared_interpreter_host import BoundSharedInterpreter, SharedInterpreterHostError
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def binding(ast: dict[str, object]) -> str:
+    return takeoff_command._canonical_json(ast)
+
+
+VARIABLE = {"id": "distance", "name": "distance-é"}
+
+
+def representative_ast() -> dict[str, object]:
+    return {
+        "version": 1,
+        "semantics": "webeeblocks-ast-v1",
+        "program": [
+            {"kind": "takeoff", "height_m": 0.8},
+            {
+                "kind": "set_variable",
+                "variable": VARIABLE,
+                "value": {"kind": "range", "direction": "front", "unit": "m"},
+            },
+            {
+                "kind": "repeat",
+                "count": 2,
+                "body": [
+                    {
+                        "kind": "if",
+                        "condition": {
+                            "kind": "logic",
+                            "op": "AND",
+                            "left": {
+                                "kind": "compare",
+                                "op": "LT",
+                                "left": {"kind": "variable_get", "variable": VARIABLE},
+                                "right": {"kind": "number", "value": 1},
+                            },
+                            "right": {
+                                "kind": "compare",
+                                "op": "LT",
+                                "left": {
+                                    "kind": "range",
+                                    "direction": "right",
+                                    "unit": "m",
+                                },
+                                "right": {"kind": "number", "value": 0.5},
+                            },
+                        },
+                        "then": [
+                            {"kind": "move", "direction": "left", "distance_m": 0.2}
+                        ],
+                        "else": [{"kind": "turn", "angle_deg": 45}],
+                    }
+                ],
+            },
+            {
+                "kind": "if",
+                "condition": {
+                    "kind": "logic",
+                    "op": "OR",
+                    "left": {
+                        "kind": "compare",
+                        "op": "EQ",
+                        "left": {"kind": "number", "value": 1},
+                        "right": {"kind": "number", "value": 1},
+                    },
+                    "right": {
+                        "kind": "compare",
+                        "op": "GT",
+                        "left": {"kind": "range", "direction": "up", "unit": "m"},
+                        "right": {"kind": "number", "value": 0},
+                    },
+                },
+                "then": [{"kind": "set_light", "color": "green"}],
+                "else": [],
+            },
+            {"kind": "land"},
+        ],
+    }
+
+
+class FakeBackend:
+    def __init__(self) -> None:
+        self.trace: list[tuple[object, ...]] = []
+        self.ranges = {"front": [0.8], "right": [0.3, 0.7], "up": [0.2]}
+
+    def takeoff(self, height_m):
+        self.trace.append(("takeoff", height_m))
+        return {"authority": "must-not-cross"}
+
+    def land(self):
+        self.trace.append(("land",))
+        return {"authority": "must-not-cross"}
+
+    def move(self, direction, distance_m):
+        self.trace.append(("move", direction, distance_m))
+        return {"authority": "must-not-cross"}
+
+    def vertical(self, direction, distance_m):
+        self.trace.append(("vertical", direction, distance_m))
+        return {"authority": "must-not-cross"}
+
+    def turn(self, angle_deg):
+        self.trace.append(("turn", angle_deg))
+        return {"authority": "must-not-cross"}
+
+    def wait(self, seconds):
+        self.trace.append(("wait", seconds))
+        return {"authority": "must-not-cross"}
+
+    def setSpeed(self, speed_m_s):
+        self.trace.append(("setSpeed", speed_m_s))
+        return {"authority": "must-not-cross"}
+
+    def setLight(self, color):
+        self.trace.append(("setLight", color))
+        return {"authority": "must-not-cross"}
+
+    def readRange(self, direction):
+        self.trace.append(("readRange", direction))
+        return self.ranges[direction].pop(0)
+
+
+def test_real_shared_interpreter_owns_control_flow_and_sensor_demand() -> None:
+    backend = FakeBackend()
+    exact = binding(representative_ast())
+    host = BoundSharedInterpreter(exact, backend)
+    require(host.safety_evidence.ast_binding == exact, "exact AST safety binding changed")
+    result = host.run()
+    require(
+        backend.trace
+        == [
+            ("takeoff", 0.8),
+            ("readRange", "front"),
+            ("readRange", "right"),
+            ("move", "left", 0.2),
+            ("readRange", "right"),
+            ("turn", 45.0),
+            ("setLight", "green"),
+            ("land",),
+        ],
+        f"shared interpreter emitted unexpected trace: {backend.trace!r}",
+    )
+    require(
+        ("readRange", "up") not in backend.trace,
+        "OR short-circuit manufactured a phantom sensor read",
+    )
+    require(
+        result.variables == {"distance-é": 0.8},
+        "shared interpreter variable environment or UTF-8 protocol changed",
+    )
+    try:
+        host.run()
+    except SharedInterpreterHostError as exc:
+        require("one-shot" in str(exc), "interpreter reuse failed for wrong reason")
+    else:
+        raise AssertionError("bound shared interpreter reuse must fail closed")
+
+
+def test_dynamic_safety_and_language_validation_precede_backend_use() -> None:
+    unsafe = {
+        "version": 1,
+        "semantics": "webeeblocks-ast-v1",
+        "program": [
+            {"kind": "takeoff", "height_m": 1.4},
+            {
+                "kind": "if",
+                "condition": {"kind": "range", "direction": "front", "unit": "m"},
+                "then": [{"kind": "vertical", "direction": "up", "distance_m": 0.2}],
+                "else": [],
+            },
+            {"kind": "land"},
+        ],
+    }
+    backend = FakeBackend()
+    try:
+        BoundSharedInterpreter(binding(unsafe), backend)
+    except DynamicPhysicalPreflightError as exc:
+        require("nominal-altitude" in str(exc), "unsafe path failed for wrong reason")
+    else:
+        raise AssertionError("reachable unsafe altitude must fail before interpreter start")
+    require(backend.trace == [], "unsafe preflight emitted a backend call")
+
+    invalid = representative_ast()
+    invalid["program"][1] = {
+        "kind": "set_variable",
+        "variable": VARIABLE,
+        "value": {"kind": "variable_get", "variable": VARIABLE},
+    }
+    backend = FakeBackend()
+    try:
+        BoundSharedInterpreter(binding(invalid), backend).run()
+    except SharedInterpreterHostError as exc:
+        require("failed closed" in str(exc), "JS validation failed for wrong reason")
+    else:
+        raise AssertionError("shared interpreter must reject read-before-assignment")
+    require(backend.trace == [], "language validation must precede backend use")
+
+
+def test_range_data_and_backend_failure_fail_closed() -> None:
+    exact = binding(representative_ast())
+
+    class BadRange(FakeBackend):
+        def readRange(self, direction):
+            self.trace.append(("readRange", direction))
+            return float("nan")
+
+    backend = BadRange()
+    try:
+        BoundSharedInterpreter(exact, backend).run()
+    except SharedInterpreterHostError as exc:
+        require("range result" in str(exc), "non-finite range failed for wrong reason")
+    else:
+        raise AssertionError("non-finite range must fail closed")
+    require(
+        backend.trace[:2] == [("takeoff", 0.8), ("readRange", "front")],
+        "failure escaped exact interpreter demand",
+    )
+
+
+def _run_with_fake_worker(source: str, backend: FakeBackend, timeout: float = 0.5) -> str:
+    original_worker = subject._WORKER
+    original_timeout = subject._PROTOCOL_IDLE_TIMEOUT_SECONDS
+    with tempfile.TemporaryDirectory() as temp:
+        worker = Path(temp) / "worker.js"
+        worker.write_text(source, encoding="utf-8")
+        subject._WORKER = worker
+        subject._PROTOCOL_IDLE_TIMEOUT_SECONDS = timeout
+        try:
+            BoundSharedInterpreter(binding(representative_ast()), backend).run()
+        except SharedInterpreterHostError as exc:
+            return str(exc)
+        finally:
+            subject._WORKER = original_worker
+            subject._PROTOCOL_IDLE_TIMEOUT_SECONDS = original_timeout
+    raise AssertionError("fake worker unexpectedly completed")
+
+
+def test_private_protocol_rejects_substitution_and_silence() -> None:
+    backend = FakeBackend()
+    message = _run_with_fake_worker(
+        """
+'use strict';
+const fs=require('fs');
+const b=Buffer.alloc(65536); fs.readSync(0,b,0,b.length,null);
+process.stdout.write(JSON.stringify({type:'call',id:1,method:'readRange',args:['down']})+'\\n');
+setInterval(()=>{},1000);
+""",
+        backend,
+    )
+    require("range direction is unsupported" in message, "down substitution wrong failure")
+    require(backend.trace == [], "rejected worker substitution reached backend")
+
+    backend = FakeBackend()
+    message = _run_with_fake_worker(
+        """
+'use strict';
+const fs=require('fs');
+const b=Buffer.alloc(65536); fs.readSync(0,b,0,b.length,null);
+setInterval(()=>{},1000);
+""",
+        backend,
+        timeout=0.2,
+    )
+    require("timed out" in message, "silent worker did not fail on protocol timeout")
+    require(backend.trace == [], "silent worker reached backend")
+
+
+def test_surface_contains_no_second_language_engine_or_caller_semantics() -> None:
+    host_source = (PHYSICAL / "shared_interpreter_host.py").read_text(encoding="utf-8")
+    worker_source = (PHYSICAL / "shared_interpreter_worker.js").read_text(encoding="utf-8")
+    interpreter_source = (
+        ROOT / "plugins/robot_windows/blockly/webeeblocks/interpreter.js"
+    ).read_text(encoding="utf-8")
+    require("interpreter.js" in worker_source, "worker does not load product interpreter")
+    require("Interpreter.run(ast, backend)" in worker_source, "worker bypasses shared run()")
+    for forbidden in ("case 'if'", "case 'repeat'", "statement.kind", "expression.kind"):
+        require(forbidden not in worker_source, f"worker duplicates evaluator: {forbidden}")
+    for forbidden in ("cflib", "send_packet", "setpoint", "commander"):
+        require(forbidden not in host_source.lower(), f"adapter leaked physical authority: {forbidden}")
+    for forbidden in ("--ast", "--direction", "--value", "--branch", "--iteration"):
+        require(forbidden not in host_source + worker_source, f"caller semantic option: {forbidden}")
+    require("module.exports = factory()" in interpreter_source, "shared interpreter lost CommonJS")
+    require("requireMethod(backend,'readRange')" in interpreter_source, "range path changed")
+
+
+def main() -> int:
+    test_real_shared_interpreter_owns_control_flow_and_sensor_demand()
+    test_dynamic_safety_and_language_validation_precede_backend_use()
+    test_range_data_and_backend_failure_fail_closed()
+    test_private_protocol_rejects_substitution_and_silence()
+    test_surface_contains_no_second_language_engine_or_caller_semantics()
+    print(
+        "PASS exact teacher-bound AST executes through the existing shared Runtime interpreter "
+        "with host-owned control flow/sensor demand and a fail-closed private backend protocol"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/shared_interpreter_host.py
+++ b/tools/physical/shared_interpreter_host.py
@@ -7,7 +7,7 @@ Node process loads the repository's existing ``interpreter.js`` and can request
 only the fixed backend methods below over a private stdio protocol.
 
 This adapter is deliberately not physical composition by itself: it owns no
-Crazyflie session, observer, commander or effect authority. A later trusted host
+Crazyflie session, observer or effect-transport authority. A later trusted host
 must bind ``readRange`` to the fresh range observer and bind each action method to
 its already-authorized consumer while re-establishing current-program provenance.
 """

--- a/tools/physical/shared_interpreter_host.py
+++ b/tools/physical/shared_interpreter_host.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Host-owned wrapper around the existing Runtime v2 JavaScript interpreter.
+
+The exact canonical AST binding is the only semantic input. ``run()`` accepts no
+caller-selected direction, value, branch, iteration or action parameter. A child
+Node process loads the repository's existing ``interpreter.js`` and can request
+only the fixed backend methods below over a private stdio protocol.
+
+This adapter is deliberately not physical composition by itself: it owns no
+Crazyflie session, observer, commander or effect authority. A later trusted host
+must bind ``readRange`` to the fresh range observer and bind each action method to
+its already-authorized consumer while re-establishing current-program provenance.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from math import isfinite
+from pathlib import Path
+from queue import Empty, Queue
+import subprocess
+from threading import Thread
+from typing import Protocol, TextIO
+
+from physical_dynamic_preflight import (
+    ReachablePhysicalEnvelope,
+    validate_bound_dynamic_program,
+)
+
+_WORKER = Path(__file__).with_name("shared_interpreter_worker.js")
+_MAX_PROTOCOL_BYTES = 1024 * 1024
+_PROTOCOL_IDLE_TIMEOUT_SECONDS = 2.0
+_MOVE_DIRECTIONS = frozenset({"forward", "back", "left", "right"})
+_VERTICAL_DIRECTIONS = frozenset({"up", "down"})
+_RANGE_DIRECTIONS = frozenset({"front", "back", "left", "right", "up"})
+_LIGHT_COLORS = frozenset({"off", "red", "green", "blue", "yellow", "white"})
+_METHOD_ARITY = {
+    "takeoff": 1,
+    "land": 0,
+    "move": 2,
+    "vertical": 2,
+    "turn": 1,
+    "wait": 1,
+    "setSpeed": 1,
+    "setLight": 1,
+    "readRange": 1,
+}
+_EOF = object()
+
+
+class SharedInterpreterHostError(RuntimeError):
+    """Fail-closed error for the host-owned shared interpreter adapter."""
+
+
+class PhysicalInterpreterBackend(Protocol):
+    def takeoff(self, height_m: float): ...
+    def land(self): ...
+    def move(self, direction: str, distance_m: float): ...
+    def vertical(self, direction: str, distance_m: float): ...
+    def turn(self, angle_deg: float): ...
+    def wait(self, seconds: float): ...
+    def setSpeed(self, speed_m_s: float): ...
+    def setLight(self, color: str): ...
+    def readRange(self, direction: str) -> float: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SharedInterpreterResult:
+    remaining_budget: int
+    variables: dict[str, object]
+
+
+class _LinePump:
+    """Read child stdout without letting a silent child block the trusted host."""
+
+    def __init__(self, stream: TextIO) -> None:
+        self._queue: Queue[object] = Queue()
+
+        def pump() -> None:
+            try:
+                while True:
+                    line = stream.readline()
+                    if not line:
+                        break
+                    self._queue.put(line)
+            except Exception as exc:  # pragma: no cover - defensive transport path
+                self._queue.put(exc)
+            finally:
+                self._queue.put(_EOF)
+
+        Thread(target=pump, name="shared-interpreter-stdout", daemon=True).start()
+
+    def read(self) -> str:
+        try:
+            item = self._queue.get(timeout=_PROTOCOL_IDLE_TIMEOUT_SECONDS)
+        except Empty as exc:
+            raise SharedInterpreterHostError(
+                "shared interpreter protocol timed out"
+            ) from exc
+        if item is _EOF:
+            raise SharedInterpreterHostError(
+                "shared interpreter exited before completion"
+            )
+        if isinstance(item, Exception):
+            raise SharedInterpreterHostError(
+                "shared interpreter output failed"
+            ) from item
+        if not isinstance(item, str):
+            raise SharedInterpreterHostError(
+                "shared interpreter output is malformed"
+            )
+        return item
+
+
+def _finite_number(value: object, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SharedInterpreterHostError(label + " must be finite")
+    parsed = float(value)
+    if not isfinite(parsed):
+        raise SharedInterpreterHostError(label + " must be finite")
+    return parsed
+
+
+def _exact_string(value: object, allowed: frozenset[str], label: str) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        raise SharedInterpreterHostError(label + " is unsupported")
+    return value
+
+
+class BoundSharedInterpreter:
+    """One exact-AST interpreter execution with no caller-selected semantics."""
+
+    def __init__(self, ast_binding: str, backend: PhysicalInterpreterBackend) -> None:
+        self._safety: ReachablePhysicalEnvelope = validate_bound_dynamic_program(
+            ast_binding
+        )
+        self._ast_binding = ast_binding
+        self._backend = backend
+        self._used = False
+
+    @property
+    def safety_evidence(self) -> ReachablePhysicalEnvelope:
+        return self._safety
+
+    @staticmethod
+    def _write(process: subprocess.Popen[str], message: dict[str, object]) -> None:
+        if process.stdin is None:
+            raise SharedInterpreterHostError(
+                "shared interpreter input is unavailable"
+            )
+        encoded = json.dumps(
+            message,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(encoded.encode("utf-8")) > _MAX_PROTOCOL_BYTES:
+            raise SharedInterpreterHostError(
+                "shared interpreter protocol message is too large"
+            )
+        try:
+            process.stdin.write(encoded + "\n")
+            process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise SharedInterpreterHostError(
+                "shared interpreter input failed"
+            ) from exc
+
+    @staticmethod
+    def _read(pump: _LinePump) -> dict[str, object]:
+        line = pump.read()
+        if len(line.encode("utf-8")) > _MAX_PROTOCOL_BYTES:
+            raise SharedInterpreterHostError(
+                "shared interpreter protocol message is too large"
+            )
+        try:
+            message = json.loads(line)
+        except (TypeError, ValueError) as exc:
+            raise SharedInterpreterHostError(
+                "shared interpreter protocol is malformed"
+            ) from exc
+        if not isinstance(message, dict):
+            raise SharedInterpreterHostError(
+                "shared interpreter protocol is malformed"
+            )
+        return message
+
+    @staticmethod
+    def _terminate(process: subprocess.Popen[str]) -> None:
+        if process.stdin is not None:
+            try:
+                process.stdin.close()
+            except OSError:
+                pass
+        if process.poll() is None:
+            try:
+                process.kill()
+            except OSError:
+                pass
+        try:
+            process.wait(timeout=1.0)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    def _validated_args(self, method: str, args: list[object]) -> list[object]:
+        expected = _METHOD_ARITY.get(method)
+        if expected is None or len(args) != expected:
+            raise SharedInterpreterHostError(
+                "shared interpreter requested unsupported backend call"
+            )
+        if method == "land":
+            return []
+        if method == "takeoff":
+            return [_finite_number(args[0], "takeoff height")]
+        if method == "move":
+            return [
+                _exact_string(args[0], _MOVE_DIRECTIONS, "move direction"),
+                _finite_number(args[1], "move distance"),
+            ]
+        if method == "vertical":
+            return [
+                _exact_string(args[0], _VERTICAL_DIRECTIONS, "vertical direction"),
+                _finite_number(args[1], "vertical distance"),
+            ]
+        if method == "turn":
+            return [_finite_number(args[0], "turn angle")]
+        if method == "wait":
+            return [_finite_number(args[0], "wait duration")]
+        if method == "setSpeed":
+            return [_finite_number(args[0], "horizontal speed")]
+        if method == "setLight":
+            return [_exact_string(args[0], _LIGHT_COLORS, "light color")]
+        if method == "readRange":
+            return [_exact_string(args[0], _RANGE_DIRECTIONS, "range direction")]
+        raise SharedInterpreterHostError(
+            "shared interpreter requested unsupported backend call"
+        )
+
+    def _dispatch(self, method: str, args: list[object]):
+        validated = self._validated_args(method, args)
+        target = getattr(self._backend, method, None)
+        if not callable(target):
+            raise SharedInterpreterHostError(
+                "trusted physical backend method is unavailable"
+            )
+        try:
+            value = target(*validated)
+        except Exception as exc:
+            raise SharedInterpreterHostError(
+                "trusted physical backend call failed"
+            ) from exc
+        if method != "readRange":
+            # Action/no-effect consumer return objects stay inside the Python TCB.
+            return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise SharedInterpreterHostError(
+                "physical range result must be finite non-authority data"
+            )
+        parsed = float(value)
+        if not isfinite(parsed):
+            raise SharedInterpreterHostError(
+                "physical range result must be finite non-authority data"
+            )
+        return parsed
+
+    def run(self) -> SharedInterpreterResult:
+        if self._used:
+            raise SharedInterpreterHostError("bound shared interpreter is one-shot")
+        self._used = True
+        if not _WORKER.is_file():
+            raise SharedInterpreterHostError(
+                "shared interpreter worker is unavailable"
+            )
+        try:
+            process = subprocess.Popen(
+                ["node", str(_WORKER)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+            )
+        except (OSError, ValueError) as exc:
+            raise SharedInterpreterHostError(
+                "could not start shared interpreter"
+            ) from exc
+        if process.stdout is None:
+            self._terminate(process)
+            raise SharedInterpreterHostError(
+                "shared interpreter output is unavailable"
+            )
+
+        pump = _LinePump(process.stdout)
+        expected_call_id = 1
+        try:
+            self._write(
+                process,
+                {"op": "run-bound-program", "astBinding": self._ast_binding},
+            )
+            while True:
+                message = self._read(pump)
+                message_type = message.get("type")
+                if message_type == "call":
+                    if set(message) != {"type", "id", "method", "args"}:
+                        raise SharedInterpreterHostError(
+                            "shared interpreter call is malformed"
+                        )
+                    call_id = message["id"]
+                    method = message["method"]
+                    args = message["args"]
+                    if (
+                        not isinstance(call_id, int)
+                        or isinstance(call_id, bool)
+                        or call_id != expected_call_id
+                        or not isinstance(method, str)
+                        or not isinstance(args, list)
+                    ):
+                        raise SharedInterpreterHostError(
+                            "shared interpreter call is malformed"
+                        )
+                    expected_call_id += 1
+                    try:
+                        value = self._dispatch(method, args)
+                    except SharedInterpreterHostError:
+                        self._write(
+                            process,
+                            {"type": "return", "id": call_id, "ok": False},
+                        )
+                        raise
+                    self._write(
+                        process,
+                        {
+                            "type": "return",
+                            "id": call_id,
+                            "ok": True,
+                            "value": value,
+                        },
+                    )
+                    continue
+
+                if message_type != "done":
+                    raise SharedInterpreterHostError(
+                        "shared interpreter protocol is malformed"
+                    )
+                if (
+                    message.get("ok") is not True
+                    or set(message) != {"type", "ok", "result"}
+                ):
+                    raise SharedInterpreterHostError(
+                        "shared interpreter failed closed"
+                    )
+                result = message["result"]
+                if (
+                    not isinstance(result, dict)
+                    or set(result) != {"remainingBudget", "variables"}
+                ):
+                    raise SharedInterpreterHostError(
+                        "shared interpreter result is malformed"
+                    )
+                remaining = result["remainingBudget"]
+                variables = result["variables"]
+                if (
+                    not isinstance(remaining, int)
+                    or isinstance(remaining, bool)
+                    or remaining < 0
+                    or not isinstance(variables, dict)
+                ):
+                    raise SharedInterpreterHostError(
+                        "shared interpreter result is malformed"
+                    )
+                try:
+                    exit_code = process.wait(timeout=_PROTOCOL_IDLE_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired as exc:
+                    raise SharedInterpreterHostError(
+                        "shared interpreter did not terminate"
+                    ) from exc
+                if exit_code != 0:
+                    raise SharedInterpreterHostError(
+                        "shared interpreter exited unsuccessfully"
+                    )
+                return SharedInterpreterResult(remaining, dict(variables))
+        finally:
+            self._terminate(process)

--- a/tools/physical/shared_interpreter_worker.js
+++ b/tools/physical/shared_interpreter_worker.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {StringDecoder} = require('string_decoder');
+const Interpreter = require(path.resolve(
+  __dirname,
+  '../../plugins/robot_windows/blockly/webeeblocks/interpreter.js'
+));
+
+const MAX_PROTOCOL_BYTES = 1024 * 1024;
+const decoder = new StringDecoder('utf8');
+let inputBuffer = '';
+
+function readLineSync() {
+  while (true) {
+    const newline = inputBuffer.indexOf('\n');
+    if (newline >= 0) {
+      const line = inputBuffer.slice(0, newline);
+      inputBuffer = inputBuffer.slice(newline + 1);
+      return line;
+    }
+    const bytes = Buffer.alloc(4096);
+    const count = fs.readSync(0, bytes, 0, bytes.length, null);
+    if (count === 0) {
+      inputBuffer += decoder.end();
+      if (inputBuffer.length) {
+        const line = inputBuffer;
+        inputBuffer = '';
+        return line;
+      }
+      throw new Error('shared interpreter input closed');
+    }
+    inputBuffer += decoder.write(bytes.subarray(0, count));
+    if (Buffer.byteLength(inputBuffer, 'utf8') > MAX_PROTOCOL_BYTES)
+      throw new Error('shared interpreter message too large');
+  }
+}
+
+function send(message) {
+  const encoded = JSON.stringify(message);
+  if (Buffer.byteLength(encoded, 'utf8') > MAX_PROTOCOL_BYTES)
+    throw new Error('shared interpreter message too large');
+  process.stdout.write(encoded + '\n');
+}
+
+function exactKeys(value, expected) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value).sort();
+  const wanted = expected.slice().sort();
+  return keys.length === wanted.length && keys.every((key, index) => key === wanted[index]);
+}
+
+let nextCallId = 1;
+async function rpc(method, args) {
+  const id = nextCallId++;
+  send({type: 'call', id, method, args});
+  const response = JSON.parse(readLineSync());
+  const expected = response && response.ok === true
+    ? ['type', 'id', 'ok', 'value']
+    : ['type', 'id', 'ok'];
+  if (!exactKeys(response, expected))
+    throw new Error('malformed shared interpreter backend response');
+  if (response.type !== 'return' || response.id !== id || typeof response.ok !== 'boolean')
+    throw new Error('mismatched shared interpreter backend response');
+  if (!response.ok) throw new Error('physical backend call failed closed');
+  return response.value;
+}
+
+(async function main() {
+  try {
+    if (process.argv.length !== 2)
+      throw new Error('shared interpreter worker accepts no arguments');
+    const startup = JSON.parse(readLineSync());
+    if (!exactKeys(startup, ['op', 'astBinding']) || startup.op !== 'run-bound-program')
+      throw new Error('malformed shared interpreter startup');
+    if (typeof startup.astBinding !== 'string' || !startup.astBinding.trim() || startup.astBinding !== startup.astBinding.trim())
+      throw new Error('exact AST binding is unavailable');
+    const ast = JSON.parse(startup.astBinding);
+    Interpreter.validateProgram(ast);
+
+    const backend = {
+      takeoff: (height) => rpc('takeoff', [height]),
+      land: () => rpc('land', []),
+      move: (direction, distance) => rpc('move', [direction, distance]),
+      vertical: (direction, distance) => rpc('vertical', [direction, distance]),
+      turn: (angle) => rpc('turn', [angle]),
+      wait: (seconds) => rpc('wait', [seconds]),
+      setSpeed: (speed) => rpc('setSpeed', [speed]),
+      setLight: (color) => rpc('setLight', [color]),
+      readRange: (direction) => rpc('readRange', [direction])
+    };
+    const result = await Interpreter.run(ast, backend);
+    send({type: 'done', ok: true, result});
+  } catch (_error) {
+    try {
+      send({type: 'done', ok: false, error: 'shared interpreter failed closed'});
+    } catch (_sendError) {
+      // The parent will fail closed if the protocol is no longer writable.
+    }
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
Refs #345 #157.

This bounded infrastructure slice follows the integrated all-path physical preflight from #353 and establishes the host-owned bridge into the **existing** Runtime v2 JavaScript interpreter. It deliberately does not compose a live Crazyflie run yet.

Complete scope of this candidate:
- accepts only the exact canonical teacher/current-program AST binding and runs the integrated conservative dynamic physical preflight before starting the interpreter worker;
- loads `plugins/robot_windows/blockly/webeeblocks/interpreter.js` directly in a private Node child, so the existing shared Runtime interpreter remains the sole language evaluator for variables, arithmetic/comparisons, short-circuit logic, `if`, `repeat` and `range(direction)`;
- exposes no caller-selected direction, sensor value, branch, iteration or action parameter: `run()` is parameter-free after construction from the exact bound AST;
- translates only the interpreter's fixed backend vocabulary over a private UTF-8 stdio protocol with exact monotonic call IDs, exact message shapes, bounded messages and fail-closed protocol-idle timeout;
- validates the fixed movement/vertical/range/light vocabulary and finite numeric arguments again at the host boundary before dispatch; `range(down)` and unknown/malformed calls are rejected before reaching the supplied backend;
- lets only a finite `readRange` number cross back into interpreter data; action/no-effect callback return objects are discarded inside the Python host so they cannot become interpreter authority or branch/cursor state;
- fails closed on malformed/closed/silent child protocol, non-finite range data, backend failure, wrong call order and unsuccessful worker termination;
- adds deterministic Runtime-core regression coverage using the real shared interpreter for variable state, repeated sensor-dependent branching, AND/OR short-circuiting with no phantom range read, exact action trace, unsafe reachable altitude rejection before backend use, language validation before backend use, non-finite range rejection, forbidden `down` substitution and silent-worker timeout.

This deliberately does **not** complete #345. `readRange` is not yet bound to the integrated fresh same-epoch Multi-ranger observer, action callbacks are not yet bound to the existing trusted physical effect consumers, and this adapter does not establish current-program/session/watchdog/exclusion/effect provenance by itself. The next composition step must perform those bindings inside the trusted physical host while preserving each existing downstream authority boundary.

No real-device qualification, motorized flight, human checkpoint or `TEST_REQUIRED` is claimed. Current candidate HEAD `dce66ca0f594c999f49286b5227865dc3fc948cc` is based directly on `main@1e7be7803f3cce1bc2b9c7362abdc747e812cda3`.