### PR TITLE
Compose shared interpreter with trusted physical backend

### DIFF
--- a/tools/ci/run_runtime_v2_core_harness.py
+++ b/tools/ci/run_runtime_v2_core_harness.py
@@ -129,6 +129,18 @@ def main():
     if physical_shared_interpreter_test.returncode:
         print('FAIL trusted shared Runtime interpreter physical core',file=sys.stderr);print(physical_shared_interpreter_test.stdout,file=sys.stderr);print(physical_shared_interpreter_test.stderr,file=sys.stderr);return physical_shared_interpreter_test.returncode
     print(physical_shared_interpreter_test.stdout.strip())
+    dynamic_backend_test=subprocess.run([sys.executable,'tools/ci/test_physical_dynamic_backend.py'],text=True,capture_output=True)
+    if dynamic_backend_test.returncode:
+        print('FAIL trusted dynamic physical backend composition',file=sys.stderr);print(dynamic_backend_test.stdout,file=sys.stderr);print(dynamic_backend_test.stderr,file=sys.stderr);return dynamic_backend_test.returncode
+    print(dynamic_backend_test.stdout.strip())
+    dynamic_run_test=subprocess.run([sys.executable,'tools/ci/test_dynamic_physical_run.py'],text=True,capture_output=True)
+    if dynamic_run_test.returncode:
+        print('FAIL one-shot bound dynamic physical run owner',file=sys.stderr);print(dynamic_run_test.stdout,file=sys.stderr);print(dynamic_run_test.stderr,file=sys.stderr);return dynamic_run_test.returncode
+    print(dynamic_run_test.stdout.strip())
+    dynamic_landing_test=subprocess.run([sys.executable,'tools/ci/test_dynamic_controlled_landing_transport.py'],text=True,capture_output=True)
+    if dynamic_landing_test.returncode:
+        print('FAIL dynamic runtime-altitude controlled landing',file=sys.stderr);print(dynamic_landing_test.stdout,file=sys.stderr);print(dynamic_landing_test.stderr,file=sys.stderr);return dynamic_landing_test.returncode
+    print(dynamic_landing_test.stdout.strip())
     physical_color_led_transport_test=subprocess.run([sys.executable,'tools/ci/test_physical_color_led_transport.py'],text=True,capture_output=True)
     if physical_color_led_transport_test.returncode:
         print('FAIL trusted one-shot bottom Color LED transport',file=sys.stderr);print(physical_color_led_transport_test.stdout,file=sys.stderr);print(physical_color_led_transport_test.stderr,file=sys.stderr);return physical_color_led_transport_test.returncode

--- a/tools/ci/test_dynamic_controlled_landing_transport.py
+++ b/tools/ci/test_dynamic_controlled_landing_transport.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from math import isclose
+from pathlib import Path
+import struct
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+sys.path.insert(0, str(CI))
+sys.path.insert(0, str(PHYSICAL))
+
+import dynamic_controlled_landing_transport as subject  # noqa: E402
+import high_level_timing as timing  # noqa: E402
+import serve_reference_capabilities as capability_bridge  # noqa: E402
+import test_physical_controlled_landing_transport as landing_test  # noqa: E402
+import test_physical_setpoint_hl_transport as base  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+class TestHostBoundDynamicTransport(subject.TrustedDynamicControlledLandingTransport):
+    def __init__(self, *, bridge, **kwargs) -> None:
+        self._test_bridge = bridge
+        super().__init__(**kwargs)
+
+    def _read_current_binding(self):
+        binding = self.teacher_binding
+        try:
+            evidence = self._test_bridge.assert_current_program(
+                profile_id=binding.profile_id,
+                ast_binding=binding.ast_binding,
+                connection_epoch=binding.connection_epoch,
+                timeout_seconds=0.25,
+            )
+        except Exception as exc:
+            raise subject.DynamicControlledLandingTransportError(
+                "integrated current-program re-assertion failed"
+            ) from exc
+        if type(evidence) is not capability_bridge.CurrentProgramPreflightEvidence:
+            raise subject.DynamicControlledLandingTransportError(
+                "invalid current-program evidence"
+            )
+        if evidence.execution_authority is not False:
+            raise subject.DynamicControlledLandingTransportError(
+                "current-program evidence became authority"
+            )
+        if (
+            evidence.profile_id != binding.profile_id
+            or evidence.ast_binding != binding.ast_binding
+            or evidence.connection_epoch != binding.connection_epoch
+        ):
+            raise subject.DynamicControlledLandingTransportError(
+                "current-program binding mismatch"
+            )
+        return binding
+
+
+def make_fixture(label: str, *, initial_altitude: float = 0.8, reply_status: int | None = 0):
+    cf = base.FakeCrazyflie(reply_status=reply_status)
+    fixture = base.Fixture(label, cf)
+    transport = TestHostBoundDynamicTransport(
+        bridge=fixture.bridge,
+        initial_nominal_altitude_m=initial_altitude,
+        connection_epoch_reader=fixture.epoch,
+        **fixture.kwargs,
+    )
+    return fixture, transport
+
+
+def unpack_last_land(fixture):
+    require(fixture.cf.send_calls, "dynamic landing must emit one terminal packet")
+    data = bytes(fixture.cf.send_calls[-1][0][0].data)
+    return struct.unpack("<BBf?f?f", data)
+
+
+def test_vertical_completion_advances_runtime_nominal_altitude() -> None:
+    fixture, transport = make_fixture("dynamic-altitude")
+    try:
+        result = transport.send_vertical_move(
+            direction="up",
+            distance_m=0.3,
+            timing_policy=timing.HighLevelTimingPolicy(),
+        )
+        require(result.accepted is True, "accepted dynamic vertical effect required")
+        require(
+            isclose(transport.nominal_altitude_m, 1.1, rel_tol=0, abs_tol=1e-9),
+            "accepted vertical effect did not advance host-owned nominal altitude",
+        )
+    finally:
+        fixture.close()
+
+
+def test_rejected_or_out_of_bounds_vertical_does_not_advance_state() -> None:
+    fixture, transport = make_fixture("dynamic-reject", reply_status=7)
+    try:
+        result = transport.send_vertical_move(
+            direction="up",
+            distance_m=0.3,
+            timing_policy=timing.HighLevelTimingPolicy(),
+        )
+        require(result.accepted is False, "nonzero firmware status must reject vertical effect")
+        require(
+            transport.nominal_altitude_m == 0.8,
+            "rejected vertical effect changed host-owned nominal altitude",
+        )
+    finally:
+        fixture.close()
+
+    fixture, transport = make_fixture("dynamic-bound", initial_altitude=1.4)
+    try:
+        try:
+            transport.send_vertical_move(
+                direction="up",
+                distance_m=0.2,
+                timing_policy=timing.HighLevelTimingPolicy(),
+            )
+        except subject.DynamicControlledLandingTransportError as exc:
+            require("0.2-1.5" in str(exc), "runtime altitude defense failed for wrong reason")
+        else:
+            raise AssertionError("runtime vertical effect escaped preflight-equivalent altitude bound")
+        require(not fixture.cf.send_calls, "out-of-bounds runtime vertical request emitted a packet")
+        require(transport.nominal_altitude_m == 1.4, "rejected runtime bound changed nominal altitude")
+    finally:
+        fixture.close()
+
+
+def test_terminal_landing_uses_completed_dynamic_path_altitude() -> None:
+    fixture, transport = make_fixture("dynamic-landing")
+    try:
+        vertical = transport.send_vertical_move(
+            direction="up",
+            distance_m=0.3,
+            timing_policy=timing.HighLevelTimingPolicy(),
+        )
+        require(vertical.accepted is True, "dynamic vertical prefix must complete")
+        require(isclose(transport.nominal_altitude_m, 1.1, abs_tol=1e-9), "dynamic prefix altitude")
+
+        landing_test.queue_pre_land(
+            fixture,
+            completion=base.state(
+                is_flying=False,
+                hl_control_active=False,
+                hl_traj_finished=True,
+            ),
+        )
+        result = transport.send_controlled_landing()
+        require(result.accepted is True, "dynamic terminal landing acknowledgement")
+        command, group, descent, relative, yaw, current_yaw, velocity = unpack_last_land(fixture)
+        require((command, group) == (10, 0), "dynamic terminal landing command/header changed")
+        require(
+            isclose(descent, 1.1, rel_tol=0, abs_tol=1e-6) and relative is True,
+            "terminal descent did not derive from definitively completed selected vertical path",
+        )
+        require(yaw == 0.0 and current_yaw is True, "dynamic landing must preserve current yaw")
+        require(isclose(velocity, 0.5, abs_tol=1e-6), "dynamic landing safe velocity changed")
+        require(
+            fixture.domain.phase == base.execution.INACTIVE,
+            "dynamic landing must still require fresh controlled-landing completion",
+        )
+    finally:
+        fixture.close()
+
+
+def main() -> int:
+    test_vertical_completion_advances_runtime_nominal_altitude()
+    test_rejected_or_out_of_bounds_vertical_does_not_advance_state()
+    test_terminal_landing_uses_completed_dynamic_path_altitude()
+    print(
+        "PASS dynamic controlled landing: selected vertical completion owns nominal Z, "
+        "rejection/bounds do not advance it, terminal command-10 uses completed runtime altitude"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_dynamic_controlled_landing_transport.py
+++ b/tools/ci/test_dynamic_controlled_landing_transport.py
@@ -15,6 +15,8 @@ sys.path.insert(0, str(PHYSICAL))
 import dynamic_controlled_landing_transport as subject  # noqa: E402
 import high_level_timing as timing  # noqa: E402
 import serve_reference_capabilities as capability_bridge  # noqa: E402
+import takeoff_command  # noqa: E402
+import teacher_run_authorization as teacher  # noqa: E402
 import test_physical_controlled_landing_transport as landing_test  # noqa: E402
 import test_physical_setpoint_hl_transport as base  # noqa: E402
 
@@ -22,6 +24,19 @@ import test_physical_setpoint_hl_transport as base  # noqa: E402
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
+
+
+def canonical_ast(takeoff_height_m: float) -> str:
+    return takeoff_command._canonical_json(
+        {
+            "program": [
+                {"height_m": takeoff_height_m, "kind": "takeoff"},
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        }
+    )
 
 
 class TestHostBoundDynamicTransport(subject.TrustedDynamicControlledLandingTransport):
@@ -61,12 +76,22 @@ class TestHostBoundDynamicTransport(subject.TrustedDynamicControlledLandingTrans
         return binding
 
 
-def make_fixture(label: str, *, initial_altitude: float = 0.8, reply_status: int | None = 0):
+def make_fixture(label: str, *, takeoff_height_m: float = 0.8, reply_status: int | None = 0):
     cf = base.FakeCrazyflie(reply_status=reply_status)
     fixture = base.Fixture(label, cf)
+    binding = teacher.PhysicalRunBinding(
+        profile_id="activity-dynamic-landing",
+        ast_binding=canonical_ast(takeoff_height_m),
+        connection_epoch=fixture.epoch(),
+    )
+    authorizer = teacher.TrustedTeacherAuthorizer()
+    authorization = authorizer.authorize_run(binding, lambda _binding: True)
+    fixture.binding = binding
+    fixture.current_binding = binding
+    fixture.authorization = authorization
+    fixture.kwargs["teacher_authorization"] = authorization
     transport = TestHostBoundDynamicTransport(
         bridge=fixture.bridge,
-        initial_nominal_altitude_m=initial_altitude,
         connection_epoch_reader=fixture.epoch,
         **fixture.kwargs,
     )
@@ -77,6 +102,21 @@ def unpack_last_land(fixture):
     require(fixture.cf.send_calls, "dynamic landing must emit one terminal packet")
     data = bytes(fixture.cf.send_calls[-1][0][0].data)
     return struct.unpack("<BBf?f?f", data)
+
+
+def test_initial_altitude_is_derived_only_from_exact_teacher_ast() -> None:
+    fixture, transport = make_fixture("dynamic-root", takeoff_height_m=0.8)
+    try:
+        require(
+            transport.initial_nominal_altitude_m == 0.8,
+            "dynamic landing root did not derive exact teacher-bound takeoff height",
+        )
+        require(
+            transport.nominal_altitude_m == 0.8,
+            "runtime nominal altitude did not start at exact preflight-proven takeoff",
+        )
+    finally:
+        fixture.close()
 
 
 def test_vertical_completion_advances_runtime_nominal_altitude() -> None:
@@ -112,7 +152,7 @@ def test_rejected_or_out_of_bounds_vertical_does_not_advance_state() -> None:
     finally:
         fixture.close()
 
-    fixture, transport = make_fixture("dynamic-bound", initial_altitude=1.4)
+    fixture, transport = make_fixture("dynamic-bound", takeoff_height_m=1.4)
     try:
         try:
             transport.send_vertical_move(
@@ -168,12 +208,13 @@ def test_terminal_landing_uses_completed_dynamic_path_altitude() -> None:
 
 
 def main() -> int:
+    test_initial_altitude_is_derived_only_from_exact_teacher_ast()
     test_vertical_completion_advances_runtime_nominal_altitude()
     test_rejected_or_out_of_bounds_vertical_does_not_advance_state()
     test_terminal_landing_uses_completed_dynamic_path_altitude()
     print(
-        "PASS dynamic controlled landing: selected vertical completion owns nominal Z, "
-        "rejection/bounds do not advance it, terminal command-10 uses completed runtime altitude"
+        "PASS dynamic controlled landing: exact teacher AST owns initial Z, selected vertical "
+        "completion owns runtime Z, terminal command-10 uses completed runtime altitude"
     )
     return 0
 

--- a/tools/ci/test_dynamic_physical_run.py
+++ b/tools/ci/test_dynamic_physical_run.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+if str(PHYSICAL) not in sys.path:
+    sys.path.insert(0, str(PHYSICAL))
+
+import dynamic_physical_run as subject  # noqa: E402
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+class FakeBackend:
+    ast_binding = "canonical-ast"
+
+    def __init__(self) -> None:
+        self.closed = 0
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def test_exact_backend_and_one_shot_execution() -> None:
+    original_backend = subject.TrustedDynamicPhysicalBackend
+    original_interpreter = subject.BoundSharedInterpreter
+
+    class ExactBackend(FakeBackend):
+        pass
+
+    class FakeInterpreter:
+        calls: list[tuple[str, object]] = []
+
+        def __init__(self, ast_binding: str, backend: object) -> None:
+            self.ast_binding = ast_binding
+            self.backend = backend
+
+        def run(self):
+            self.calls.append((self.ast_binding, self.backend))
+            return SimpleNamespace(remaining_budget=7, variables={})
+
+    subject.TrustedDynamicPhysicalBackend = ExactBackend
+    subject.BoundSharedInterpreter = FakeInterpreter
+    try:
+        backend = ExactBackend()
+        run = subject.BoundDynamicPhysicalRun(backend)
+        result = run.execute()
+        require(result.accepted is True, "successful bound run must return non-authority acceptance data")
+        require(
+            FakeInterpreter.calls == [("canonical-ast", backend)],
+            "dynamic run must execute exactly the bound shared interpreter/backend pair",
+        )
+        try:
+            run.execute()
+        except subject.DynamicPhysicalRunError as exc:
+            require("one-shot" in str(exc), "second execution failed for wrong reason")
+        else:
+            raise AssertionError("bound dynamic physical run was reusable")
+        run.close()
+        require(backend.closed == 1, "dynamic run must close backend-owned observers")
+    finally:
+        subject.TrustedDynamicPhysicalBackend = original_backend
+        subject.BoundSharedInterpreter = original_interpreter
+
+
+def test_interpreter_failure_is_fail_closed_but_cleanup_remains_explicit() -> None:
+    original_backend = subject.TrustedDynamicPhysicalBackend
+    original_interpreter = subject.BoundSharedInterpreter
+
+    class ExactBackend(FakeBackend):
+        pass
+
+    class FailingInterpreter:
+        def __init__(self, _ast_binding: str, _backend: object) -> None:
+            pass
+
+        def run(self):
+            raise RuntimeError("worker lost")
+
+    subject.TrustedDynamicPhysicalBackend = ExactBackend
+    subject.BoundSharedInterpreter = FailingInterpreter
+    try:
+        backend = ExactBackend()
+        run = subject.BoundDynamicPhysicalRun(backend)
+        try:
+            run.execute()
+        except subject.DynamicPhysicalRunError as exc:
+            require("failed closed" in str(exc), "interpreter failure escaped fail-closed boundary")
+        else:
+            raise AssertionError("interpreter failure was accepted")
+        require(backend.closed == 0, "run wrapper must not hide teardown outcome during execution failure")
+        run.close()
+        require(backend.closed == 1, "trusted host can still perform explicit terminal cleanup")
+    finally:
+        subject.TrustedDynamicPhysicalBackend = original_backend
+        subject.BoundSharedInterpreter = original_interpreter
+
+
+def main() -> int:
+    test_exact_backend_and_one_shot_execution()
+    test_interpreter_failure_is_fail_closed_but_cleanup_remains_explicit()
+    print(
+        "PASS dynamic physical run owner: exact bound shared interpreter, one-shot execution, "
+        "fail-closed worker failure and explicit observer teardown"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_dynamic_backend.py
+++ b/tools/ci/test_physical_dynamic_backend.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-import json
 from pathlib import Path
 from types import SimpleNamespace
 import sys
@@ -18,6 +17,7 @@ from dynamic_physical_backend import (  # noqa: E402
 )
 from physical_execution_domain import FLYING, INACTIVE  # noqa: E402
 from shared_interpreter_host import BoundSharedInterpreter  # noqa: E402
+import takeoff_command  # noqa: E402
 
 
 EVENTS: list[object] = []
@@ -29,15 +29,12 @@ def require(condition: bool, message: str) -> None:
 
 
 def canonical(program: list[dict[str, object]]) -> str:
-    return json.dumps(
+    return takeoff_command._canonical_json(
         {
             "program": program,
             "semantics": "webeeblocks-ast-v1",
             "version": 1,
-        },
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
+        }
     )
 
 

--- a/tools/ci/test_physical_dynamic_backend.py
+++ b/tools/ci/test_physical_dynamic_backend.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+if str(PHYSICAL) not in sys.path:
+    sys.path.insert(0, str(PHYSICAL))
+
+from dynamic_physical_backend import (  # noqa: E402
+    DynamicPhysicalBackendError,
+    TrustedDynamicPhysicalBackend,
+)
+from physical_execution_domain import FLYING, INACTIVE  # noqa: E402
+from shared_interpreter_host import BoundSharedInterpreter  # noqa: E402
+
+
+EVENTS: list[object] = []
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical(program: list[dict[str, object]]) -> str:
+    return json.dumps(
+        {
+            "program": program,
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+class FakeDomain:
+    def __init__(self) -> None:
+        self.phase = FLYING
+
+    def observation_transaction(self, *checks):
+        @contextmanager
+        def transaction():
+            EVENTS.append("observation-enter")
+            require(self.phase == FLYING, "observation requires flying")
+            for check in checks:
+                check()
+            try:
+                yield object()
+            finally:
+                require(self.phase == FLYING, "observation changed physical phase")
+                EVENTS.append("observation-exit")
+
+        return transaction()
+
+
+class FakeAuthorization:
+    def __init__(self, ast_binding: str) -> None:
+        self.binding = SimpleNamespace(
+            profile_id="activity-physical",
+            ast_binding=ast_binding,
+            connection_epoch="epoch-live",
+        )
+
+    def assert_effect_binding(self, *, profile_id: str, ast_binding: str, connection_epoch: str) -> None:
+        EVENTS.append("teacher-assert")
+        require(profile_id == self.binding.profile_id, "profile binding changed")
+        require(ast_binding == self.binding.ast_binding, "AST binding changed")
+        require(connection_epoch == self.binding.connection_epoch, "teacher epoch changed")
+
+
+class FakeWatchdog:
+    def assert_live(self) -> None:
+        EVENTS.append("watchdog-live")
+
+
+class FakeRun:
+    def __init__(self, ast_binding: str, domain: FakeDomain) -> None:
+        self.crazyflie = object()
+        self.execution_domain = domain
+        self.teacher_authorization = FakeAuthorization(ast_binding)
+        self.powered_session = SimpleNamespace(connection_epoch="epoch-live")
+        self.watchdog_guard = FakeWatchdog()
+
+
+class FakeRangeObserver:
+    def __init__(self, run: FakeRun, direction: str, value: float, *, fail_read: bool = False, fail_close: bool = False) -> None:
+        self.bound_crazyflie = run.crazyflie
+        self.bound_connection_epoch = None
+        self.direction = direction
+        self._epoch = run.powered_session.connection_epoch
+        self._value = value
+        self._fail_read = fail_read
+        self._fail_close = fail_close
+
+    def open(self) -> None:
+        EVENTS.append(("range-open", self.direction))
+        self.bound_connection_epoch = self._epoch
+
+    def read(self):
+        EVENTS.append(("range-read", self.direction))
+        if self._fail_read:
+            raise RuntimeError("unavailable")
+        return SimpleNamespace(
+            connection_epoch=self._epoch,
+            direction=self.direction,
+            range_m=self._value,
+        )
+
+    def close(self) -> None:
+        EVENTS.append(("range-close", self.direction))
+        if self._fail_close:
+            raise RuntimeError("uncertain teardown")
+
+
+class FakeYawObserver:
+    def __init__(self, run: FakeRun) -> None:
+        self.bound_crazyflie = run.crazyflie
+        self.bound_connection_epoch = run.powered_session.connection_epoch
+
+    def open(self) -> None:
+        EVENTS.append("yaw-open")
+
+    def close(self) -> None:
+        EVENTS.append("yaw-close")
+
+
+class Accepted:
+    accepted = True
+
+
+class Rejected:
+    accepted = False
+
+
+class FakeTransport:
+    def __init__(self, domain: FakeDomain) -> None:
+        self.domain = domain
+        self.reject_next = False
+
+    def _result(self):
+        if self.reject_next:
+            self.reject_next = False
+            return Rejected()
+        return Accepted()
+
+    def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
+        EVENTS.append(("move", direction, distance_m, yaw_reader, timing_policy))
+        return self._result()
+
+    def send_vertical_move(self, *, direction, distance_m, timing_policy):
+        EVENTS.append(("vertical", direction, distance_m, timing_policy))
+        return self._result()
+
+    def send_turn(self, *, angle_deg, timing_policy):
+        EVENTS.append(("turn", angle_deg, timing_policy))
+        return self._result()
+
+    def send_controlled_landing(self):
+        EVENTS.append("land")
+        result = self._result()
+        if result.accepted:
+            self.domain.phase = INACTIVE
+        return result
+
+
+class FakeColorTransport:
+    def __init__(self) -> None:
+        self.reject_next = False
+
+    def send_color(self, *, color: str):
+        EVENTS.append(("light", color))
+        if self.reject_next:
+            self.reject_next = False
+            return Rejected()
+        return Accepted()
+
+
+class FakeTimingPolicy:
+    def __init__(self) -> None:
+        self.speed = None
+
+    def set_horizontal_speed(self, speed_m_s: float) -> None:
+        EVENTS.append(("speed", speed_m_s))
+        self.speed = speed_m_s
+
+
+def representative_program() -> list[dict[str, object]]:
+    variable = {"id": "front-distance", "name": "distance"}
+    return [
+        {"height_m": 0.8, "kind": "takeoff"},
+        {
+            "kind": "set_variable",
+            "value": {"direction": "front", "kind": "range", "unit": "m"},
+            "variable": variable,
+        },
+        {
+            "condition": {
+                "kind": "compare",
+                "left": {"kind": "variable_get", "variable": variable},
+                "op": "LT",
+                "right": {"kind": "number", "value": 1.0},
+            },
+            "else": [{"angle_deg": 45.0, "kind": "turn"}],
+            "kind": "if",
+            "then": [{"direction": "left", "distance_m": 0.2, "kind": "move"}],
+        },
+        {
+            "body": [{"color": "green", "kind": "set_light"}],
+            "count": 2,
+            "kind": "repeat",
+        },
+        {"kind": "wait", "seconds": 0.1},
+        {"kind": "set_speed", "speed_m_s": 0.25},
+        {"kind": "land"},
+    ]
+
+
+def make_backend(*, range_value: float = 0.4, fail_read: bool = False, fail_close: bool = False):
+    exact = canonical(representative_program())
+    domain = FakeDomain()
+    run = FakeRun(exact, domain)
+    epoch = {"value": "epoch-live"}
+    transport = FakeTransport(domain)
+    color = FakeColorTransport()
+    timing = FakeTimingPolicy()
+
+    def current_program() -> None:
+        EVENTS.append("current-program")
+        require(epoch["value"] == "epoch-live", "current program must use live epoch")
+
+    def range_factory(direction: str):
+        EVENTS.append(("range-factory", direction))
+        return FakeRangeObserver(
+            run,
+            direction,
+            range_value,
+            fail_read=fail_read,
+            fail_close=fail_close,
+        )
+
+    def exact_wait(seconds: float) -> None:
+        EVENTS.append(("wait", seconds))
+        require(domain.phase == FLYING, "wait must remain in flying phase")
+
+    backend = TrustedDynamicPhysicalBackend(
+        ast_binding=exact,
+        initial_takeoff_height_m=0.8,
+        active_run=run,
+        connection_epoch_reader=lambda: epoch["value"],
+        assert_current_program=current_program,
+        inflight_transport=transport,
+        color_transport=color,
+        timing_policy=timing,
+        execute_wait=exact_wait,
+        range_observer_factory=range_factory,
+        yaw_observer_factory=lambda: FakeYawObserver(run),
+    )
+    return backend, domain, run, epoch, transport, color, timing
+
+
+def test_real_shared_interpreter_drives_fresh_range_and_existing_consumers() -> None:
+    EVENTS.clear()
+    backend, domain, _run, _epoch, _transport, _color, timing = make_backend(range_value=0.4)
+    try:
+        result = BoundSharedInterpreter(backend.ast_binding, backend).run()
+        require(result.variables == {"distance": 0.4}, "range value did not remain interpreter data")
+        require(domain.phase == INACTIVE, "terminal controlled landing did not establish inactive")
+        require(timing.speed == 0.25, "interpreter-selected speed state was not consumed")
+        require(
+            [event for event in EVENTS if isinstance(event, tuple) and event and event[0] in {"move", "turn"}][0][0]
+            == "move",
+            "range-driven branch did not reach the expected existing motion consumer",
+        )
+        require(not any(isinstance(event, tuple) and event and event[0] == "turn" for event in EVENTS), "non-selected branch emitted an action")
+        require(EVENTS.count(("light", "green")) == 2, "repeat progression did not stay in shared interpreter")
+        require(EVENTS.count(("range-read", "front")) == 1, "interpreter demand did not produce exactly one fresh range read")
+        require(EVENTS.count("land") == 1, "terminal landing was not consumed exactly once")
+        require("yaw-open" in EVENTS, "horizontal action did not retain fresh yaw consumer")
+    finally:
+        backend.close()
+    require(EVENTS.count("yaw-close") == 1, "dynamic backend did not close its yaw observer")
+
+
+def test_range_observation_is_exclusion_held_and_reasserted_around_sample() -> None:
+    EVENTS.clear()
+    backend, _domain, _run, _epoch, _transport, _color, _timing = make_backend()
+    backend.takeoff(0.8)
+    start = len(EVENTS)
+    value = backend.readRange("front")
+    require(value == 0.4, "fresh range metres changed")
+    trace = EVENTS[start:]
+    enter = trace.index("observation-enter")
+    factory = trace.index(("range-factory", "front"))
+    opened = trace.index(("range-open", "front"))
+    read = trace.index(("range-read", "front"))
+    closed = trace.index(("range-close", "front"))
+    exit_ = trace.index("observation-exit")
+    require(enter < factory < opened < read < closed < exit_, "fresh range escaped observation exclusion")
+    require(trace.count("current-program") >= 2, "current-program provenance was not reasserted around observation")
+    require(trace.count("watchdog-live") >= 2, "watchdog provenance was not reasserted around observation")
+
+
+def test_takeoff_is_verification_only_and_cannot_repeat() -> None:
+    EVENTS.clear()
+    backend, domain, _run, _epoch, _transport, _color, _timing = make_backend()
+    backend.takeoff(0.8)
+    require(domain.phase == FLYING, "verification-only takeoff changed physical phase")
+    require(not any(event == "land" or (isinstance(event, tuple) and event and event[0] in {"move", "turn", "vertical"}) for event in EVENTS), "takeoff verification emitted a downstream action")
+    try:
+        backend.takeoff(0.8)
+    except DynamicPhysicalBackendError as exc:
+        require("repeated bound takeoff" in str(exc), "repeat takeoff failed for wrong reason")
+    else:
+        raise AssertionError("shared interpreter could repeat causal takeoff")
+
+
+def test_stale_epoch_and_unavailable_range_fail_before_progression() -> None:
+    EVENTS.clear()
+    backend, _domain, _run, epoch, _transport, _color, _timing = make_backend()
+    backend.takeoff(0.8)
+    epoch["value"] = "epoch-reconnected"
+    try:
+        backend.readRange("front")
+    except DynamicPhysicalBackendError as exc:
+        require("epoch" in str(exc), "stale epoch failed for wrong reason")
+    else:
+        raise AssertionError("stale epoch reached a fresh range result")
+    require(("range-open", "front") not in EVENTS, "stale epoch opened a range observer")
+
+    EVENTS.clear()
+    backend, _domain, _run, _epoch, _transport, _color, _timing = make_backend(fail_read=True)
+    backend.takeoff(0.8)
+    try:
+        backend.readRange("front")
+    except DynamicPhysicalBackendError:
+        pass
+    else:
+        raise AssertionError("unavailable range was converted into interpreter data")
+    require(("range-close", "front") in EVENTS, "failed fresh range read leaked its observer")
+
+
+def test_observer_teardown_uncertainty_and_action_rejection_fail_closed() -> None:
+    EVENTS.clear()
+    backend, _domain, _run, _epoch, transport, _color, _timing = make_backend(fail_close=True)
+    backend.takeoff(0.8)
+    try:
+        backend.readRange("front")
+    except DynamicPhysicalBackendError as exc:
+        require("teardown" in str(exc), "range teardown uncertainty failed for wrong reason")
+    else:
+        raise AssertionError("uncertain range observer teardown was accepted")
+
+    EVENTS.clear()
+    backend, _domain, _run, _epoch, transport, _color, _timing = make_backend()
+    backend.takeoff(0.8)
+    transport.reject_next = True
+    try:
+        backend.turn(45.0)
+    except DynamicPhysicalBackendError as exc:
+        require("positively acknowledged" in str(exc), "definitive action rejection failed for wrong reason")
+    else:
+        raise AssertionError("rejected physical action was treated as interpreter progress")
+
+
+def test_no_caller_sensor_or_effect_surface_is_introduced() -> None:
+    source = (PHYSICAL / "dynamic_physical_backend.py").read_text(encoding="utf-8")
+    require("FreshRangeObserver" in source, "live range composition does not use integrated observer")
+    require("observation_transaction" in source, "live range composition bypasses physical exclusion")
+    require("assert_effect_binding" in source and "assert_current_program" in source, "live range provenance chain is incomplete")
+    for forbidden in ("socket.", "http.server", "serve_forever", "send_packet(", "caller_direction", "caller_value"):
+        require(forbidden not in source, "dynamic backend exposed a caller/effect bypass: " + forbidden)
+
+
+def main() -> int:
+    test_real_shared_interpreter_drives_fresh_range_and_existing_consumers()
+    test_range_observation_is_exclusion_held_and_reasserted_around_sample()
+    test_takeoff_is_verification_only_and_cannot_repeat()
+    test_stale_epoch_and_unavailable_range_fail_before_progression()
+    test_observer_teardown_uncertainty_and_action_rejection_fail_closed()
+    test_no_caller_sensor_or_effect_surface_is_introduced()
+    print(
+        "PASS dynamic physical backend: shared interpreter demand -> exclusion-held fresh range "
+        "data -> existing trusted action consumers, with one causal takeoff and terminal landing"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_dynamic_backend.py
+++ b/tools/ci/test_physical_dynamic_backend.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+import inspect
 from pathlib import Path
 from types import SimpleNamespace
 import sys
@@ -138,8 +139,9 @@ class Rejected:
 
 
 class FakeTransport:
-    def __init__(self, domain: FakeDomain) -> None:
+    def __init__(self, domain: FakeDomain, initial_nominal_altitude_m: float = 0.8) -> None:
         self.domain = domain
+        self.initial_nominal_altitude_m = initial_nominal_altitude_m
         self.reject_next = False
 
     def _result(self):
@@ -220,12 +222,18 @@ def representative_program() -> list[dict[str, object]]:
     ]
 
 
-def make_backend(*, range_value: float = 0.4, fail_read: bool = False, fail_close: bool = False):
+def make_backend(
+    *,
+    range_value: float = 0.4,
+    fail_read: bool = False,
+    fail_close: bool = False,
+    transport_initial_altitude_m: float = 0.8,
+):
     exact = canonical(representative_program())
     domain = FakeDomain()
     run = FakeRun(exact, domain)
     epoch = {"value": "epoch-live"}
-    transport = FakeTransport(domain)
+    transport = FakeTransport(domain, transport_initial_altitude_m)
     color = FakeColorTransport()
     timing = FakeTimingPolicy()
 
@@ -249,7 +257,6 @@ def make_backend(*, range_value: float = 0.4, fail_read: bool = False, fail_clos
 
     backend = TrustedDynamicPhysicalBackend(
         ast_binding=exact,
-        initial_takeoff_height_m=0.8,
         active_run=run,
         connection_epoch_reader=lambda: epoch["value"],
         assert_current_program=current_program,
@@ -310,6 +317,7 @@ def test_takeoff_is_verification_only_and_cannot_repeat() -> None:
     backend, domain, _run, _epoch, _transport, _color, _timing = make_backend()
     backend.takeoff(0.8)
     require(domain.phase == FLYING, "verification-only takeoff changed physical phase")
+    require(backend.initial_takeoff_height_m == 0.8, "takeoff verification height did not come from exact preflight")
     require(not any(event == "land" or (isinstance(event, tuple) and event and event[0] in {"move", "turn", "vertical"}) for event in EVENTS), "takeoff verification emitted a downstream action")
     try:
         backend.takeoff(0.8)
@@ -317,6 +325,29 @@ def test_takeoff_is_verification_only_and_cannot_repeat() -> None:
         require("repeated bound takeoff" in str(exc), "repeat takeoff failed for wrong reason")
     else:
         raise AssertionError("shared interpreter could repeat causal takeoff")
+
+
+def test_initial_altitude_has_no_auxiliary_authority_root() -> None:
+    EVENTS.clear()
+    signature = inspect.signature(TrustedDynamicPhysicalBackend)
+    require(
+        "initial_takeoff_height_m" not in signature.parameters,
+        "dynamic backend still accepts an independent initial takeoff height",
+    )
+    try:
+        make_backend(transport_initial_altitude_m=0.6)
+    except DynamicPhysicalBackendError as exc:
+        require("altitude differs" in str(exc), "split dynamic landing root failed for wrong reason")
+    else:
+        raise AssertionError("mismatched dynamic landing altitude survived composition")
+    require(
+        not any(
+            event == "land"
+            or (isinstance(event, tuple) and event and event[0] in {"move", "turn", "vertical", "range-read"})
+            for event in EVENTS
+        ),
+        "altitude-root mismatch was discovered only after interpreter progression",
+    )
 
 
 def test_stale_epoch_and_unavailable_range_fail_before_progression() -> None:
@@ -380,12 +411,13 @@ def main() -> int:
     test_real_shared_interpreter_drives_fresh_range_and_existing_consumers()
     test_range_observation_is_exclusion_held_and_reasserted_around_sample()
     test_takeoff_is_verification_only_and_cannot_repeat()
+    test_initial_altitude_has_no_auxiliary_authority_root()
     test_stale_epoch_and_unavailable_range_fail_before_progression()
     test_observer_teardown_uncertainty_and_action_rejection_fail_closed()
     test_no_caller_sensor_or_effect_surface_is_introduced()
     print(
-        "PASS dynamic physical backend: shared interpreter demand -> exclusion-held fresh range "
-        "data -> existing trusted action consumers, with one causal takeoff and terminal landing"
+        "PASS dynamic physical backend: canonical shared-interpreter demand -> exclusion-held fresh "
+        "range data -> existing trusted action consumers, with preflight-derived single altitude root"
     )
     return 0
 

--- a/tools/ci/test_physical_host_activation.py
+++ b/tools/ci/test_physical_host_activation.py
@@ -31,6 +31,7 @@ import watchdog_liveness  # noqa: E402
 
 
 EVENTS: list[object] = []
+ACTIVATION_ENTERED = Event()
 
 
 def require(condition: bool, message: str) -> None:
@@ -169,6 +170,7 @@ class FakeBridge:
         )
         self.pending_epoch = previous_epoch
         EVENTS.append(("bridge-begin", previous_epoch))
+        ACTIVATION_ENTERED.set()
         return previous_epoch
 
     def install_post_reset_session(self, session: FakeSession) -> str:
@@ -374,6 +376,7 @@ def install_fakes() -> None:
 
 
 def run_host(*, teacher_enabled: bool) -> dict[str, object]:
+    ACTIVATION_ENTERED.clear()
     caller_host, caller_peer = socket.socketpair()
     browser_read, browser_write = os.pipe()
     teacher_peer = None
@@ -425,6 +428,11 @@ def run_host(*, teacher_enabled: bool) -> dict[str, object]:
     caller_peer.sendall((json.dumps(request, separators=(",", ":")) + "\n").encode())
     response = json.loads(caller_peer.makefile("r", encoding="utf-8").readline())
     require(response == {"executionAuthority": False, "ok": True, "requestId": "request-1"}, "caller reply remains diagnostic")
+    if teacher_enabled:
+        require(
+            ACTIVATION_ENTERED.wait(timeout=1.0),
+            "trusted activation must enter reset cutover before test caller EOF",
+        )
     caller_peer.shutdown(socket.SHUT_WR)
     worker.join(timeout=3.0)
     require(not worker.is_alive(), "production host runner must terminate after caller EOF")

--- a/tools/ci/test_physical_host_activation.py
+++ b/tools/ci/test_physical_host_activation.py
@@ -31,7 +31,7 @@ import watchdog_liveness  # noqa: E402
 
 
 EVENTS: list[object] = []
-ACTIVATION_ENTERED = Event()
+ACTIVATION_COMPLETED = Event()
 
 
 def require(condition: bool, message: str) -> None:
@@ -170,7 +170,6 @@ class FakeBridge:
         )
         self.pending_epoch = previous_epoch
         EVENTS.append(("bridge-begin", previous_epoch))
-        ACTIVATION_ENTERED.set()
         return previous_epoch
 
     def install_post_reset_session(self, session: FakeSession) -> str:
@@ -343,6 +342,7 @@ class FakeTransportBase:
         require(binding == self.teacher_binding, "fresh provenance exact teacher binding")
         EVENTS.append(("transport-send", binding.connection_epoch))
         self.execution_domain.phase = physical_execution_domain.FLYING
+        ACTIVATION_COMPLETED.set()
         return FakeAckResult()
 
 
@@ -376,7 +376,7 @@ def install_fakes() -> None:
 
 
 def run_host(*, teacher_enabled: bool) -> dict[str, object]:
-    ACTIVATION_ENTERED.clear()
+    ACTIVATION_COMPLETED.clear()
     caller_host, caller_peer = socket.socketpair()
     browser_read, browser_write = os.pipe()
     teacher_peer = None
@@ -430,8 +430,8 @@ def run_host(*, teacher_enabled: bool) -> dict[str, object]:
     require(response == {"executionAuthority": False, "ok": True, "requestId": "request-1"}, "caller reply remains diagnostic")
     if teacher_enabled:
         require(
-            ACTIVATION_ENTERED.wait(timeout=1.0),
-            "trusted activation must enter reset cutover before test caller EOF",
+            ACTIVATION_COMPLETED.wait(timeout=1.0),
+            "trusted activation must complete accepted fake takeoff before test caller EOF",
         )
     caller_peer.shutdown(socket.SHUT_WR)
     worker.join(timeout=3.0)

--- a/tools/ci/test_physical_shared_interpreter.py
+++ b/tools/ci/test_physical_shared_interpreter.py
@@ -176,6 +176,44 @@ def test_real_shared_interpreter_owns_control_flow_and_sensor_demand() -> None:
         raise AssertionError("bound shared interpreter reuse must fail closed")
 
 
+def test_validation_only_preflight_reuses_shared_language_contract_before_effect() -> None:
+    exact = binding(representative_ast())
+    safety = subject.validate_bound_shared_program(exact)
+    require(safety.ast_binding == exact, "validation-only preflight changed exact AST identity")
+
+    read_before_assignment = representative_ast()
+    read_before_assignment["program"][1] = {
+        "kind": "set_variable",
+        "variable": VARIABLE,
+        "value": {"kind": "variable_get", "variable": VARIABLE},
+    }
+    unsupported_arithmetic = representative_ast()
+    unsupported_arithmetic["program"][1] = {
+        "kind": "set_variable",
+        "variable": VARIABLE,
+        "value": {
+            "kind": "arithmetic",
+            "op": "POWER",
+            "left": {"kind": "number", "value": 2},
+            "right": {"kind": "number", "value": 3},
+        },
+    }
+
+    for invalid, label in (
+        (read_before_assignment, "read-before-assignment"),
+        (unsupported_arithmetic, "unsupported arithmetic"),
+    ):
+        try:
+            subject.validate_bound_shared_program(binding(invalid))
+        except SharedInterpreterHostError as exc:
+            require(
+                "language validation failed closed" in str(exc),
+                label + " failed for wrong reason",
+            )
+        else:
+            raise AssertionError(label + " reached a causal-effect-capable phase")
+
+
 def test_dynamic_safety_and_language_validation_precede_backend_use() -> None:
     unsafe = {
         "version": 1,
@@ -292,6 +330,8 @@ def test_surface_contains_no_second_language_engine_or_caller_semantics() -> Non
         ROOT / "plugins/robot_windows/blockly/webeeblocks/interpreter.js"
     ).read_text(encoding="utf-8")
     require("interpreter.js" in worker_source, "worker does not load product interpreter")
+    require("Interpreter.validateProgram(ast)" in worker_source, "worker bypasses shared validation")
+    require("validate-bound-program" in host_source + worker_source, "pre-effect validation mode is unavailable")
     require("Interpreter.run(ast, backend)" in worker_source, "worker bypasses shared run()")
     for forbidden in ("case 'if'", "case 'repeat'", "statement.kind", "expression.kind"):
         require(forbidden not in worker_source, f"worker duplicates evaluator: {forbidden}")
@@ -305,13 +345,15 @@ def test_surface_contains_no_second_language_engine_or_caller_semantics() -> Non
 
 def main() -> int:
     test_real_shared_interpreter_owns_control_flow_and_sensor_demand()
+    test_validation_only_preflight_reuses_shared_language_contract_before_effect()
     test_dynamic_safety_and_language_validation_precede_backend_use()
     test_range_data_and_backend_failure_fail_closed()
     test_private_protocol_rejects_substitution_and_silence()
     test_surface_contains_no_second_language_engine_or_caller_semantics()
     print(
         "PASS exact teacher-bound AST executes through the existing shared Runtime interpreter "
-        "with host-owned control flow/sensor demand and a fail-closed private backend protocol"
+        "with backend-free pre-effect language validation, host-owned control flow/sensor demand "
+        "and a fail-closed private backend protocol"
     )
     return 0
 

--- a/tools/physical/dynamic_controlled_landing_transport.py
+++ b/tools/physical/dynamic_controlled_landing_transport.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Trusted controlled landing for shared-interpreter dynamic physical programs.
+
+The integrated static physical sequence can derive terminal descent from the whole
+flat AST before takeoff.  A dynamic program cannot: the exact branch/repeat path
+is selected later by the existing shared Runtime interpreter from fresh sensor
+data.  This transport therefore retains one host-local nominal world-Z value and
+advances it only after a definitively accepted vertical effect.  Terminal landing
+uses that completed runtime state while preserving the existing teacher/current-
+program, powered-session, watchdog, supervisor, SafeLink, acknowledgement and
+fresh completion authority chain.
+
+No caller-facing altitude or landing-command surface is added.  The nominal
+altitude is constructed inside the trusted host from the preflight-proven initial
+takeoff height and interpreter-selected vertical effects that already traversed
+the established physical transport.
+"""
+
+from __future__ import annotations
+
+from math import isfinite
+import struct
+from threading import Event, Lock
+
+import controlled_landing_transport
+import high_level_ack
+import high_level_semantics
+import high_level_timing
+import landing_command
+import physical_execution_domain
+import physical_program_sequence
+import setpoint_hl_transport
+
+_LAND_PACKET = struct.Struct("<BBf?f?f")
+
+
+class DynamicControlledLandingTransportError(
+    controlled_landing_transport.ControlledLandingTransportError
+):
+    """Fail-closed error for dynamic host-owned terminal-altitude composition."""
+
+
+def _nominal_altitude(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise DynamicControlledLandingTransportError(
+            "dynamic nominal altitude must be finite"
+        )
+    parsed = float(value)
+    if (
+        not isfinite(parsed)
+        or parsed < physical_program_sequence.MIN_NOMINAL_ALTITUDE_M
+        or parsed > physical_program_sequence.MAX_NOMINAL_ALTITUDE_M
+    ):
+        raise DynamicControlledLandingTransportError(
+            "dynamic nominal altitude violates established 0.2-1.5 m bounds"
+        )
+    return parsed
+
+
+class TrustedDynamicControlledLandingTransport(
+    controlled_landing_transport.TrustedControlledLandingTransport
+):
+    """Existing trusted effect transport plus runtime-selected nominal altitude."""
+
+    def __init__(self, *, initial_nominal_altitude_m: object, **kwargs) -> None:
+        self._nominal_altitude_m = _nominal_altitude(initial_nominal_altitude_m)
+        super().__init__(**kwargs)
+
+    @property
+    def nominal_altitude_m(self) -> float:
+        return self._nominal_altitude_m
+
+    def send_vertical_move(
+        self,
+        *,
+        direction: str,
+        distance_m: object,
+        timing_policy: high_level_timing.HighLevelTimingPolicy,
+        reply_timeout_seconds: float = setpoint_hl_transport._DEFAULT_REPLY_TIMEOUT_SECONDS,
+    ) -> high_level_ack.HighLevelAckResult:
+        """Advance host-local nominal Z only after definitive vertical completion."""
+        try:
+            target = high_level_semantics.vertical_move(direction, distance_m)
+        except (TypeError, ValueError, high_level_semantics.HighLevelSemanticError) as exc:
+            raise DynamicControlledLandingTransportError(
+                "dynamic vertical move violates integrated semantics"
+            ) from exc
+        next_altitude = _nominal_altitude(self._nominal_altitude_m + target.z_m)
+        result = super().send_vertical_move(
+            direction=direction,
+            distance_m=distance_m,
+            timing_policy=timing_policy,
+            reply_timeout_seconds=reply_timeout_seconds,
+        )
+        if getattr(result, "accepted", None) is True:
+            self._nominal_altitude_m = next_altitude
+        return result
+
+    def _dynamic_landing_request(self) -> bytes:
+        descent_m = _nominal_altitude(self._nominal_altitude_m)
+        return _LAND_PACKET.pack(
+            landing_command.LAND_WITH_VELOCITY_COMMAND,
+            landing_command.LAND_GROUP_MASK,
+            descent_m,
+            True,
+            0.0,
+            True,
+            landing_command.LAND_VELOCITY_M_S,
+        )
+
+    def send_controlled_landing(
+        self,
+        *,
+        reply_timeout_seconds: float = controlled_landing_transport._DEFAULT_REPLY_TIMEOUT_SECONDS,
+    ) -> high_level_ack.HighLevelAckResult:
+        """Land from the definitively completed interpreter-selected nominal Z."""
+        timeout = setpoint_hl_transport._positive_timeout(
+            reply_timeout_seconds,
+            "SETPOINT_HL landing reply timeout",
+        )
+        result: high_level_ack.HighLevelAckResult | None = None
+        completion_permit: physical_execution_domain.AcceptedEffectCompletionPermit | None = None
+        baseline = None
+
+        with self.execution_domain.effect_transaction(self._assert_current_authority) as effect:
+            initial_binding = self._read_current_binding()
+            self._assert_binding_authority(initial_binding)
+            request = self._dynamic_landing_request()
+            packet = setpoint_hl_transport._default_packet_factory(request)
+            self._validate_packet(packet, request)
+
+            self._read_fresh_finished_flying()
+            baseline = self._landing_observer.capture_pre_land_flight()
+            final_binding = self._read_current_binding()
+            self._assert_binding_authority(final_binding)
+            if final_binding != initial_binding:
+                raise DynamicControlledLandingTransportError(
+                    "current physical program changed during dynamic landing preparation"
+                )
+            self._safelink.assert_ready()
+
+            with self._ack.transaction(request) as acknowledgement:
+                reply_event = Event()
+                reply_lock = Lock()
+                first_reply: list[bytes] = []
+
+                def on_reply(reply_packet: object) -> None:
+                    try:
+                        data = bytes(getattr(reply_packet, "data"))
+                    except Exception:
+                        data = b""
+                    with reply_lock:
+                        if first_reply:
+                            return
+                        first_reply.append(data)
+                        reply_event.set()
+
+                def read_reply() -> bytes | None:
+                    with reply_lock:
+                        return first_reply[0] if first_reply else None
+
+                add_callback = getattr(self._cf, "add_port_callback", None)
+                remove_callback = getattr(self._cf, "remove_port_callback", None)
+                send_packet = getattr(self._cf, "send_packet", None)
+                if (
+                    not callable(add_callback)
+                    or not callable(remove_callback)
+                    or not callable(send_packet)
+                ):
+                    raise DynamicControlledLandingTransportError(
+                        "Crazyflie SETPOINT_HL callback/send surface is unavailable"
+                    )
+
+                callback_installed = False
+                try:
+                    add_callback(setpoint_hl_transport._SETPOINT_HL_PORT, on_reply)
+                    callback_installed = True
+                    acknowledgement.mark_emitted()
+                    effect.mark_emitted()
+                    send_packet(packet)
+                    try:
+                        reply = self._wait_for_reply(reply_event, read_reply, timeout)
+                    except Exception as exc:
+                        acknowledgement.fail_ambiguous(str(exc))
+                    result = acknowledgement.resolve_reply(reply)
+                    if result.accepted:
+                        completion_permit = effect.mark_accepted()
+                    else:
+                        effect.mark_definitive_rejection()
+                finally:
+                    if callback_installed:
+                        try:
+                            remove_callback(
+                                setpoint_hl_transport._SETPOINT_HL_PORT,
+                                on_reply,
+                            )
+                        except Exception:
+                            pass
+
+        if result is None:
+            raise DynamicControlledLandingTransportError(
+                "dynamic controlled landing acknowledgement result is unavailable"
+            )
+        if result.accepted:
+            if completion_permit is None or baseline is None:
+                raise DynamicControlledLandingTransportError(
+                    "accepted dynamic landing lacks private completion state"
+                )
+            self._await_landing_completion(completion_permit, baseline)
+        return result

--- a/tools/physical/dynamic_controlled_landing_transport.py
+++ b/tools/physical/dynamic_controlled_landing_transport.py
@@ -2,18 +2,19 @@
 """Trusted controlled landing for shared-interpreter dynamic physical programs.
 
 The integrated static physical sequence can derive terminal descent from the whole
-flat AST before takeoff.  A dynamic program cannot: the exact branch/repeat path
-is selected later by the existing shared Runtime interpreter from fresh sensor
-data.  This transport therefore retains one host-local nominal world-Z value and
-advances it only after a definitively accepted vertical effect.  Terminal landing
-uses that completed runtime state while preserving the existing teacher/current-
-program, powered-session, watchdog, supervisor, SafeLink, acknowledgement and
-fresh completion authority chain.
+flat AST before takeoff. A dynamic program cannot: the exact branch/repeat path is
+selected later by the existing shared Runtime interpreter from fresh sensor data.
+This transport therefore retains one host-local nominal world-Z value and advances
+it only after a definitively accepted vertical effect. Terminal landing uses that
+completed runtime state while preserving the existing teacher/current-program,
+powered-session, watchdog, supervisor, SafeLink, acknowledgement and fresh
+completion authority chain.
 
-No caller-facing altitude or landing-command surface is added.  The nominal
-altitude is constructed inside the trusted host from the preflight-proven initial
-takeoff height and interpreter-selected vertical effects that already traversed
-the established physical transport.
+No independent initial-altitude input exists. The transport derives its initial
+nominal altitude from the exact teacher-bound canonical AST through the integrated
+conservative dynamic preflight. This makes the runtime landing root the same
+preflight-proven takeoff height used by the bound dynamic backend; a later host
+composition can reject any disagreement before the shared interpreter progresses.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ import high_level_ack
 import high_level_semantics
 import high_level_timing
 import landing_command
+import physical_dynamic_preflight
 import physical_execution_domain
 import physical_program_sequence
 import setpoint_hl_transport
@@ -62,9 +64,29 @@ class TrustedDynamicControlledLandingTransport(
 ):
     """Existing trusted effect transport plus runtime-selected nominal altitude."""
 
-    def __init__(self, *, initial_nominal_altitude_m: object, **kwargs) -> None:
-        self._nominal_altitude_m = _nominal_altitude(initial_nominal_altitude_m)
+    def __init__(self, **kwargs) -> None:
+        authorization = kwargs.get("teacher_authorization")
+        binding = getattr(authorization, "binding", None)
+        ast_binding = getattr(binding, "ast_binding", None)
+        try:
+            safety = physical_dynamic_preflight.validate_bound_dynamic_program(ast_binding)
+        except physical_dynamic_preflight.DynamicPhysicalPreflightError as exc:
+            raise DynamicControlledLandingTransportError(
+                "exact dynamic preflight cannot establish initial landing altitude"
+            ) from exc
+        if safety.ast_binding != ast_binding:
+            raise DynamicControlledLandingTransportError(
+                "dynamic landing preflight changed the exact teacher-bound AST"
+            )
+        initial = _nominal_altitude(safety.initial_altitude_m)
+        self._initial_nominal_altitude_m = initial
+        self._nominal_altitude_m = initial
         super().__init__(**kwargs)
+
+    @property
+    def initial_nominal_altitude_m(self) -> float:
+        """Exact teacher-AST/preflight-derived root for runtime altitude state."""
+        return self._initial_nominal_altitude_m
 
     @property
     def nominal_altitude_m(self) -> float:

--- a/tools/physical/dynamic_physical_backend.py
+++ b/tools/physical/dynamic_physical_backend.py
@@ -3,19 +3,24 @@
 
 This module is the process-local composition seam between the already integrated
 host-owned shared Runtime interpreter and the existing trusted physical
-primitives.  It does not expose caller IPC and it does not interpret Blockly or
+primitives. It does not expose caller IPC and it does not interpret Blockly or
 AST control flow itself.
 
 The causal takeoff has already been completed by ``ProductionTakeoffRunController``
-before this backend is used.  The interpreter's first ``takeoff(height)`` call is
-therefore verification-only and emits no second command.  Later action callbacks
-consume the already established trusted transports.  ``readRange(direction)``
-opens the exact ``FreshRangeObserver`` selected by the shared interpreter only
-while the process-wide physical observation exclusion is held, and requires
-current-program, teacher, watchdog and reconnect-sensitive epoch provenance both
-before and after the fresh sample.
+before this backend is used. The interpreter's first ``takeoff(height)`` call is
+therefore verification-only and emits no second command. The verification height
+is derived here from the same exact canonical AST through the integrated dynamic
+preflight; it is never accepted as an independent host semantic input. The
+in-flight transport must expose the same AST-derived initial nominal altitude, so
+takeoff verification and runtime landing cannot acquire split altitude roots.
 
-Sensor values remain finite non-authority data.  This class never turns a range
+Later action callbacks consume the already established trusted transports.
+``readRange(direction)`` opens the exact ``FreshRangeObserver`` selected by the
+shared interpreter only while the process-wide physical observation exclusion is
+held, and requires current-program, teacher, watchdog and reconnect-sensitive
+epoch provenance both before and after the fresh sample.
+
+Sensor values remain finite non-authority data. This class never turns a range
 value, branch result or worker message into physical authority; every selected
 action still crosses the independently established downstream transport.
 """
@@ -25,6 +30,10 @@ from __future__ import annotations
 from math import isfinite
 from typing import Callable
 
+from physical_dynamic_preflight import (
+    DynamicPhysicalPreflightError,
+    validate_bound_dynamic_program,
+)
 from physical_execution_domain import FLYING, INACTIVE
 from range_observer import FreshRangeObserver, SUPPORTED_DIRECTIONS
 from yaw_observer import FreshYawObserver
@@ -50,7 +59,6 @@ class TrustedDynamicPhysicalBackend:
         self,
         *,
         ast_binding: str,
-        initial_takeoff_height_m: float,
         active_run: object,
         connection_epoch_reader: Callable[[], str],
         assert_current_program: Callable[[], object],
@@ -63,9 +71,17 @@ class TrustedDynamicPhysicalBackend:
     ) -> None:
         if not isinstance(ast_binding, str) or not ast_binding.strip() or ast_binding != ast_binding.strip():
             raise DynamicPhysicalBackendError("exact canonical AST binding is required")
-        height = _finite(initial_takeoff_height_m, "initial takeoff height")
+        try:
+            safety = validate_bound_dynamic_program(ast_binding)
+        except DynamicPhysicalPreflightError as exc:
+            raise DynamicPhysicalBackendError(
+                "exact dynamic physical preflight evidence is unavailable"
+            ) from exc
+        height = _finite(safety.initial_altitude_m, "preflight-proven takeoff height")
         if height <= 0:
-            raise DynamicPhysicalBackendError("initial takeoff height must be positive")
+            raise DynamicPhysicalBackendError("preflight-proven takeoff height must be positive")
+        if safety.ast_binding != ast_binding:
+            raise DynamicPhysicalBackendError("dynamic preflight changed the exact AST binding")
         if not callable(connection_epoch_reader):
             raise DynamicPhysicalBackendError("connection epoch reader is required")
         if not callable(assert_current_program):
@@ -93,6 +109,15 @@ class TrustedDynamicPhysicalBackend:
                 "active run does not match the exact bound interpreter program"
             )
 
+        transport_initial = _finite(
+            getattr(inflight_transport, "initial_nominal_altitude_m", None),
+            "dynamic landing transport initial nominal altitude",
+        )
+        if transport_initial != height:
+            raise DynamicPhysicalBackendError(
+                "dynamic landing transport altitude differs from exact preflight-proven takeoff"
+            )
+
         self._ast_binding = ast_binding
         self._initial_height = height
         self._active_run = active_run
@@ -118,6 +143,11 @@ class TrustedDynamicPhysicalBackend:
     @property
     def bound_connection_epoch(self) -> str:
         return self._bound_epoch
+
+    @property
+    def initial_takeoff_height_m(self) -> float:
+        """Exact preflight-derived height retained only as verification evidence."""
+        return self._initial_height
 
     def _read_epoch(self) -> str:
         try:

--- a/tools/physical/dynamic_physical_backend.py
+++ b/tools/physical/dynamic_physical_backend.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Trusted backend for one exact shared-interpreter physical run.
+
+This module is the process-local composition seam between the already integrated
+host-owned shared Runtime interpreter and the existing trusted physical
+primitives.  It does not expose caller IPC and it does not interpret Blockly or
+AST control flow itself.
+
+The causal takeoff has already been completed by ``ProductionTakeoffRunController``
+before this backend is used.  The interpreter's first ``takeoff(height)`` call is
+therefore verification-only and emits no second command.  Later action callbacks
+consume the already established trusted transports.  ``readRange(direction)``
+opens the exact ``FreshRangeObserver`` selected by the shared interpreter only
+while the process-wide physical observation exclusion is held, and requires
+current-program, teacher, watchdog and reconnect-sensitive epoch provenance both
+before and after the fresh sample.
+
+Sensor values remain finite non-authority data.  This class never turns a range
+value, branch result or worker message into physical authority; every selected
+action still crosses the independently established downstream transport.
+"""
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Callable
+
+from physical_execution_domain import FLYING, INACTIVE
+from range_observer import FreshRangeObserver, SUPPORTED_DIRECTIONS
+from yaw_observer import FreshYawObserver
+
+
+class DynamicPhysicalBackendError(RuntimeError):
+    """Fail-closed error for shared-interpreter/live-physical composition."""
+
+
+def _finite(value: object, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise DynamicPhysicalBackendError(label + " must be finite")
+    parsed = float(value)
+    if not isfinite(parsed):
+        raise DynamicPhysicalBackendError(label + " must be finite")
+    return parsed
+
+
+class TrustedDynamicPhysicalBackend:
+    """Backend methods reached only by one bound shared Runtime interpreter."""
+
+    def __init__(
+        self,
+        *,
+        ast_binding: str,
+        initial_takeoff_height_m: float,
+        active_run: object,
+        connection_epoch_reader: Callable[[], str],
+        assert_current_program: Callable[[], object],
+        inflight_transport: object,
+        color_transport: object,
+        timing_policy: object,
+        execute_wait: Callable[[float], object],
+        range_observer_factory: Callable[[str], object] | None = None,
+        yaw_observer_factory: Callable[[], object] | None = None,
+    ) -> None:
+        if not isinstance(ast_binding, str) or not ast_binding.strip() or ast_binding != ast_binding.strip():
+            raise DynamicPhysicalBackendError("exact canonical AST binding is required")
+        height = _finite(initial_takeoff_height_m, "initial takeoff height")
+        if height <= 0:
+            raise DynamicPhysicalBackendError("initial takeoff height must be positive")
+        if not callable(connection_epoch_reader):
+            raise DynamicPhysicalBackendError("connection epoch reader is required")
+        if not callable(assert_current_program):
+            raise DynamicPhysicalBackendError("current-program assertion is required")
+        if not callable(execute_wait):
+            raise DynamicPhysicalBackendError("trusted exact-wait consumer is required")
+
+        authorization = getattr(active_run, "teacher_authorization", None)
+        binding = getattr(authorization, "binding", None)
+        powered_session = getattr(active_run, "powered_session", None)
+        epoch = getattr(powered_session, "connection_epoch", None)
+        crazyflie = getattr(active_run, "crazyflie", None)
+        execution_domain = getattr(active_run, "execution_domain", None)
+        watchdog = getattr(active_run, "watchdog_guard", None)
+        if (
+            binding is None
+            or getattr(binding, "ast_binding", None) != ast_binding
+            or not isinstance(epoch, str)
+            or not epoch.strip()
+            or crazyflie is None
+            or execution_domain is None
+            or watchdog is None
+        ):
+            raise DynamicPhysicalBackendError(
+                "active run does not match the exact bound interpreter program"
+            )
+
+        self._ast_binding = ast_binding
+        self._initial_height = height
+        self._active_run = active_run
+        self._epoch_reader = connection_epoch_reader
+        self._assert_current_program_callback = assert_current_program
+        self._transport = inflight_transport
+        self._color_transport = color_transport
+        self._timing_policy = timing_policy
+        self._execute_wait_callback = execute_wait
+        self._bound_epoch = epoch
+        self._takeoff_verified = False
+        self._landed = False
+        self._yaw_reader = None
+        self._range_factory = range_observer_factory or self._default_range_observer
+        self._yaw_factory = yaw_observer_factory or self._default_yaw_observer
+        if not callable(self._range_factory) or not callable(self._yaw_factory):
+            raise DynamicPhysicalBackendError("trusted physical observer factory is unavailable")
+
+    @property
+    def ast_binding(self) -> str:
+        return self._ast_binding
+
+    @property
+    def bound_connection_epoch(self) -> str:
+        return self._bound_epoch
+
+    def _read_epoch(self) -> str:
+        try:
+            value = self._epoch_reader()
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("live connection epoch is unavailable") from exc
+        if value != self._bound_epoch:
+            raise DynamicPhysicalBackendError("connection epoch changed during dynamic physical run")
+        return value
+
+    def _assert_live_flying(self) -> None:
+        execution_domain = self._active_run.execution_domain
+        if getattr(execution_domain, "phase", None) != FLYING:
+            raise DynamicPhysicalBackendError(
+                "dynamic physical operation requires causally established flying state"
+            )
+        assert_live = getattr(self._active_run.watchdog_guard, "assert_live", None)
+        if not callable(assert_live):
+            raise DynamicPhysicalBackendError("dynamic physical run has no live watchdog guard")
+        assert_live()
+        self._read_epoch()
+
+        authorization = self._active_run.teacher_authorization
+        binding = authorization.binding
+        assert_effect_binding = getattr(authorization, "assert_effect_binding", None)
+        if not callable(assert_effect_binding):
+            raise DynamicPhysicalBackendError("dynamic physical run has no teacher binding assertion")
+        assert_effect_binding(
+            profile_id=binding.profile_id,
+            ast_binding=self._ast_binding,
+            connection_epoch=self._bound_epoch,
+        )
+        try:
+            self._assert_current_program_callback()
+        except Exception as exc:
+            raise DynamicPhysicalBackendError(
+                "fresh current-program assertion failed during dynamic physical run"
+            ) from exc
+
+    def _require_interpreter_started(self) -> None:
+        if not self._takeoff_verified:
+            raise DynamicPhysicalBackendError(
+                "shared interpreter has not verified the completed bound takeoff"
+            )
+        if self._landed:
+            raise DynamicPhysicalBackendError("dynamic physical run is already terminal")
+
+    def _default_range_observer(self, direction: str) -> FreshRangeObserver:
+        return FreshRangeObserver(
+            self._active_run.crazyflie,
+            self._epoch_reader,
+            direction,
+        )
+
+    def _default_yaw_observer(self) -> FreshYawObserver:
+        return FreshYawObserver(
+            self._active_run.crazyflie,
+            self._epoch_reader,
+        )
+
+    def _ensure_yaw_reader(self):
+        if self._yaw_reader is not None:
+            return self._yaw_reader
+        try:
+            reader = self._yaw_factory()
+            reader.open()
+        except Exception as exc:
+            raise DynamicPhysicalBackendError(
+                "fresh yaw observer could not be opened for dynamic physical run"
+            ) from exc
+        if (
+            getattr(reader, "bound_crazyflie", None) is not self._active_run.crazyflie
+            or getattr(reader, "bound_connection_epoch", None) != self._bound_epoch
+        ):
+            try:
+                reader.close()
+            except Exception:
+                pass
+            raise DynamicPhysicalBackendError(
+                "fresh yaw observer does not match the active physical run"
+            )
+        self._yaw_reader = reader
+        return reader
+
+    def _accepted_flying(self, result: object, label: str) -> None:
+        if getattr(result, "accepted", None) is not True:
+            raise DynamicPhysicalBackendError(label + " was not positively acknowledged")
+        if getattr(self._active_run.execution_domain, "phase", None) != FLYING:
+            raise DynamicPhysicalBackendError(label + " did not causally return to flying")
+
+    def takeoff(self, height_m: float) -> None:
+        """Verify, but never repeat, the already completed causal takeoff."""
+        if self._takeoff_verified:
+            raise DynamicPhysicalBackendError("shared interpreter repeated bound takeoff")
+        height = _finite(height_m, "shared interpreter takeoff height")
+        if height != self._initial_height:
+            raise DynamicPhysicalBackendError(
+                "shared interpreter takeoff differs from preflight-proven bound height"
+            )
+        self._assert_live_flying()
+        self._takeoff_verified = True
+
+    def readRange(self, direction: str) -> float:
+        """Return one fresh same-epoch range selected only by the bound interpreter."""
+        self._require_interpreter_started()
+        if not isinstance(direction, str) or direction not in SUPPORTED_DIRECTIONS:
+            raise DynamicPhysicalBackendError("shared interpreter range direction is unsupported")
+
+        execution_domain = self._active_run.execution_domain
+        observation = execution_domain.observation_transaction(self._assert_live_flying)
+        observer = None
+        close_error = None
+        try:
+            with observation:
+                try:
+                    observer = self._range_factory(direction)
+                    observer.open()
+                    if (
+                        getattr(observer, "bound_crazyflie", None) is not self._active_run.crazyflie
+                        or getattr(observer, "bound_connection_epoch", None) != self._bound_epoch
+                        or getattr(observer, "direction", None) != direction
+                    ):
+                        raise DynamicPhysicalBackendError(
+                            "fresh range observer does not match interpreter-selected live demand"
+                        )
+                    sample = observer.read()
+                    if (
+                        getattr(sample, "connection_epoch", None) != self._bound_epoch
+                        or getattr(sample, "direction", None) != direction
+                    ):
+                        raise DynamicPhysicalBackendError(
+                            "fresh range sample does not match active run demand"
+                        )
+                    value = _finite(
+                        getattr(sample, "range_m", None),
+                        "fresh physical range",
+                    )
+                    self._assert_live_flying()
+                finally:
+                    if observer is not None:
+                        try:
+                            observer.close()
+                        except Exception as exc:
+                            close_error = exc
+                if close_error is not None:
+                    raise DynamicPhysicalBackendError(
+                        "fresh range observer teardown is uncertain"
+                    ) from close_error
+                return value
+        except DynamicPhysicalBackendError:
+            raise
+        except Exception as exc:
+            raise DynamicPhysicalBackendError(
+                "fresh physical range observation failed closed"
+            ) from exc
+
+    def move(self, direction: str, distance_m: float) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        try:
+            result = self._transport.send_horizontal_move(
+                direction=direction,
+                distance_m=distance_m,
+                yaw_reader=self._ensure_yaw_reader(),
+                timing_policy=self._timing_policy,
+            )
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic horizontal move failed closed") from exc
+        self._accepted_flying(result, "dynamic horizontal move")
+
+    def vertical(self, direction: str, distance_m: float) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        try:
+            result = self._transport.send_vertical_move(
+                direction=direction,
+                distance_m=distance_m,
+                timing_policy=self._timing_policy,
+            )
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic vertical move failed closed") from exc
+        self._accepted_flying(result, "dynamic vertical move")
+
+    def turn(self, angle_deg: float) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        try:
+            result = self._transport.send_turn(
+                angle_deg=angle_deg,
+                timing_policy=self._timing_policy,
+            )
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic turn failed closed") from exc
+        self._accepted_flying(result, "dynamic turn")
+
+    def wait(self, seconds: float) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        try:
+            self._execute_wait_callback(seconds)
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic exact wait failed closed") from exc
+        self._assert_live_flying()
+
+    def setSpeed(self, speed_m_s: float) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        setter = getattr(self._timing_policy, "set_horizontal_speed", None)
+        if not callable(setter):
+            raise DynamicPhysicalBackendError("dynamic run timing policy is unavailable")
+        try:
+            setter(speed_m_s)
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic set_speed failed closed") from exc
+        self._assert_live_flying()
+
+    def setLight(self, color: str) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        try:
+            result = self._color_transport.send_color(color=color)
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic bottom Color LED effect failed closed") from exc
+        self._accepted_flying(result, "dynamic bottom Color LED effect")
+
+    def land(self) -> None:
+        self._require_interpreter_started()
+        self._assert_live_flying()
+        try:
+            result = self._transport.send_controlled_landing()
+        except Exception as exc:
+            raise DynamicPhysicalBackendError("dynamic terminal landing failed closed") from exc
+        if getattr(result, "accepted", None) is not True:
+            raise DynamicPhysicalBackendError(
+                "dynamic terminal landing was not positively acknowledged"
+            )
+        if getattr(self._active_run.execution_domain, "phase", None) != INACTIVE:
+            raise DynamicPhysicalBackendError(
+                "dynamic terminal landing did not causally establish inactive"
+            )
+        self._landed = True
+
+    def close(self) -> None:
+        """Close process-local observers; teardown uncertainty remains an error."""
+        reader = self._yaw_reader
+        self._yaw_reader = None
+        if reader is None:
+            return
+        try:
+            reader.close()
+        except Exception as exc:
+            raise DynamicPhysicalBackendError(
+                "fresh yaw observer teardown is uncertain"
+            ) from exc

--- a/tools/physical/dynamic_physical_run.py
+++ b/tools/physical/dynamic_physical_run.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""One-shot shared-interpreter execution inside an already activated physical run.
+
+This helper is intentionally process-local and exposes no caller-selected semantics.
+It binds the exact teacher/current-program AST to the integrated shared Runtime
+interpreter and the trusted dynamic physical backend.  The causal takeoff has
+already completed before this helper is entered; the interpreter's takeoff call is
+verification-only inside ``TrustedDynamicPhysicalBackend``.
+
+The helper does not own reset/teacher activation.  It owns only the interpreter
+worker lifetime and the dynamic backend observers.  Any interpreter/backend
+failure is returned as a fail-closed error so the surrounding trusted host can
+enter its existing terminal shutdown/recovery path rather than continue ordinary
+execution after a partially evaluated dynamic program.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dynamic_physical_backend import TrustedDynamicPhysicalBackend
+from shared_interpreter_host import BoundSharedInterpreter, SharedInterpreterHostError
+
+
+class DynamicPhysicalRunError(RuntimeError):
+    """Fail-closed error for one exact dynamic physical interpreter run."""
+
+
+@dataclass(frozen=True, slots=True)
+class DynamicPhysicalRunResult:
+    accepted: bool = True
+
+
+class BoundDynamicPhysicalRun:
+    """One-shot owner of an exact bound shared-interpreter physical execution."""
+
+    def __init__(self, backend: TrustedDynamicPhysicalBackend) -> None:
+        if type(backend) is not TrustedDynamicPhysicalBackend:
+            raise DynamicPhysicalRunError("exact trusted dynamic physical backend is required")
+        self._backend = backend
+        self._used = False
+
+    @property
+    def ast_binding(self) -> str:
+        return self._backend.ast_binding
+
+    def execute(self) -> DynamicPhysicalRunResult:
+        if self._used:
+            raise DynamicPhysicalRunError("bound dynamic physical run is one-shot")
+        self._used = True
+        try:
+            BoundSharedInterpreter(self._backend.ast_binding, self._backend).run()
+        except Exception as exc:
+            if isinstance(exc, DynamicPhysicalRunError):
+                raise
+            raise DynamicPhysicalRunError(
+                "bound shared-interpreter physical run failed closed"
+            ) from exc
+        return DynamicPhysicalRunResult()
+
+    def close(self) -> None:
+        try:
+            self._backend.close()
+        except Exception as exc:
+            raise DynamicPhysicalRunError(
+                "dynamic physical run observer teardown is uncertain"
+            ) from exc

--- a/tools/physical/shared_interpreter_host.py
+++ b/tools/physical/shared_interpreter_host.py
@@ -6,6 +6,12 @@ caller-selected direction, value, branch, iteration or action parameter. A child
 Node process loads the repository's existing ``interpreter.js`` and can request
 only the fixed backend methods below over a private stdio protocol.
 
+``validate_bound_shared_program()`` reuses that same product interpreter's
+``validateProgram()`` contract in a validation-only worker mode. It performs no
+backend call and therefore lets the trusted physical host reject deterministic
+shared-language invalidity before any causal physical effect without growing a
+second evaluator in Python.
+
 This adapter is deliberately not physical composition by itself: it owns no
 Crazyflie session, observer or effect-transport authority. A later trusted host
 must bind ``readRange`` to the fresh range observer and bind each action method to
@@ -382,3 +388,62 @@ class BoundSharedInterpreter:
                 return SharedInterpreterResult(remaining, dict(variables))
         finally:
             self._terminate(process)
+
+
+def validate_bound_shared_program(ast_binding: str) -> ReachablePhysicalEnvelope:
+    """Validate one exact bound AST through the shared product interpreter only.
+
+    The conservative physical envelope is reconstructed first, then the existing
+    JavaScript ``Interpreter.validateProgram()`` contract runs in a backend-free
+    worker mode. No range value is read, no branch is evaluated and no physical
+    consumer can be called. The returned envelope is therefore pre-effect safety
+    evidence bound to the same exact canonical AST.
+    """
+
+    safety = validate_bound_dynamic_program(ast_binding)
+    if not _WORKER.is_file():
+        raise SharedInterpreterHostError("shared interpreter worker is unavailable")
+    try:
+        process = subprocess.Popen(
+            ["node", str(_WORKER)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            bufsize=1,
+        )
+    except (OSError, ValueError) as exc:
+        raise SharedInterpreterHostError(
+            "could not start shared interpreter validation"
+        ) from exc
+    if process.stdout is None:
+        BoundSharedInterpreter._terminate(process)
+        raise SharedInterpreterHostError(
+            "shared interpreter validation output is unavailable"
+        )
+
+    pump = _LinePump(process.stdout)
+    try:
+        BoundSharedInterpreter._write(
+            process,
+            {"op": "validate-bound-program", "astBinding": ast_binding},
+        )
+        message = BoundSharedInterpreter._read(pump)
+        if message != {"type": "validated", "ok": True}:
+            raise SharedInterpreterHostError(
+                "shared interpreter language validation failed closed"
+            )
+        try:
+            exit_code = process.wait(timeout=_PROTOCOL_IDLE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            raise SharedInterpreterHostError(
+                "shared interpreter validation did not terminate"
+            ) from exc
+        if exit_code != 0:
+            raise SharedInterpreterHostError(
+                "shared interpreter validation exited unsuccessfully"
+            )
+        return safety
+    finally:
+        BoundSharedInterpreter._terminate(process)

--- a/tools/physical/shared_interpreter_worker.js
+++ b/tools/physical/shared_interpreter_worker.js
@@ -73,12 +73,20 @@ async function rpc(method, args) {
     if (process.argv.length !== 2)
       throw new Error('shared interpreter worker accepts no arguments');
     const startup = JSON.parse(readLineSync());
-    if (!exactKeys(startup, ['op', 'astBinding']) || startup.op !== 'run-bound-program')
+    if (
+      !exactKeys(startup, ['op', 'astBinding']) ||
+      (startup.op !== 'run-bound-program' && startup.op !== 'validate-bound-program')
+    )
       throw new Error('malformed shared interpreter startup');
     if (typeof startup.astBinding !== 'string' || !startup.astBinding.trim() || startup.astBinding !== startup.astBinding.trim())
       throw new Error('exact AST binding is unavailable');
     const ast = JSON.parse(startup.astBinding);
     Interpreter.validateProgram(ast);
+
+    if (startup.op === 'validate-bound-program') {
+      send({type: 'validated', ok: true});
+      return;
+    }
 
     const backend = {
       takeoff: (height) => rpc('takeoff', [height]),


### PR DESCRIPTION
Refs #345 #157.

Bounded deterministic infrastructure slice for trusted physical `range(direction)` composition. Current exact Ready head: `664f548a19aea14f31103cfd7f520f8f803c6c19`, based directly on `main@f8699533c679cdccb6b298e7c9a935d2d17a2c73`.

This candidate deliberately stops one boundary before production activation wiring. It establishes the process-local components needed for that next step without claiming that `activate_validated_run()` already uses them.

Complete scope of this candidate:
- adds `TrustedDynamicPhysicalBackend`, reached only through the exact bound shared Runtime interpreter, so variables/expressions/short-circuiting/branches/repeats and sensor direction remain interpreter-owned rather than caller-selected;
- keeps the already-completed causal takeoff verification-only: no second takeoff effect is emitted, and the expected height is derived from the exact canonical AST through the integrated conservative dynamic preflight rather than accepted as an auxiliary semantic input;
- adds backend-free `validate_bound_shared_program()` using the same existing JavaScript `Interpreter.validateProgram()` contract, so deterministic shared-language invalidity (including read-before-assignment/unsupported expression semantics) can be rejected before a future causal physical effect without adding a second evaluator;
- binds exact interpreter-selected `front/back/left/right/up` demand to one fresh same-epoch `FreshRangeObserver` inside the shared physical observation exclusion, with immediate current-program, teacher, watchdog and connection-epoch checks before/after the sample and fail-closed teardown;
- preserves range values as finite non-authority data while selected move/turn/vertical/light/wait/speed/landing operations delegate to the existing trusted physical consumers;
- adds `TrustedDynamicControlledLandingTransport`, whose initial nominal altitude is derived from the exact teacher-bound AST/preflight, advances only after definitively accepted vertical effects, and builds terminal command-10 descent from the completed interpreter-selected runtime path while retaining the existing acknowledgement and fresh landing-completion chain;
- cross-checks the dynamic landing transport's AST-derived altitude root against the backend's independently re-derived exact preflight height before interpreter progression, rejecting any split root before a range/action/landing can run;
- adds a one-shot `BoundDynamicPhysicalRun` owner around the exact shared-interpreter/backend pair, with fail-closed worker failure and explicit observer teardown;
- uses the repository's Runtime-compatible canonical AST serializer in positive backend fixtures; stale auxiliary altitude constructor inputs have been removed from both production and test surfaces;
- wires the new dynamic backend/run/landing deterministic regressions into the canonical Runtime v2 core harness, while the existing shared-interpreter regression now also exercises the backend-free pre-effect language-validation mode;
- repairs the pre-existing physical-host activation oracle exposed by Ready run `#1352`: validation acknowledgement and the trusted activation worker are asynchronous, so the teacher-enabled fixture now waits on an explicit accepted fake takeoff completion event before inducing caller EOF. The exact previous head had already passed the same oracle in run `#1351`, establishing the observed failure as a test-synchronization race rather than a product-path change. This exact repair follows the recorded `NO_GO 2d50f036422a0bc82f28c177fdfcfde8bace5e63` boundary without sleeps, weakened assertions, or production shutdown changes.

Earlier Draft findings on noncanonical fixture identity, independent/stale altitude constructor roots and post-takeoff-only shared-language validation have corresponding repairs in this branch. Prior GO/NO_GO evidence applies only to its named older heads; this new head requires fresh independent review after promotion.

Deliberate non-goals / next #345 step:
- this PR does not yet replace `PhysicalProgramSequence` inside `activate_validated_run()` or change ordinary parameter-free caller IPC;
- the backend-free shared-language preflight is provided here but is not yet wired into the production activation path before reset/takeoff;
- this PR does not yet prove the post-takeoff host recovery behavior of the final live wiring on interpreter/range/protocol failure;
- therefore it does not close #345 and does not claim live physical Multi-ranger continuity, real-device qualification or motorized flight.

No human checkpoint or `TEST_REQUIRED` follows from this deterministic infrastructure slice.