### PR TITLE
Derive path-invariant dynamic terminal landing

### DIFF
--- a/tools/ci/test_physical_dynamic_preflight.py
+++ b/tools/ci/test_physical_dynamic_preflight.py
@@ -10,6 +10,7 @@ PHYSICAL = ROOT / "tools/physical"
 if str(PHYSICAL) not in sys.path:
     sys.path.insert(0, str(PHYSICAL))
 
+import landing_command  # noqa: E402
 import takeoff_command  # noqa: E402
 from physical_dynamic_preflight import (  # noqa: E402
     DynamicPhysicalPreflightError,
@@ -39,6 +40,15 @@ def expect_error(program: list[dict[str, object]], pattern: str) -> None:
         require(pattern in str(exc), f"expected {pattern!r} in {str(exc)!r}")
         return
     raise AssertionError("expected DynamicPhysicalPreflightError containing " + repr(pattern))
+
+
+def expect_landing_error(program: list[dict[str, object]], pattern: str) -> None:
+    try:
+        landing_command.derive_bound_landing_command(canonical(program))
+    except landing_command.LandingCommandError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {str(exc)!r}")
+        return
+    raise AssertionError("expected LandingCommandError containing " + repr(pattern))
 
 
 def number(value: float) -> dict[str, object]:
@@ -89,6 +99,30 @@ def representative_dynamic_program() -> list[dict[str, object]]:
     ]
 
 
+def path_invariant_dynamic_program() -> list[dict[str, object]]:
+    ref = variable("front", "front")
+    return [
+        {"kind": "takeoff", "height_m": 0.8},
+        {
+            "kind": "set_variable",
+            "variable": ref,
+            "value": {"kind": "range", "direction": "front", "unit": "m"},
+        },
+        {
+            "kind": "if",
+            "condition": {
+                "kind": "compare",
+                "op": "LT",
+                "left": {"kind": "variable_get", "variable": ref},
+                "right": number(1.0),
+            },
+            "then": [{"kind": "move", "direction": "left", "distance_m": 0.2}],
+            "else": [{"kind": "turn", "angle_deg": 45.0}],
+        },
+        {"kind": "land"},
+    ]
+
+
 def test_representative_dynamic_program_is_proven_conservatively() -> None:
     binding = canonical(representative_dynamic_program())
     envelope = validate_bound_dynamic_program(binding)
@@ -100,6 +134,38 @@ def test_representative_dynamic_program_is_proven_conservatively() -> None:
         abs(envelope.terminal_min_altitude_m - 0.7) < 1e-12
         and envelope.terminal_max_altitude_m == 1.0,
         "terminal reachable altitude interval is wrong",
+    )
+
+
+def test_path_invariant_dynamic_landing_remains_ast_derived() -> None:
+    binding = canonical(path_invariant_dynamic_program())
+    command = landing_command.derive_bound_landing_command(binding)
+    require(command.ast_binding == binding, "dynamic landing lost exact AST provenance")
+    require(command.descent_m == 0.8, "altitude-neutral dynamic branches changed landing descent")
+
+    balanced = canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {
+                "kind": "if",
+                "condition": number(1.0),
+                "then": [{"kind": "vertical", "direction": "up", "distance_m": 0.2}],
+                "else": [{"kind": "vertical", "direction": "up", "distance_m": 0.2}],
+            },
+            {"kind": "land"},
+        ]
+    )
+    balanced_command = landing_command.derive_bound_landing_command(balanced)
+    require(
+        balanced_command.descent_m == 1.0,
+        "equal terminal dynamic branches must derive their shared AST-only altitude",
+    )
+
+
+def test_branch_dependent_dynamic_landing_fails_closed() -> None:
+    expect_landing_error(
+        representative_dynamic_program(),
+        "branch-dependent terminal nominal altitude",
     )
 
 
@@ -265,6 +331,8 @@ def test_noncanonical_or_malformed_binding_fails_closed() -> None:
 
 def main() -> int:
     test_representative_dynamic_program_is_proven_conservatively()
+    test_path_invariant_dynamic_landing_remains_ast_derived()
+    test_branch_dependent_dynamic_landing_fails_closed()
     test_any_unsafe_if_branch_rejects_before_effect()
     test_repeat_expands_the_full_altitude_path()
     test_nested_flight_boundaries_and_unknown_statements_fail_closed()
@@ -273,7 +341,8 @@ def main() -> int:
     test_noncanonical_or_malformed_binding_fails_closed()
     print(
         "PASS dynamic physical preflight: every reachable control-flow path "
-        "stays inside integrated action and altitude bounds before effect"
+        "stays inside integrated action and altitude bounds before effect; path-invariant "
+        "dynamic terminal landing remains AST-derived and branch-dependent altitude fails closed"
     )
     return 0
 

--- a/tools/physical/landing_command.py
+++ b/tools/physical/landing_command.py
@@ -4,18 +4,22 @@
 This module is deliberately non-authority and emits no CRTP packet. It consumes
 only the exact canonical ``astBinding`` already bound by the trusted physical
 host and derives the one terminal ``land`` statement after validating the whole
-currently supported physical program envelope through
-:class:`physical_program_sequence.PhysicalProgramSequence`.
+currently supported physical program envelope.
+
+For the original flat deterministic slice, ``PhysicalProgramSequence`` remains
+the exact source of the planned terminal altitude. Dynamic control-flow programs
+are also admissible when the conservative pre-takeoff envelope proves that every
+reachable branch has the same terminal nominal altitude. In that path-invariant
+case the landing distance is still derived solely from the immutable teacher-
+bound AST; no runtime sensor value, branch choice or caller-supplied altitude can
+select the landing command. A branch-dependent terminal altitude remains fail
+closed until the trusted host owns completed runtime altitude progression.
 
 The resulting request is the pinned Crazyflie firmware
-``COMMAND_LAND_WITH_VELOCITY`` packet (command 10). The bounded physical slice
-tracks every accepted vertical statement from the exact teacher-bound program as
-a host-owned nominal world-Z state. Landing therefore descends by the exact final
-nominal altitude derived from that immutable AST, rather than assuming the
-original takeoff height still describes the aircraft after vertical effects.
-This deterministically targets the estimator-zero landing level without exposing
-an independent caller-selected landing height. The command preserves current yaw
-and uses the firmware's explicit safe-default 0.5 m/s landing velocity.
+``COMMAND_LAND_WITH_VELOCITY`` packet (command 10). It descends by the exact
+AST-derived terminal nominal altitude, targets the estimator-zero landing level,
+preserves current yaw and uses the firmware's explicit safe-default 0.5 m/s
+landing velocity.
 
 No caller-supplied height, velocity, yaw, raw packet bytes, teacher decision,
 session object or other effect authority is accepted here. A trusted physical-
@@ -29,6 +33,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import struct
 
+import physical_dynamic_preflight
 import physical_program_sequence
 
 LAND_WITH_VELOCITY_COMMAND = 10
@@ -50,13 +55,32 @@ class BoundLandingCommand:
     request: bytes
 
 
-def derive_bound_landing_command(ast_binding: object) -> BoundLandingCommand:
-    """Derive command 10 solely from the exact supported canonical AST."""
+def _derive_terminal_altitude(ast_binding: object) -> tuple[str, float]:
+    """Return an AST-only terminal altitude, never a runtime-selected value."""
     try:
         sequence = physical_program_sequence.PhysicalProgramSequence(ast_binding)
-        descent_m = sequence.planned_terminal_altitude_m
-    except physical_program_sequence.PhysicalProgramSequenceError as exc:
-        raise LandingCommandError(str(exc)) from exc
+    except physical_program_sequence.PhysicalProgramSequenceError:
+        try:
+            envelope = physical_dynamic_preflight.validate_bound_dynamic_program(
+                ast_binding
+            )
+        except physical_dynamic_preflight.DynamicPhysicalPreflightError as exc:
+            raise LandingCommandError(str(exc)) from exc
+
+        low = envelope.terminal_min_altitude_m
+        high = envelope.terminal_max_altitude_m
+        if low != high:
+            raise LandingCommandError(
+                "dynamic physical program has branch-dependent terminal nominal altitude"
+            )
+        return envelope.ast_binding, low
+
+    return sequence.ast_binding, sequence.planned_terminal_altitude_m
+
+
+def derive_bound_landing_command(ast_binding: object) -> BoundLandingCommand:
+    """Derive command 10 solely from the exact supported canonical AST."""
+    canonical_binding, descent_m = _derive_terminal_altitude(ast_binding)
 
     request = _LAND_PACKET.pack(
         LAND_WITH_VELOCITY_COMMAND,
@@ -68,7 +92,7 @@ def derive_bound_landing_command(ast_binding: object) -> BoundLandingCommand:
         LAND_VELOCITY_M_S,
     )
     return BoundLandingCommand(
-        ast_binding=sequence.ast_binding,
+        ast_binding=canonical_binding,
         descent_m=descent_m,
         request=request,
     )


### PR DESCRIPTION
Refs #345 #157.

This narrow path-invariant landing fallback is superseded by the more complete runtime-altitude design now durably present on Draft #356 at exact head `e1ac7c1001bb3e9d601597870f0f76ebd3e10999`.

The experiment established one useful boundary: an immutable AST can safely pre-derive terminal landing altitude only when all reachable dynamic paths end at the same nominal altitude; branch-dependent terminal altitude must not be guessed from static structure. However, #356 now owns the stronger required solution: `TrustedDynamicControlledLandingTransport` keeps host-local nominal altitude, advances it only after definitively accepted interpreter-selected vertical effects, and derives terminal descent from that completed runtime state while preserving the existing effect authority/completion chain.

Keeping this separate fallback would add a second dynamic-landing path through the legacy flat landing command without being required by the product boundary. The branch and commits remain durable historical evidence, but this candidate is intentionally not integrated.

No real-device qualification or `TEST_REQUIRED` follows.