### PR TITLE
Add resumable exact-AST shared interpreter session

### DIFF
--- a/tools/ci/test_physical_dynamic_preflight.py
+++ b/tools/ci/test_physical_dynamic_preflight.py
@@ -15,6 +15,7 @@ from physical_dynamic_preflight import (  # noqa: E402
     DynamicPhysicalPreflightError,
     validate_bound_dynamic_program,
 )
+import test_physical_shared_interpreter_session as shared_interpreter_test  # noqa: E402
 
 
 def require(condition: bool, message: str) -> None:
@@ -271,6 +272,7 @@ def main() -> int:
     test_all_existing_action_bounds_apply_inside_dynamic_control_flow()
     test_control_flow_metadata_cannot_hide_unsupported_fields()
     test_noncanonical_or_malformed_binding_fails_closed()
+    shared_interpreter_test.main()
     print(
         "PASS dynamic physical preflight: every reachable control-flow path "
         "stays inside integrated action and altitude bounds before effect"

--- a/tools/ci/test_physical_shared_interpreter_session.py
+++ b/tools/ci/test_physical_shared_interpreter_session.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+PHYSICAL = ROOT / "tools" / "physical"
+if str(PHYSICAL) not in sys.path:
+    sys.path.insert(0, str(PHYSICAL))
+
+import takeoff_command  # noqa: E402
+from shared_interpreter_session import (  # noqa: E402
+    SelectedPhysicalAction,
+    SharedInterpreterSession,
+    SharedInterpreterSessionError,
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(callable_, pattern: str) -> None:
+    try:
+        callable_()
+    except SharedInterpreterSessionError as exc:
+        require(pattern in str(exc), f"expected {pattern!r} in {str(exc)!r}")
+        return
+    raise AssertionError(f"expected SharedInterpreterSessionError containing {pattern!r}")
+
+
+def canonical(program: list[dict[str, object]]) -> str:
+    return takeoff_command._canonical_json(
+        {"version": 1, "semantics": "webeeblocks-ast-v1", "program": program}
+    )
+
+
+def ref() -> dict[str, str]:
+    return {"id": "v-range", "name": "distance"}
+
+
+def number(value: float) -> dict[str, object]:
+    return {"kind": "number", "value": value}
+
+
+def program() -> list[dict[str, object]]:
+    variable = ref()
+    return [
+        {"kind": "takeoff", "height_m": 0.8},
+        {
+            "kind": "set_variable",
+            "variable": variable,
+            "value": {"kind": "range", "direction": "front", "unit": "m"},
+        },
+        {
+            "kind": "if",
+            "condition": {
+                "kind": "logic",
+                "op": "AND",
+                "left": {
+                    "kind": "compare",
+                    "op": "LT",
+                    "left": {"kind": "variable_get", "variable": variable},
+                    "right": number(1.0),
+                },
+                "right": {
+                    "kind": "compare",
+                    "op": "LT",
+                    "left": {"kind": "range", "direction": "right", "unit": "m"},
+                    "right": number(1.0),
+                },
+            },
+            "then": [{"kind": "set_light", "color": "green"}],
+            "else": [{"kind": "set_light", "color": "red"}],
+        },
+        {
+            "kind": "repeat",
+            "count": 2,
+            "body": [{"kind": "move", "direction": "forward", "distance_m": 0.3}],
+        },
+        {"kind": "land"},
+    ]
+
+
+def consume(session: SharedInterpreterSession) -> list[SelectedPhysicalAction]:
+    actions = [session.acknowledge_bound_takeoff()]
+    while True:
+        action = session.next_inflight_action()
+        if action is None:
+            break
+        actions.append(action)
+        session.acknowledge_action(action)
+    return actions
+
+
+def test_exact_bound_interpreter_selects_branch_and_repeat_path() -> None:
+    reads: list[str] = []
+
+    def read_range(direction: str) -> float:
+        reads.append(direction)
+        return {"front": 1.2, "right": 0.4}[direction]
+
+    session = SharedInterpreterSession(canonical(program()), read_range)
+    try:
+        actions = consume(session)
+        require(
+            [action.kind for action in actions]
+            == ["takeoff", "set_light", "move", "move", "land"],
+            "shared interpreter selected wrong action sequence",
+        )
+        require(
+            actions[1].statement == {"kind": "set_light", "color": "red"},
+            "wrong branch selected",
+        )
+        require(reads == ["front"], "short-circuit evaluated a phantom right range read")
+        require(session.completed, "interpreter did not complete after exact landing acknowledgement")
+        require(session.variables == {"distance": 1.2}, "shared interpreter variable environment changed")
+    finally:
+        session.close()
+
+
+def test_true_left_operand_evaluates_second_exact_range_expression() -> None:
+    reads: list[str] = []
+
+    def read_range(direction: str) -> float:
+        reads.append(direction)
+        return {"front": 0.5, "right": 0.4}[direction]
+
+    session = SharedInterpreterSession(canonical(program()), read_range)
+    try:
+        actions = consume(session)
+        require(
+            actions[1].statement == {"kind": "set_light", "color": "green"},
+            "then branch not selected",
+        )
+        require(reads == ["front", "right"], "exact interpreter range demand trace changed")
+    finally:
+        session.close()
+
+
+def test_action_progression_requires_exact_opaque_claim_identity() -> None:
+    session = SharedInterpreterSession(canonical(program()), lambda _direction: 1.2)
+    try:
+        session.acknowledge_bound_takeoff()
+        action = session.next_inflight_action()
+        require(action is not None and action.kind == "set_light", "expected selected light action")
+        forged = SelectedPhysicalAction(
+            path=action.path,
+            kind=action.kind,
+            statement=dict(action.statement),
+        )
+        expect_error(
+            lambda: session.acknowledge_action(forged),
+            "exact pending interpreter action claim",
+        )
+        require(
+            session.next_inflight_action() is action,
+            "failed forged acknowledgement advanced interpreter",
+        )
+        session.acknowledge_action(action)
+    finally:
+        session.close()
+
+
+def test_worker_payload_cannot_substitute_bound_ast_action() -> None:
+    binding = canonical(
+        [
+            {"kind": "takeoff", "height_m": 0.8},
+            {"kind": "wait", "seconds": 0.1},
+            {"kind": "land"},
+        ]
+    )
+    with tempfile.TemporaryDirectory() as directory:
+        worker = Path(directory) / "forged_worker.js"
+        worker.write_text(
+            "const readline=require('readline');"
+            "const rl=readline.createInterface({input:process.stdin});"
+            "rl.once('line',()=>{process.stdout.write(JSON.stringify({"
+            "event:'action',id:1,path:['program',0],"
+            "node:{height_m:0.8,kind:'takeoff'},kind:'move',direction:'forward',distance_m:0.3"
+            "})+'\\n');});\n",
+            encoding="utf-8",
+        )
+        session = SharedInterpreterSession(
+            binding,
+            lambda _direction: 0.5,
+            worker_path=worker,
+        )
+        try:
+            expect_error(session.acknowledge_bound_takeoff, "interpreter action differs")
+            require(session.terminal, "forged worker event did not poison interpreter session")
+        finally:
+            session.close()
+
+
+def test_worker_loss_fails_closed_without_fabricating_progress() -> None:
+    session = SharedInterpreterSession(canonical(program()), lambda _direction: 1.2)
+    try:
+        session._process.kill()
+        session._process.wait(timeout=1.0)
+        expect_error(session.acknowledge_bound_takeoff, "exited before completion")
+        require(session.terminal, "worker loss did not poison session")
+    finally:
+        session.close()
+
+
+def test_local_surface_exposes_no_browser_or_physical_effect_api() -> None:
+    source = (PHYSICAL / "shared_interpreter_session.py").read_text(encoding="utf-8")
+    worker = (PHYSICAL / "shared_interpreter_worker.js").read_text(encoding="utf-8")
+    for forbidden in (
+        "send_packet(",
+        "send_setpoint",
+        "HighLevelCommander(",
+        "Param.set_value",
+        "http.server",
+        "serve_forever",
+        "socket.socket",
+    ):
+        require(forbidden not in source, f"session crossed authority/browser boundary: {forbidden}")
+    require("interpreter.js" in worker, "worker does not load authoritative shared interpreter")
+    require("readRange" in worker and "range" in source, "shared range demand bridge missing")
+
+
+def main() -> int:
+    test_exact_bound_interpreter_selects_branch_and_repeat_path()
+    test_true_left_operand_evaluates_second_exact_range_expression()
+    test_action_progression_requires_exact_opaque_claim_identity()
+    test_worker_payload_cannot_substitute_bound_ast_action()
+    test_worker_loss_fails_closed_without_fabricating_progress()
+    test_local_surface_exposes_no_browser_or_physical_effect_api()
+    print(
+        "PASS trusted host-owned shared interpreter preserves exact range demand, "
+        "short-circuit/control flow and opaque action selection without effects"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/physical/shared_interpreter_session.py
+++ b/tools/physical/shared_interpreter_session.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Compatibility import for the isolated resumable shared-interpreter session.
+
+The implementation lives under ``tools/session`` so its private
+``shared_interpreter_worker.js`` cannot replace the already-integrated worker
+used by ``shared_interpreter_host.py``. Range/control-flow semantics remain in
+the authoritative Runtime interpreter; this file only exposes the trusted-host
+session types from their isolated transport directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+_PHYSICAL = Path(__file__).resolve().parent
+_TOOLS = _PHYSICAL.parent
+for _directory in (_PHYSICAL, _TOOLS):
+    _text = str(_directory)
+    if _text not in sys.path:
+        sys.path.insert(0, _text)
+
+from session.shared_interpreter_session import (  # noqa: E402,F401
+    SelectedPhysicalAction,
+    SharedInterpreterSession,
+    SharedInterpreterSessionError,
+)
+
+__all__ = [
+    "SelectedPhysicalAction",
+    "SharedInterpreterSession",
+    "SharedInterpreterSessionError",
+]

--- a/tools/session/shared_interpreter_session.py
+++ b/tools/session/shared_interpreter_session.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Host-owned resumable adapter for the authoritative Runtime v2 interpreter.
+
+This module does not implement WebeeBlocks expression or control-flow semantics.
+It runs the existing CommonJS ``interpreter.js`` in a private Node subprocess and
+turns only the backend calls reached by that interpreter into process-local
+requests. The exact canonical teacher-bound AST remains the sole program input.
+
+Range requests are resolved immediately through a trusted callback derived from
+the exact expression path. Physical action requests are paused and exposed as an
+opaque host-local claim whose semantics are re-derived from the exact bound AST;
+the worker-supplied payload is only checked for agreement. A later physical-host
+consumer may acknowledge that exact claim after its already-established
+independent authority/completion chain succeeds. Nothing here emits cflib/CRTP,
+changes the physical execution domain, or exposes browser/caller IPC.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from math import isfinite
+from pathlib import Path
+from queue import Empty, Queue
+import subprocess
+from threading import Thread
+from typing import Callable
+
+import physical_dynamic_preflight
+import takeoff_command
+
+
+class SharedInterpreterSessionError(RuntimeError):
+    """Fail-closed error for the private shared-interpreter adapter."""
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedPhysicalAction:
+    """Non-authority description of one exact action selected by interpreter.js."""
+
+    path: tuple[object, ...]
+    kind: str
+    statement: dict[str, object]
+
+
+class _ActionClaim:
+    __slots__ = ("action", "request_id")
+
+    def __init__(self, action: SelectedPhysicalAction, request_id: int) -> None:
+        self.action = action
+        self.request_id = request_id
+
+
+_EOF = object()
+_ACTION_KINDS = frozenset(
+    ("takeoff", "land", "move", "vertical", "turn", "wait", "set_speed", "set_light")
+)
+
+
+class SharedInterpreterSession:
+    """One exact-AST interpreter execution owned entirely by the trusted host."""
+
+    def __init__(
+        self,
+        ast_binding: str,
+        read_range: Callable[[str], float],
+        *,
+        node_binary: str = "node",
+        worker_path: Path | None = None,
+        response_timeout_seconds: float = 2.0,
+    ) -> None:
+        if not isinstance(ast_binding, str) or not ast_binding.strip() or ast_binding != ast_binding.strip():
+            raise SharedInterpreterSessionError("exact canonical ast binding is required")
+        if not callable(read_range):
+            raise SharedInterpreterSessionError("trusted range callback is required")
+        if not isinstance(response_timeout_seconds, (int, float)) or isinstance(response_timeout_seconds, bool):
+            raise SharedInterpreterSessionError("interpreter response timeout must be positive")
+        timeout = float(response_timeout_seconds)
+        if not isfinite(timeout) or timeout <= 0:
+            raise SharedInterpreterSessionError("interpreter response timeout must be positive")
+
+        try:
+            parsed = takeoff_command._parse_ast_binding(ast_binding)
+            envelope = physical_dynamic_preflight.validate_bound_dynamic_program(ast_binding)
+        except Exception as exc:
+            raise SharedInterpreterSessionError(
+                "teacher-bound AST is not eligible for shared physical interpretation"
+            ) from exc
+        if envelope.ast_binding != ast_binding:
+            raise SharedInterpreterSessionError("dynamic preflight changed exact ast binding identity")
+
+        root = Path(__file__).resolve().parents[2]
+        worker = worker_path or (Path(__file__).resolve().parent / "shared_interpreter_worker.js")
+        if not isinstance(worker, Path):
+            worker = Path(worker)
+        if not worker.is_file():
+            raise SharedInterpreterSessionError("trusted shared-interpreter worker is unavailable")
+
+        self._ast_binding = ast_binding
+        self._ast = parsed
+        self._envelope = envelope
+        self._read_range = read_range
+        self._timeout = timeout
+        self._events: Queue[object] = Queue()
+        self._pending: _ActionClaim | None = None
+        self._takeoff_acknowledged = False
+        self._completed = False
+        self._terminal_reason: str | None = None
+        self._variables: dict[str, object] | None = None
+
+        try:
+            self._process = subprocess.Popen(
+                [node_binary, str(worker)],
+                cwd=str(root),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+            )
+        except Exception as exc:
+            raise SharedInterpreterSessionError("could not start trusted shared interpreter") from exc
+        if self._process.stdin is None or self._process.stdout is None:
+            self._terminate_process()
+            raise SharedInterpreterSessionError("trusted shared interpreter pipes are unavailable")
+
+        self._reader = Thread(target=self._read_worker, daemon=True)
+        self._reader.start()
+        try:
+            self._send({"type": "start", "astBinding": ast_binding})
+        except Exception:
+            self._terminate_process()
+            raise
+
+    @property
+    def ast_binding(self) -> str:
+        return self._ast_binding
+
+    @property
+    def reachable_envelope(self) -> physical_dynamic_preflight.ReachablePhysicalEnvelope:
+        return self._envelope
+
+    @property
+    def completed(self) -> bool:
+        return self._completed
+
+    @property
+    def terminal(self) -> bool:
+        return self._terminal_reason is not None
+
+    @property
+    def variables(self) -> dict[str, object] | None:
+        return None if self._variables is None else dict(self._variables)
+
+    def _read_worker(self) -> None:
+        assert self._process.stdout is not None
+        try:
+            for line in self._process.stdout:
+                self._events.put(line.rstrip("\n"))
+        finally:
+            self._events.put(_EOF)
+
+    def _send(self, message: dict[str, object]) -> None:
+        if self._terminal_reason is not None:
+            raise SharedInterpreterSessionError(
+                "shared interpreter session is terminal: " + self._terminal_reason
+            )
+        stdin = self._process.stdin
+        if stdin is None or self._process.poll() is not None:
+            self._poison("trusted shared interpreter process is unavailable")
+        try:
+            assert stdin is not None
+            stdin.write(json.dumps(message, separators=(",", ":"), sort_keys=True) + "\n")
+            stdin.flush()
+        except Exception as exc:
+            self._poison("trusted shared interpreter protocol write failed")
+            raise SharedInterpreterSessionError(self._terminal_reason or "protocol write failed") from exc
+
+    def _poison(self, reason: str) -> None:
+        if self._terminal_reason is None:
+            self._terminal_reason = reason
+
+    def _next_event(self) -> dict[str, object]:
+        if self._terminal_reason is not None:
+            raise SharedInterpreterSessionError(
+                "shared interpreter session is terminal: " + self._terminal_reason
+            )
+        try:
+            raw = self._events.get(timeout=self._timeout)
+        except Empty as exc:
+            self._poison("trusted shared interpreter timed out")
+            raise SharedInterpreterSessionError(self._terminal_reason) from exc
+        if raw is _EOF:
+            self._poison("trusted shared interpreter exited before completion")
+            raise SharedInterpreterSessionError(self._terminal_reason)
+        if not isinstance(raw, str):
+            self._poison("trusted shared interpreter produced an invalid event")
+            raise SharedInterpreterSessionError(self._terminal_reason)
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            self._poison("trusted shared interpreter emitted malformed JSON")
+            raise SharedInterpreterSessionError(self._terminal_reason) from exc
+        if not isinstance(event, dict):
+            self._poison("trusted shared interpreter event is not an object")
+            raise SharedInterpreterSessionError(self._terminal_reason)
+        return event
+
+    def _node_at_path(self, raw_path: object) -> tuple[tuple[object, ...], dict[str, object]]:
+        if not isinstance(raw_path, list) or not raw_path or raw_path[0] != "program":
+            raise SharedInterpreterSessionError("interpreter event path is outside the bound program")
+        current: object = self._ast
+        normalized: list[object] = []
+        for component in raw_path:
+            if isinstance(component, bool) or not isinstance(component, (str, int)):
+                raise SharedInterpreterSessionError("interpreter event path is malformed")
+            normalized.append(component)
+            try:
+                if isinstance(component, int):
+                    if not isinstance(current, list) or component < 0 or component >= len(current):
+                        raise KeyError(component)
+                    current = current[component]
+                else:
+                    if not isinstance(current, dict) or component not in current:
+                        raise KeyError(component)
+                    current = current[component]
+            except (KeyError, IndexError) as exc:
+                raise SharedInterpreterSessionError(
+                    "interpreter event path does not resolve in exact bound AST"
+                ) from exc
+        if not isinstance(current, dict):
+            raise SharedInterpreterSessionError("interpreter event path does not resolve to a node")
+        return tuple(normalized), current
+
+    @staticmethod
+    def _request_id(event: dict[str, object]) -> int:
+        request_id = event.get("id")
+        if isinstance(request_id, bool) or not isinstance(request_id, int) or request_id < 1:
+            raise SharedInterpreterSessionError("interpreter backend request id is invalid")
+        return request_id
+
+    def _validate_exact_node(self, event: dict[str, object]) -> tuple[tuple[object, ...], dict[str, object]]:
+        path, node = self._node_at_path(event.get("path"))
+        if event.get("node") != node:
+            raise SharedInterpreterSessionError(
+                "interpreter backend request node differs from exact bound AST"
+            )
+        return path, node
+
+    def _range_direction(self, event: dict[str, object]) -> str:
+        self._request_id(event)
+        _path, node = self._validate_exact_node(event)
+        if set(node) != {"kind", "direction", "unit"} or node.get("kind") != "range" or node.get("unit") != "m":
+            raise SharedInterpreterSessionError("interpreter range request is not an exact range expression")
+        direction = node.get("direction")
+        if not isinstance(direction, str) or event.get("direction") != direction:
+            raise SharedInterpreterSessionError("interpreter range direction differs from exact bound AST")
+        return direction
+
+    def _action_claim(self, event: dict[str, object]) -> _ActionClaim:
+        request_id = self._request_id(event)
+        path, node = self._validate_exact_node(event)
+        kind = node.get("kind")
+        if not isinstance(kind, str) or kind not in _ACTION_KINDS or event.get("kind") != kind:
+            raise SharedInterpreterSessionError("interpreter action differs from exact bound AST")
+        protocol = {key: value for key, value in event.items() if key not in {"event", "id", "path", "node"}}
+        expected = dict(node)
+        if protocol != expected:
+            raise SharedInterpreterSessionError(
+                "interpreter action payload differs from exact bound AST"
+            )
+        action = SelectedPhysicalAction(path=path, kind=kind, statement=dict(node))
+        return _ActionClaim(action, request_id)
+
+    def _respond(self, request_id: int, *, value: object = None, include_value: bool = False) -> None:
+        message: dict[str, object] = {"type": "response", "id": request_id, "ok": True}
+        if include_value:
+            message["value"] = value
+        self._send(message)
+
+    def acknowledge_bound_takeoff(self) -> SelectedPhysicalAction:
+        """Advance only the exact first takeoff already completed by trusted activation."""
+        if self._takeoff_acknowledged:
+            raise SharedInterpreterSessionError("bound takeoff was already acknowledged")
+        claim = self._wait_for_action()
+        if claim is None:
+            self._poison("shared interpreter completed before exact bound takeoff")
+            raise SharedInterpreterSessionError(self._terminal_reason)
+        if claim.action.kind != "takeoff" or claim.action.path != ("program", 0):
+            self._poison("shared interpreter did not begin with exact bound takeoff")
+            raise SharedInterpreterSessionError(self._terminal_reason)
+        self._respond(claim.request_id)
+        self._pending = None
+        self._takeoff_acknowledged = True
+        return claim.action
+
+    def _wait_for_action(self) -> _ActionClaim | None:
+        if self._pending is not None:
+            return self._pending
+        while True:
+            event = self._next_event()
+            event_type = event.get("event")
+            try:
+                if event_type == "range":
+                    direction = self._range_direction(event)
+                    value = self._read_range(direction)
+                    if isinstance(value, bool) or not isinstance(value, (int, float)) or not isfinite(float(value)):
+                        raise SharedInterpreterSessionError(
+                            "trusted range callback returned a non-finite numeric value"
+                        )
+                    self._respond(self._request_id(event), value=float(value), include_value=True)
+                    continue
+                if event_type == "action":
+                    claim = self._action_claim(event)
+                    self._pending = claim
+                    return claim
+                if event_type == "done":
+                    variables = event.get("variables")
+                    remaining = event.get("remainingBudget")
+                    if not isinstance(variables, dict) or isinstance(remaining, bool) or not isinstance(remaining, int):
+                        raise SharedInterpreterSessionError("shared interpreter completion is malformed")
+                    self._variables = dict(variables)
+                    self._completed = True
+                    return None
+                if event_type == "error" and isinstance(event.get("error"), str):
+                    raise SharedInterpreterSessionError("shared interpreter failed: " + event["error"])
+                raise SharedInterpreterSessionError("shared interpreter emitted an unsupported event")
+            except Exception as exc:
+                if isinstance(exc, SharedInterpreterSessionError):
+                    self._poison(str(exc))
+                    raise
+                self._poison("trusted shared interpreter collaborator failed")
+                raise SharedInterpreterSessionError(self._terminal_reason) from exc
+
+    def next_inflight_action(self) -> SelectedPhysicalAction | None:
+        """Resolve private sensor/control flow and pause at the next exact action."""
+        if not self._takeoff_acknowledged:
+            raise SharedInterpreterSessionError("exact completed takeoff must be acknowledged first")
+        if self._completed:
+            return None
+        claim = self._wait_for_action()
+        if claim is None:
+            return None
+        if claim.action.kind == "takeoff":
+            self._poison("nested or replayed takeoff reached physical interpreter")
+            raise SharedInterpreterSessionError(self._terminal_reason)
+        return claim.action
+
+    def acknowledge_action(self, action: SelectedPhysicalAction) -> None:
+        """Resume only after the exact selected action definitively completed elsewhere."""
+        claim = self._pending
+        if claim is None or action is not claim.action:
+            raise SharedInterpreterSessionError("exact pending interpreter action claim is required")
+        self._respond(claim.request_id)
+        self._pending = None
+
+    def reject_action_terminal(self, action: SelectedPhysicalAction, reason: str) -> None:
+        claim = self._pending
+        if claim is None or action is not claim.action:
+            raise SharedInterpreterSessionError("exact pending interpreter action claim is required")
+        if not isinstance(reason, str) or not reason.strip():
+            raise SharedInterpreterSessionError("terminal action rejection reason is required")
+        try:
+            self._send({"type": "response", "id": claim.request_id, "ok": False, "error": reason.strip()})
+        finally:
+            self._pending = None
+            self._poison("selected physical action failed or became ambiguous")
+
+    def _terminate_process(self) -> None:
+        process = getattr(self, "_process", None)
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=0.5)
+            except Exception:
+                try:
+                    process.kill()
+                except Exception:
+                    pass
+
+    def close(self) -> None:
+        self._terminate_process()

--- a/tools/session/shared_interpreter_session.py
+++ b/tools/session/shared_interpreter_session.py
@@ -27,6 +27,7 @@ from threading import Thread
 from typing import Callable
 
 import physical_dynamic_preflight
+import shared_interpreter_host
 import takeoff_command
 
 
@@ -82,12 +83,13 @@ class SharedInterpreterSession:
         try:
             parsed = takeoff_command._parse_ast_binding(ast_binding)
             envelope = physical_dynamic_preflight.validate_bound_dynamic_program(ast_binding)
+            shared_envelope = shared_interpreter_host.validate_bound_shared_program(ast_binding)
         except Exception as exc:
             raise SharedInterpreterSessionError(
                 "teacher-bound AST is not eligible for shared physical interpretation"
             ) from exc
-        if envelope.ast_binding != ast_binding:
-            raise SharedInterpreterSessionError("dynamic preflight changed exact ast binding identity")
+        if envelope.ast_binding != ast_binding or shared_envelope.ast_binding != ast_binding:
+            raise SharedInterpreterSessionError("preflight changed exact ast binding identity")
 
         root = Path(__file__).resolve().parents[2]
         worker = worker_path or (Path(__file__).resolve().parent / "shared_interpreter_worker.js")
@@ -114,7 +116,7 @@ class SharedInterpreterSession:
                 cwd=str(root),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 encoding="utf-8",
                 bufsize=1,

--- a/tools/session/shared_interpreter_worker.js
+++ b/tools/session/shared_interpreter_worker.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+'use strict';
+
+const readline = require('readline');
+const path = require('path');
+
+const interpreterPath = path.resolve(
+  __dirname,
+  '../../plugins/robot_windows/blockly/webeeblocks/interpreter.js'
+);
+const interpreter = require(interpreterPath);
+
+const rl = readline.createInterface({input: process.stdin, crlfDelay: Infinity});
+const pending = new Map();
+let nextId = 1;
+let started = false;
+let currentContext = null;
+
+function emit(message) {
+  process.stdout.write(JSON.stringify(message) + '\n');
+}
+
+function fail(message) {
+  throw new Error('trusted shared interpreter worker: ' + message);
+}
+
+function exactContext(expectedRole) {
+  const context = currentContext;
+  if (!context || context.role !== expectedRole || !Array.isArray(context.path) || !context.node) {
+    fail('backend request has no exact interpreter context');
+  }
+  return context;
+}
+
+function request(event, payload, expectedRole) {
+  const context = exactContext(expectedRole);
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, {resolve, reject});
+    emit(Object.assign({
+      event,
+      id,
+      path: context.path,
+      node: context.node,
+    }, payload || {}));
+  });
+}
+
+const backend = {
+  takeoff: height_m => request('action', {kind: 'takeoff', height_m}, 'statement'),
+  land: () => request('action', {kind: 'land'}, 'statement'),
+  move: (direction, distance_m) => request('action', {kind: 'move', direction, distance_m}, 'statement'),
+  vertical: (direction, distance_m) => request('action', {kind: 'vertical', direction, distance_m}, 'statement'),
+  turn: angle_deg => request('action', {kind: 'turn', angle_deg}, 'statement'),
+  wait: seconds => request('action', {kind: 'wait', seconds}, 'statement'),
+  setSpeed: speed_m_s => request('action', {kind: 'set_speed', speed_m_s}, 'statement'),
+  setLight: color => request('action', {kind: 'set_light', color}, 'statement'),
+  readRange: direction => request('range', {direction}, 'expression'),
+};
+
+function settleResponse(message) {
+  if (!Number.isInteger(message.id) || !pending.has(message.id)) {
+    fail('response id does not match a pending backend request');
+  }
+  const entry = pending.get(message.id);
+  pending.delete(message.id);
+  if (message.ok === true && Object.prototype.hasOwnProperty.call(message, 'value')) {
+    entry.resolve(message.value);
+    return;
+  }
+  if (message.ok === true) {
+    entry.resolve(undefined);
+    return;
+  }
+  if (message.ok === false && typeof message.error === 'string' && message.error) {
+    entry.reject(new Error(message.error));
+    return;
+  }
+  fail('backend response is malformed');
+}
+
+async function runStart(astBinding) {
+  if (started) fail('start is one-shot');
+  if (typeof astBinding !== 'string' || !astBinding.trim() || astBinding !== astBinding.trim()) {
+    fail('exact canonical ast binding is required');
+  }
+  let ast;
+  try {
+    ast = JSON.parse(astBinding);
+  } catch (error) {
+    fail('ast binding is not valid JSON');
+  }
+  if (JSON.stringify(ast) !== astBinding) {
+    fail('ast binding is not exact canonical JSON');
+  }
+  started = true;
+  try {
+    const result = await interpreter.run(ast, backend, {
+      maxSteps: 1000,
+      hooks: {
+        beforeStep: context => { currentContext = context; },
+      },
+    });
+    currentContext = null;
+    emit({event: 'done', remainingBudget: result.remainingBudget, variables: result.variables});
+  } catch (error) {
+    currentContext = null;
+    emit({event: 'error', error: String(error && error.message ? error.message : error)});
+  }
+}
+
+rl.on('line', line => {
+  try {
+    const message = JSON.parse(line);
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      fail('protocol message must be an object');
+    }
+    if (message.type === 'start') {
+      void runStart(message.astBinding);
+      return;
+    }
+    if (message.type === 'response') {
+      settleResponse(message);
+      return;
+    }
+    fail('unsupported protocol message');
+  } catch (error) {
+    emit({event: 'error', error: String(error && error.message ? error.message : error)});
+    process.exitCode = 1;
+    rl.close();
+  }
+});
+
+rl.on('close', () => {
+  for (const entry of pending.values()) {
+    entry.reject(new Error('trusted interpreter worker input closed'));
+  }
+  pending.clear();
+});


### PR DESCRIPTION
Refs #345 #157.

Draft infrastructure slice for the next trusted-host composition boundary after #356. The existing durable branch is intentionally preserved as-is; this PR targets current `main@f198e5fafbefe49e5ce2bedcf842beda2cb5b9eb`, so the eventual merge result composes the resumable session with the just-integrated dynamic backend infrastructure rather than rewriting concurrent history.

Intended bounded scope:
- keep the existing CommonJS Runtime `interpreter.js` authoritative for variables, expressions, short-circuiting, branches and repeats;
- run one exact canonical teacher-bound AST in a private host-owned Node session;
- resolve exact interpreter-selected `range(direction)` requests through a trusted host callback as non-authority data;
- pause only at the next exact action selected by the interpreter and expose an opaque process-local `SelectedPhysicalAction` whose node/path/payload are re-derived from the exact bound AST;
- require exact claim identity before interpreter progression, and poison the session on rejection/ambiguity/worker loss;
- preserve the ordinary caller boundary as parameter-free in the later production composition; this Draft itself exposes no browser/HTTP/CRTP effect surface.

This is not production activation wiring, does not replace `execute-next-inflight`, does not close #345, and establishes no real-device qualification or `TEST_REQUIRED`.

Known Draft review debt before Ready:
1. `test_local_surface_exposes_no_browser_or_physical_effect_api()` currently reads the compatibility wrapper and the already-integrated `tools/physical/shared_interpreter_worker.js`, not the new implementation/worker under `tools/session/`. The oracle must inspect the actual new files so it cannot miss a duplicated evaluator or authority leak.
2. `SharedInterpreterSession` launches the child with `stderr=subprocess.PIPE` but never drains stderr; the private protocol must not acquire an avoidable child-process deadlock path (use a non-blocking/drained sink or equivalent fail-closed handling).

Further review must also verify the resumable session consumes #356's pre-effect shared-language validation contract before any future causal takeoff, and that canonical Runtime CI exercises the corrected session oracle before promotion.