### PR TITLE
Wire shared dynamic run into production physical host

### DIFF
--- a/tools/ci/test_dynamic_physical_run.py
+++ b/tools/ci/test_dynamic_physical_run.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 import sys
 
@@ -11,8 +12,6 @@ if str(PHYSICAL) not in sys.path:
     sys.path.insert(0, str(PHYSICAL))
 
 import dynamic_physical_run as subject  # noqa: E402
-import test_dynamic_run_activation as activation_test  # noqa: E402
-import test_physical_dynamic_run_activation as host_activation_test  # noqa: E402
 
 
 def require(condition: bool, message: str) -> None:
@@ -105,15 +104,32 @@ def test_interpreter_failure_is_fail_closed_but_cleanup_remains_explicit() -> No
         subject.BoundSharedInterpreter = original_interpreter
 
 
+def run_production_regression(relative_path: str, label: str) -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / relative_path)],
+        text=True,
+        capture_output=True,
+    )
+    if result.stdout.strip():
+        print(result.stdout.strip())
+    if result.returncode:
+        if result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
+        raise AssertionError(label)
+
+
 def main() -> int:
     test_exact_backend_and_one_shot_execution()
     test_interpreter_failure_is_fail_closed_but_cleanup_remains_explicit()
-    require(
-        activation_test.main() == 0,
+    # These production-host regressions install broad fake trusted-host surfaces.
+    # Run each in a fresh interpreter so one oracle cannot leak monkeypatch state
+    # into the next and manufacture a false product-path failure.
+    run_production_regression(
+        "tools/ci/test_dynamic_run_activation.py",
         "production dynamic activation/dispatch regression must pass",
     )
-    require(
-        host_activation_test.main() == 0,
+    run_production_regression(
+        "tools/ci/test_physical_dynamic_run_activation.py",
         "production dynamic host range/recovery regression must pass",
     )
     print(

--- a/tools/ci/test_dynamic_physical_run.py
+++ b/tools/ci/test_dynamic_physical_run.py
@@ -11,6 +11,8 @@ if str(PHYSICAL) not in sys.path:
     sys.path.insert(0, str(PHYSICAL))
 
 import dynamic_physical_run as subject  # noqa: E402
+import test_dynamic_run_activation as activation_test  # noqa: E402
+import test_physical_dynamic_run_activation as host_activation_test  # noqa: E402
 
 
 def require(condition: bool, message: str) -> None:
@@ -106,9 +108,17 @@ def test_interpreter_failure_is_fail_closed_but_cleanup_remains_explicit() -> No
 def main() -> int:
     test_exact_backend_and_one_shot_execution()
     test_interpreter_failure_is_fail_closed_but_cleanup_remains_explicit()
+    require(
+        activation_test.main() == 0,
+        "production dynamic activation/dispatch regression must pass",
+    )
+    require(
+        host_activation_test.main() == 0,
+        "production dynamic host range/recovery regression must pass",
+    )
     print(
         "PASS dynamic physical run owner: exact bound shared interpreter, one-shot execution, "
-        "fail-closed worker failure and explicit observer teardown"
+        "production activation/dispatch, fresh range host path and terminal recovery"
     )
     return 0
 

--- a/tools/ci/test_dynamic_run_activation.py
+++ b/tools/ci/test_dynamic_run_activation.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from contextlib import contextmanager
+from math import isclose
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+for directory in (CI, PHYSICAL):
+    text = str(directory)
+    if text not in sys.path:
+        sys.path.insert(0, text)
+
+import dynamic_physical_backend as backend_module  # noqa: E402
+import dynamic_run_activation as activation  # noqa: E402
+import physical_dynamic_preflight  # noqa: E402
+import physical_run_dispatch as dispatch  # noqa: E402
+import takeoff_command  # noqa: E402
+import test_physical_host_activation as base  # noqa: E402
+import test_physical_host_inflight_sequence as host  # noqa: E402
+
+
+RANGE_VALUE = 0.4
+RANGE_FAIL = False
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical(program: list[dict[str, object]]) -> str:
+    return takeoff_command._canonical_json(
+        {
+            "program": program,
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        }
+    )
+
+
+def dynamic_ast() -> str:
+    variable = {"id": "front-distance", "name": "distance"}
+    return canonical(
+        [
+            {"height_m": 0.8, "kind": "takeoff"},
+            {
+                "kind": "set_variable",
+                "value": {"direction": "front", "kind": "range", "unit": "m"},
+                "variable": variable,
+            },
+            {
+                "condition": {
+                    "kind": "compare",
+                    "left": {"kind": "variable_get", "variable": variable},
+                    "op": "LT",
+                    "right": {"kind": "number", "value": 1.0},
+                },
+                "else": [{"angle_deg": 45.0, "kind": "turn"}],
+                "kind": "if",
+                "then": [
+                    {"direction": "left", "distance_m": 0.2, "kind": "move"}
+                ],
+            },
+            {"direction": "up", "distance_m": 0.2, "kind": "vertical"},
+            {"kind": "land"},
+        ]
+    )
+
+
+def language_invalid_ast() -> str:
+    target = {"id": "target", "name": "target"}
+    missing = {"id": "missing", "name": "missing"}
+    return canonical(
+        [
+            {"height_m": 0.8, "kind": "takeoff"},
+            {
+                "kind": "set_variable",
+                "value": {"kind": "variable_get", "variable": missing},
+                "variable": target,
+            },
+            {"kind": "land"},
+        ]
+    )
+
+
+def flat_ast() -> str:
+    return canonical(
+        [
+            {"height_m": 0.8, "kind": "takeoff"},
+            {"kind": "land"},
+        ]
+    )
+
+
+class FakeDynamicTransport:
+    def __init__(
+        self,
+        *,
+        crazyflie: object,
+        execution_domain: object,
+        acknowledgement_domain: object,
+        safelink_guard: object,
+        teacher_authorization: object,
+        powered_session: object,
+        watchdog_guard: object,
+        supervisor_reader: object,
+        connection_epoch_reader=None,
+    ) -> None:
+        del acknowledgement_domain, safelink_guard, supervisor_reader
+        require(powered_session.session is crazyflie, "dynamic transport exact powered session")
+        require(
+            execution_domain.phase == base.physical_execution_domain.FLYING,
+            "dynamic transport requires completed causal takeoff",
+        )
+        if connection_epoch_reader is not None:
+            require(
+                connection_epoch_reader() == powered_session.connection_epoch,
+                "dynamic transport binds exact active epoch",
+            )
+        self.teacher_binding = teacher_authorization.binding
+        self.bound_connection_epoch = powered_session.connection_epoch
+        self.execution_domain = execution_domain
+        self._crazyflie = crazyflie
+        self._watchdog = watchdog_guard
+        safety = physical_dynamic_preflight.validate_bound_dynamic_program(
+            self.teacher_binding.ast_binding
+        )
+        self.initial_nominal_altitude_m = safety.initial_altitude_m
+        self.nominal_altitude_m = safety.initial_altitude_m
+
+    def _read_current_binding(self):
+        raise AssertionError("dynamic activation must provide host-local current-program binding")
+
+    def _binding(self):
+        require(self._watchdog.active, "dynamic effect requires live watchdog")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "dynamic effect lost exact teacher binding")
+        return binding
+
+    def send_horizontal_move(self, *, direction, distance_m, yaw_reader, timing_policy):
+        del timing_policy
+        binding = self._binding()
+        require(yaw_reader is not None and yaw_reader.is_open, "dynamic move requires fresh yaw")
+        require(yaw_reader.bound_crazyflie is self._crazyflie, "dynamic yaw exact Crazyflie")
+        base.EVENTS.append(
+            ("dynamic-move", direction, distance_m, binding.connection_epoch)
+        )
+        return SimpleNamespace(accepted=True, status=0)
+
+    def send_vertical_move(self, *, direction, distance_m, timing_policy):
+        del timing_policy
+        binding = self._binding()
+        delta = float(distance_m) if direction == "up" else -float(distance_m)
+        self.nominal_altitude_m += delta
+        base.EVENTS.append(
+            (
+                "dynamic-vertical",
+                direction,
+                distance_m,
+                self.nominal_altitude_m,
+                binding.connection_epoch,
+            )
+        )
+        return SimpleNamespace(accepted=True, status=0)
+
+    def send_turn(self, *, angle_deg, timing_policy):
+        del timing_policy
+        binding = self._binding()
+        base.EVENTS.append(("dynamic-turn", angle_deg, binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0)
+
+    def send_controlled_landing(self):
+        binding = self._binding()
+        require(
+            self.execution_domain.phase == base.physical_execution_domain.FLYING,
+            "dynamic landing starts from flying",
+        )
+        base.EVENTS.append(
+            ("dynamic-land", self.nominal_altitude_m, binding.connection_epoch)
+        )
+        self.execution_domain.phase = base.physical_execution_domain.INACTIVE
+        return SimpleNamespace(accepted=True, status=0)
+
+
+class FakeColorTransport:
+    def __init__(
+        self,
+        *,
+        crazyflie: object,
+        execution_domain: object,
+        safelink_guard: object,
+        teacher_authorization: object,
+        powered_session: object,
+        watchdog_guard: object,
+        connection_epoch_reader=None,
+    ) -> None:
+        del crazyflie, execution_domain, safelink_guard
+        self.teacher_binding = teacher_authorization.binding
+        self.bound_connection_epoch = powered_session.connection_epoch
+        self._watchdog = watchdog_guard
+        if connection_epoch_reader is not None:
+            require(
+                connection_epoch_reader() == self.bound_connection_epoch,
+                "dynamic color transport binds exact active epoch",
+            )
+
+    def _read_current_binding(self):
+        raise AssertionError("dynamic activation must provide host-local color binding")
+
+    def send_color(self, *, color: str):
+        require(self._watchdog.active, "dynamic light requires live watchdog")
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "dynamic light lost exact teacher binding")
+        base.EVENTS.append(("dynamic-light", color, binding.connection_epoch))
+        return SimpleNamespace(accepted=True, status=0)
+
+
+class FakeRangeObserver:
+    def __init__(self, crazyflie: object, epoch_reader, direction: str) -> None:
+        self.bound_crazyflie = crazyflie
+        self._epoch_reader = epoch_reader
+        self.bound_connection_epoch = None
+        self.direction = direction
+        self.is_open = False
+
+    def open(self) -> None:
+        self.bound_connection_epoch = self._epoch_reader()
+        self.is_open = True
+        base.EVENTS.append(("dynamic-range-open", self.direction))
+
+    def read(self):
+        base.EVENTS.append(("dynamic-range-read", self.direction))
+        if RANGE_FAIL:
+            raise RuntimeError("injected fresh range failure")
+        return SimpleNamespace(
+            connection_epoch=self.bound_connection_epoch,
+            direction=self.direction,
+            range_m=RANGE_VALUE,
+        )
+
+    def close(self) -> None:
+        if self.is_open:
+            base.EVENTS.append(("dynamic-range-close", self.direction))
+        self.is_open = False
+
+
+class FakeYawObserver:
+    def __init__(self, crazyflie: object, epoch_reader) -> None:
+        self.bound_crazyflie = crazyflie
+        self.bound_connection_epoch = epoch_reader()
+        self.is_open = False
+
+    def open(self) -> None:
+        self.is_open = True
+        base.EVENTS.append(("dynamic-yaw-open", self.bound_connection_epoch))
+
+    def close(self) -> None:
+        if self.is_open:
+            base.EVENTS.append(("dynamic-yaw-close", self.bound_connection_epoch))
+        self.is_open = False
+
+
+def install_dynamic_fakes() -> None:
+    host.install_fakes()
+
+    @contextmanager
+    def observation_transaction(self, *checks):
+        base.EVENTS.append("dynamic-observation-enter")
+        require(
+            self.phase == base.physical_execution_domain.FLYING,
+            "dynamic observation requires flying",
+        )
+        for check in checks:
+            check()
+        try:
+            yield object()
+        finally:
+            base.EVENTS.append("dynamic-observation-exit")
+
+    base.FakeExecutionDomain.observation_transaction = observation_transaction
+
+    activation.TrustedPoweredSessionFactory = base.FakePoweredFactory
+    activation.PostResetTeacherDecisionChannel = base.FakeTeacherChannel
+    activation.TrustedTeacherAuthorizer = base.FakeAuthorizer
+    activation.FreshSupervisorStateReader = base.FakeSupervisorReader
+    activation.TrustedTakeoffTransport = base.FakeTransportBase
+    activation.PhysicalExecutionDomain = base.FakeExecutionDomain
+    activation.make_cflib_stm_deck_power_cycle = (
+        lambda _uri: lambda: base.EVENTS.append("power-cycle")
+    )
+    activation.TrustedDynamicControlledLandingTransport = FakeDynamicTransport
+    activation.TrustedBottomColorLedTransport = FakeColorTransport
+
+    backend_module.FreshRangeObserver = FakeRangeObserver
+    backend_module.FreshYawObserver = FakeYawObserver
+
+
+def test_dispatch_preserves_static_path_and_routes_only_dynamic_ast() -> None:
+    original_static = dispatch.activate_validated_static_run
+    original_dynamic = dispatch.activate_validated_dynamic_run
+    calls: list[str] = []
+
+    def static(**_kwargs):
+        calls.append("static")
+        return "static"
+
+    def dynamic(**_kwargs):
+        calls.append("dynamic")
+        return "dynamic"
+
+    dispatch.activate_validated_static_run = static
+    dispatch.activate_validated_dynamic_run = dynamic
+    try:
+        result = dispatch.activate_validated_run(
+            staged_binding=SimpleNamespace(ast_binding=flat_ast())
+        )
+        require(result == "static" and calls == ["static"], "flat exact program left static path")
+        calls.clear()
+        result = dispatch.activate_validated_run(
+            staged_binding=SimpleNamespace(ast_binding=dynamic_ast())
+        )
+        require(
+            result == "dynamic" and calls == ["dynamic"],
+            "dynamic exact program did not use shared-interpreter path",
+        )
+    finally:
+        dispatch.activate_validated_static_run = original_static
+        dispatch.activate_validated_dynamic_run = original_dynamic
+
+
+def test_production_host_runs_one_dynamic_program_from_fresh_range() -> None:
+    global RANGE_FAIL, RANGE_VALUE
+    RANGE_FAIL = False
+    RANGE_VALUE = 0.4
+    base.EVENTS.clear()
+    install_dynamic_fakes()
+
+    replies = host.run_host_sequence(dynamic_ast(), steps=1)
+    require(replies[0]["ok"] is True, "dynamic run context validation failed")
+    require(replies[1]["ok"] is False, "caller semantic substitution was accepted")
+    require(
+        replies[2] == {
+            "executionAuthority": False,
+            "ok": True,
+            "requestId": "step-1",
+        },
+        "parameter-free dynamic execution did not complete",
+    )
+
+    require(
+        base.EVENTS.count(("transport-send", "epoch-after")) == 1,
+        "dynamic program did not preserve exactly one causal takeoff",
+    )
+    require(
+        base.EVENTS.count(("dynamic-range-read", "front")) == 1,
+        "exact interpreter demand did not produce one fresh front range",
+    )
+    require(
+        "dynamic-observation-enter" in base.EVENTS
+        and "dynamic-observation-exit" in base.EVENTS,
+        "fresh range did not stay inside physical observation exclusion",
+    )
+    require(
+        ("dynamic-move", "left", 0.2, "epoch-after") in base.EVENTS,
+        "range-selected branch did not reach trusted motion consumer",
+    )
+    require(
+        not any(
+            isinstance(event, tuple) and event and event[0] == "dynamic-turn"
+            for event in base.EVENTS
+        ),
+        "non-selected dynamic branch emitted an action",
+    )
+    vertical = [
+        event
+        for event in base.EVENTS
+        if isinstance(event, tuple) and event and event[0] == "dynamic-vertical"
+    ]
+    require(len(vertical) == 1, "dynamic vertical path did not complete exactly once")
+    require(
+        vertical[0][1:3] == ("up", 0.2)
+        and isclose(vertical[0][3], 1.0, abs_tol=1e-9),
+        "accepted selected vertical effect did not advance runtime nominal altitude",
+    )
+    require(
+        any(
+            isinstance(event, tuple)
+            and event[0] == "dynamic-land"
+            and isclose(event[1], 1.0, abs_tol=1e-9)
+            and event[2] == "epoch-after"
+            for event in base.EVENTS
+        ),
+        "terminal dynamic landing did not derive from completed selected path",
+    )
+    require(
+        not any(
+            isinstance(event, tuple)
+            and event
+            and event[0] in {"inflight-move", "inflight-turn", "inflight-vertical", "terminal-land"}
+            for event in base.EVENTS
+        ),
+        "dynamic program retained the flat PhysicalProgramSequence effect cursor",
+    )
+    require(
+        base.EVENTS.count(("current-program", "epoch-after")) >= 4,
+        "dynamic range/effects did not repeatedly re-establish current-program provenance",
+    )
+    require(("dynamic-yaw-close", "epoch-after") in base.EVENTS, "dynamic yaw observer leaked")
+
+
+def test_post_takeoff_range_failure_enters_terminal_recovery() -> None:
+    global RANGE_FAIL, RANGE_VALUE
+    RANGE_FAIL = True
+    RANGE_VALUE = 0.4
+    base.EVENTS.clear()
+    install_dynamic_fakes()
+    try:
+        replies = host.run_host_sequence(dynamic_ast(), steps=2)
+    finally:
+        RANGE_FAIL = False
+
+    require(replies[2]["ok"] is False, "post-takeoff range failure was accepted")
+    require(replies[3]["ok"] is False, "terminal dynamic failure allowed later execution")
+    require(
+        base.EVENTS.count(("transport-send", "epoch-after")) == 1,
+        "failure path changed the one causal takeoff boundary",
+    )
+    require(("dynamic-range-close", "front") in base.EVENTS, "failed range observer leaked")
+    require("watchdog-stop" in base.EVENTS, "dynamic failure did not enter terminal watchdog recovery")
+    require(
+        any(
+            isinstance(event, tuple) and event and event[0] == "teacher-close"
+            for event in base.EVENTS
+        ),
+        "dynamic failure did not close exact teacher authority",
+    )
+    require(
+        not any(
+            isinstance(event, tuple)
+            and event
+            and event[0] in {"dynamic-move", "dynamic-turn", "dynamic-vertical", "dynamic-land"}
+            for event in base.EVENTS
+        ),
+        "failed fresh range advanced into a later physical action",
+    )
+
+
+def test_shared_language_invalidity_fails_before_reset_or_takeoff() -> None:
+    global RANGE_FAIL
+    RANGE_FAIL = False
+    base.EVENTS.clear()
+    install_dynamic_fakes()
+    replies = host.run_host_sequence(language_invalid_ast(), steps=1)
+
+    require(replies[0]["ok"] is True, "run-context bridge should remain diagnostic")
+    require(replies[2]["ok"] is False, "language-invalid program acquired execution")
+    require(
+        not any(
+            isinstance(event, tuple) and event and event[0] == "bridge-begin"
+            for event in base.EVENTS
+        ),
+        "shared-language invalidity was discovered only after reset cutover",
+    )
+    require("power-cycle" not in base.EVENTS, "language-invalid program reached reset effect")
+    require(
+        ("transport-send", "epoch-after") not in base.EVENTS,
+        "language-invalid program reached causal takeoff",
+    )
+
+
+def main() -> int:
+    test_dispatch_preserves_static_path_and_routes_only_dynamic_ast()
+    test_production_host_runs_one_dynamic_program_from_fresh_range()
+    test_post_takeoff_range_failure_enters_terminal_recovery()
+    test_shared_language_invalidity_fails_before_reset_or_takeoff()
+    print(
+        "PASS production dynamic activation: static dispatch preserved, one causal takeoff, "
+        "fresh range-driven shared control flow, runtime landing and terminal recovery"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_dynamic_run_activation.py
+++ b/tools/ci/test_physical_dynamic_run_activation.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import runpy
+import socket
+import sys
+from types import SimpleNamespace
+from threading import Thread
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / "tools" / "ci"
+PHYSICAL = ROOT / "tools" / "physical"
+for directory in (CI, PHYSICAL):
+    if str(directory) not in sys.path:
+        sys.path.insert(0, str(directory))
+
+HOST = PHYSICAL / "serve_physical_host.py"
+
+import dynamic_physical_backend  # noqa: E402
+import dynamic_run_activation  # noqa: E402
+import physical_execution_domain  # noqa: E402
+import test_physical_host_activation as base  # noqa: E402
+
+
+RANGE_STATE = {"value": 0.4, "fail": False}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def canonical(value: object) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def dynamic_ast() -> str:
+    return canonical(
+        {
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {
+                    "condition": {
+                        "kind": "compare",
+                        "left": {"direction": "front", "kind": "range", "unit": "m"},
+                        "op": "LT",
+                        "right": {"kind": "number", "value": 1.0},
+                    },
+                    "else": [{"color": "red", "kind": "set_light"}],
+                    "kind": "if",
+                    "then": [{"color": "green", "kind": "set_light"}],
+                },
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        }
+    )
+
+
+def unsupported_language_ast() -> str:
+    return canonical(
+        {
+            "program": [
+                {"height_m": 0.8, "kind": "takeoff"},
+                {
+                    "condition": {
+                        "kind": "compare",
+                        "left": {
+                            "kind": "arithmetic",
+                            "left": {"kind": "number", "value": 2.0},
+                            "op": "POWER",
+                            "right": {"kind": "number", "value": 3.0},
+                        },
+                        "op": "GT",
+                        "right": {"kind": "number", "value": 1.0},
+                    },
+                    "else": [{"kind": "wait", "seconds": 0.1}],
+                    "kind": "if",
+                    "then": [{"kind": "wait", "seconds": 0.1}],
+                },
+                {"kind": "land"},
+            ],
+            "semantics": "webeeblocks-ast-v1",
+            "version": 1,
+        }
+    )
+
+
+class DynamicFakeExecutionDomain(base.FakeExecutionDomain):
+    def observation_transaction(self, *checks):
+        @contextmanager
+        def transaction():
+            require(
+                self.phase == physical_execution_domain.FLYING,
+                "dynamic observation must start from flying",
+            )
+            base.EVENTS.append("dynamic-observation-enter")
+            for check in checks:
+                check()
+            try:
+                yield object()
+            finally:
+                require(
+                    self.phase == physical_execution_domain.FLYING,
+                    "dynamic observation changed physical phase",
+                )
+                base.EVENTS.append("dynamic-observation-exit")
+
+        return transaction()
+
+
+class FakeDynamicInflightTransport:
+    def __init__(self, **kwargs) -> None:
+        self.execution_domain = kwargs["execution_domain"]
+        self.teacher_binding = kwargs["teacher_authorization"].binding
+        self.bound_connection_epoch = kwargs["powered_session"].connection_epoch
+        self._watchdog = kwargs["watchdog_guard"]
+        self._epoch_reader = kwargs["connection_epoch_reader"]
+        ast = json.loads(self.teacher_binding.ast_binding)
+        self.initial_nominal_altitude_m = float(ast["program"][0]["height_m"])
+
+    def _read_current_binding(self):
+        raise AssertionError("dynamic host adapter must override current-program binding")
+
+    def send_horizontal_move(self, **_kwargs):
+        raise AssertionError("non-selected dynamic move reached transport")
+
+    def send_vertical_move(self, **_kwargs):
+        raise AssertionError("non-selected dynamic vertical move reached transport")
+
+    def send_turn(self, **_kwargs):
+        raise AssertionError("non-selected dynamic turn reached transport")
+
+    def send_controlled_landing(self):
+        require(self._watchdog.active, "watchdog must remain live through dynamic landing")
+        require(
+            self._epoch_reader() == self.bound_connection_epoch,
+            "dynamic landing must stay on exact active epoch",
+        )
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "dynamic landing lost exact teacher binding")
+        require(
+            self.execution_domain.phase == physical_execution_domain.FLYING,
+            "dynamic landing must start from flying",
+        )
+        base.EVENTS.append(("dynamic-land", binding.connection_epoch))
+        self.execution_domain.phase = physical_execution_domain.INACTIVE
+        return base.FakeAckResult()
+
+
+class FakeDynamicColorTransport:
+    def __init__(self, **kwargs) -> None:
+        self.teacher_binding = kwargs["teacher_authorization"].binding
+        self.bound_connection_epoch = kwargs["powered_session"].connection_epoch
+        self._watchdog = kwargs["watchdog_guard"]
+        self._epoch_reader = kwargs["connection_epoch_reader"]
+
+    def _read_current_binding(self):
+        raise AssertionError("dynamic color host adapter must override current-program binding")
+
+    def send_color(self, *, color: str):
+        require(self._watchdog.active, "watchdog must remain live through dynamic color effect")
+        require(
+            self._epoch_reader() == self.bound_connection_epoch,
+            "dynamic color effect must stay on exact active epoch",
+        )
+        binding = self._read_current_binding()
+        require(binding == self.teacher_binding, "dynamic color effect lost exact teacher binding")
+        base.EVENTS.append(("dynamic-light", color, binding.connection_epoch))
+        return base.FakeAckResult()
+
+
+class FakeRangeObserver:
+    def __init__(self, crazyflie: object, epoch_reader, direction: str) -> None:
+        self.bound_crazyflie = crazyflie
+        self._epoch_reader = epoch_reader
+        self.bound_connection_epoch = epoch_reader()
+        self.direction = direction
+        self._open = False
+
+    def open(self) -> None:
+        require(not self._open, "range observer is one-shot")
+        self._open = True
+        base.EVENTS.append(("dynamic-range-open", self.direction))
+
+    def read(self):
+        require(self._open, "range observer must be open")
+        base.EVENTS.append(("dynamic-range-read", self.direction))
+        if RANGE_STATE["fail"]:
+            raise RuntimeError("synthetic fresh range failure")
+        return SimpleNamespace(
+            connection_epoch=self._epoch_reader(),
+            direction=self.direction,
+            range_m=float(RANGE_STATE["value"]),
+        )
+
+    def close(self) -> None:
+        if self._open:
+            base.EVENTS.append(("dynamic-range-close", self.direction))
+        self._open = False
+
+
+def install_dynamic_fakes() -> None:
+    base.install_fakes()
+
+    physical_execution_domain.PhysicalExecutionDomain = DynamicFakeExecutionDomain
+    base.activation.PhysicalExecutionDomain = DynamicFakeExecutionDomain
+
+    dynamic_run_activation.PhysicalExecutionDomain = DynamicFakeExecutionDomain
+    dynamic_run_activation.TrustedPoweredSessionFactory = base.FakePoweredFactory
+    dynamic_run_activation.PostResetTeacherDecisionChannel = base.FakeTeacherChannel
+    dynamic_run_activation.TrustedTeacherAuthorizer = base.FakeAuthorizer
+    dynamic_run_activation.FreshSupervisorStateReader = base.FakeSupervisorReader
+    dynamic_run_activation.TrustedTakeoffTransport = base.FakeTransportBase
+    dynamic_run_activation.TrustedDynamicControlledLandingTransport = (
+        FakeDynamicInflightTransport
+    )
+    dynamic_run_activation.TrustedBottomColorLedTransport = FakeDynamicColorTransport
+    dynamic_run_activation.make_cflib_stm_deck_power_cycle = (
+        lambda _uri: lambda: base.EVENTS.append("power-cycle")
+    )
+
+    dynamic_physical_backend.FreshRangeObserver = FakeRangeObserver
+
+
+def _send(sock: socket.socket, payload: dict[str, object]) -> None:
+    sock.sendall(
+        (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
+    )
+
+
+def _read(stream) -> dict[str, object]:
+    line = stream.readline()
+    require(bool(line), "physical host closed caller channel unexpectedly")
+    value = json.loads(line)
+    require(isinstance(value, dict), "caller response must be an object")
+    return value
+
+
+def run_dynamic_host(
+    ast_binding: str,
+    *,
+    range_fail: bool = False,
+    execute: bool = True,
+) -> list[dict[str, object]]:
+    base.ACTIVATION_COMPLETED.clear()
+    RANGE_STATE["fail"] = range_fail
+
+    caller_host, caller_peer = socket.socketpair()
+    caller_stream = caller_peer.makefile("r", encoding="utf-8")
+    browser_read, browser_write = os.pipe()
+    teacher_host, teacher_peer = socket.socketpair()
+
+    argv = [
+        str(HOST),
+        "--uri",
+        "radio://0/80/2M/E7E7E7E7E7",
+        "--caller-fd",
+        str(caller_host.detach()),
+        "--browser-config-fd",
+        str(browser_write),
+        "--teacher-fd",
+        str(teacher_host.detach()),
+    ]
+    outcome: dict[str, object] = {}
+    old_argv = sys.argv[:]
+
+    def target() -> None:
+        sys.argv = argv
+        try:
+            runpy.run_path(str(HOST), run_name="__main__")
+        except Exception as exc:
+            outcome["error"] = exc
+        finally:
+            sys.argv = old_argv
+
+    worker = Thread(target=target, daemon=True)
+    worker.start()
+
+    with os.fdopen(browser_read, "r", encoding="utf-8") as stream:
+        bootstrap = json.loads(stream.readline())
+    require(bootstrap["executionAuthority"] is False, "browser bootstrap remains non-authority")
+
+    _send(
+        caller_peer,
+        {
+            "op": "validate-run-context",
+            "requestId": "validate-dynamic",
+            "profileId": "activity-dynamic",
+            "astBinding": ast_binding,
+            "connectionEpoch": "epoch-before",
+        },
+    )
+    replies = [_read(caller_stream)]
+
+    if execute:
+        _send(
+            caller_peer,
+            {
+                "op": "execute-next-inflight",
+                "requestId": "substitute-dynamic",
+                "direction": "right",
+                "rangeM": 0.01,
+                "branch": "else",
+            },
+        )
+        replies.append(_read(caller_stream))
+
+        _send(
+            caller_peer,
+            {"op": "execute-next-inflight", "requestId": "execute-dynamic"},
+        )
+        replies.append(_read(caller_stream))
+
+    caller_peer.shutdown(socket.SHUT_WR)
+    worker.join(timeout=5.0)
+    require(not worker.is_alive(), "dynamic production host must terminate after caller EOF")
+    require("error" not in outcome, "dynamic production host failed: " + repr(outcome.get("error")))
+
+    caller_stream.close()
+    caller_peer.close()
+    teacher_peer.close()
+    return replies
+
+
+def test_dynamic_host_runs_range_branch_once_after_single_causal_takeoff() -> None:
+    base.EVENTS.clear()
+    install_dynamic_fakes()
+    replies = run_dynamic_host(dynamic_ast())
+
+    require(
+        replies[0]
+        == {
+            "executionAuthority": False,
+            "ok": True,
+            "requestId": "validate-dynamic",
+        },
+        "dynamic validation must remain diagnostic",
+    )
+    require(
+        replies[1]["ok"] is False and replies[1]["executionAuthority"] is False,
+        "caller-selected dynamic semantics must be rejected",
+    )
+    require(
+        replies[2]
+        == {
+            "executionAuthority": False,
+            "ok": True,
+            "requestId": "execute-dynamic",
+        },
+        "parameter-free dynamic execution did not complete",
+    )
+
+    require(
+        base.EVENTS.count(("transport-send", "epoch-after")) == 1,
+        "shared interpreter emitted or caused a second causal takeoff",
+    )
+    require(
+        base.EVENTS.count(("dynamic-range-read", "front")) == 1,
+        "bound interpreter did not issue exactly one fresh front range demand",
+    )
+    require(
+        ("dynamic-light", "green", "epoch-after") in base.EVENTS,
+        "range-driven selected branch did not reach trusted color consumer",
+    )
+    require(
+        not any(
+            isinstance(event, tuple)
+            and event[:2] == ("dynamic-light", "red")
+            for event in base.EVENTS
+        ),
+        "non-selected dynamic branch emitted an effect",
+    )
+    require(
+        base.EVENTS.count(("dynamic-land", "epoch-after")) == 1,
+        "dynamic terminal landing did not complete exactly once",
+    )
+    require(
+        base.EVENTS.index(("dynamic-range-open", "front"))
+        < base.EVENTS.index(("dynamic-range-read", "front"))
+        < base.EVENTS.index(("dynamic-range-close", "front")),
+        "fresh dynamic range observer lifecycle is not ordered",
+    )
+
+
+def test_post_takeoff_range_failure_enters_terminal_recovery() -> None:
+    base.EVENTS.clear()
+    install_dynamic_fakes()
+    replies = run_dynamic_host(dynamic_ast(), range_fail=True)
+
+    require(replies[2]["ok"] is False, "post-takeoff range failure was reported as success")
+    require(
+        replies[2]["executionAuthority"] is False,
+        "post-takeoff failure minted caller execution authority",
+    )
+    require(
+        base.EVENTS.count(("transport-send", "epoch-after")) == 1,
+        "failure test did not establish exactly one causal takeoff",
+    )
+    require(
+        ("dynamic-range-close", "front") in base.EVENTS,
+        "failed fresh range observation leaked its observer",
+    )
+    require("watchdog-stop" in base.EVENTS, "post-takeoff failure did not enter terminal watchdog recovery")
+    require(
+        any(
+            isinstance(event, tuple) and event[0] == "teacher-close"
+            for event in base.EVENTS
+        ),
+        "post-takeoff failure did not close teacher run authority",
+    )
+    require(
+        not any(
+            isinstance(event, tuple) and event[0] in {"dynamic-light", "dynamic-land"}
+            for event in base.EVENTS
+        ),
+        "execution continued after failed range observation",
+    )
+
+
+def test_unsupported_shared_language_fallback_remains_pre_effect() -> None:
+    base.EVENTS.clear()
+    install_dynamic_fakes()
+    replies = run_dynamic_host(unsupported_language_ast())
+
+    require(replies[2]["ok"] is False, "unsupported shared-language program was executed")
+    require(
+        not base.ACTIVATION_COMPLETED.is_set(),
+        "unsupported language reached causal takeoff",
+    )
+    for forbidden in ("power-cycle", "watchdog-activate"):
+        require(forbidden not in base.EVENTS, "unsupported language reached effect preparation")
+    require(
+        not any(
+            isinstance(event, tuple)
+            and event[0] in {"bridge-begin", "transport-send", "dynamic-range-open"}
+            for event in base.EVENTS
+        ),
+        "unsupported language fallback crossed the pre-effect boundary",
+    )
+
+
+def main() -> int:
+    test_dynamic_host_runs_range_branch_once_after_single_causal_takeoff()
+    test_post_takeoff_range_failure_enters_terminal_recovery()
+    test_unsupported_shared_language_fallback_remains_pre_effect()
+    print(
+        "PASS production dynamic physical host: pre-effect shared validation -> one causal "
+        "takeoff -> interpreter-owned fresh range branch/effects/landing, with terminal recovery"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_physical_dynamic_run_activation.py
+++ b/tools/ci/test_physical_dynamic_run_activation.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-from contextlib import contextmanager
-import json
-import os
 from pathlib import Path
-import runpy
-import socket
 import sys
-from types import SimpleNamespace
-from threading import Thread
 
 ROOT = Path(__file__).resolve().parents[2]
 CI = ROOT / "tools" / "ci"
@@ -18,15 +11,7 @@ for directory in (CI, PHYSICAL):
     if str(directory) not in sys.path:
         sys.path.insert(0, str(directory))
 
-HOST = PHYSICAL / "serve_physical_host.py"
-
-import dynamic_physical_backend  # noqa: E402
-import dynamic_run_activation  # noqa: E402
-import physical_execution_domain  # noqa: E402
-import test_physical_host_activation as base  # noqa: E402
-
-
-RANGE_STATE = {"value": 0.4, "fail": False}
+import test_dynamic_run_activation as activation_test  # noqa: E402
 
 
 def require(condition: bool, message: str) -> None:
@@ -34,424 +19,81 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
-def canonical(value: object) -> str:
-    return json.dumps(value, separators=(",", ":"), sort_keys=True)
-
-
-def dynamic_ast() -> str:
-    return canonical(
-        {
-            "program": [
-                {"height_m": 0.8, "kind": "takeoff"},
-                {
-                    "condition": {
-                        "kind": "compare",
-                        "left": {"direction": "front", "kind": "range", "unit": "m"},
-                        "op": "LT",
-                        "right": {"kind": "number", "value": 1.0},
-                    },
-                    "else": [{"color": "red", "kind": "set_light"}],
-                    "kind": "if",
-                    "then": [{"color": "green", "kind": "set_light"}],
-                },
-                {"kind": "land"},
-            ],
-            "semantics": "webeeblocks-ast-v1",
-            "version": 1,
-        }
-    )
-
-
-def unsupported_language_ast() -> str:
-    return canonical(
-        {
-            "program": [
-                {"height_m": 0.8, "kind": "takeoff"},
-                {
-                    "condition": {
-                        "kind": "compare",
-                        "left": {
-                            "kind": "arithmetic",
-                            "left": {"kind": "number", "value": 2.0},
-                            "op": "POWER",
-                            "right": {"kind": "number", "value": 3.0},
-                        },
-                        "op": "GT",
-                        "right": {"kind": "number", "value": 1.0},
-                    },
-                    "else": [{"kind": "wait", "seconds": 0.1}],
-                    "kind": "if",
-                    "then": [{"kind": "wait", "seconds": 0.1}],
-                },
-                {"kind": "land"},
-            ],
-            "semantics": "webeeblocks-ast-v1",
-            "version": 1,
-        }
-    )
-
-
-class DynamicFakeExecutionDomain(base.FakeExecutionDomain):
-    def observation_transaction(self, *checks):
-        @contextmanager
-        def transaction():
-            require(
-                self.phase == physical_execution_domain.FLYING,
-                "dynamic observation must start from flying",
-            )
-            base.EVENTS.append("dynamic-observation-enter")
-            for check in checks:
-                check()
-            try:
-                yield object()
-            finally:
-                require(
-                    self.phase == physical_execution_domain.FLYING,
-                    "dynamic observation changed physical phase",
-                )
-                base.EVENTS.append("dynamic-observation-exit")
-
-        return transaction()
-
-
-class FakeDynamicInflightTransport:
-    def __init__(self, **kwargs) -> None:
-        self.execution_domain = kwargs["execution_domain"]
-        self.teacher_binding = kwargs["teacher_authorization"].binding
-        self.bound_connection_epoch = kwargs["powered_session"].connection_epoch
-        self._watchdog = kwargs["watchdog_guard"]
-        self._epoch_reader = kwargs["connection_epoch_reader"]
-        ast = json.loads(self.teacher_binding.ast_binding)
-        self.initial_nominal_altitude_m = float(ast["program"][0]["height_m"])
-
-    def _read_current_binding(self):
-        raise AssertionError("dynamic host adapter must override current-program binding")
-
-    def send_horizontal_move(self, **_kwargs):
-        raise AssertionError("non-selected dynamic move reached transport")
-
-    def send_vertical_move(self, **_kwargs):
-        raise AssertionError("non-selected dynamic vertical move reached transport")
-
-    def send_turn(self, **_kwargs):
-        raise AssertionError("non-selected dynamic turn reached transport")
-
-    def send_controlled_landing(self):
-        require(self._watchdog.active, "watchdog must remain live through dynamic landing")
-        require(
-            self._epoch_reader() == self.bound_connection_epoch,
-            "dynamic landing must stay on exact active epoch",
-        )
-        binding = self._read_current_binding()
-        require(binding == self.teacher_binding, "dynamic landing lost exact teacher binding")
-        require(
-            self.execution_domain.phase == physical_execution_domain.FLYING,
-            "dynamic landing must start from flying",
-        )
-        base.EVENTS.append(("dynamic-land", binding.connection_epoch))
-        self.execution_domain.phase = physical_execution_domain.INACTIVE
-        return base.FakeAckResult()
-
-
-class FakeDynamicColorTransport:
-    def __init__(self, **kwargs) -> None:
-        self.teacher_binding = kwargs["teacher_authorization"].binding
-        self.bound_connection_epoch = kwargs["powered_session"].connection_epoch
-        self._watchdog = kwargs["watchdog_guard"]
-        self._epoch_reader = kwargs["connection_epoch_reader"]
-
-    def _read_current_binding(self):
-        raise AssertionError("dynamic color host adapter must override current-program binding")
-
-    def send_color(self, *, color: str):
-        require(self._watchdog.active, "watchdog must remain live through dynamic color effect")
-        require(
-            self._epoch_reader() == self.bound_connection_epoch,
-            "dynamic color effect must stay on exact active epoch",
-        )
-        binding = self._read_current_binding()
-        require(binding == self.teacher_binding, "dynamic color effect lost exact teacher binding")
-        base.EVENTS.append(("dynamic-light", color, binding.connection_epoch))
-        return base.FakeAckResult()
-
-
-class FakeRangeObserver:
-    def __init__(self, crazyflie: object, epoch_reader, direction: str) -> None:
-        self.bound_crazyflie = crazyflie
-        self._epoch_reader = epoch_reader
-        self.bound_connection_epoch = epoch_reader()
-        self.direction = direction
-        self._open = False
-
-    def open(self) -> None:
-        require(not self._open, "range observer is one-shot")
-        self._open = True
-        base.EVENTS.append(("dynamic-range-open", self.direction))
-
-    def read(self):
-        require(self._open, "range observer must be open")
-        base.EVENTS.append(("dynamic-range-read", self.direction))
-        if RANGE_STATE["fail"]:
-            raise RuntimeError("synthetic fresh range failure")
-        return SimpleNamespace(
-            connection_epoch=self._epoch_reader(),
-            direction=self.direction,
-            range_m=float(RANGE_STATE["value"]),
-        )
-
-    def close(self) -> None:
-        if self._open:
-            base.EVENTS.append(("dynamic-range-close", self.direction))
-        self._open = False
-
-
-def install_dynamic_fakes() -> None:
-    base.install_fakes()
-
-    physical_execution_domain.PhysicalExecutionDomain = DynamicFakeExecutionDomain
-    base.activation.PhysicalExecutionDomain = DynamicFakeExecutionDomain
-
-    dynamic_run_activation.PhysicalExecutionDomain = DynamicFakeExecutionDomain
-    dynamic_run_activation.TrustedPoweredSessionFactory = base.FakePoweredFactory
-    dynamic_run_activation.PostResetTeacherDecisionChannel = base.FakeTeacherChannel
-    dynamic_run_activation.TrustedTeacherAuthorizer = base.FakeAuthorizer
-    dynamic_run_activation.FreshSupervisorStateReader = base.FakeSupervisorReader
-    dynamic_run_activation.TrustedTakeoffTransport = base.FakeTransportBase
-    dynamic_run_activation.TrustedDynamicControlledLandingTransport = (
-        FakeDynamicInflightTransport
-    )
-    dynamic_run_activation.TrustedBottomColorLedTransport = FakeDynamicColorTransport
-    dynamic_run_activation.make_cflib_stm_deck_power_cycle = (
-        lambda _uri: lambda: base.EVENTS.append("power-cycle")
-    )
-
-    dynamic_physical_backend.FreshRangeObserver = FakeRangeObserver
-
-
-def _send(sock: socket.socket, payload: dict[str, object]) -> None:
-    sock.sendall(
-        (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
-    )
-
-
-def _read(stream) -> dict[str, object]:
-    line = stream.readline()
-    require(bool(line), "physical host closed caller channel unexpectedly")
-    value = json.loads(line)
-    require(isinstance(value, dict), "caller response must be an object")
-    return value
-
-
-def run_dynamic_host(
-    ast_binding: str,
-    *,
-    range_fail: bool = False,
-    execute: bool = True,
-) -> list[dict[str, object]]:
-    base.ACTIVATION_COMPLETED.clear()
-    RANGE_STATE["fail"] = range_fail
-
-    caller_host, caller_peer = socket.socketpair()
-    caller_stream = caller_peer.makefile("r", encoding="utf-8")
-    browser_read, browser_write = os.pipe()
-    teacher_host, teacher_peer = socket.socketpair()
-
-    argv = [
-        str(HOST),
-        "--uri",
-        "radio://0/80/2M/E7E7E7E7E7",
-        "--caller-fd",
-        str(caller_host.detach()),
-        "--browser-config-fd",
-        str(browser_write),
-        "--teacher-fd",
-        str(teacher_host.detach()),
-    ]
-    outcome: dict[str, object] = {}
-    old_argv = sys.argv[:]
-
-    def target() -> None:
-        sys.argv = argv
-        try:
-            runpy.run_path(str(HOST), run_name="__main__")
-        except Exception as exc:
-            outcome["error"] = exc
-        finally:
-            sys.argv = old_argv
-
-    worker = Thread(target=target, daemon=True)
-    worker.start()
-
-    with os.fdopen(browser_read, "r", encoding="utf-8") as stream:
-        bootstrap = json.loads(stream.readline())
-    require(bootstrap["executionAuthority"] is False, "browser bootstrap remains non-authority")
-
-    _send(
-        caller_peer,
-        {
-            "op": "validate-run-context",
-            "requestId": "validate-dynamic",
-            "profileId": "activity-dynamic",
-            "astBinding": ast_binding,
-            "connectionEpoch": "epoch-before",
-        },
-    )
-    replies = [_read(caller_stream)]
-
-    if execute:
-        _send(
-            caller_peer,
+def unsupported_operator_ast() -> str:
+    return activation_test.canonical(
+        [
+            {"height_m": 0.8, "kind": "takeoff"},
             {
-                "op": "execute-next-inflight",
-                "requestId": "substitute-dynamic",
-                "direction": "right",
-                "rangeM": 0.01,
-                "branch": "else",
+                "condition": {
+                    "kind": "compare",
+                    "left": {
+                        "kind": "arithmetic",
+                        "left": {"kind": "number", "value": 2.0},
+                        "op": "POWER",
+                        "right": {"kind": "number", "value": 3.0},
+                    },
+                    "op": "GT",
+                    "right": {"kind": "number", "value": 1.0},
+                },
+                "else": [{"kind": "wait", "seconds": 0.1}],
+                "kind": "if",
+                "then": [{"kind": "wait", "seconds": 0.1}],
             },
-        )
-        replies.append(_read(caller_stream))
-
-        _send(
-            caller_peer,
-            {"op": "execute-next-inflight", "requestId": "execute-dynamic"},
-        )
-        replies.append(_read(caller_stream))
-
-    caller_peer.shutdown(socket.SHUT_WR)
-    worker.join(timeout=5.0)
-    require(not worker.is_alive(), "dynamic production host must terminate after caller EOF")
-    require("error" not in outcome, "dynamic production host failed: " + repr(outcome.get("error")))
-
-    caller_stream.close()
-    caller_peer.close()
-    teacher_peer.close()
-    return replies
-
-
-def test_dynamic_host_runs_range_branch_once_after_single_causal_takeoff() -> None:
-    base.EVENTS.clear()
-    install_dynamic_fakes()
-    replies = run_dynamic_host(dynamic_ast())
-
-    require(
-        replies[0]
-        == {
-            "executionAuthority": False,
-            "ok": True,
-            "requestId": "validate-dynamic",
-        },
-        "dynamic validation must remain diagnostic",
-    )
-    require(
-        replies[1]["ok"] is False and replies[1]["executionAuthority"] is False,
-        "caller-selected dynamic semantics must be rejected",
-    )
-    require(
-        replies[2]
-        == {
-            "executionAuthority": False,
-            "ok": True,
-            "requestId": "execute-dynamic",
-        },
-        "parameter-free dynamic execution did not complete",
+            {"kind": "land"},
+        ]
     )
 
+
+def test_unsupported_shared_expression_fails_before_reset_or_takeoff() -> None:
+    activation_test.RANGE_FAIL = False
+    activation_test.base.EVENTS.clear()
+    activation_test.install_dynamic_fakes()
+
+    replies = activation_test.host.run_host_sequence(
+        unsupported_operator_ast(),
+        steps=1,
+    )
+
+    require(replies[0]["ok"] is True, "run-context validation must remain diagnostic")
+    require(replies[1]["ok"] is False, "caller semantic substitution must remain rejected")
+    require(replies[2]["ok"] is False, "unsupported shared expression acquired execution")
     require(
-        base.EVENTS.count(("transport-send", "epoch-after")) == 1,
-        "shared interpreter emitted or caused a second causal takeoff",
+        not any(
+            isinstance(event, tuple) and event and event[0] == "bridge-begin"
+            for event in activation_test.base.EVENTS
+        ),
+        "unsupported shared expression was discovered only after reset cutover",
     )
     require(
-        base.EVENTS.count(("dynamic-range-read", "front")) == 1,
-        "bound interpreter did not issue exactly one fresh front range demand",
+        "power-cycle" not in activation_test.base.EVENTS,
+        "unsupported shared expression reached reset effect",
     )
     require(
-        ("dynamic-light", "green", "epoch-after") in base.EVENTS,
-        "range-driven selected branch did not reach trusted color consumer",
+        ("transport-send", "epoch-after") not in activation_test.base.EVENTS,
+        "unsupported shared expression reached causal takeoff",
     )
     require(
         not any(
             isinstance(event, tuple)
-            and event[:2] == ("dynamic-light", "red")
-            for event in base.EVENTS
+            and event
+            and event[0] in {
+                "dynamic-range-open",
+                "dynamic-move",
+                "dynamic-turn",
+                "dynamic-vertical",
+                "dynamic-land",
+            }
+            for event in activation_test.base.EVENTS
         ),
-        "non-selected dynamic branch emitted an effect",
-    )
-    require(
-        base.EVENTS.count(("dynamic-land", "epoch-after")) == 1,
-        "dynamic terminal landing did not complete exactly once",
-    )
-    require(
-        base.EVENTS.index(("dynamic-range-open", "front"))
-        < base.EVENTS.index(("dynamic-range-read", "front"))
-        < base.EVENTS.index(("dynamic-range-close", "front")),
-        "fresh dynamic range observer lifecycle is not ordered",
-    )
-
-
-def test_post_takeoff_range_failure_enters_terminal_recovery() -> None:
-    base.EVENTS.clear()
-    install_dynamic_fakes()
-    replies = run_dynamic_host(dynamic_ast(), range_fail=True)
-
-    require(replies[2]["ok"] is False, "post-takeoff range failure was reported as success")
-    require(
-        replies[2]["executionAuthority"] is False,
-        "post-takeoff failure minted caller execution authority",
-    )
-    require(
-        base.EVENTS.count(("transport-send", "epoch-after")) == 1,
-        "failure test did not establish exactly one causal takeoff",
-    )
-    require(
-        ("dynamic-range-close", "front") in base.EVENTS,
-        "failed fresh range observation leaked its observer",
-    )
-    require("watchdog-stop" in base.EVENTS, "post-takeoff failure did not enter terminal watchdog recovery")
-    require(
-        any(
-            isinstance(event, tuple) and event[0] == "teacher-close"
-            for event in base.EVENTS
-        ),
-        "post-takeoff failure did not close teacher run authority",
-    )
-    require(
-        not any(
-            isinstance(event, tuple) and event[0] in {"dynamic-light", "dynamic-land"}
-            for event in base.EVENTS
-        ),
-        "execution continued after failed range observation",
-    )
-
-
-def test_unsupported_shared_language_fallback_remains_pre_effect() -> None:
-    base.EVENTS.clear()
-    install_dynamic_fakes()
-    replies = run_dynamic_host(unsupported_language_ast())
-
-    require(replies[2]["ok"] is False, "unsupported shared-language program was executed")
-    require(
-        not base.ACTIVATION_COMPLETED.is_set(),
-        "unsupported language reached causal takeoff",
-    )
-    for forbidden in ("power-cycle", "watchdog-activate"):
-        require(forbidden not in base.EVENTS, "unsupported language reached effect preparation")
-    require(
-        not any(
-            isinstance(event, tuple)
-            and event[0] in {"bridge-begin", "transport-send", "dynamic-range-open"}
-            for event in base.EVENTS
-        ),
-        "unsupported language fallback crossed the pre-effect boundary",
+        "unsupported shared expression reached dynamic observation/effect progression",
     )
 
 
 def main() -> int:
-    test_dynamic_host_runs_range_branch_once_after_single_causal_takeoff()
-    test_post_takeoff_range_failure_enters_terminal_recovery()
-    test_unsupported_shared_language_fallback_remains_pre_effect()
+    test_unsupported_shared_expression_fails_before_reset_or_takeoff()
     print(
-        "PASS production dynamic physical host: pre-effect shared validation -> one causal "
-        "takeoff -> interpreter-owned fresh range branch/effects/landing, with terminal recovery"
+        "PASS production dynamic host rejects unsupported shared expressions before "
+        "reset/takeoff while caller IPC remains non-authority"
     )
     return 0
 

--- a/tools/physical/dynamic_run_activation.py
+++ b/tools/physical/dynamic_run_activation.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Production trusted-host activation for one dynamic physical Runtime v2 program.
+
+This composition reuses the existing reset/teacher/watchdog/causal-takeoff chain,
+then gives the exact teacher-bound AST to the shared Runtime interpreter through
+``BoundDynamicPhysicalRun``.  Ordinary caller IPC supplies no direction, branch,
+expression value, cursor or action parameter.
+
+Deterministic shared-language and conservative dynamic-physical validation happen
+before reset or takeoff.  The one real takeoff remains owned by
+``ProductionTakeoffRunController``; the interpreter's takeoff callback is only a
+verification inside ``TrustedDynamicPhysicalBackend``.  Any failure after that
+causal takeoff terminates the powered-session/watchdog authority through the
+existing controller shutdown path rather than permitting ordinary continuation.
+
+Importing this module performs no physical effect.
+"""
+
+from __future__ import annotations
+
+import socket
+
+from color_led_transport import ColorLedTransportError, TrustedBottomColorLedTransport
+from dynamic_controlled_landing_transport import (
+    DynamicControlledLandingTransportError,
+    TrustedDynamicControlledLandingTransport,
+)
+from dynamic_physical_backend import TrustedDynamicPhysicalBackend
+from dynamic_physical_run import BoundDynamicPhysicalRun, DynamicPhysicalRunError
+from high_level_timing import HighLevelTimingPolicy
+from physical_execution_domain import PhysicalExecutionDomain
+from physical_run_activation import (
+    PhysicalRunActivationError,
+    _assert_current_program,
+    _execute_exact_wait,
+    _live_crazyflie,
+    _require_flight_inactive,
+)
+from post_reset_teacher_decision import PostResetTeacherDecisionChannel
+from powered_session_authority import (
+    TrustedPoweredSessionFactory,
+    make_cflib_stm_deck_power_cycle,
+)
+from production_takeoff_run import ProductionTakeoffRunController
+from shared_interpreter_host import SharedInterpreterHostError, validate_bound_shared_program
+from supervisor_state import FreshSupervisorStateReader
+from takeoff_transport import TakeoffTransportError, TrustedTakeoffTransport
+from teacher_run_authorization import PhysicalRunBinding, TrustedTeacherAuthorizer
+
+
+class DynamicRunActivationError(PhysicalRunActivationError):
+    """Fail-closed error for production shared-interpreter physical activation."""
+
+
+def _terminal_shutdown(controller: ProductionTakeoffRunController) -> None:
+    """Enter the existing powered-session terminal recovery path best-effort."""
+    try:
+        controller.shutdown()
+    except Exception:
+        # The trusted watchdog lifecycle records terminal uncertainty itself.
+        pass
+
+
+def activate_validated_dynamic_run(
+    *,
+    uri: str,
+    session: object,
+    bridge: object,
+    teacher_socket: socket.socket,
+    staged_binding: PhysicalRunBinding,
+    execution_domain: PhysicalExecutionDomain,
+    assertion_timeout_seconds: float = 1.0,
+):
+    """Activate and return one exact parameter-free dynamic physical run owner."""
+    if not isinstance(uri, str) or not uri.startswith("radio://"):
+        raise DynamicRunActivationError("dynamic physical activation requires explicit radio:// URI")
+    if type(staged_binding) is not PhysicalRunBinding:
+        raise DynamicRunActivationError("exact host-staged PhysicalRunBinding is required")
+    if type(execution_domain) is not PhysicalExecutionDomain:
+        raise DynamicRunActivationError("exact process-wide physical execution domain is required")
+    if not isinstance(teacher_socket, socket.socket):
+        raise DynamicRunActivationError("distinct trusted teacher socket is required")
+    if assertion_timeout_seconds <= 0:
+        raise DynamicRunActivationError("current-program assertion timeout must be positive")
+
+    # This is deliberately before bridge cutover/reset/takeoff.  It invokes the
+    # existing JS product validator and conservative dynamic physical envelope,
+    # but no backend/effect surface.
+    try:
+        safety = validate_bound_shared_program(staged_binding.ast_binding)
+    except Exception as exc:
+        if isinstance(exc, (SharedInterpreterHostError, RuntimeError)):
+            raise DynamicRunActivationError(
+                "teacher-bound dynamic program failed pre-effect shared validation"
+            ) from exc
+        raise
+    if safety.ast_binding != staged_binding.ast_binding:
+        raise DynamicRunActivationError("pre-effect validation changed the exact AST binding")
+
+    begin_replacement = getattr(bridge, "begin_post_reset_replacement", None)
+    install_replacement = getattr(bridge, "install_post_reset_session", None)
+    if not callable(begin_replacement) or not callable(install_replacement):
+        raise DynamicRunActivationError(
+            "trusted dynamic activation requires the fail-closed post-reset bridge"
+        )
+
+    previous_epoch = staged_binding.connection_epoch
+    try:
+        current_epoch = session.read_connection_epoch()
+    except Exception as exc:
+        raise DynamicRunActivationError("pre-reset connection epoch is unavailable") from exc
+    if current_epoch != previous_epoch:
+        raise DynamicRunActivationError("staged dynamic run belongs to a stale pre-reset epoch")
+
+    _assert_current_program(
+        bridge,
+        staged_binding,
+        timeout_seconds=assertion_timeout_seconds,
+    )
+    pre_reset_cf = _live_crazyflie(session)
+    pre_reset_reader = FreshSupervisorStateReader(pre_reset_cf, session.read_connection_epoch)
+
+    def require_flight_known_inactive() -> bool:
+        return _require_flight_inactive(pre_reset_reader)
+
+    def invalidate_prior_evidence() -> None:
+        begin_replacement(previous_epoch)
+        session.close()
+
+    def open_post_reset_session() -> object:
+        session.open()
+        try:
+            installed_epoch = install_replacement(session)
+            live_epoch = session.read_connection_epoch()
+            if installed_epoch != live_epoch or live_epoch == previous_epoch:
+                raise DynamicRunActivationError(
+                    "post-reset bridge was not rebound to the genuinely new live epoch"
+                )
+            return _live_crazyflie(session)
+        except Exception:
+            try:
+                session.close()
+            except Exception:
+                pass
+            raise
+
+    def close_post_reset_session(crazyflie: object) -> None:
+        if crazyflie is not _live_crazyflie(session):
+            raise DynamicRunActivationError(
+                "post-reset cleanup is not bound to the live Crazyflie"
+            )
+        session.close()
+
+    def read_connection_epoch(crazyflie: object) -> str:
+        if crazyflie is not _live_crazyflie(session):
+            raise DynamicRunActivationError(
+                "post-reset epoch read is not bound to the live Crazyflie"
+            )
+        return session.read_connection_epoch()
+
+    def read_capabilities(crazyflie: object):
+        if crazyflie is not _live_crazyflie(session):
+            raise DynamicRunActivationError(
+                "post-reset capability read is not bound to the live Crazyflie"
+            )
+        return session.read_capabilities()
+
+    def assert_bound_preflight(crazyflie: object, epoch: str) -> bool:
+        if crazyflie is not _live_crazyflie(session):
+            raise DynamicRunActivationError(
+                "post-reset preflight is not bound to the live Crazyflie"
+            )
+        binding = PhysicalRunBinding(
+            profile_id=staged_binding.profile_id,
+            ast_binding=staged_binding.ast_binding,
+            connection_epoch=epoch,
+        )
+        _assert_current_program(
+            bridge,
+            binding,
+            timeout_seconds=assertion_timeout_seconds,
+        )
+        return True
+
+    def read_fresh_supervisor(crazyflie: object, epoch: str):
+        if crazyflie is not _live_crazyflie(session):
+            raise DynamicRunActivationError(
+                "post-reset supervisor read is not bound to the live Crazyflie"
+            )
+        if session.read_connection_epoch() != epoch:
+            raise DynamicRunActivationError(
+                "post-reset supervisor read belongs to another connection epoch"
+            )
+        return FreshSupervisorStateReader(
+            crazyflie,
+            session.read_connection_epoch,
+        ).read(timeout_seconds=0.2)
+
+    powered_factory = TrustedPoweredSessionFactory(
+        require_flight_known_inactive=require_flight_known_inactive,
+        invalidate_prior_evidence=invalidate_prior_evidence,
+        stm_deck_power_cycle=make_cflib_stm_deck_power_cycle(uri),
+        open_post_reset_session=open_post_reset_session,
+        close_post_reset_session=close_post_reset_session,
+        read_connection_epoch=read_connection_epoch,
+        read_capabilities=read_capabilities,
+        assert_bound_preflight=assert_bound_preflight,
+        read_fresh_supervisor=read_fresh_supervisor,
+    )
+    authorizer = TrustedTeacherAuthorizer()
+    decision_channel = PostResetTeacherDecisionChannel(
+        teacher_socket,
+        session.read_connection_epoch,
+    )
+
+    class _HostBoundInitialFlightTransport(TrustedTakeoffTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            binding = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    binding,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise TakeoffTransportError(str(exc)) from exc
+            return binding
+
+    def host_bound_transport_factory(**kwargs) -> TrustedTakeoffTransport:
+        return _HostBoundInitialFlightTransport(**kwargs)
+
+    controller = ProductionTakeoffRunController(
+        powered_session_factory=powered_factory,
+        teacher_channel=decision_channel,
+        teacher_authorizer=authorizer,
+        connection_epoch_reader=session.read_connection_epoch,
+        host_bound_transport_factory=host_bound_transport_factory,
+        execution_domain=execution_domain,
+    )
+    try:
+        controller.start(
+            profile_id=staged_binding.profile_id,
+            ast_binding=staged_binding.ast_binding,
+            previous_connection_epoch=previous_epoch,
+        )
+    finally:
+        decision_channel.close()
+
+    active_run = controller.active_run
+    if active_run is None:
+        _terminal_shutdown(controller)
+        raise DynamicRunActivationError(
+            "causal takeoff completed without an active dynamic physical run bundle"
+        )
+    binding = active_run.teacher_authorization.binding
+    if (
+        binding.profile_id != staged_binding.profile_id
+        or binding.ast_binding != staged_binding.ast_binding
+        or binding.connection_epoch != active_run.powered_session.connection_epoch
+    ):
+        _terminal_shutdown(controller)
+        raise DynamicRunActivationError(
+            "post-takeoff teacher run no longer matches the exact dynamic AST"
+        )
+
+    class _HostBoundDynamicInflightTransport(TrustedDynamicControlledLandingTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            current = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    current,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise DynamicControlledLandingTransportError(str(exc)) from exc
+            return current
+
+    class _HostBoundColorLedTransport(TrustedBottomColorLedTransport):
+        def _read_current_binding(self) -> PhysicalRunBinding:
+            current = self.teacher_binding
+            try:
+                _assert_current_program(
+                    bridge,
+                    current,
+                    timeout_seconds=assertion_timeout_seconds,
+                )
+            except PhysicalRunActivationError as exc:
+                raise ColorLedTransportError(str(exc)) from exc
+            return current
+
+    def assert_current_program() -> object:
+        return _assert_current_program(
+            bridge,
+            binding,
+            timeout_seconds=assertion_timeout_seconds,
+        )
+
+    def execute_wait(seconds: float) -> None:
+        _execute_exact_wait(
+            seconds,
+            active_run.watchdog_guard,
+            session.read_connection_epoch,
+            active_run.powered_session.connection_epoch,
+        )
+
+    try:
+        inflight_transport = _HostBoundDynamicInflightTransport(
+            crazyflie=active_run.crazyflie,
+            execution_domain=active_run.execution_domain,
+            acknowledgement_domain=active_run.acknowledgement_domain,
+            safelink_guard=active_run.safelink_guard,
+            teacher_authorization=active_run.teacher_authorization,
+            powered_session=active_run.powered_session,
+            watchdog_guard=active_run.watchdog_guard,
+            supervisor_reader=active_run.supervisor_reader,
+            connection_epoch_reader=session.read_connection_epoch,
+        )
+        color_transport = _HostBoundColorLedTransport(
+            crazyflie=active_run.crazyflie,
+            execution_domain=active_run.execution_domain,
+            safelink_guard=active_run.safelink_guard,
+            teacher_authorization=active_run.teacher_authorization,
+            powered_session=active_run.powered_session,
+            watchdog_guard=active_run.watchdog_guard,
+            connection_epoch_reader=session.read_connection_epoch,
+        )
+        live_epoch = session.read_connection_epoch()
+        if (
+            inflight_transport.bound_connection_epoch != live_epoch
+            or color_transport.bound_connection_epoch != live_epoch
+        ):
+            raise DynamicRunActivationError(
+                "dynamic physical consumers are not bound to the exact active host epoch"
+            )
+        backend = TrustedDynamicPhysicalBackend(
+            ast_binding=staged_binding.ast_binding,
+            active_run=active_run,
+            connection_epoch_reader=session.read_connection_epoch,
+            assert_current_program=assert_current_program,
+            inflight_transport=inflight_transport,
+            color_transport=color_transport,
+            timing_policy=HighLevelTimingPolicy(),
+            execute_wait=execute_wait,
+        )
+        dynamic_run = BoundDynamicPhysicalRun(backend)
+    except Exception as exc:
+        _terminal_shutdown(controller)
+        if isinstance(exc, DynamicRunActivationError):
+            raise
+        raise DynamicRunActivationError(
+            "post-takeoff dynamic physical composition failed closed"
+        ) from exc
+
+    class _ActivatedDynamicRunController:
+        __slots__ = ("_run", "_executed", "_closed", "_terminal")
+
+        def __init__(self) -> None:
+            self._run = dynamic_run
+            self._executed = False
+            self._closed = False
+            self._terminal = False
+
+        @property
+        def active_run(self):
+            return controller.active_run
+
+        def execute_next_inflight(self):
+            """Execute the whole exact interpreter-owned dynamic program once."""
+            if self._executed:
+                raise DynamicRunActivationError("dynamic physical program is one-shot")
+            if self._terminal:
+                raise DynamicRunActivationError("dynamic physical program is terminal")
+            self._executed = True
+            try:
+                result = self._run.execute()
+                self._run.close()
+                self._closed = True
+                return result
+            except Exception as exc:
+                self._terminal = True
+                if not self._closed:
+                    try:
+                        self._run.close()
+                    except Exception:
+                        pass
+                    self._closed = True
+                _terminal_shutdown(controller)
+                raise DynamicRunActivationError(
+                    "post-takeoff dynamic physical execution failed closed into terminal recovery"
+                ) from exc
+
+        def shutdown(self) -> None:
+            close_error = None
+            if not self._closed:
+                try:
+                    self._run.close()
+                except Exception as exc:
+                    close_error = exc
+                self._closed = True
+            _terminal_shutdown(controller)
+            if close_error is not None:
+                raise DynamicRunActivationError(
+                    "dynamic physical observer teardown is uncertain"
+                ) from close_error
+
+    return _ActivatedDynamicRunController()

--- a/tools/physical/physical_run_dispatch.py
+++ b/tools/physical/physical_run_dispatch.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Choose the integrated static or shared-interpreter physical activation path.
+
+The existing flat ``PhysicalProgramSequence`` remains authoritative for programs
+it can represent exactly.  Programs containing shared Runtime control-flow,
+variables or range expressions are rejected by that flat cursor before any
+physical effect and are instead admitted only through the dynamic activation
+path, whose pre-effect validator and shared interpreter own their semantics.
+
+This module is process-local dispatch only.  It accepts no caller-selected
+semantic parameter beyond the already host-staged exact binding.
+"""
+
+from __future__ import annotations
+
+from dynamic_run_activation import activate_validated_dynamic_run
+from physical_program_sequence import PhysicalProgramSequence, PhysicalProgramSequenceError
+from physical_run_activation import activate_validated_run as activate_validated_static_run
+
+
+def activate_validated_run(**kwargs):
+    staged_binding = kwargs.get("staged_binding")
+    ast_binding = getattr(staged_binding, "ast_binding", None)
+    try:
+        PhysicalProgramSequence(ast_binding)
+    except PhysicalProgramSequenceError:
+        # The dynamic path performs its complete backend-free shared-language and
+        # conservative physical validation before reset/takeoff.  An invalid AST
+        # therefore still fails before effect; this fallback does not authorize it.
+        return activate_validated_dynamic_run(**kwargs)
+    return activate_validated_static_run(**kwargs)

--- a/tools/physical/serve_physical_host.py
+++ b/tools/physical/serve_physical_host.py
@@ -8,21 +8,23 @@ session and the integrated #278 bridge/responder relationship.
 
 The ordinary caller/UI is outside this process. Run-context validation requests
 remain diagnostic/non-authority. After the distinct launcher-installed teacher
-capability has established one exact #293 run, ordinary IPC may also request a
-parameter-free ``execute-next-inflight`` step. That request carries no motion
-semantics or authority: ``activate_validated_run()`` derives the next eligible
-move/turn from the exact #267 canonical AST and keeps the #276 effect/provenance
-objects inside the trusted process. A positive reply is still non-authority data.
+capability has established one exact run, ordinary IPC may also request a
+parameter-free ``execute-next-inflight`` operation. That request carries no
+motion, sensor, branch or expression semantics or authority: trusted dispatch
+keeps flat programs on the exact static sequence and routes dynamic programs
+through the exact teacher-bound shared Runtime interpreter. A positive reply is
+still non-authority data.
 
 Browser bootstrap is a distinct one-way composition channel. Its responder
 credential is written there once and never returned on ordinary caller IPC. The
 teacher socket is distinct from both channels and is consumed only inside the
 one-shot production activation path; ordinary caller data cannot supply, replace
-or write that trusted decision channel. The #276 transport belongs inside this
-same process so fresh #249 and all identity-sensitive #257/#260/#262/#266/#267/
-#271/#272/#273 objects share the one live Crazyflie/session/connection epoch.
-Starting the host, validating a run without the trusted teacher capability, or
-requesting an in-flight step before successful activation remains effect-free.
+or write that trusted decision channel. The physical transports and observers
+belong inside this same process so current-program, teacher, powered-session,
+watchdog, acknowledgement and reconnect-sensitive epoch identity stay lexical to
+one trusted host. Starting the host, validating a run without the trusted teacher
+capability, or requesting execution before successful activation remains
+effect-free.
 """
 
 if __name__ == "__main__":
@@ -41,7 +43,7 @@ if __name__ == "__main__":
             sys.path.insert(0, str(physical))
 
         from physical_execution_domain import PhysicalExecutionDomain
-        from physical_run_activation import activate_validated_run
+        from physical_run_dispatch import activate_validated_run
         from post_reset_capability_bridge import PostResetCapabilityHttpBridge
         from probe_reference_hardware import ReadOnlyCapabilitySession
         from serve_reference_capabilities import CapabilityBridgeError
@@ -72,7 +74,7 @@ if __name__ == "__main__":
             default=None,
             help=(
                 "distinct launcher-installed teacher capability; its presence enables "
-                "one post-reset host-first #290 decision for a freshly validated candidate"
+                "one post-reset host-first decision for a freshly validated candidate"
             ),
         )
         args = parser.parse_args()


### PR DESCRIPTION
Refs #345 #157.

Production-composition candidate synchronized with current `main@1bd50265b7fdfb797b3391756f5b7f86cc12de74`. Current exact Draft head: `6c1f1ab6b200cb0d901ff8ad0609d2ec5c04f483`.

This branch follows the durable post-#356 #345 boundary: it reuses the already-integrated `BoundDynamicPhysicalRun` / `TrustedDynamicPhysicalBackend` rather than introducing another interpreter or semantic cursor.

Implemented scope:
- `dynamic_run_activation.py` runs the existing backend-free `validate_bound_shared_program()` before reset/takeoff, preserves `ProductionTakeoffRunController` as the sole causal takeoff authority, then composes the exact teacher-bound shared interpreter with the integrated dynamic backend and dynamic landing transport;
- interpreter-selected fresh `range(direction)` data, branch/repeat progression and later actions remain inside the trusted host; ordinary caller IPC remains parameter-free `execute-next-inflight` and cannot supply sensor direction/value, branch, cursor or effect parameters;
- post-takeoff interpreter/backend/range/observer/protocol failure closes process-local dynamic observers and enters the existing controller terminal shutdown path, including terminal watchdog/powered-session handling and teacher-run invalidation, rather than permitting ordinary continuation;
- `physical_run_dispatch.py` keeps ASTs exactly representable by `PhysicalProgramSequence` on the established static path; programs rejected by that flat cursor are admitted only through the dynamic path's complete pre-effect shared-language plus conservative physical validation;
- the production host imports that dispatcher, preserving the existing static behavior while routing dynamic Runtime programs through the shared interpreter.

Deterministic production proof is wired into the canonical Runtime core gate through the existing `test_dynamic_physical_run.py` entrypoint. The regressions run broad production-host fake surfaces in isolated Python subprocesses so monkeypatch state cannot leak between oracles. They cover:
- flat/static dispatch remains unchanged while dynamic ASTs take the shared-interpreter path;
- one causal takeoff only, followed by fresh exclusion-held front-range demand selected by the exact bound interpreter;
- range-driven branch selection reaches the existing trusted motion/color consumers while the non-selected branch emits nothing;
- accepted branch-dependent vertical completion updates host-owned nominal altitude and terminal dynamic landing derives from that completed runtime path;
- caller-supplied direction/range/branch/effect fields remain rejected;
- worker/range failure after takeoff closes observers, enters terminal watchdog/powered-session handling, closes teacher authority and prevents later effects;
- deterministic shared-language invalidity (read-before-assignment and unsupported expression semantics) uses the repository's Runtime-compatible canonical AST serializer and fails before bridge cutover/reset/power-cycle/takeoff.

Ready run #1373 on predecessor `2f18a59...` exposed only cross-test monkeypatch leakage after the first production dynamic regression passed. The later isolated-subprocess repair on `e48bcd2...` produced a successful Runtime core in Ready run #1376 before `main` advanced. This head non-destructively merges the unrelated #363 X3 documentation update and has the same six-file product diff relative to current `main`; strict branch policy nevertheless requires fresh exact-head Ready CI and independent exact-head review.

This execution has modified the candidate and cannot supply its independent exact-head GO. This candidate establishes deterministic production composition only. It does not by itself close the broader hardware qualification boundary, does not claim motorized/real-device evidence, and creates no new human checkpoint or `TEST_REQUIRED`.