### PR TITLE
Correct X3 timing provenance for pinned firmware clock

### DIFF
--- a/experiments/crazyflie-ukf-surface-range/INDEPENDENT_INPUT_CAPTURE.md
+++ b/experiments/crazyflie-ukf-surface-range/INDEPENDENT_INPUT_CAPTURE.md
@@ -30,17 +30,26 @@ Every field is fetched as a float; each block fits cflib's 26-byte log payload.
 Units remain the pinned firmware units: barometer altitude in m, pressure in
 mbar, temperature in Celsius; accelerometer in g; filtered gyro in degrees/s;
 downward range in mm; roll/pitch in degrees; UKF Z in m and VZ in m/s.
-`stabilizer.intToOut` is the pinned firmware's microsecond latency from the IMU
-interrupt timestamp carried by the stabilizer's current `sensorData` to the end
-of that stabilizer iteration. Diagnostic UKF outputs and this latency diagnostic
-must not become independent displacement inputs.
+`stabilizer.intToOut` is a difference of two values from the pinned firmware's
+`usecTimestamp()` clock, from the interrupt timestamp carried by the stabilizer's
+current `sensorData` to the end of that stabilizer iteration. The pinned
+`2026.08@54f31e...` TIM7 prescaler has a known 84/85 nominal-rate defect documented
+in [X3_PRELPF_TIMING_OBSERVER.md](X3_PRELPF_TIMING_OBSERVER.md) and upstream PR
+[bitcraze/crazyflie-firmware#1684](https://github.com/bitcraze/crazyflie-firmware/pull/1684),
+which is based on that exact firmware commit. Consequently the raw `intToOut`
+number is not a true elapsed-microsecond measurement as stored; the deterministic
+prescaler correction alone is `raw * 85 / 84`, before separate oscillator and
+sensor/interrupt provenance uncertainty. Diagnostic UKF outputs and this latency
+diagnostic must not become independent displacement inputs.
 
 Both the 24-bit device log timestamp and host monotonic receipt time are retained
-for every row. Log time does not identify a sensor's producer time, and fetching
-acceleration/gyro in one block does not prove simultaneous sensor acquisition.
-The `intToOut` value is read later by the log worker from shared state and is not
-atomically paired with the pose or IMU row; it characterizes the firmware's
-internal sensor-to-output path but does not validate `sensor_time_error_s` or
+for every row. The wireless log timestamp uses a different FreeRTOS-based clock
+path and is not corrected by the TIM7 85/84 rule. Log time does not identify a
+sensor's producer time, and fetching acceleration/gyro in one block does not prove
+simultaneous sensor acquisition. The `intToOut` value is read later by the log
+worker from shared state and is not atomically paired with the pose or IMU row; it
+characterizes the firmware's internal sensor-to-output path only after preserving
+its distinct clock semantics and still does not validate `sensor_time_error_s` or
 supply a producer timestamp. The chosen cadence is an acquisition configuration,
 not proof that inertial integration or a 5 cm / 1 s bound is achievable. No
 missing row is interpolated.
@@ -125,5 +134,6 @@ boundary. No estimator or controller change follows from successful acquisition.
 ## Inspected API sources
 
 - [Firmware log names/units](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/modules/src/stabilizer.c), including the existing `stabilizer.intToOut` sensor-to-output diagnostic.
+- [Pinned `usecTimestamp()` timer configuration](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/hal/src/usec_time.c) and upstream exact-base correction/review in [bitcraze/crazyflie-firmware#1684](https://github.com/bitcraze/crazyflie-firmware/pull/1684).
 - [Pinned cflib LogConfig/TOC/log lifecycle](https://github.com/bitcraze/crazyflie-lib-python/blob/45fdb784c9d13074c42835f3b5ac1d12133bf873/cflib/crazyflie/log.py).
 - [Pinned cflib asynchronous connection/parameter-ready and close lifecycle](https://github.com/bitcraze/crazyflie-lib-python/blob/45fdb784c9d13074c42835f3b5ac1d12133bf873/cflib/crazyflie/__init__.py).

--- a/experiments/crazyflie-ukf-surface-range/X3_PRELPF_TIMING_OBSERVER.md
+++ b/experiments/crazyflie-ukf-surface-range/X3_PRELPF_TIMING_OBSERVER.md
@@ -18,10 +18,10 @@ The applicator adds two log groups to `src/hal/src/sensors_bmi088_bmp3xx.c`.
 | --- | --- | --- |
 | `x/y/z` | float | aligned, gravity-corrected acceleration in the current firmware units, before its 30 Hz software LPF |
 | `seq` | uint32 | monotonically incremented firmware snapshot sequence |
-| `readBeg` | uint32 | low 32 bits of `usecTimestamp()` immediately before the accelerometer register read |
-| `readEnd` | uint32 | low 32 bits of `usecTimestamp()` immediately after that read returns |
+| `readBeg` | uint32 | low 32 bits of `usecTimestamp()` immediately before the accelerometer register read; on pinned 2026.08 this counter has the known TIM7 84/85 nominal-rate defect described below |
+| `readEnd` | uint32 | low 32 bits of `usecTimestamp()` immediately after that read returns; same clock semantics as `readBeg` |
 
-The log payload is 24 bytes. `readBeg/readEnd` bound a CPU-side register-read window. They are not accelerometer sample-production timestamps.
+The log payload is 24 bytes. `readBeg/readEnd` bound a CPU-side register-read window. They are not accelerometer sample-production timestamps and, on the pinned firmware, their raw deltas are not true elapsed microseconds without the clock-scale correction below.
 
 `x3BaroObs` is captured after `bmp3_get_sensor_data()` and `sensorsScaleBaro()`:
 
@@ -29,10 +29,23 @@ The log payload is 24 bytes. `readBeg/readEnd` bound a CPU-side register-read wi
 | --- | --- | --- |
 | `asl/pressure/temp` | float | one scaled barometer snapshot |
 | `seq` | uint32 | monotonically incremented firmware snapshot sequence |
-| `readBeg/readEnd` | uint32 | low 32 bits of CPU time around `bmp3_get_sensor_data()` |
+| `readBeg/readEnd` | uint32 | low 32 bits of the same `usecTimestamp()` counter around `bmp3_get_sensor_data()` |
 | `chipId` | uint8 | exact runtime `bmp3_chip_id` (BMP388 or BMP390 identity) |
 
 The log payload is 25 bytes. The CPU read window does not remove BMP3xx conversion, oversampling or IIR response uncertainty.
+
+## Pinned `usecTimestamp()` clock-scale erratum
+
+Upstream PR [bitcraze/crazyflie-firmware#1684](https://github.com/bitcraze/crazyflie-firmware/pull/1684) is based exactly on the firmware commit pinned here, `54f31e243a0b28b67efef5ba20dbb6d9890a5478`. That source programs TIM7 with
+`TIM_Prescaler = SystemCoreClock / (1000 * 1000) / 2`. On the CF2 timer clock this writes PSC=84, while the STM32 timer divides by PSC+1. The nominal `usecTimestamp()` counter therefore advances at `84/85` of the intended 1 MHz rate. PR #1684 repairs the one line by subtracting one from the programmed prescaler. Its exact current head `bb58cadfa348f903e4e8e6995a5557c42cd5754d` remains upstream/open as of 2026-09-12, but has two upstream approvals; one review independently quantified the old timing behavior and the expected Flow-deck/high-level-command consequences.
+
+For a modular interval formed from this counter on the unchanged pinned firmware, the deterministic prescaler correction alone is therefore:
+
+`nominal_real_interval = raw_usecTimestamp_delta * 85 / 84`
+
+This correction is only the digital divider ratio. It does not establish absolute clock accuracy: STM32 oscillator accuracy/drift remains separate, as do interrupt-source, sensor-producer, filter, bus-read and scheduling uncertainties. In particular, it does not rehabilitate `sensorData.interruptTimestamp` or justify a smaller `sensor_time_error_s`.
+
+The normal wireless log packet timestamp is a different clock path based on the FreeRTOS logging timestamp and is not converted by this rule. A later analysis must never compare these clocks as though they shared an already-proven common real-time scale or producer epoch merely because both are numeric timestamps.
 
 ## Row coherence
 
@@ -56,8 +69,8 @@ This diagnostic build proves compilation only. It does not replace the exact #25
 
 ## Proof boundary
 
-The low 32-bit microsecond timestamps wrap modulo 2^32; any later duration must be computed with unsigned modular subtraction rather than ordinary signed ordering.
+The low 32-bit `usecTimestamp()` counter wraps modulo 2^32; any later duration must first be computed with unsigned modular subtraction rather than ordinary signed ordering. On the pinned 2026.08 firmware, a raw modular delta must then account for the known 84/85 TIM7 rate defect before it is called a nominal elapsed microsecond interval. Oscillator accuracy and all sensor/producer timing uncertainty remain separate and are not removed by that deterministic correction.
 
-No numeric value for `sensor_time_error_s`, `specific_force_error_g`, `intersample_acceleration_error_m_s2`, `barometer_displacement_error_m` or `delivery_latency_error_s` follows from this observer. Manufacturer typical/RMS values and nominal ODR are not deterministic bounds.
+No numeric value for `sensor_time_error_s`, `specific_force_error_g`, `intersample_acceleration_error_m_s2`, `barometer_displacement_error_m` or `delivery_latency_error_s` follows from this observer or from the TIM7 prescaler correction. Manufacturer typical/RMS values and nominal ODR are not deterministic bounds.
 
 A later capture may use these fields only with their exact stated clock semantics. If the remaining producer/filter/physical-motion uncertainties cannot be pre-registered independently, the X3 independent-displacement result remains `UNPROVEN`. No `TEST_REQUIRED` or motorized action follows from integration.


### PR DESCRIPTION
Refs #70.

The X3 logging/provenance documentation currently describes `usecTimestamp()`-derived values as microseconds on the exact firmware pinned by the #70/#251 work. Upstream Bitcraze PR #1684 is based exactly on that same firmware SHA, `54f31e243a0b28b67efef5ba20dbb6d9890a5478`, and establishes a TIM7 prescaler off-by-one: the programmed counter advances at 84/85 of the intended nominal 1 MHz rate. Its current exact upstream head is `bb58cadfa348f903e4e8e6995a5557c42cd5754d` and it has two upstream approvals.

This documentation-only correction:
- records that `x3AccObs.readBeg/readEnd`, `x3BaroObs.readBeg/readEnd` and `stabilizer.intToOut` inherit that exact `usecTimestamp()` clock-scale defect on the pinned firmware;
- records the deterministic divider-only correction `raw_delta * 85 / 84` after modular subtraction;
- keeps oscillator accuracy, BMI088 interrupt-source provenance, producer/filter/bus/scheduling uncertainty and `sensor_time_error_s` explicitly separate and unresolved;
- distinguishes the wireless FreeRTOS log-packet timestamp from the TIM7 clock so the two are not silently treated as one proven clock domain;
- preserves the existing X3 `UNPROVEN`, no-motorized and no-checkpoint boundaries.

No firmware binary, runtime behavior, estimator/controller equation, parameter, physical action, checkpoint mechanism or human boundary changes. No `TEST_REQUIRED` follows from this candidate.